### PR TITLE
chore(data): refresh lobsters signals 2026-05-23T20:29:13Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-23T18:40:11.815Z",
+  "ts": "2026-05-23T20:29:13.304Z",
   "count": 1,
-  "durationMs": 6719,
+  "durationMs": 2989,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T18:40:05.118Z",
+  "fetchedAt": "2026-05-23T20:29:10.338Z",
   "windowDays": 7,
   "scannedStories": 76,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T18:40:05.118Z",
+  "fetchedAt": "2026-05-23T20:29:10.338Z",
   "windowHours": 72,
   "scannedTotal": 76,
   "stories": [
@@ -561,6 +561,23 @@
       ]
     },
     {
+      "shortId": "6rwldo",
+      "title": "Jira is Turing-Complete",
+      "url": "https://seriot.ch/computation/jira.html",
+      "commentsUrl": "https://lobste.rs/s/6rwldo/jira_is_turing_complete",
+      "by": "",
+      "score": 8,
+      "commentCount": 1,
+      "createdUtc": 1779562505,
+      "ageHours": 1.5680555555555555,
+      "trendingScore": 1.1869777420626098,
+      "tags": [
+        "compsci"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "msrczi",
       "title": "What is BusyBox?",
       "url": "https://specular.fi/post/what-is-busybox",
@@ -877,23 +894,6 @@
       "trendingScore": 0.9809451001573645,
       "tags": [
         "rust"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "5pjoom",
-      "title": "Introducing Casuarina Linux: A glibc-Based Chimera Linux Derivative",
-      "url": "https://casuarina.org/news/introducing-casuarina-linux/",
-      "commentsUrl": "https://lobste.rs/s/5pjoom/introducing_casuarina_linux_glibc_based",
-      "by": "",
-      "score": 4,
-      "commentCount": 2,
-      "createdUtc": 1779145465,
-      "ageHours": 0.5963888888888889,
-      "trendingScore": 0.9561045356564685,
-      "tags": [
-        "linux"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26342747951

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.