### PR TITLE
chore(data): refresh huggingface signals 2026-05-23T19:39:24Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-23T14:04:21.950Z",
+  "ts": "2026-05-23T19:39:24.230Z",
   "count": 1,
-  "durationMs": 5473,
+  "durationMs": 6668,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,10 +1,38 @@
 {
-  "fetchedAt": "2026-05-23T14:04:16.478Z",
+  "fetchedAt": "2026-05-23T19:39:17.564Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
     {
       "rank": 1,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/bytedance-research/Lance",
+      "downloads": 1227,
+      "likes": 697,
+      "trendingScore": 663,
+      "pipelineTag": "any-to-any",
+      "libraryName": "Lance",
+      "tags": [
+        "Lance",
+        "safetensors",
+        "multimodal",
+        "image-generation",
+        "video-generation",
+        "image-editing",
+        "video-understanding",
+        "any-to-any",
+        "arxiv:2605.18678",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T08:05:57.000Z",
+      "lastModified": "2026-05-23T07:26:12.000Z"
+    },
+    {
+      "rank": 2,
       "id": "openbmb/MiniCPM-V-4.6",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6",
@@ -33,34 +61,6 @@
       ],
       "createdAt": "2026-04-13T09:12:47.000Z",
       "lastModified": "2026-05-18T12:58:20.000Z"
-    },
-    {
-      "rank": 2,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 1227,
-      "likes": 673,
-      "trendingScore": 647,
-      "pipelineTag": "any-to-any",
-      "libraryName": "Lance",
-      "tags": [
-        "Lance",
-        "safetensors",
-        "multimodal",
-        "image-generation",
-        "video-generation",
-        "image-editing",
-        "video-understanding",
-        "any-to-any",
-        "arxiv:2605.18678",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T08:05:57.000Z",
-      "lastModified": "2026-05-23T07:26:12.000Z"
     },
     {
       "rank": 3,
@@ -132,6 +132,51 @@
     },
     {
       "rank": 6,
+      "id": "tencent/Hy-MT2-1.8B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
+      "downloads": 2564,
+      "likes": 388,
+      "trendingScore": 370,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T08:22:10.000Z",
+      "lastModified": "2026-05-22T05:09:24.000Z"
+    },
+    {
+      "rank": 7,
       "id": "deepseek-ai/DeepSeek-V4-Pro",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
@@ -157,7 +202,7 @@
       "lastModified": "2026-05-06T04:18:44.000Z"
     },
     {
-      "rank": 7,
+      "rank": 8,
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic-3",
@@ -202,7 +247,7 @@
       "lastModified": "2026-05-18T08:59:01.000Z"
     },
     {
-      "rank": 8,
+      "rank": 9,
       "id": "HiDream-ai/HiDream-O1-Image",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
@@ -226,86 +271,13 @@
       "lastModified": "2026-05-15T10:40:00.000Z"
     },
     {
-      "rank": 9,
-      "id": "tencent/Hy-MT2-1.8B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
-      "downloads": 2564,
-      "likes": 338,
-      "trendingScore": 324,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T08:22:10.000Z",
-      "lastModified": "2026-05-22T05:09:24.000Z"
-    },
-    {
       "rank": 10,
-      "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 268305,
-      "likes": 292,
-      "trendingScore": 271,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-11T12:57:11.000Z",
-      "lastModified": "2026-05-18T05:58:01.000Z"
-    },
-    {
-      "rank": 11,
       "id": "tencent/Hy-MT2-30B-A3B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
       "downloads": 970,
-      "likes": 282,
-      "trendingScore": 266,
+      "likes": 288,
+      "trendingScore": 272,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -344,13 +316,41 @@
       "lastModified": "2026-05-22T05:15:55.000Z"
     },
     {
+      "rank": 11,
+      "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
+      "downloads": 268305,
+      "likes": 292,
+      "trendingScore": 271,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-11T12:57:11.000Z",
+      "lastModified": "2026-05-18T05:58:01.000Z"
+    },
+    {
       "rank": 12,
       "id": "NemoStation/Marlin-2B",
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
       "downloads": 5283,
-      "likes": 260,
-      "trendingScore": 252,
+      "likes": 264,
+      "trendingScore": 256,
       "pipelineTag": "video-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -384,8 +384,8 @@
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
       "downloads": 78771,
-      "likes": 250,
-      "trendingScore": 247,
+      "likes": 255,
+      "trendingScore": 252,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -588,8 +588,8 @@
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
       "downloads": 4261,
-      "likes": 176,
-      "trendingScore": 173,
+      "likes": 179,
+      "trendingScore": 176,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -748,6 +748,51 @@
     },
     {
       "rank": 26,
+      "id": "tencent/Hy-MT2-7B",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
+      "downloads": 1321,
+      "likes": 142,
+      "trendingScore": 135,
+      "pipelineTag": "translation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hunyuan_v1_dense",
+        "text-generation",
+        "translation",
+        "zh",
+        "en",
+        "fr",
+        "pt",
+        "es",
+        "ja",
+        "tr",
+        "ru",
+        "ar",
+        "ko",
+        "th",
+        "it",
+        "de",
+        "vi",
+        "ms",
+        "id",
+        "tl",
+        "hi",
+        "pl",
+        "cs",
+        "nl",
+        "km",
+        "my",
+        "fa",
+        "gu"
+      ],
+      "createdAt": "2026-05-11T14:56:58.000Z",
+      "lastModified": "2026-05-22T05:16:06.000Z"
+    },
+    {
+      "rank": 27,
       "id": "Qwen/Qwen3.6-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
@@ -772,7 +817,7 @@
       "lastModified": "2026-04-24T02:39:16.000Z"
     },
     {
-      "rank": 27,
+      "rank": 28,
       "id": "mistralai/Mistral-Medium-3.5-128B",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B",
@@ -817,7 +862,7 @@
       "lastModified": "2026-05-04T14:16:22.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "Qwen/Qwen3.6-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
@@ -842,7 +887,7 @@
       "lastModified": "2026-04-24T02:53:42.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "google/gemma-4-26B-A4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-assistant",
@@ -865,7 +910,7 @@
       "lastModified": "2026-05-11T07:50:08.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -907,46 +952,13 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 31,
-      "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
-      "author": "Jiunsong",
-      "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
-      "downloads": 267449,
-      "likes": 626,
-      "trendingScore": 108,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "gemma4",
-        "uncensored",
-        "fast",
-        "llama.cpp",
-        "apple-silicon",
-        "conversational",
-        "korean",
-        "coding",
-        "tool-use",
-        "text-generation",
-        "en",
-        "ko",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-11T11:03:05.000Z",
-      "lastModified": "2026-04-12T13:42:43.000Z"
-    },
-    {
       "rank": 32,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
       "downloads": 12186,
-      "likes": 109,
-      "trendingScore": 108,
+      "likes": 110,
+      "trendingScore": 109,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -986,6 +998,39 @@
     },
     {
       "rank": 33,
+      "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
+      "author": "Jiunsong",
+      "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
+      "downloads": 267449,
+      "likes": 626,
+      "trendingScore": 108,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "gemma4",
+        "uncensored",
+        "fast",
+        "llama.cpp",
+        "apple-silicon",
+        "conversational",
+        "korean",
+        "coding",
+        "tool-use",
+        "text-generation",
+        "en",
+        "ko",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:gemma",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-11T11:03:05.000Z",
+      "lastModified": "2026-04-12T13:42:43.000Z"
+    },
+    {
+      "rank": 34,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -1011,7 +1056,7 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -1039,7 +1084,7 @@
       "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "jackxinning/Leanly_AI",
       "author": "jackxinning",
       "url": "https://huggingface.co/jackxinning/Leanly_AI",
@@ -1063,7 +1108,7 @@
       "lastModified": "2026-05-04T07:50:46.000Z"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
@@ -1087,7 +1132,7 @@
       "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "google/gemma-4-31B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B-it",
@@ -1114,7 +1159,7 @@
       "lastModified": "2026-05-07T07:39:17.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "ScenemaAI/scenema-audio",
       "author": "ScenemaAI",
       "url": "https://huggingface.co/ScenemaAI/scenema-audio",
@@ -1153,7 +1198,7 @@
       "lastModified": "2026-05-14T03:19:58.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "microsoft/Fara-7B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Fara-7B",
@@ -1180,7 +1225,7 @@
       "lastModified": "2026-05-19T15:37:05.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -1209,7 +1254,7 @@
       "lastModified": "2026-05-05T12:57:20.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -1235,7 +1280,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -1263,7 +1308,7 @@
       "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1288,7 +1333,7 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
@@ -1312,7 +1357,32 @@
       "lastModified": "2026-05-19T08:01:07.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 90,
+      "trendingScore": 89,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
+    },
+    {
+      "rank": 47,
       "id": "inclusionAI/Ring-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
@@ -1337,32 +1407,44 @@
       "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
-      "rank": 46,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 89,
-      "trendingScore": 88,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
+      "rank": 48,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 9918,
+      "likes": 88,
+      "trendingScore": 86,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
+        "transformers",
         "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
         "license:apache-2.0",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
-      "rank": 47,
+      "rank": 49,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1407,7 +1489,7 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 48,
+      "rank": 50,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1434,7 +1516,7 @@
       "lastModified": "2026-05-10T15:43:51.000Z"
     },
     {
-      "rank": 49,
+      "rank": 51,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -1472,52 +1554,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 50,
-      "id": "tencent/Hy-MT2-7B",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 1321,
-      "likes": 87,
-      "trendingScore": 82,
-      "pipelineTag": "translation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hunyuan_v1_dense",
-        "text-generation",
-        "translation",
-        "zh",
-        "en",
-        "fr",
-        "pt",
-        "es",
-        "ja",
-        "tr",
-        "ru",
-        "ar",
-        "ko",
-        "th",
-        "it",
-        "de",
-        "vi",
-        "ms",
-        "id",
-        "tl",
-        "hi",
-        "pl",
-        "cs",
-        "nl",
-        "km",
-        "my",
-        "fa",
-        "gu"
-      ],
-      "createdAt": "2026-05-11T14:56:58.000Z",
-      "lastModified": "2026-05-22T05:16:06.000Z"
-    },
-    {
-      "rank": 51,
+      "rank": 52,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1545,7 +1582,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 52,
+      "rank": 53,
       "id": "facebook/VGGT-Omega",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/VGGT-Omega",
@@ -1565,44 +1602,51 @@
       "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
-      "rank": 53,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 9918,
-      "likes": 82,
+      "rank": 54,
+      "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
+      "downloads": 2853,
+      "likes": 84,
       "trendingScore": 80,
-      "pipelineTag": "image-to-text",
+      "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
+        "gguf",
+        "text-generation-inference",
+        "image",
+        "unsloth",
+        "qwen3_6",
         "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "science",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
+      "createdAt": "2026-05-16T10:48:10.000Z",
+      "lastModified": "2026-05-23T00:39:37.000Z"
     },
     {
-      "rank": 54,
+      "rank": 55,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1631,7 +1675,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 55,
+      "rank": 56,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -1657,7 +1701,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 56,
+      "rank": 57,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -1686,7 +1730,51 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 57,
+      "rank": 58,
+      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
+      "downloads": 27398,
+      "likes": 81,
+      "trendingScore": 78,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
+        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-18T05:48:32.000Z",
+      "lastModified": "2026-05-19T23:43:59.000Z"
+    },
+    {
+      "rank": 59,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -1719,7 +1807,7 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 58,
+      "rank": 60,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -1752,7 +1840,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 59,
+      "rank": 61,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -1797,7 +1885,7 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 60,
+      "rank": 62,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -1817,57 +1905,13 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 61,
-      "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 27398,
-      "likes": 75,
-      "trendingScore": 72,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
-        "text-generation",
-        "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "base_model:Jackrong/Qwopus3.5-9B-v3.5",
-        "base_model:adapter:Jackrong/Qwopus3.5-9B-v3.5",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-18T05:48:32.000Z",
-      "lastModified": "2026-05-19T23:43:59.000Z"
-    },
-    {
-      "rank": 62,
+      "rank": 63,
       "id": "nvidia/Nemotron-Labs-Diffusion-14B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
       "downloads": 3282,
-      "likes": 72,
-      "trendingScore": 71,
+      "likes": 74,
+      "trendingScore": 72,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1887,7 +1931,7 @@
       "lastModified": "2026-05-23T01:01:26.000Z"
     },
     {
-      "rank": 63,
+      "rank": 64,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -1908,50 +1952,6 @@
       ],
       "createdAt": "2026-04-23T18:44:33.000Z",
       "lastModified": "2026-05-11T07:50:40.000Z"
