### PR TITLE
chore(data): refresh arxiv signals 2026-05-23T19:57:18Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-23T08:39:30.653Z",
+  "ts": "2026-05-23T19:50:20.366Z",
   "count": 1,
-  "durationMs": 61999,
+  "durationMs": 61267,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T08:39:30.778Z",
+  "fetchedAt": "2026-05-23T19:50:20.452Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -12,7 +12,455 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22819v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22809v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22791v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22776v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22775v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22759v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22751v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22749v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22748v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22737v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22733v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22731v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22723v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22720v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22715v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22714v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22707v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22705v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22681v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22679v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22678v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22677v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22672v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22671v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22658v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22651v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22645v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22641v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22631v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22620v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22612v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22608v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22607v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22605v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22602v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22586v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22572v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22570v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22564v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22558v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22552v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22547v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22544v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22538v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22536v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22492v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22487v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22484v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22465v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22462v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22455v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22447v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22425v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22411v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22389v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22380v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22373v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22355v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22310v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22258v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22247v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22228v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22204v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22203v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
       "arxivId": "2605.22823v1",
@@ -26,21 +474,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22819v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22818v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22817v1",
@@ -54,7 +495,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22814v1",
@@ -65,13 +506,6 @@
     },
     {
       "arxivId": "2605.22812v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22809v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -89,17 +523,10 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22794v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22791v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -124,7 +551,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22779v1",
@@ -138,28 +565,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22776v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22775v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22774v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22773v1",
@@ -180,31 +593,24 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22767v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22765v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22763v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22759v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -215,42 +621,21 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22751v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22749v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22748v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22746v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22743v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22740v1",
@@ -264,49 +649,28 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22737v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22736v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22734v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22733v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22732v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22731v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22724v1",
@@ -314,20 +678,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22723v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22720v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
       "arxivId": "2605.22719v1",
@@ -355,49 +705,21 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22715v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22714v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22711v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22707v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22705v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22703v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22697v1",
@@ -418,7 +740,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22691v1",
@@ -435,60 +757,18 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22681v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22679v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22678v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22677v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
       "arxivId": "2605.22675v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22672v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22671v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22668v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22666v1",
@@ -519,13 +799,6 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22658v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
       "arxivId": "2605.22654v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -540,13 +813,6 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22651v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
       "arxivId": "2605.22650v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -558,38 +824,24 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22645v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22644v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22643v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22642v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22641v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -610,13 +862,6 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22631v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
       "arxivId": "2605.22629v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -628,7 +873,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22621v1",
@@ -638,25 +883,18 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22620v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
       "arxivId": "2605.22619v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22616v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22613v1",
@@ -666,60 +904,25 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22612v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
       "arxivId": "2605.22611v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22608v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22607v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22605v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22604v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22602v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22597v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22596v1",
@@ -740,14 +943,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22586v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22581v1",
@@ -761,24 +957,10 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22578v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22572v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22570v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -789,84 +971,35 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22567v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22564v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22563v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22558v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22552v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22550v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22547v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22544v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22542v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22538v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22536v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22511v1",
@@ -887,31 +1020,10 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22501v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22492v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22487v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22484v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -922,115 +1034,52 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22476v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22469v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22467v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22465v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22462v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22455v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22447v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22446v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22435v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22425v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22423v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22411v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22391v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22389v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22380v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22373v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -1041,59 +1090,10 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22355v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22310v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22258v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22247v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22228v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22217v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22204v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22203v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T08:38:28.674Z",
+  "fetchedAt": "2026-05-23T19:49:19.121Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26341914680

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.