### PR TITLE
chore(data): refresh huggingface space signals 2026-05-23T19:47:32Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-23T14:12:41.942Z",
+  "ts": "2026-05-23T19:47:31.956Z",
   "count": 1,
-  "durationMs": 4292,
+  "durationMs": 6686,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T14:12:37.653Z",
+  "fetchedAt": "2026-05-23T19:47:25.272Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -181,8 +181,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 75,
-      "trendingScore": 73,
+      "likes": 76,
+      "trendingScore": 74,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -374,6 +374,23 @@
     },
     {
       "rank": 23,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 71,
+      "trendingScore": 44,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 24,
       "id": "akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
       "author": "akhaliq",
       "url": "https://huggingface.co/spaces/akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
@@ -386,23 +403,6 @@
       ],
       "createdAt": "2026-05-07T16:52:45.000Z",
       "lastModified": "2026-05-07T19:19:41.000Z",
-      "models": []
-    },
-    {
-      "rank": 24,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 69,
-      "trendingScore": 43,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -588,6 +588,22 @@
     },
     {
       "rank": 36,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 30,
+      "trendingScore": 30,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-22T21:24:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 37,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -603,7 +619,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -620,28 +636,29 @@
       "models": []
     },
     {
-      "rank": 38,
-      "id": "stabilityai/stable-audio-3",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 27,
-      "trendingScore": 27,
+      "rank": 39,
+      "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
+      "author": "r3gm",
+      "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
+      "likes": 31,
+      "trendingScore": 28,
       "sdk": "gradio",
       "tags": [
         "gradio",
+        "mcp-server",
         "region:us"
       ],
-      "createdAt": "2026-05-20T15:54:00.000Z",
-      "lastModified": "2026-05-22T21:24:33.000Z",
+      "createdAt": "2026-05-16T22:11:49.000Z",
+      "lastModified": "2026-05-16T22:14:21.000Z",
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 44,
-      "trendingScore": 26,
+      "likes": 46,
+      "trendingScore": 27,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -652,7 +669,7 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -665,23 +682,6 @@
       ],
       "createdAt": "2026-05-14T10:12:08.000Z",
       "lastModified": "2026-05-16T00:07:35.000Z",
-      "models": []
-    },
-    {
-      "rank": 41,
-      "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
-      "author": "r3gm",
-      "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
-      "likes": 28,
-      "trendingScore": 25,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T22:11:49.000Z",
-      "lastModified": "2026-05-16T22:14:21.000Z",
       "models": []
     },
     {
@@ -775,7 +775,7 @@
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
-      "likes": 30,
+      "likes": 32,
       "trendingScore": 22,
       "sdk": "gradio",
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26341875915

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.