-    },
-    {
-      "rank": 64,
-      "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "downloads": 2853,
-      "likes": 72,
-      "trendingScore": 69,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "image",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "science",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T10:48:10.000Z",
-      "lastModified": "2026-05-23T00:39:37.000Z"
     },
     {
       "rank": 65,
@@ -2149,6 +2149,62 @@
     },
     {
       "rank": 71,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 65,
+      "trendingScore": 62,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
+    },
+    {
+      "rank": 72,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 63,
+      "trendingScore": 62,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-22T02:58:39.000Z"
+    },
+    {
+      "rank": 73,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -2180,7 +2236,7 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 72,
+      "rank": 74,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -2209,63 +2265,75 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 73,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 63,
-      "trendingScore": 61,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
-    },
-    {
-      "rank": 74,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
-      "downloads": 0,
-      "likes": 61,
+      "rank": 75,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 381,
+      "likes": 60,
       "trendingScore": 60,
-      "pipelineTag": null,
+      "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
-        "onnx",
         "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
-        "transformers",
-        "avatar",
-        "video-generation",
+        "text-to-image",
         "en",
-        "zh",
+        "arxiv:2605.21573",
         "license:mit",
+        "diffusers:LensPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-22T02:58:39.000Z"
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
     },
     {
-      "rank": 75,
+      "rank": 76,
+      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "downloads": 3532,
+      "likes": 61,
+      "trendingScore": 60,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "devops",
+        "math",
+        "science",
+        "image",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T06:37:47.000Z",
+      "lastModified": "2026-05-23T00:38:45.000Z"
+    },
+    {
+      "rank": 77,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -2290,30 +2358,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 76,
-      "id": "microsoft/Lens-Turbo",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 381,
-      "likes": 59,
-      "trendingScore": 59,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
-    },
-    {
-      "rank": 77,
+      "rank": 78,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -2341,7 +2386,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -2368,7 +2413,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 79,
+      "rank": 80,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -2395,7 +2440,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 80,
+      "rank": 81,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2418,7 +2463,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 81,
+      "rank": 82,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2449,7 +2494,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 82,
+      "rank": 83,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2479,12 +2524,12 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 83,
+      "rank": 84,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
-      "downloads": 2146726,
-      "likes": 1244,
+      "downloads": 2159379,
+      "likes": 1248,
       "trendingScore": 55,
       "pipelineTag": "image-to-video",
       "libraryName": "diffusers",
@@ -2523,7 +2568,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 84,
+      "rank": 85,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2541,7 +2586,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -2568,7 +2613,7 @@
       "lastModified": "2026-05-14T02:37:15.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2595,7 +2640,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2626,51 +2671,6 @@
       ],
       "createdAt": "2026-05-05T18:45:32.000Z",
       "lastModified": "2026-05-07T09:30:56.000Z"
-    },
-    {
-      "rank": 88,
-      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "downloads": 3532,
-      "likes": 53,
-      "trendingScore": 53,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
-        "devops",
-        "math",
-        "science",
-        "image",
-        "text-generation",
-        "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T06:37:47.000Z",
-      "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
       "rank": 89,
@@ -2774,6 +2774,24 @@
     },
     {
       "rank": 92,
+      "id": "zhen-nan/L2P",
+      "author": "zhen-nan",
+      "url": "https://huggingface.co/zhen-nan/L2P",
+      "downloads": 0,
+      "likes": 50,
+      "trendingScore": 50,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "arxiv:2605.12013",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-03T13:24:20.000Z",
+      "lastModified": "2026-05-22T07:53:35.000Z"
+    },
+    {
+      "rank": 93,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2807,7 +2825,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2837,7 +2855,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -2855,24 +2873,6 @@
       ],
       "createdAt": "2026-05-14T05:38:45.000Z",
       "lastModified": "2026-05-14T05:39:47.000Z"
-    },
-    {
-      "rank": 95,
-      "id": "zhen-nan/L2P",
-      "author": "zhen-nan",
-      "url": "https://huggingface.co/zhen-nan/L2P",
-      "downloads": 0,
-      "likes": 48,
-      "trendingScore": 48,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "arxiv:2605.12013",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-03T13:24:20.000Z",
-      "lastModified": "2026-05-22T07:53:35.000Z"
     },
     {
       "rank": 96,
@@ -3006,6 +3006,64 @@
     },
     {
       "rank": 100,
+      "id": "microsoft/Lens",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 296,
+      "likes": 50,
+      "trendingScore": 47,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
+    },
+    {
+      "rank": 101,
+      "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
+      "author": "OBLITERATUS",
+      "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
+      "downloads": 1863,
+      "likes": 47,
+      "trendingScore": 47,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "qwen3_5_text",
+        "text-generation",
+        "qwen",
+        "qwen3",
+        "qwen3.6",
+        "llama.cpp",
+        "lm-studio",
+        "ollama",
+        "conversational",
+        "obliteratus",
+        "refusal-analysis",
+        "red-team",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T23:14:00.000Z",
+      "lastModified": "2026-05-23T09:28:57.000Z"
+    },
+    {
+      "rank": 102,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -3033,7 +3091,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 101,
+      "rank": 103,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
@@ -3057,7 +3115,7 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 102,
+      "rank": 104,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -3080,7 +3138,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 103,
+      "rank": 105,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -3107,30 +3165,48 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 104,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 296,
-      "likes": 47,
-      "trendingScore": 44,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "rank": 106,
+      "id": "Kijai/LTX2.3_comfy",
+      "author": "Kijai",
+      "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
+      "downloads": 1599401,
+      "likes": 397,
+      "trendingScore": 45,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
       "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
+      "createdAt": "2026-03-05T15:20:18.000Z",
+      "lastModified": "2026-05-20T20:31:07.000Z"
     },
     {
-      "rank": 105,
+      "rank": 107,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 6510,
+      "likes": 45,
+      "trendingScore": 44,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-22T05:15:52.000Z"
+    },
+    {
+      "rank": 108,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -3163,7 +3239,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 106,
+      "rank": 109,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -3194,7 +3270,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 107,
+      "rank": 110,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -3210,54 +3286,13 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 108,
-      "id": "Kijai/LTX2.3_comfy",
-      "author": "Kijai",
-      "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
-      "downloads": 1599401,
-      "likes": 394,
-      "trendingScore": 42,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T15:20:18.000Z",
-      "lastModified": "2026-05-20T20:31:07.000Z"
-    },
-    {
-      "rank": 109,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 6510,
-      "likes": 43,
-      "trendingScore": 42,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-22T05:15:52.000Z"
-    },
-    {
-      "rank": 110,
+      "rank": 111,
       "id": "LatitudeGames/Equinox-31B",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
       "downloads": 277,
-      "likes": 40,
-      "trendingScore": 40,
+      "likes": 42,
+      "trendingScore": 42,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
@@ -3275,7 +3310,7 @@
       "lastModified": "2026-05-22T04:55:49.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -3294,7 +3329,34 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 112,
+      "rank": 113,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 12747,
+      "likes": 39,
+      "trendingScore": 39,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
+      "rank": 114,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3326,7 +3388,34 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 113,
+      "rank": 115,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 39,
+      "trendingScore": 38,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 116,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3353,7 +3442,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 114,
+      "rank": 117,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3380,39 +3469,12 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 115,
-      "id": "stabilityai/stable-audio-3-small-music",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
-      "downloads": 0,
-      "likes": 38,
-      "trendingScore": 37,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
-    },
-    {
-      "rank": 116,
+      "rank": 118,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "downloads": 31296,
-      "likes": 39,
+      "likes": 40,
       "trendingScore": 37,
       "pipelineTag": null,
       "libraryName": null,
@@ -3439,34 +3501,33 @@
       "lastModified": "2026-05-21T21:34:50.000Z"
     },
     {
-      "rank": 117,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 12747,
-      "likes": 37,
+      "rank": 119,
+      "id": "Tongyi-MAI/Z-Image-Turbo",
+      "author": "Tongyi-MAI",
+      "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
+      "downloads": 1229497,
+      "likes": 4667,
       "trendingScore": 37,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2511.22699",
+        "arxiv:2511.22677",
+        "arxiv:2511.13649",
         "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "diffusers:ZImagePipeline",
+        "deploy:azure",
+        "region:us"
       ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
+      "createdAt": "2025-11-25T15:09:48.000Z",
+      "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 118,
+      "rank": 120,
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
@@ -3499,33 +3560,7 @@
       "lastModified": "2026-03-08T12:54:54.000Z"
     },
     {
-      "rank": 119,
-      "id": "Tongyi-MAI/Z-Image-Turbo",
-      "author": "Tongyi-MAI",
-      "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
-      "downloads": 1229497,
-      "likes": 4666,
-      "trendingScore": 36,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2511.22699",
-        "arxiv:2511.22677",
-        "arxiv:2511.13649",
-        "license:apache-2.0",
-        "diffusers:ZImagePipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-25T15:09:48.000Z",
-      "lastModified": "2026-01-30T16:58:07.000Z"
-    },
-    {
-      "rank": 120,
+      "rank": 121,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -3557,7 +3592,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 121,
+      "rank": 122,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -3580,7 +3615,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 122,
+      "rank": 123,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -3604,7 +3639,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 123,
+      "rank": 124,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -3633,12 +3668,12 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 124,
+      "rank": 125,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
-      "downloads": 359608,
-      "likes": 648,
+      "downloads": 360574,
+      "likes": 651,
       "trendingScore": 35,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -3662,7 +3697,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 125,
+      "rank": 126,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3686,7 +3721,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3703,7 +3738,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 127,
+      "rank": 128,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3727,7 +3762,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 128,
+      "rank": 129,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3753,7 +3788,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -3769,7 +3804,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 130,
+      "rank": 131,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -3796,7 +3831,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -3815,7 +3850,33 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 39,
+      "trendingScore": 34,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-21T14:39:01.000Z"
+    },
+    {
+      "rank": 134,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -3860,7 +3921,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 133,
+      "rank": 135,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -3905,7 +3966,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 134,
+      "rank": 136,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -3949,7 +4010,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 135,
+      "rank": 137,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3989,7 +4050,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 136,
+      "rank": 138,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -4015,7 +4076,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 137,
+      "rank": 139,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
@@ -4047,42 +4108,33 @@
       "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 138,
-      "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
-      "author": "OBLITERATUS",
-      "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
-      "downloads": 1863,
-      "likes": 33,
+      "rank": 140,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 3311,
+      "likes": 35,
       "trendingScore": 33,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "gguf",
-        "qwen3_5_text",
+        "llama",
         "text-generation",
-        "qwen",
-        "qwen3",
-        "qwen3.6",
-        "llama.cpp",
-        "lm-studio",
-        "ollama",
-        "conversational",
-        "obliteratus",
-        "refusal-analysis",
-        "red-team",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "dna",
+        "genomic",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
         "license:apache-2.0",
+        "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-19T23:14:00.000Z",
-      "lastModified": "2026-05-23T09:28:57.000Z"
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -4126,7 +4178,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 140,
+      "rank": 142,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -4151,7 +4203,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 141,
+      "rank": 143,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -4196,38 +4248,12 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 142,
-      "id": "HuggingFaceBio/Carbon-3B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 3311,
-      "likes": 34,
-      "trendingScore": 32,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-20T13:39:48.000Z"
-    },
-    {
-      "rank": 143,
+      "rank": 144,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
       "downloads": 2676824,
-      "likes": 2040,
+      "likes": 2041,
       "trendingScore": 32,
       "pipelineTag": "mask-generation",
       "libraryName": "transformers",
@@ -4247,32 +4273,6 @@
       ],
       "createdAt": "2025-11-07T05:17:48.000Z",
       "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 144,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 37,
-      "trendingScore": 32,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
-        "en",
-        "zh",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-21T14:39:01.000Z"
     },
     {
       "rank": 145,
@@ -4681,7 +4681,7 @@
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "downloads": 0,
-      "likes": 2043,
+      "likes": 2044,
       "trendingScore": 29,
       "pipelineTag": "text-to-image",
       "libraryName": "comfyUI",
@@ -5028,7 +5028,7 @@
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
       "downloads": 260118595,
-      "likes": 4821,
+      "likes": 4822,
       "trendingScore": 28,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -5069,6 +5069,65 @@
     },
     {
       "rank": 171,
+      "id": "stabilityai/stable-audio-3-small-sfx",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
+      "downloads": 0,
+      "likes": 28,
+      "trendingScore": 28,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-sfx-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:16.000Z",
+      "lastModified": "2026-05-19T20:02:45.000Z"
+    },
+    {
+      "rank": 172,
+      "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
+      "downloads": 39712,
+      "likes": 54,
+      "trendingScore": 28,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3_5_moe",
+        "qwen3_5",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "mpoa",
+        "mtp",
+        "image-text-to-text",
+        "base_model:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
+        "base_model:quantized:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-08T22:19:56.000Z",
+      "lastModified": "2026-05-09T01:18:02.000Z"
+    },
+    {
+      "rank": 173,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -5108,7 +5167,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 172,
+      "rank": 174,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -5145,7 +5204,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 173,
+      "rank": 175,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -5188,7 +5247,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 174,
+      "rank": 176,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -5208,7 +5267,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 175,
+      "rank": 177,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -5233,7 +5292,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 176,
+      "rank": 178,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5256,65 +5315,6 @@
       ],
       "createdAt": "2026-05-16T02:00:22.000Z",
       "lastModified": "2026-05-16T04:32:12.000Z"
-    },
-    {
-      "rank": 177,
-      "id": "stabilityai/stable-audio-3-small-sfx",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
-      "downloads": 0,
-      "likes": 27,
-      "trendingScore": 27,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-sfx-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:16.000Z",
-      "lastModified": "2026-05-19T20:02:45.000Z"
-    },
-    {
-      "rank": 178,
-      "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
-      "downloads": 39712,
-      "likes": 52,
-      "trendingScore": 27,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3_5_moe",
-        "qwen3_5",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "mpoa",
-        "mtp",
-        "image-text-to-text",
-        "base_model:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
-        "base_model:quantized:llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-08T22:19:56.000Z",
-      "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
       "rank": 179,
@@ -5556,8 +5556,8 @@
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
-      "downloads": 28332931,
-      "likes": 3031,
+      "downloads": 28726979,
+      "likes": 3032,
       "trendingScore": 26,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -6185,7 +6185,7 @@
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
       "downloads": 1410,
-      "likes": 27,
+      "likes": 28,
       "trendingScore": 24,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -6234,6 +6234,28 @@
     },
     {
       "rank": 211,
+      "id": "facebook/sam3.1",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3.1",
+      "downloads": 313182,
+      "likes": 285,
+      "trendingScore": 24,
+      "pipelineTag": "mask-generation",
+      "libraryName": "checkpoint",
+      "tags": [
+        "checkpoint",
+        "sam3_video",
+        "sam3.1",
+        "mask-generation",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T01:25:54.000Z",
+      "lastModified": "2026-03-27T17:40:55.000Z"
+    },
+    {
+      "rank": 212,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -6260,7 +6282,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 212,
+      "rank": 213,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -6289,7 +6311,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 213,
+      "rank": 214,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -6306,7 +6328,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 214,
+      "rank": 215,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -6327,7 +6349,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 215,
+      "rank": 216,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -6348,7 +6370,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 216,
+      "rank": 217,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6369,7 +6391,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 217,
+      "rank": 218,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -6401,7 +6423,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 218,
+      "rank": 219,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6432,7 +6454,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 219,
+      "rank": 220,
       "id": "tencent/Hy-MT2-7B-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
@@ -6454,7 +6476,7 @@
       "lastModified": "2026-05-22T05:16:12.000Z"
     },
     {
-      "rank": 220,
+      "rank": 221,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6485,7 +6507,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 221,
+      "rank": 222,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6514,7 +6536,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 222,
+      "rank": 223,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6559,7 +6581,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 223,
+      "rank": 224,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6586,7 +6608,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 224,
+      "rank": 225,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6612,7 +6634,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 225,
+      "rank": 226,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -6636,7 +6658,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 226,
+      "rank": 227,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -6674,7 +6696,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 227,
+      "rank": 228,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6691,7 +6713,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 228,
+      "rank": 229,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -6717,28 +6739,6 @@
       ],
       "createdAt": "2026-05-15T19:03:18.000Z",
       "lastModified": "2026-05-18T03:29:50.000Z"
-    },
-    {
-      "rank": 229,
-      "id": "facebook/sam3.1",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 313182,
-      "likes": 283,
-      "trendingScore": 22,
-      "pipelineTag": "mask-generation",
-      "libraryName": "checkpoint",
-      "tags": [
-        "checkpoint",
-        "sam3_video",
-        "sam3.1",
-        "mask-generation",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T01:25:54.000Z",
-      "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
       "rank": 230,
@@ -6923,6 +6923,31 @@
     },
     {
       "rank": 236,
+      "id": "Efficient-Large-Model/LongLive-2.0-5B",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
+      "downloads": 0,
+      "likes": 21,
+      "trendingScore": 21,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "text-to-video",
+        "multi-shot",
+        "video-generation",
+        "diffusion",
+        "long-video",
+        "longlive2",
+        "arxiv:2605.18739",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:10:14.000Z",
+      "lastModified": "2026-05-19T02:54:48.000Z"
+    },
+    {
+      "rank": 237,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -6950,7 +6975,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 237,
+      "rank": 238,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -6983,7 +7008,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 238,
+      "rank": 239,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -7008,7 +7033,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 239,
+      "rank": 240,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -7045,7 +7070,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 240,
+      "rank": 241,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -7088,7 +7113,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 241,
+      "rank": 242,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -7112,7 +7137,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 242,
+      "rank": 243,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -7136,7 +7161,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 243,
+      "rank": 244,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -7165,7 +7190,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 244,
+      "rank": 245,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -7196,7 +7221,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 245,
+      "rank": 246,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -7214,7 +7239,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 246,
+      "rank": 247,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7259,7 +7284,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 247,
+      "rank": 248,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7304,7 +7329,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 248,
+      "rank": 249,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -7333,7 +7358,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 249,
+      "rank": 250,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -7355,31 +7380,6 @@
       ],
       "createdAt": "2026-05-01T08:12:57.000Z",
       "lastModified": "2026-05-18T17:56:08.000Z"
-    },
-    {
-      "rank": 250,
-      "id": "Efficient-Large-Model/LongLive-2.0-5B",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
-      "downloads": 0,
-      "likes": 20,
-      "trendingScore": 20,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
-      "tags": [
-        "wan2.2",
-        "text-to-video",
-        "multi-shot",
-        "video-generation",
-        "diffusion",
-        "long-video",
-        "longlive2",
-        "arxiv:2605.18739",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:10:14.000Z",
-      "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
       "rank": 251,
@@ -7438,6 +7438,49 @@
     },
     {
       "rank": 253,
+      "id": "lkzd7/WAN2.2_LoraSet_NSFW",
+      "author": "lkzd7",
+      "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
+      "downloads": 0,
+      "likes": 335,
+      "trendingScore": 20,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "license:unknown",
+        "region:us"
+      ],
+      "createdAt": "2025-12-04T13:37:39.000Z",
+      "lastModified": "2026-01-20T21:35:11.000Z"
+    },
+    {
+      "rank": 254,
+      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
+      "downloads": 24132,
+      "likes": 20,
+      "trendingScore": 20,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T17:45:13.000Z",
+      "lastModified": "2026-05-23T00:38:45.000Z"
+    },
+    {
+      "rank": 255,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -7482,7 +7525,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 254,
+      "rank": 256,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -7515,7 +7558,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 255,
+      "rank": 257,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -7537,7 +7580,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 256,
+      "rank": 258,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -7564,7 +7607,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 257,
+      "rank": 259,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -7580,24 +7623,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 258,
-      "id": "lkzd7/WAN2.2_LoraSet_NSFW",
-      "author": "lkzd7",
-      "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
-      "downloads": 0,
-      "likes": 333,
-      "trendingScore": 19,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:unknown",
-        "region:us"
-      ],
-      "createdAt": "2025-12-04T13:37:39.000Z",
-      "lastModified": "2026-01-20T21:35:11.000Z"
-    },
-    {
-      "rank": 259,
+      "rank": 260,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -7620,7 +7646,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7645,7 +7671,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -7681,7 +7707,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -7710,7 +7736,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -7740,7 +7766,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -7785,7 +7811,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -7812,7 +7838,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 266,
+      "rank": 267,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7838,7 +7864,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7866,7 +7892,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -7895,33 +7921,57 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 269,
-      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 24132,
+      "rank": 270,
+      "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
+      "downloads": 10637,
       "likes": 19,
       "trendingScore": 19,
-      "pipelineTag": "text-generation",
+      "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-03-18T17:45:13.000Z",
-      "lastModified": "2026-05-23T00:38:45.000Z"
+      "createdAt": "2026-05-19T21:47:29.000Z",
+      "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 270,
+      "rank": 271,
+      "id": "Qwen/Qwen-Image-Edit-2511",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
+      "downloads": 222699,
+      "likes": 1008,
+      "trendingScore": 19,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "license:apache-2.0",
+        "diffusers:QwenImageEditPlusPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-12-17T05:55:58.000Z",
+      "lastModified": "2025-12-23T13:13:52.000Z"
+    },
+    {
+      "rank": 272,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -7943,7 +7993,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 271,
+      "rank": 273,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -7977,7 +8027,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 272,
+      "rank": 274,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -8001,7 +8051,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 273,
+      "rank": 275,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -8027,7 +8077,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 274,
+      "rank": 276,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -8049,7 +8099,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 275,
+      "rank": 277,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -8078,7 +8128,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 276,
+      "rank": 278,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8110,7 +8160,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 277,
+      "rank": 279,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8128,7 +8178,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 278,
+      "rank": 280,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8157,7 +8207,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 279,
+      "rank": 281,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -8184,7 +8234,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 280,
+      "rank": 282,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8202,38 +8252,12 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 281,
-      "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 10637,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T21:47:29.000Z",
-      "lastModified": "2026-05-19T22:23:34.000Z"
-    },
-    {
-      "rank": 282,
+      "rank": 283,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
       "downloads": 2903005,
-      "likes": 396,
+      "likes": 398,
       "trendingScore": 18,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "pyannote-audio",
@@ -8259,30 +8283,6 @@
       ],
       "createdAt": "2025-04-15T21:31:35.000Z",
       "lastModified": "2025-09-29T08:43:24.000Z"
-    },
-    {
-      "rank": 283,
-      "id": "Qwen/Qwen-Image-Edit-2511",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
-      "downloads": 222699,
-      "likes": 1007,
-      "trendingScore": 18,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "license:apache-2.0",
-        "diffusers:QwenImageEditPlusPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-12-17T05:55:58.000Z",
-      "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
       "rank": 284,
@@ -8704,6 +8704,66 @@
     },
     {
       "rank": 298,
+      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "author": "mudler",
+      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
+      "downloads": 19032,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "apex",
+        "apex-mtp",
+        "moe",
+        "mixture-of-experts",
+        "qwen3",
+        "qwen3.6",
+        "speculative-decoding",
+        "self-speculative",
+        "mtp",
+        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T04:50:12.000Z",
+      "lastModified": "2026-05-21T21:34:54.000Z"
+    },
+    {
+      "rank": 299,
+      "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
+      "downloads": 12524,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T05:52:43.000Z",
+      "lastModified": "2026-05-19T08:16:03.000Z"
+    },
+    {
+      "rank": 300,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -8728,7 +8788,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 299,
+      "rank": 301,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -8763,7 +8823,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 300,
+      "rank": 302,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -8808,7 +8868,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 301,
+      "rank": 303,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -8835,7 +8895,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 302,
+      "rank": 304,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -8864,7 +8924,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 303,
+      "rank": 305,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -8887,7 +8947,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -8931,7 +8991,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -8976,7 +9036,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 306,
+      "rank": 308,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -8994,7 +9054,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 307,
+      "rank": 309,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -9039,7 +9099,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 308,
+      "rank": 310,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -9077,7 +9137,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 309,
+      "rank": 311,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -9097,7 +9157,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 310,
+      "rank": 312,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -9130,7 +9190,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 311,
+      "rank": 313,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -9160,7 +9220,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 312,
+      "rank": 314,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -9192,7 +9252,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 313,
+      "rank": 315,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -9217,7 +9277,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 314,
+      "rank": 316,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -9240,7 +9300,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 315,
+      "rank": 317,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9264,7 +9324,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 316,
+      "rank": 318,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9294,7 +9354,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 317,
+      "rank": 319,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -9321,7 +9381,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9340,39 +9400,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 319,
-      "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "author": "mudler",
-      "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
-      "downloads": 19032,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "apex",
-        "apex-mtp",
-        "moe",
-        "mixture-of-experts",
-        "qwen3",
-        "qwen3.6",
-        "speculative-decoding",
-        "self-speculative",
-        "mtp",
-        "base_model:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "base_model:quantized:lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T04:50:12.000Z",
-      "lastModified": "2026-05-21T21:34:54.000Z"
-    },
-    {
-      "rank": 320,
+      "rank": 321,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -9399,7 +9427,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 321,
+      "rank": 322,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -9444,7 +9472,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 322,
+      "rank": 323,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -9474,7 +9502,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 323,
+      "rank": 324,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -9504,7 +9532,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 324,
+      "rank": 325,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -9549,7 +9577,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 325,
+      "rank": 326,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -9584,7 +9612,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 326,
+      "rank": 327,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9612,7 +9640,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 327,
+      "rank": 328,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -9641,7 +9669,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 328,
+      "rank": 329,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -9666,7 +9694,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 329,
+      "rank": 330,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -9694,7 +9722,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 330,
+      "rank": 331,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -9722,7 +9750,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 331,
+      "rank": 332,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -9753,7 +9781,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 332,
+      "rank": 333,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -9798,7 +9826,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 333,
+      "rank": 334,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -9830,7 +9858,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 334,
+      "rank": 335,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -9857,7 +9885,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 335,
+      "rank": 336,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -9880,7 +9908,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 336,
+      "rank": 337,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -9907,7 +9935,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 337,
+      "rank": 338,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -9930,7 +9958,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 338,
+      "rank": 339,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -9956,7 +9984,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 339,
+      "rank": 340,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -9986,7 +10014,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 340,
+      "rank": 341,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -10013,7 +10041,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 341,
+      "rank": 342,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -10044,7 +10072,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 342,
+      "rank": 343,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -10072,7 +10100,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 343,
+      "rank": 344,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10104,7 +10132,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 344,
+      "rank": 345,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -10130,7 +10158,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 345,
+      "rank": 346,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10175,34 +10203,6 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 346,
-      "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "downloads": 12524,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T05:52:43.000Z",
-      "lastModified": "2026-05-19T08:16:03.000Z"
-    },
-    {
       "rank": 347,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
@@ -10237,6 +10237,87 @@
     },
     {
       "rank": 348,
+      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
+      "downloads": 16080,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "gemma4",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "creative writing",
+        "translation",
+        "visual novels",
+        "finetune",
+        "roleplay",
+        "rp",
+        "image-text-to-text",
+        "en",
+        "ja",
+        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-13T06:59:32.000Z",
+      "lastModified": "2026-05-23T00:51:18.000Z"
+    },
+    {
+      "rank": 349,
+      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
+      "author": "NousResearch",
+      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
+      "downloads": 222314,
+      "likes": 440,
+      "trendingScore": 15,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "Llama-3",
+        "instruct",
+        "finetune",
+        "chatml",
+        "gpt4",
+        "synthetic data",
+        "distillation",
+        "function calling",
+        "json mode",
+        "axolotl",
+        "roleplaying",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2408.11857",
+        "base_model:meta-llama/Llama-3.1-8B",
+        "base_model:finetune:meta-llama/Llama-3.1-8B",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-07-28T06:00:57.000Z",
+      "lastModified": "2024-09-08T07:39:55.000Z"
+    },
+    {
+      "rank": 350,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -10260,7 +10341,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 349,
+      "rank": 351,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -10287,7 +10368,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 350,
+      "rank": 352,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -10315,7 +10396,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 351,
+      "rank": 353,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -10334,7 +10415,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 352,
+      "rank": 354,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -10366,7 +10447,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 353,
+      "rank": 355,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -10395,7 +10476,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 354,
+      "rank": 356,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -10422,7 +10503,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 355,
+      "rank": 357,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -10448,12 +10529,12 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 356,
+      "rank": 358,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
-      "downloads": 14018215,
-      "likes": 1268,
+      "downloads": 13167875,
+      "likes": 1294,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -10479,7 +10560,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 357,
+      "rank": 359,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -10507,7 +10588,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 358,
+      "rank": 360,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -10530,7 +10611,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 359,
+      "rank": 361,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -10564,7 +10645,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 360,
+      "rank": 362,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -10590,7 +10671,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 361,
+      "rank": 363,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -10632,7 +10713,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 362,
+      "rank": 364,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -10670,7 +10751,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 363,
+      "rank": 365,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -10689,7 +10770,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 364,
+      "rank": 366,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -10709,7 +10790,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 365,
+      "rank": 367,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -10736,7 +10817,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 366,
+      "rank": 368,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -10762,7 +10843,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 367,
+      "rank": 369,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -10787,7 +10868,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 368,
+      "rank": 370,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -10816,7 +10897,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 369,
+      "rank": 371,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -10861,7 +10942,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 370,
+      "rank": 372,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -10888,93 +10969,12 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 371,
-      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
-      "downloads": 16080,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "gemma4",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "creative writing",
-        "translation",
-        "visual novels",
-        "finetune",
-        "roleplay",
-        "rp",
-        "image-text-to-text",
-        "en",
-        "ja",
-        "base_model:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-13T06:59:32.000Z",
-      "lastModified": "2026-05-23T00:51:18.000Z"
-    },
-    {
-      "rank": 372,
-      "id": "NousResearch/Hermes-3-Llama-3.1-8B",
-      "author": "NousResearch",
-      "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 222314,
-      "likes": 439,
-      "trendingScore": 14,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "Llama-3",
-        "instruct",
-        "finetune",
-        "chatml",
-        "gpt4",
-        "synthetic data",
-        "distillation",
-        "function calling",
-        "json mode",
-        "axolotl",
-        "roleplaying",
-        "chat",
-        "conversational",
-        "en",
-        "arxiv:2408.11857",
-        "base_model:meta-llama/Llama-3.1-8B",
-        "base_model:finetune:meta-llama/Llama-3.1-8B",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-07-28T06:00:57.000Z",
-      "lastModified": "2024-09-08T07:39:55.000Z"
-    },
-    {
       "rank": 373,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "downloads": 465730,
-      "likes": 1400,
+      "likes": 1401,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -11785,7 +11785,7 @@
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
       "downloads": 0,
-      "likes": 15,
+      "likes": 16,
       "trendingScore": 13,
       "pipelineTag": "image-to-image",
       "libraryName": null,
@@ -11904,8 +11904,8 @@
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
       "downloads": 7645818,
-      "likes": 3025,
-      "trendingScore": 12,
+      "likes": 3027,
+      "trendingScore": 13,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "transformers",
       "tags": [
@@ -11945,6 +11945,130 @@
     },
     {
       "rank": 407,
+      "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
+      "author": "cyberneurova",
+      "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
+      "downloads": 88043,
+      "likes": 30,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "deepseek",
+        "llama.cpp",
+        "moe",
+        "research",
+        "text-generation",
+        "en",
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-05T15:28:31.000Z",
+      "lastModified": "2026-05-06T16:14:55.000Z"
+    },
+    {
+      "rank": 408,
+      "id": "Wan-AI/Wan2.2-TI2V-5B",
+      "author": "Wan-AI",
+      "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
+      "downloads": 9229,
+      "likes": 608,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-video",
+      "libraryName": "wan2.2",
+      "tags": [
+        "wan2.2",
+        "diffusers",
+        "safetensors",
+        "ti2v",
+        "text-to-video",
+        "en",
+        "zh",
+        "arxiv:2503.20314",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-07-18T09:35:44.000Z",
+      "lastModified": "2025-08-07T10:22:24.000Z"
+    },
+    {
+      "rank": 409,
+      "id": "syvai/cohere-transcribe-diarize",
+      "author": "syvai",
+      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
+      "downloads": 92,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere_asr",
+        "automatic-speech-recognition",
+        "audio",
+        "speech-recognition",
+        "transcription",
+        "diarization",
+        "speaker-diarization",
+        "timestamps",
+        "custom_code",
+        "en",
+        "ar",
+        "de",
+        "el",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "vi",
+        "zh",
+        "base_model:CohereLabs/cohere-transcribe-03-2026",
+        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T03:51:05.000Z",
+      "lastModified": "2026-05-22T20:56:30.000Z"
+    },
+    {
+      "rank": 410,
+      "id": "openbmb/BitCPM-CANN-8B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
+      "downloads": 204,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "minicpm",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:51.000Z",
+      "lastModified": "2026-05-23T18:13:21.000Z"
+    },
+    {
+      "rank": 411,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -11971,7 +12095,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 408,
+      "rank": 412,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -11999,7 +12123,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 409,
+      "rank": 413,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -12032,7 +12156,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 410,
+      "rank": 414,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -12048,7 +12172,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -12071,7 +12195,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -12105,7 +12229,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -12125,7 +12249,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -12160,7 +12284,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -12190,7 +12314,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 416,
+      "rank": 420,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -12211,7 +12335,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 417,
+      "rank": 421,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -12240,7 +12364,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 418,
+      "rank": 422,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -12270,7 +12394,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 419,
+      "rank": 423,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -12298,7 +12422,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 420,
+      "rank": 424,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -12327,7 +12451,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 421,
+      "rank": 425,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -12359,36 +12483,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 422,
-      "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
-      "author": "cyberneurova",
-      "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
-      "downloads": 88043,
-      "likes": 28,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "deepseek",
-        "llama.cpp",
-        "moe",
-        "research",
-        "text-generation",
-        "en",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-05T15:28:31.000Z",
-      "lastModified": "2026-05-06T16:14:55.000Z"
-    },
-    {
-      "rank": 423,
+      "rank": 426,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -12423,7 +12518,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 424,
+      "rank": 427,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -12445,7 +12540,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 425,
+      "rank": 428,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -12483,7 +12578,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -12522,7 +12617,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -12559,7 +12654,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -12583,7 +12678,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -12601,7 +12696,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -12620,7 +12715,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -12648,7 +12743,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 432,
+      "rank": 435,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -12689,7 +12784,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 433,
+      "rank": 436,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -12711,7 +12806,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 434,
+      "rank": 437,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -12748,7 +12843,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 435,
+      "rank": 438,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -12778,7 +12873,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 436,
+      "rank": 439,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -12807,7 +12902,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 437,
+      "rank": 440,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -12835,7 +12930,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 438,
+      "rank": 441,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -12861,7 +12956,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12886,7 +12981,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -12913,7 +13008,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -12938,7 +13033,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 442,
+      "rank": 445,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -12967,77 +13062,133 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 443,
-      "id": "Wan-AI/Wan2.2-TI2V-5B",
-      "author": "Wan-AI",
-      "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
-      "downloads": 9229,
-      "likes": 606,
+      "rank": 446,
+      "id": "openai-community/gpt2",
+      "author": "openai-community",
+      "url": "https://huggingface.co/openai-community/gpt2",
+      "downloads": 17386984,
+      "likes": 3256,
       "trendingScore": 12,
-      "pipelineTag": "text-to-video",
-      "libraryName": "wan2.2",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "wan2.2",
-        "diffusers",
+        "transformers",
+        "pytorch",
+        "tf",
+        "jax",
+        "tflite",
+        "rust",
+        "onnx",
         "safetensors",
-        "ti2v",
-        "text-to-video",
+        "gpt2",
+        "text-generation",
+        "exbert",
         "en",
-        "zh",
-        "arxiv:2503.20314",
-        "license:apache-2.0",
-        "region:us"
+        "doi:10.57967/hf/0039",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us",
+        "deploy:azure"
       ],
-      "createdAt": "2025-07-18T09:35:44.000Z",
-      "lastModified": "2025-08-07T10:22:24.000Z"
+      "createdAt": "2022-03-02T23:29:04.000Z",
+      "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 444,
-      "id": "syvai/cohere-transcribe-diarize",
-      "author": "syvai",
-      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
-      "downloads": 92,
-      "likes": 12,
+      "rank": 447,
+      "id": "meta-llama/Llama-3.2-1B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
+      "downloads": 8119515,
+      "likes": 1424,
       "trendingScore": 12,
-      "pipelineTag": "automatic-speech-recognition",
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "cohere_asr",
-        "automatic-speech-recognition",
-        "audio",
-        "speech-recognition",
-        "transcription",
-        "diarization",
-        "speaker-diarization",
-        "timestamps",
-        "custom_code",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
         "en",
-        "ar",
         "de",
-        "el",
-        "es",
         "fr",
         "it",
-        "ja",
-        "ko",
-        "nl",
-        "pl",
         "pt",
-        "vi",
-        "zh",
-        "base_model:CohereLabs/cohere-transcribe-03-2026",
-        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
-        "license:apache-2.0",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-19T03:51:05.000Z",
-      "lastModified": "2026-05-22T20:56:30.000Z"
+      "createdAt": "2024-09-18T15:12:47.000Z",
+      "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 445,
+      "rank": 448,
+      "id": "unsloth/MiniMax-M2.7-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
+      "downloads": 163268,
+      "likes": 185,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "minimax_m2",
+        "unsloth",
+        "text-generation",
+        "base_model:MiniMaxAI/MiniMax-M2.7",
+        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-11T23:31:02.000Z",
+      "lastModified": "2026-04-14T16:48:17.000Z"
+    },
+    {
+      "rank": 449,
+      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "downloads": 132,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "dataset:zerofata/Roleplay-Anime-Characters",
+        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T00:40:03.000Z",
+      "lastModified": "2026-05-23T03:47:53.000Z"
+    },
+    {
+      "rank": 450,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -13082,7 +13233,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 446,
+      "rank": 451,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -13124,7 +13275,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 447,
+      "rank": 452,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -13150,7 +13301,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 448,
+      "rank": 453,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -13175,7 +13326,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 449,
+      "rank": 454,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -13192,7 +13343,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 450,
+      "rank": 455,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -13220,7 +13371,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 451,
+      "rank": 456,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -13246,7 +13397,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 452,
+      "rank": 457,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -13273,7 +13424,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 453,
+      "rank": 458,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -13301,7 +13452,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 454,
+      "rank": 459,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -13334,7 +13485,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 455,
+      "rank": 460,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -13368,7 +13519,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 456,
+      "rank": 461,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -13397,7 +13548,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 457,
+      "rank": 462,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -13426,7 +13577,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 458,
+      "rank": 463,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -13459,7 +13610,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 459,
+      "rank": 464,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -13486,7 +13637,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 460,
+      "rank": 465,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -13516,7 +13667,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 461,
+      "rank": 466,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -13542,7 +13693,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 462,
+      "rank": 467,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -13566,7 +13717,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 463,
+      "rank": 468,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -13593,7 +13744,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 464,
+      "rank": 469,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13623,7 +13774,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 465,
+      "rank": 470,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -13657,7 +13808,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 466,
+      "rank": 471,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -13673,7 +13824,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 467,
+      "rank": 472,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -13704,7 +13855,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 468,
+      "rank": 473,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -13726,7 +13877,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 469,
+      "rank": 474,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -13746,7 +13897,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 470,
+      "rank": 475,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -13768,7 +13919,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 471,
+      "rank": 476,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -13797,7 +13948,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 472,
+      "rank": 477,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -13822,7 +13973,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 473,
+      "rank": 478,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -13847,7 +13998,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 474,
+      "rank": 479,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -13882,7 +14033,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 475,
+      "rank": 480,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -13906,7 +14057,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 476,
+      "rank": 481,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -13937,7 +14088,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 477,
+      "rank": 482,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -13963,7 +14114,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 478,
+      "rank": 483,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -13993,7 +14144,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 479,
+      "rank": 484,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -14019,7 +14170,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 480,
+      "rank": 485,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -14064,7 +14215,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 481,
+      "rank": 486,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -14091,7 +14242,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 482,
+      "rank": 487,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -14117,7 +14268,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 483,
+      "rank": 488,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -14144,7 +14295,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 484,
+      "rank": 489,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -14189,7 +14340,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 485,
+      "rank": 490,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -14215,7 +14366,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 486,
+      "rank": 491,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -14241,40 +14392,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 487,
-      "id": "openai-community/gpt2",
-      "author": "openai-community",
-      "url": "https://huggingface.co/openai-community/gpt2",
-      "downloads": 17386984,
-      "likes": 3255,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "tf",
-        "jax",
-        "tflite",
-        "rust",
-        "onnx",
-        "safetensors",
-        "gpt2",
-        "text-generation",
-        "exbert",
-        "en",
-        "doi:10.57967/hf/0039",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2022-03-02T23:29:04.000Z",
-      "lastModified": "2024-02-19T10:57:45.000Z"
-    },
-    {
-      "rank": 488,
+      "rank": 492,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -14303,45 +14421,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 489,
-      "id": "meta-llama/Llama-3.2-1B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 8119515,
-      "likes": 1422,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:12:47.000Z",
-      "lastModified": "2024-10-24T15:07:51.000Z"
-    },
-    {
-      "rank": 490,
+      "rank": 493,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -14369,7 +14449,7 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 491,
+      "rank": 494,
       "id": "SupraLabs/Supra-50M-Instruct",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
@@ -14408,7 +14488,7 @@
       "lastModified": "2026-05-23T08:10:17.000Z"
     },
     {
-      "rank": 492,
+      "rank": 495,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -14453,7 +14533,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 493,
+      "rank": 496,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -14485,7 +14565,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -14508,32 +14588,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 495,
-      "id": "unsloth/MiniMax-M2.7-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
-      "downloads": 163268,
-      "likes": 184,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "minimax_m2",
-        "unsloth",
-        "text-generation",
-        "base_model:MiniMaxAI/MiniMax-M2.7",
-        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-11T23:31:02.000Z",
-      "lastModified": "2026-04-14T16:48:17.000Z"
-    },
-    {
-      "rank": 496,
+      "rank": 498,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -14562,7 +14617,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 497,
+      "rank": 499,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -14591,7 +14646,78 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 498,
+      "rank": 500,
+      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "author": "dphn",
+      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
+      "downloads": 13389,
+      "likes": 521,
+      "trendingScore": 11,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "mistral3",
+        "image-text-to-text",
+        "text-generation",
+        "conversational",
+        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
+        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-06-12T05:29:16.000Z",
+      "lastModified": "2026-04-24T13:52:18.000Z"
+    },
+    {
+      "rank": 501,
+      "id": "Jackrong/Qwopus3.6-27B-v2",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
+      "downloads": 278,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:20:50.000Z",
+      "lastModified": "2026-05-23T00:38:29.000Z"
+    },
+    {
+      "rank": 502,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -14620,7 +14746,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 499,
+      "rank": 503,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -14654,7 +14780,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 500,
+      "rank": 504,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -14699,7 +14825,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 501,
+      "rank": 505,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -14728,7 +14854,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 502,
+      "rank": 506,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -14753,7 +14879,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 503,
+      "rank": 507,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -14788,7 +14914,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 504,
+      "rank": 508,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -14815,7 +14941,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 505,
+      "rank": 509,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -14860,7 +14986,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 506,
+      "rank": 510,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -14882,7 +15008,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 507,
+      "rank": 511,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -14914,7 +15040,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 508,
+      "rank": 512,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -14939,7 +15065,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 509,
+      "rank": 513,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -14963,7 +15089,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 510,
+      "rank": 514,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -14991,7 +15117,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 511,
+      "rank": 515,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -15034,7 +15160,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 512,
+      "rank": 516,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -15058,12 +15184,12 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 513,
+      "rank": 517,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
       "downloads": 0,
-      "likes": 514,
+      "likes": 516,
       "trendingScore": 10,
       "pipelineTag": null,
       "libraryName": null,
@@ -15103,7 +15229,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 514,
+      "rank": 518,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -15132,7 +15258,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 515,
+      "rank": 519,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -15164,7 +15290,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 516,
+      "rank": 520,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -15188,7 +15314,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 517,
+      "rank": 521,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -15210,7 +15336,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 518,
+      "rank": 522,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -15235,7 +15361,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 519,
+      "rank": 523,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -15263,7 +15389,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 520,
+      "rank": 524,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -15287,7 +15413,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 521,
+      "rank": 525,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -15314,7 +15440,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 522,
+      "rank": 526,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -15331,7 +15457,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 523,
+      "rank": 527,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -15355,7 +15481,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 524,
+      "rank": 528,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -15379,7 +15505,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -15412,7 +15538,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 526,
+      "rank": 530,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -15446,7 +15572,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 527,
+      "rank": 531,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -15468,7 +15594,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 528,
+      "rank": 532,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -15491,7 +15617,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -15511,7 +15637,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 530,
+      "rank": 534,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -15543,7 +15669,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 531,
+      "rank": 535,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -15582,7 +15708,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 532,
+      "rank": 536,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -15616,7 +15742,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 533,
+      "rank": 537,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -15640,7 +15766,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 534,
+      "rank": 538,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -15660,7 +15786,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 535,
+      "rank": 539,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -15689,7 +15815,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 536,
+      "rank": 540,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -15711,7 +15837,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 537,
+      "rank": 541,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -15743,7 +15869,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 538,
+      "rank": 542,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -15770,7 +15896,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 539,
+      "rank": 543,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -15814,7 +15940,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 540,
+      "rank": 544,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -15832,7 +15958,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 541,
+      "rank": 545,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -15871,7 +15997,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 542,
+      "rank": 546,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -15910,7 +16036,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 543,
+      "rank": 547,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -15944,7 +16070,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 544,
+      "rank": 548,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -15972,7 +16098,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 545,
+      "rank": 549,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -15994,7 +16120,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 546,
+      "rank": 550,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -16022,7 +16148,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 547,
+      "rank": 551,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -16040,7 +16166,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 548,
+      "rank": 552,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -16068,7 +16194,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 549,
+      "rank": 553,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -16099,7 +16225,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 550,
+      "rank": 554,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -16115,7 +16241,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 551,
+      "rank": 555,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -16142,7 +16268,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 552,
+      "rank": 556,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -16171,7 +16297,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 553,
+      "rank": 557,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -16199,7 +16325,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 554,
+      "rank": 558,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -16228,7 +16354,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 555,
+      "rank": 559,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -16249,7 +16375,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 556,
+      "rank": 560,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -16270,7 +16396,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 557,
+      "rank": 561,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -16297,7 +16423,7 @@
       "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 558,
+      "rank": 562,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -16317,7 +16443,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 559,
+      "rank": 563,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -16355,7 +16481,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 560,
+      "rank": 564,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -16385,7 +16511,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 561,
+      "rank": 565,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -16428,34 +16554,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 562,
-      "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "author": "dphn",
-      "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13389,
-      "likes": 520,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "mistral3",
-        "image-text-to-text",
-        "text-generation",
-        "conversational",
-        "base_model:mistralai/Mistral-Small-24B-Instruct-2501",
-        "base_model:finetune:mistralai/Mistral-Small-24B-Instruct-2501",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-06-12T05:29:16.000Z",
-      "lastModified": "2026-04-24T13:52:18.000Z"
-    },
-    {
-      "rank": 563,
+      "rank": 566,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -16492,7 +16591,7 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 564,
+      "rank": 567,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -16516,7 +16615,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 565,
+      "rank": 568,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -16560,7 +16659,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 566,
+      "rank": 569,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -16599,7 +16698,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 567,
+      "rank": 570,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -16629,7 +16728,7 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 568,
+      "rank": 571,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -16664,7 +16763,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 569,
+      "rank": 572,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -16692,7 +16791,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 570,
+      "rank": 573,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -16718,81 +16817,7 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 571,
-      "id": "Jackrong/Qwopus3.6-27B-v2",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
-      "downloads": 278,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "image",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T08:20:50.000Z",
-      "lastModified": "2026-05-23T00:38:29.000Z"
-    },
-    {
-      "rank": 572,
-      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "downloads": 132,
-      "likes": 11,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "dataset:zerofata/Instruct-Anime",
-        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
-        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
-        "dataset:zerofata/Roleplay-Anime-Characters",
-        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T00:40:03.000Z",
-      "lastModified": "2026-05-23T03:47:53.000Z"
-    },
-    {
-      "rank": 573,
+      "rank": 574,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -16819,7 +16844,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 574,
+      "rank": 575,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -16845,7 +16870,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 575,
+      "rank": 576,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -16873,7 +16898,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 576,
+      "rank": 577,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -16899,7 +16924,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 577,
+      "rank": 578,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -16939,7 +16964,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 578,
+      "rank": 579,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -16975,7 +17000,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 579,
+      "rank": 580,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -17019,7 +17044,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 580,
+      "rank": 581,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -17044,7 +17069,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 581,
+      "rank": 582,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -17089,7 +17114,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 582,
+      "rank": 583,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -17108,7 +17133,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 583,
+      "rank": 584,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -17133,7 +17158,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 584,
+      "rank": 585,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -17172,7 +17197,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 585,
+      "rank": 586,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -17189,7 +17214,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 586,
+      "rank": 587,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -17217,7 +17242,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 587,
+      "rank": 588,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -17246,7 +17271,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 588,
+      "rank": 589,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -17271,7 +17296,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 589,
+      "rank": 590,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -17306,7 +17331,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 590,
+      "rank": 591,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -17336,7 +17361,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 591,
+      "rank": 592,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -17372,7 +17397,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 592,
+      "rank": 593,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -17395,7 +17420,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 593,
+      "rank": 594,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -17412,7 +17437,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 594,
+      "rank": 595,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -17432,7 +17457,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 595,
+      "rank": 596,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -17459,7 +17484,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 596,
+      "rank": 597,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -17483,7 +17508,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 597,
+      "rank": 598,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -17505,7 +17530,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 598,
+      "rank": 599,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -17537,7 +17562,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 599,
+      "rank": 600,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -17565,7 +17590,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 600,
+      "rank": 601,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -17583,7 +17608,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 601,
+      "rank": 602,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -17608,7 +17633,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 602,
+      "rank": 603,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -17631,7 +17656,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 603,
+      "rank": 604,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -17649,7 +17674,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 604,
+      "rank": 605,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -17684,7 +17709,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 605,
+      "rank": 606,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -17712,7 +17737,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 606,
+      "rank": 607,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -17734,7 +17759,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 607,
+      "rank": 608,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -17761,7 +17786,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 608,
+      "rank": 609,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -17786,7 +17811,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 609,
+      "rank": 610,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -17820,7 +17845,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 610,
+      "rank": 611,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -17847,7 +17872,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 611,
+      "rank": 612,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -17874,7 +17899,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 612,
+      "rank": 613,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -17915,7 +17940,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 613,
+      "rank": 614,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -17945,7 +17970,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 614,
+      "rank": 615,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -17982,7 +18007,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 615,
+      "rank": 616,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -18014,7 +18039,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 616,
+      "rank": 617,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -18056,7 +18081,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 617,
+      "rank": 618,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -18086,7 +18111,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 618,
+      "rank": 619,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -18131,7 +18156,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 619,
+      "rank": 620,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -18158,7 +18183,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 620,
+      "rank": 621,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -18190,7 +18215,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 621,
+      "rank": 622,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -18224,7 +18249,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 622,
+      "rank": 623,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -18254,7 +18279,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 623,
+      "rank": 624,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -18279,7 +18304,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 624,
+      "rank": 625,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -18306,7 +18331,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 625,
+      "rank": 626,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -18338,7 +18363,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 626,
+      "rank": 627,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -18383,7 +18408,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 627,
+      "rank": 628,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -18411,7 +18436,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 628,
+      "rank": 629,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -18437,7 +18462,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 629,
+      "rank": 630,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -18466,7 +18491,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 630,
+      "rank": 631,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -18508,7 +18533,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 631,
+      "rank": 632,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -18536,7 +18561,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 632,
+      "rank": 633,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -18565,7 +18590,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 633,
+      "rank": 634,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -18595,7 +18620,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 634,
+      "rank": 635,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -18625,7 +18650,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 635,
+      "rank": 636,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -18652,7 +18677,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 636,
+      "rank": 637,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -18681,7 +18706,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 637,
+      "rank": 638,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -18706,7 +18731,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 638,
+      "rank": 639,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -18751,7 +18776,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 639,
+      "rank": 640,
       "id": "SupraLabs/Supra-50M-Base",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
@@ -18785,7 +18810,137 @@
       "lastModified": "2026-05-23T07:46:11.000Z"
     },
     {
-      "rank": 640,
+      "rank": 641,
+      "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
+      "author": "BennyDaBall",
+      "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
+      "downloads": 22235,
+      "likes": 143,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "text-generation",
+        "prompt-engineering",
+        "image-generation",
+        "qwen3",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-02-04T21:07:40.000Z",
+      "lastModified": "2026-02-04T21:29:30.000Z"
+    },
+    {
+      "rank": 642,
+      "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
+      "author": "lightx2v",
+      "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
+      "downloads": 296378,
+      "likes": 447,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "diffusion-single-file",
+        "comfyui",
+        "distillation",
+        "LoRA",
+        "lora",
+        "Qwen-Image",
+        "Qwen-Image-Edit",
+        "image-to-image",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-22T06:03:41.000Z",
+      "lastModified": "2026-01-15T10:41:12.000Z"
+    },
+    {
+      "rank": 643,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "downloads": 9515,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T11:53:48.000Z",
+      "lastModified": "2026-05-19T13:01:22.000Z"
+    },
+    {
+      "rank": 644,
+      "id": "tencent/Hy-MT2-30B-A3B-FP8",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
+      "downloads": 919,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "hy_v3",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-30B-A3B",
+        "base_model:quantized:tencent/Hy-MT2-30B-A3B",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T06:09:22.000Z",
+      "lastModified": "2026-05-22T05:16:00.000Z"
+    },
+    {
+      "rank": 645,
+      "id": "openbmb/BitCPM-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
+      "downloads": 256,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-23T18:12:57.000Z"
+    },
+    {
+      "rank": 646,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -18812,7 +18967,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 641,
+      "rank": 647,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -18836,7 +18991,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 642,
+      "rank": 648,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -18856,7 +19011,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 643,
+      "rank": 649,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -18875,7 +19030,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 644,
+      "rank": 650,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -18909,7 +19064,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 645,
+      "rank": 651,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -18941,7 +19096,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 646,
+      "rank": 652,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -18963,7 +19118,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 647,
+      "rank": 653,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -19008,7 +19163,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 648,
+      "rank": 654,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -19027,7 +19182,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 649,
+      "rank": 655,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -19061,7 +19216,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 650,
+      "rank": 656,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -19089,7 +19244,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 651,
+      "rank": 657,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -19117,7 +19272,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 652,
+      "rank": 658,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -19140,7 +19295,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 653,
+      "rank": 659,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -19167,7 +19322,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 654,
+      "rank": 660,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -19212,7 +19367,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 655,
+      "rank": 661,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -19248,7 +19403,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 656,
+      "rank": 662,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -19288,7 +19443,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 657,
+      "rank": 663,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -19317,7 +19472,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 658,
+      "rank": 664,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -19345,7 +19500,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 659,
+      "rank": 665,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -19364,7 +19519,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 660,
+      "rank": 666,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -19383,7 +19538,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 661,
+      "rank": 667,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -19415,7 +19570,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 662,
+      "rank": 668,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -19442,7 +19597,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 663,
+      "rank": 669,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -19464,7 +19619,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 664,
+      "rank": 670,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -19482,7 +19637,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 665,
+      "rank": 671,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -19511,7 +19666,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 666,
+      "rank": 672,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -19532,7 +19687,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 667,
+      "rank": 673,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -19560,7 +19715,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 668,
+      "rank": 674,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -19581,7 +19736,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 669,
+      "rank": 675,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -19617,7 +19772,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 670,
+      "rank": 676,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -19662,7 +19817,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 671,
+      "rank": 677,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -19688,7 +19843,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 672,
+      "rank": 678,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -19711,7 +19866,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 673,
+      "rank": 679,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -19736,7 +19891,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 674,
+      "rank": 680,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -19771,7 +19926,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 675,
+      "rank": 681,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -19816,7 +19971,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 676,
+      "rank": 682,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -19843,7 +19998,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 677,
+      "rank": 683,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -19872,7 +20027,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 678,
+      "rank": 684,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -19891,7 +20046,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 679,
+      "rank": 685,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -19912,7 +20067,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 680,
+      "rank": 686,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -19938,7 +20093,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 681,
+      "rank": 687,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -19964,7 +20119,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 682,
+      "rank": 688,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -20001,7 +20156,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 683,
+      "rank": 689,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -20046,7 +20201,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 684,
+      "rank": 690,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -20071,7 +20226,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 685,
+      "rank": 691,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -20088,7 +20243,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 686,
+      "rank": 692,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -20115,7 +20270,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 687,
+      "rank": 693,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -20133,7 +20288,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 688,
+      "rank": 694,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -20158,7 +20313,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 689,
+      "rank": 695,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -20190,7 +20345,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 690,
+      "rank": 696,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -20211,7 +20366,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 691,
+      "rank": 697,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -20230,7 +20385,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 692,
+      "rank": 698,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -20261,7 +20416,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 693,
+      "rank": 699,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -20284,7 +20439,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 694,
+      "rank": 700,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -20301,7 +20456,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 695,
+      "rank": 701,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -20329,7 +20484,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 696,
+      "rank": 702,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -20346,7 +20501,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 697,
+      "rank": 703,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -20382,7 +20537,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 698,
+      "rank": 704,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -20412,7 +20567,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 699,
+      "rank": 705,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -20435,7 +20590,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 700,
+      "rank": 706,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -20468,7 +20623,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 701,
+      "rank": 707,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -20499,7 +20654,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 702,
+      "rank": 708,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -20522,7 +20677,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 703,
+      "rank": 709,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -20555,7 +20710,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 704,
+      "rank": 710,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -20578,7 +20733,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 705,
+      "rank": 711,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -20608,34 +20763,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 706,
-      "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
-      "author": "BennyDaBall",
-      "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
-      "downloads": 22235,
-      "likes": 142,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "text-generation",
-        "prompt-engineering",
-        "image-generation",
-        "qwen3",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-02-04T21:07:40.000Z",
-      "lastModified": "2026-02-04T21:29:30.000Z"
-    },
-    {
-      "rank": 707,
+      "rank": 712,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -20664,7 +20792,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 708,
+      "rank": 713,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -20693,7 +20821,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 709,
+      "rank": 714,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -20729,7 +20857,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 710,
+      "rank": 715,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -20752,7 +20880,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 711,
+      "rank": 716,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -20777,7 +20905,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 712,
+      "rank": 717,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -20807,7 +20935,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 713,
+      "rank": 718,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -20843,7 +20971,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 714,
+      "rank": 719,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -20880,7 +21008,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 715,
+      "rank": 720,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -20907,7 +21035,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 716,
+      "rank": 721,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -20940,7 +21068,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 717,
+      "rank": 722,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -20965,7 +21093,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 718,
+      "rank": 723,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -20990,7 +21118,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 719,
+      "rank": 724,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -21027,7 +21155,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 720,
+      "rank": 725,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -21055,7 +21183,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 721,
+      "rank": 726,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -21094,36 +21222,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 722,
-      "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
-      "author": "lightx2v",
-      "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
-      "downloads": 296378,
-      "likes": 446,
-      "trendingScore": 8,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "diffusion-single-file",
-        "comfyui",
-        "distillation",
-        "LoRA",
-        "lora",
-        "Qwen-Image",
-        "Qwen-Image-Edit",
-        "image-to-image",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-22T06:03:41.000Z",
-      "lastModified": "2026-01-15T10:41:12.000Z"
-    },
-    {
-      "rank": 723,
+      "rank": 727,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -21143,7 +21242,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 724,
+      "rank": 728,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -21159,7 +21258,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 725,
+      "rank": 729,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -21185,7 +21284,7 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 726,
+      "rank": 730,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -21230,7 +21329,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 727,
+      "rank": 731,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -21263,7 +21362,7 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 728,
+      "rank": 732,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -21295,35 +21394,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 729,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 9515,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T11:53:48.000Z",
-      "lastModified": "2026-05-19T13:01:22.000Z"
-    },
-    {
-      "rank": 730,
+      "rank": 733,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -21348,7 +21419,7 @@
       "lastModified": "2026-05-22T04:33:05.000Z"
     },
     {
-      "rank": 731,
+      "rank": 734,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -21374,29 +21445,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 732,
-      "id": "tencent/Hy-MT2-30B-A3B-FP8",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
-      "downloads": 919,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "hy_v3",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-30B-A3B",
-        "base_model:quantized:tencent/Hy-MT2-30B-A3B",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T06:09:22.000Z",
-      "lastModified": "2026-05-22T05:16:00.000Z"
-    },
-    {
-      "rank": 733,
+      "rank": 735,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -21427,7 +21476,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 734,
+      "rank": 736,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -21445,7 +21494,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 735,
+      "rank": 737,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -21467,7 +21516,75 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 736,
+      "rank": 738,
+      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
+      "downloads": 1184,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "creative writing",
+        "translation",
+        "visual novels",
+        "finetune",
+        "roleplay",
+        "rp",
+        "conversational",
+        "en",
+        "jpn",
+        "base_model:llmfan46/gemma-4-31B-it-uncensored-heretic",
+        "base_model:finetune:llmfan46/gemma-4-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T17:54:41.000Z",
+      "lastModified": "2026-05-18T20:15:32.000Z"
+    },
+    {
+      "rank": 739,
+      "id": "meta-llama/Meta-Llama-3-8B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
+      "downloads": 2463393,
+      "likes": 6545,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "license:llama3",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-04-17T09:35:16.000Z",
+      "lastModified": "2024-09-27T15:52:33.000Z"
+    },
+    {
+      "rank": 740,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -21493,7 +21610,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 737,
+      "rank": 741,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -21510,7 +21627,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 738,
+      "rank": 742,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -21538,7 +21655,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 739,
+      "rank": 743,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -21573,7 +21690,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 740,
+      "rank": 744,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -21598,7 +21715,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 741,
+      "rank": 745,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -21628,7 +21745,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 742,
+      "rank": 746,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -21657,7 +21774,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 743,
+      "rank": 747,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -21684,7 +21801,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 744,
+      "rank": 748,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -21710,7 +21827,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 745,
+      "rank": 749,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -21741,7 +21858,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 746,
+      "rank": 750,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -21759,7 +21876,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 747,
+      "rank": 751,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -21788,7 +21905,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 748,
+      "rank": 752,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -21811,7 +21928,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 749,
+      "rank": 753,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -21856,7 +21973,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 750,
+      "rank": 754,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -21882,7 +21999,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 751,
+      "rank": 755,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -21910,7 +22027,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 752,
+      "rank": 756,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -21948,7 +22065,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 753,
+      "rank": 757,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -21975,7 +22092,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 754,
+      "rank": 758,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -22001,7 +22118,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 755,
+      "rank": 759,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -22019,7 +22136,7 @@
       "lastModified": "2026-05-20T22:18:31.000Z"
     },
     {
-      "rank": 756,
+      "rank": 760,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -22045,7 +22162,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 757,
+      "rank": 761,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -22069,7 +22186,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 758,
+      "rank": 762,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -22110,7 +22227,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 759,
+      "rank": 763,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -22127,7 +22244,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 760,
+      "rank": 764,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -22160,7 +22277,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 761,
+      "rank": 765,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -22194,7 +22311,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 762,
+      "rank": 766,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -22233,7 +22350,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 763,
+      "rank": 767,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -22263,7 +22380,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 764,
+      "rank": 768,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -22299,7 +22416,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 765,
+      "rank": 769,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -22325,7 +22442,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 766,
+      "rank": 770,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -22361,7 +22478,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 767,
+      "rank": 771,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -22391,7 +22508,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 768,
+      "rank": 772,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -22429,7 +22546,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 769,
+      "rank": 773,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -22464,7 +22581,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 770,
+      "rank": 774,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -22489,7 +22606,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 771,
+      "rank": 775,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -22506,7 +22623,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 772,
+      "rank": 776,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -22548,7 +22665,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 773,
+      "rank": 777,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -22578,7 +22695,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 774,
+      "rank": 778,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -22603,7 +22720,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 775,
+      "rank": 779,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -22631,7 +22748,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 776,
+      "rank": 780,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -22648,7 +22765,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 777,
+      "rank": 781,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -22675,7 +22792,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 778,
+      "rank": 782,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -22718,7 +22835,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 779,
+      "rank": 783,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -22758,7 +22875,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 780,
+      "rank": 784,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -22782,7 +22899,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 781,
+      "rank": 785,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -22811,7 +22928,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 782,
+      "rank": 786,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -22837,7 +22954,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 783,
+      "rank": 787,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -22876,7 +22993,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 784,
+      "rank": 788,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -22900,7 +23017,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 785,
+      "rank": 789,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -22928,7 +23045,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 786,
+      "rank": 790,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -22960,7 +23077,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 787,
+      "rank": 791,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -22990,7 +23107,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 788,
+      "rank": 792,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -23019,7 +23136,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 789,
+      "rank": 793,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -23052,7 +23169,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 790,
+      "rank": 794,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -23081,7 +23198,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 791,
+      "rank": 795,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -23101,7 +23218,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 792,
+      "rank": 796,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -23125,7 +23242,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 793,
+      "rank": 797,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -23155,7 +23272,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 794,
+      "rank": 798,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -23185,7 +23302,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 795,
+      "rank": 799,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -23203,7 +23320,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 796,
+      "rank": 800,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -23220,7 +23337,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 797,
+      "rank": 801,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -23256,7 +23373,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 798,
+      "rank": 802,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -23287,7 +23404,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 799,
+      "rank": 803,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -23318,7 +23435,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 800,
+      "rank": 804,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -23351,7 +23468,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 801,
+      "rank": 805,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -23379,7 +23496,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 802,
+      "rank": 806,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -23404,7 +23521,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 803,
+      "rank": 807,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -23427,7 +23544,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 804,
+      "rank": 808,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -23455,7 +23572,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 805,
+      "rank": 809,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -23488,7 +23605,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 806,
+      "rank": 810,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -23518,7 +23635,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 807,
+      "rank": 811,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -23553,7 +23670,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 808,
+      "rank": 812,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -23585,7 +23702,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 809,
+      "rank": 813,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -23610,7 +23727,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 810,
+      "rank": 814,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -23633,7 +23750,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 811,
+      "rank": 815,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -23660,7 +23777,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 812,
+      "rank": 816,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -23683,7 +23800,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 813,
+      "rank": 817,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -23728,7 +23845,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 814,
+      "rank": 818,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -23760,7 +23877,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 815,
+      "rank": 819,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -23787,7 +23904,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 816,
+      "rank": 820,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -23813,7 +23930,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 817,
+      "rank": 821,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -23845,7 +23962,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 818,
+      "rank": 822,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -23874,7 +23991,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 819,
+      "rank": 823,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -23906,7 +24023,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 820,
+      "rank": 824,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -23936,7 +24053,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 821,
+      "rank": 825,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -23953,7 +24070,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 822,
+      "rank": 826,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -23973,7 +24090,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 823,
+      "rank": 827,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -24012,7 +24129,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 824,
+      "rank": 828,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -24050,7 +24167,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 825,
+      "rank": 829,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -24078,7 +24195,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 826,
+      "rank": 830,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -24123,7 +24240,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 827,
+      "rank": 831,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -24147,7 +24264,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 828,
+      "rank": 832,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -24177,7 +24294,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 829,
+      "rank": 833,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -24204,7 +24321,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 830,
+      "rank": 834,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -24230,7 +24347,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 831,
+      "rank": 835,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -24259,7 +24376,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 832,
+      "rank": 836,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -24277,7 +24394,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 833,
+      "rank": 837,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -24309,7 +24426,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 834,
+      "rank": 838,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -24336,7 +24453,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 835,
+      "rank": 839,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -24354,7 +24471,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 836,
+      "rank": 840,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -24381,7 +24498,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 837,
+      "rank": 841,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -24405,7 +24522,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 838,
+      "rank": 842,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -24450,7 +24567,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 839,
+      "rank": 843,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -24481,47 +24598,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 840,
-      "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
-      "downloads": 1184,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "creative writing",
-        "translation",
-        "visual novels",
-        "finetune",
-        "roleplay",
-        "rp",
-        "conversational",
-        "en",
-        "jpn",
-        "base_model:llmfan46/gemma-4-31B-it-uncensored-heretic",
-        "base_model:finetune:llmfan46/gemma-4-31B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T17:54:41.000Z",
-      "lastModified": "2026-05-18T20:15:32.000Z"
-    },
-    {
-      "rank": 841,
+      "rank": 844,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -24546,7 +24623,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 842,
+      "rank": 845,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -24580,7 +24657,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 843,
+      "rank": 846,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -24625,7 +24702,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 844,
+      "rank": 847,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -24652,7 +24729,7 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 845,
+      "rank": 848,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -24693,7 +24770,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 846,
+      "rank": 849,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -24720,7 +24797,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 847,
+      "rank": 850,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -24749,7 +24826,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 848,
+      "rank": 851,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -24771,7 +24848,7 @@
       "lastModified": "2026-05-22T05:15:45.000Z"
     },
     {
-      "rank": 849,
+      "rank": 852,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
@@ -24806,7 +24883,7 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 850,
+      "rank": 853,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -24832,35 +24909,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 851,
-      "id": "meta-llama/Meta-Llama-3-8B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-      "downloads": 2463393,
-      "likes": 6544,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "license:llama3",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-04-17T09:35:16.000Z",
-      "lastModified": "2024-09-27T15:52:33.000Z"
-    },
-    {
-      "rank": 852,
+      "rank": 854,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -24892,7 +24941,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 853,
+      "rank": 855,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -24916,7 +24965,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 854,
+      "rank": 856,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -24949,7 +24998,7 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 855,
+      "rank": 857,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -24967,7 +25016,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 856,
+      "rank": 858,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
@@ -24996,7 +25045,7 @@
       "lastModified": "2026-05-22T20:32:34.000Z"
     },
     {
-      "rank": 857,
+      "rank": 859,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
@@ -25036,7 +25085,135 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 858,
+      "rank": 860,
+      "id": "Qwen/Qwen2.5-0.5B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
+      "downloads": 2335014,
+      "likes": 409,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "en",
+        "arxiv:2407.10671",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-09-15T12:15:39.000Z",
+      "lastModified": "2024-09-25T12:32:36.000Z"
+    },
+    {
+      "rank": 861,
+      "id": "Vortex5/Elysian-Sunrise-12B",
+      "author": "Vortex5",
+      "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
+      "downloads": 65,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "mistral",
+        "text-generation",
+        "mergekit",
+        "merge",
+        "roleplay",
+        "conversational",
+        "base_model:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
+        "base_model:merge:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
+        "base_model:AuriAetherwiing/MN-12B-Starcannon-v3",
+        "base_model:merge:AuriAetherwiing/MN-12B-Starcannon-v3",
+        "base_model:LatitudeGames/Muse-12B",
+        "base_model:merge:LatitudeGames/Muse-12B",
+        "base_model:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
+        "base_model:merge:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
+        "base_model:elinas/Chronos-Gold-12B-1.0",
+        "base_model:merge:elinas/Chronos-Gold-12B-1.0",
+        "base_model:yamatazen/EtherealAurora-12B-Lorablated",
+        "base_model:merge:yamatazen/EtherealAurora-12B-Lorablated",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:14:17.000Z",
+      "lastModified": "2026-05-17T12:38:01.000Z"
+    },
+    {
+      "rank": 862,
+      "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
+      "author": "Fortytwo-Network",
+      "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
+      "downloads": 530,
+      "likes": 177,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "dataset:Fortytwo-Network/Strandset-Rust-v1",
+        "arxiv:2510.24801",
+        "arxiv:2409.08386",
+        "base_model:Qwen/Qwen2.5-Coder-14B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-Coder-14B-Instruct",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-09-29T06:09:17.000Z",
+      "lastModified": "2026-01-05T17:19:35.000Z"
+    },
+    {
+      "rank": 863,
+      "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
+      "author": "canada-quant",
+      "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
+      "downloads": 7380,
+      "likes": 14,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": "vllm",
+      "tags": [
+        "vllm",
+        "safetensors",
+        "deepseek_v4",
+        "mixture-of-experts",
+        "moe",
+        "compressed-tensors",
+        "w4a16",
+        "gptq",
+        "fp8-block",
+        "deepseek",
+        "deepseek-v4",
+        "en",
+        "zh",
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-04T06:15:20.000Z",
+      "lastModified": "2026-05-21T20:52:08.000Z"
+    },
+    {
+      "rank": 864,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -25069,7 +25246,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 859,
+      "rank": 865,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -25098,7 +25275,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 860,
+      "rank": 866,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -25143,7 +25320,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 861,
+      "rank": 867,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -25172,7 +25349,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 862,
+      "rank": 868,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -25217,7 +25394,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 863,
+      "rank": 869,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -25261,7 +25438,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 864,
+      "rank": 870,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -25287,7 +25464,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 865,
+      "rank": 871,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -25313,7 +25490,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 866,
+      "rank": 872,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -25345,7 +25522,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 867,
+      "rank": 873,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -25368,7 +25545,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 868,
+      "rank": 874,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -25411,7 +25588,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 869,
+      "rank": 875,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -25456,7 +25633,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 870,
+      "rank": 876,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -25501,7 +25678,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 871,
+      "rank": 877,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -25528,7 +25705,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 872,
+      "rank": 878,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -25555,7 +25732,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 873,
+      "rank": 879,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -25580,7 +25757,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 874,
+      "rank": 880,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -25619,7 +25796,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 875,
+      "rank": 881,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -25644,7 +25821,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 876,
+      "rank": 882,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -25672,7 +25849,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 877,
+      "rank": 883,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -25697,7 +25874,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 878,
+      "rank": 884,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -25713,7 +25890,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 879,
+      "rank": 885,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -25740,7 +25917,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 880,
+      "rank": 886,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -25772,7 +25949,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 881,
+      "rank": 887,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -25802,7 +25979,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 882,
+      "rank": 888,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -25834,7 +26011,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 883,
+      "rank": 889,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -25862,7 +26039,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 884,
+      "rank": 890,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -25888,7 +26065,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 885,
+      "rank": 891,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -25913,7 +26090,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 886,
+      "rank": 892,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -25942,7 +26119,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 887,
+      "rank": 893,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -25984,7 +26161,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 888,
+      "rank": 894,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -26011,7 +26188,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 889,
+      "rank": 895,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -26056,7 +26233,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 890,
+      "rank": 896,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -26082,7 +26259,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 891,
+      "rank": 897,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -26102,7 +26279,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 892,
+      "rank": 898,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -26129,7 +26306,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 893,
+      "rank": 899,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -26171,7 +26348,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 894,
+      "rank": 900,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -26198,7 +26375,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 895,
+      "rank": 901,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -26232,7 +26409,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 896,
+      "rank": 902,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -26261,7 +26438,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 897,
+      "rank": 903,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -26288,7 +26465,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 898,
+      "rank": 904,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -26315,7 +26492,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 899,
+      "rank": 905,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -26342,7 +26519,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 900,
+      "rank": 906,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -26370,7 +26547,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 901,
+      "rank": 907,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -26393,7 +26570,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 902,
+      "rank": 908,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -26424,7 +26601,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 903,
+      "rank": 909,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -26469,7 +26646,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 904,
+      "rank": 910,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -26491,7 +26668,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 905,
+      "rank": 911,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -26517,7 +26694,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 906,
+      "rank": 912,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -26548,7 +26725,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 907,
+      "rank": 913,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -26571,7 +26748,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 908,
+      "rank": 914,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -26601,7 +26778,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 909,
+      "rank": 915,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -26633,7 +26810,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 910,
+      "rank": 916,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -26662,7 +26839,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 911,
+      "rank": 917,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -26694,7 +26871,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 912,
+      "rank": 918,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -26726,7 +26903,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 913,
+      "rank": 919,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -26757,7 +26934,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 914,
+      "rank": 920,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -26788,7 +26965,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 915,
+      "rank": 921,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -26811,7 +26988,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 916,
+      "rank": 922,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -26838,12 +27015,12 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 917,
+      "rank": 923,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
-      "downloads": 2017550,
-      "likes": 1332,
+      "downloads": 1997554,
+      "likes": 1334,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -26883,7 +27060,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 918,
+      "rank": 924,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -26901,7 +27078,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 919,
+      "rank": 925,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -26924,7 +27101,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 920,
+      "rank": 926,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -26954,7 +27131,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 921,
+      "rank": 927,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -26993,7 +27170,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 922,
+      "rank": 928,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -27031,7 +27208,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 923,
+      "rank": 929,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -27076,7 +27253,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 924,
+      "rank": 930,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -27101,7 +27278,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 925,
+      "rank": 931,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -27135,7 +27312,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 926,
+      "rank": 932,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -27160,7 +27337,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 927,
+      "rank": 933,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -27193,7 +27370,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 928,
+      "rank": 934,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -27220,7 +27397,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 929,
+      "rank": 935,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -27250,7 +27427,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 930,
+      "rank": 936,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -27282,7 +27459,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 931,
+      "rank": 937,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -27315,7 +27492,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 932,
+      "rank": 938,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -27333,7 +27510,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 933,
+      "rank": 939,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -27356,7 +27533,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 934,
+      "rank": 940,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -27388,7 +27565,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 935,
+      "rank": 941,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -27433,7 +27610,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 936,
+      "rank": 942,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -27472,7 +27649,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 937,
+      "rank": 943,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -27499,7 +27676,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 938,
+      "rank": 944,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -27536,7 +27713,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 939,
+      "rank": 945,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -27572,7 +27749,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 940,
+      "rank": 946,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -27590,7 +27767,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 941,
+      "rank": 947,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -27629,7 +27806,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 942,
+      "rank": 948,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -27658,7 +27835,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 943,
+      "rank": 949,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -27685,7 +27862,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 944,
+      "rank": 950,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -27712,7 +27889,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 945,
+      "rank": 951,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -27742,7 +27919,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 946,
+      "rank": 952,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -27769,7 +27946,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 947,
+      "rank": 953,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -27800,7 +27977,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 948,
+      "rank": 954,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -27819,7 +27996,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 949,
+      "rank": 955,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -27846,7 +28023,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 950,
+      "rank": 956,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -27871,7 +28048,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 951,
+      "rank": 957,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -27901,7 +28078,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 952,
+      "rank": 958,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -27923,7 +28100,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 953,
+      "rank": 959,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -27944,7 +28121,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 954,
+      "rank": 960,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -27980,7 +28157,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 955,
+      "rank": 961,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -28003,7 +28180,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 956,
+      "rank": 962,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -28048,7 +28225,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 957,
+      "rank": 963,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -28078,7 +28255,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 958,
+      "rank": 964,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -28103,7 +28280,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 959,
+      "rank": 965,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -28136,7 +28313,7 @@
       "lastModified": "2026-05-15T09:58:44.000Z"
     },
     {
-      "rank": 960,
+      "rank": 966,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -28159,7 +28336,7 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 961,
+      "rank": 967,
       "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
       "author": "Novice25",
       "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
@@ -28179,7 +28356,7 @@
       "lastModified": "2026-01-25T11:06:55.000Z"
     },
     {
-      "rank": 962,
+      "rank": 968,
       "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
@@ -28224,7 +28401,7 @@
       "lastModified": "2026-04-14T05:57:02.000Z"
     },
     {
-      "rank": 963,
+      "rank": 969,
       "id": "Supertone/supertonic",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic",
@@ -28245,7 +28422,7 @@
       "lastModified": "2025-12-10T10:16:41.000Z"
     },
     {
-      "rank": 964,
+      "rank": 970,
       "id": "SupraLabs/Supra-Mini-v4-2M",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-Mini-v4-2M",
@@ -28278,7 +28455,7 @@
       "lastModified": "2026-05-20T08:34:10.000Z"
     },
     {
-      "rank": 965,
+      "rank": 971,
       "id": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
@@ -28306,7 +28483,7 @@
       "lastModified": "2026-05-11T19:30:59.000Z"
     },
     {
-      "rank": 966,
+      "rank": 972,
       "id": "intfloat/multilingual-e5-small",
       "author": "intfloat",
       "url": "https://huggingface.co/intfloat/multilingual-e5-small",
@@ -28351,7 +28528,7 @@
       "lastModified": "2026-04-02T02:16:05.000Z"
     },
     {
-      "rank": 967,
+      "rank": 973,
       "id": "meta-llama/Llama-2-7b",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-2-7b",
@@ -28376,7 +28553,7 @@
       "lastModified": "2024-04-17T08:12:44.000Z"
     },
     {
-      "rank": 968,
+      "rank": 974,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-1.3B-Diffusers",
@@ -28404,7 +28581,7 @@
       "lastModified": "2026-05-14T07:09:38.000Z"
     },
     {
-      "rank": 969,
+      "rank": 975,
       "id": "Minachist/Qwen3.6-27B-INT8-AutoRound",
       "author": "Minachist",
       "url": "https://huggingface.co/Minachist/Qwen3.6-27B-INT8-AutoRound",
@@ -28435,7 +28612,7 @@
       "lastModified": "2026-05-19T03:18:47.000Z"
     },
     {
-      "rank": 970,
+      "rank": 976,
       "id": "infly/Infinity-Parser2-Pro",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
@@ -28454,7 +28631,7 @@
       "lastModified": "2026-05-15T14:24:00.000Z"
     },
     {
-      "rank": 971,
+      "rank": 977,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -28480,34 +28657,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 972,
-      "id": "Qwen/Qwen2.5-0.5B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
-      "downloads": 2335014,
-      "likes": 408,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "en",
-        "arxiv:2407.10671",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-09-15T12:15:39.000Z",
-      "lastModified": "2024-09-25T12:32:36.000Z"
-    },
-    {
-      "rank": 973,
+      "rank": 978,
       "id": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",
@@ -28539,7 +28689,7 @@
       "lastModified": "2025-01-12T02:08:48.000Z"
     },
     {
-      "rank": 974,
+      "rank": 979,
       "id": "bytedance-research/GRN",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/GRN",
@@ -28557,7 +28707,7 @@
       "lastModified": "2026-05-13T08:40:50.000Z"
     },
     {
-      "rank": 975,
+      "rank": 980,
       "id": "Itau-Unibanco/NorBERTo",
       "author": "Itau-Unibanco",
       "url": "https://huggingface.co/Itau-Unibanco/NorBERTo",
@@ -28580,7 +28730,7 @@
       "lastModified": "2026-04-14T13:52:00.000Z"
     },
     {
-      "rank": 976,
+      "rank": 981,
       "id": "huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-E4B-it-abliterated",
@@ -28607,7 +28757,7 @@
       "lastModified": "2026-04-10T18:05:04.000Z"
     },
     {
-      "rank": 977,
+      "rank": 982,
       "id": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit",
@@ -28639,7 +28789,7 @@
       "lastModified": "2026-04-18T20:47:46.000Z"
     },
     {
-      "rank": 978,
+      "rank": 983,
       "id": "TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
       "author": "TheBurgstall",
       "url": "https://huggingface.co/TheBurgstall/VR-360-Outpaint-LTX2.3-IC-LoRA",
@@ -28657,7 +28807,7 @@
       "lastModified": "2026-04-23T19:15:56.000Z"
     },
     {
-      "rank": 979,
+      "rank": 984,
       "id": "Octen/Octen-Embedding-8B",
       "author": "Octen",
       "url": "https://huggingface.co/Octen/Octen-Embedding-8B",
@@ -28690,7 +28840,7 @@
       "lastModified": "2026-02-09T04:11:02.000Z"
     },
     {
-      "rank": 980,
+      "rank": 985,
       "id": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
       "author": "Ttimofeyka",
       "url": "https://huggingface.co/Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
@@ -28715,7 +28865,7 @@
       "lastModified": "2024-02-10T11:41:00.000Z"
     },
     {
-      "rank": 981,
+      "rank": 986,
       "id": "HuggingFaceTB/SmolLM2-135M-Instruct",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct",
@@ -28746,7 +28896,7 @@
       "lastModified": "2025-09-22T20:43:15.000Z"
     },
     {
-      "rank": 982,
+      "rank": 987,
       "id": "mistralai/Ministral-3-8B-Instruct-2512-GGUF",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512-GGUF",
@@ -28781,7 +28931,7 @@
       "lastModified": "2026-01-15T11:18:05.000Z"
     },
     {
-      "rank": 983,
+      "rank": 988,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -28826,7 +28976,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 984,
+      "rank": 989,
       "id": "hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
       "author": "hampsonw",
       "url": "https://huggingface.co/hampsonw/Qwen3.6-27B-AWQ-BF16-INT4-mtp-bf16",
@@ -28852,46 +29002,7 @@
       "lastModified": "2026-05-14T19:42:51.000Z"
     },
     {
-      "rank": 985,
-      "id": "Vortex5/Elysian-Sunrise-12B",
-      "author": "Vortex5",
-      "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
-      "downloads": 65,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "mistral",
-        "text-generation",
-        "mergekit",
-        "merge",
-        "roleplay",
-        "conversational",
-        "base_model:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
-        "base_model:merge:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
-        "base_model:AuriAetherwiing/MN-12B-Starcannon-v3",
-        "base_model:merge:AuriAetherwiing/MN-12B-Starcannon-v3",
-        "base_model:LatitudeGames/Muse-12B",
-        "base_model:merge:LatitudeGames/Muse-12B",
-        "base_model:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
-        "base_model:merge:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
-        "base_model:elinas/Chronos-Gold-12B-1.0",
-        "base_model:merge:elinas/Chronos-Gold-12B-1.0",
-        "base_model:yamatazen/EtherealAurora-12B-Lorablated",
-        "base_model:merge:yamatazen/EtherealAurora-12B-Lorablated",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T02:14:17.000Z",
-      "lastModified": "2026-05-17T12:38:01.000Z"
-    },
-    {
-      "rank": 986,
+      "rank": 990,
       "id": "Qwen/QwQ-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/QwQ-32B",
@@ -28922,7 +29033,7 @@
       "lastModified": "2025-03-11T12:15:48.000Z"
     },
     {
-      "rank": 987,
+      "rank": 991,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -28950,7 +29061,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 988,
+      "rank": 992,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -28966,7 +29077,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 989,
+      "rank": 993,
       "id": "inclusionAI/ARGenSeg-8B",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/ARGenSeg-8B",
@@ -28986,7 +29097,7 @@
       "lastModified": "2026-05-15T02:36:20.000Z"
     },
     {
-      "rank": 990,
+      "rank": 994,
       "id": "unsloth/Z-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-GGUF",
@@ -29012,12 +29123,12 @@
       "lastModified": "2026-01-28T06:04:22.000Z"
     },
     {
-      "rank": 991,
+      "rank": 995,
       "id": "Wan-AI/Wan2.2-Animate-14B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
-      "downloads": 17616,
-      "likes": 1157,
+      "downloads": 17680,
+      "likes": 1159,
       "trendingScore": 6,
       "pipelineTag": "video-to-video",
       "libraryName": "diffusers",
@@ -29036,7 +29147,7 @@
       "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 992,
+      "rank": 996,
       "id": "dx8152/LTX2.3-Multifunctional",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/LTX2.3-Multifunctional",
@@ -29057,7 +29168,7 @@
       "lastModified": "2026-04-30T07:06:19.000Z"
     },
     {
-      "rank": 993,
+      "rank": 997,
       "id": "FINAL-Bench/Darwin-2B-Opus-LoRA",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-2B-Opus-LoRA",
@@ -29083,7 +29194,7 @@
       "lastModified": "2026-05-15T02:29:20.000Z"
     },
     {
-      "rank": 994,
+      "rank": 998,
       "id": "FINAL-Bench/Darwin-28B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Opus",
@@ -29128,7 +29239,7 @@
       "lastModified": "2026-05-15T02:27:32.000Z"
     },
     {
-      "rank": 995,
+      "rank": 999,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -29161,7 +29272,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 996,
+      "rank": 1000,
       "id": "Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
       "author": "Baraje",
       "url": "https://huggingface.co/Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511",
@@ -29182,123 +29293,6 @@
       ],
       "createdAt": "2026-04-22T06:19:31.000Z",
       "lastModified": "2026-04-22T06:19:53.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "cross-encoder/ettin-reranker-17m-v1",
-      "author": "cross-encoder",
-      "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
-      "downloads": 1316,
-      "likes": 7,
-      "trendingScore": 6,
-      "pipelineTag": "text-ranking",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "onnx",
-        "safetensors",
-        "openvino",
-        "modernbert",
-        "cross-encoder",
-        "reranker",
-        "generated_from_trainer",
-        "dataset_size:143393475",
-        "loss:MSELoss",
-        "text-ranking",
-        "en",
-        "arxiv:1908.10084",
-        "base_model:jhu-clsp/ettin-encoder-17m",
-        "base_model:quantized:jhu-clsp/ettin-encoder-17m",
-        "license:apache-2.0",
-        "model-index",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T09:08:41.000Z",
-      "lastModified": "2026-05-19T13:58:35.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "stabilityai/stable-audio-3-small-sfx-base",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:05:35.000Z",
-      "lastModified": "2026-05-20T15:05:26.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "baidu/ERNIE-Image-Aes",
-      "author": "baidu",
-      "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
-      "downloads": 72,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "internvl_chat",
-        "custom_code",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T09:12:17.000Z",
-      "lastModified": "2026-05-20T14:14:45.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "numind/NuExtract3-GGUF",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3-GGUF",
-      "downloads": 1319,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "image-text-to-text",
-        "safetensors",
-        "qwen3_5",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "base_model:numind/NuExtract3",
-        "base_model:quantized:numind/NuExtract3",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T16:24:32.000Z",
-      "lastModified": "2026-05-20T10:49:42.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26341709449

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.