### PR TITLE
chore(data): refresh lobsters signals 2026-05-23T21:30:21Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-23T20:29:13.304Z",
+  "ts": "2026-05-23T21:30:21.379Z",
   "count": 1,
-  "durationMs": 2989,
+  "durationMs": 2806,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T20:29:10.338Z",
+  "fetchedAt": "2026-05-23T21:30:18.593Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T20:29:10.338Z",
+  "fetchedAt": "2026-05-23T21:30:18.593Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -245,6 +245,23 @@
         "freebsd"
       ],
       "description": "<p>The commit introducing the new design: <a href=\"https://cgit.freebsd.org/doc/commit/?id=c9c518d9dbb70240c23810f300ce4a5ba60442c6\" rel=\"ugc\">https://cgit.freebsd.org/doc/commit/?id=c9c518d9dbb70240c23810f300ce4a5ba60442c6</a></p>\n",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "6rwldo",
+      "title": "Jira is Turing-Complete",
+      "url": "https://seriot.ch/computation/jira.html",
+      "commentsUrl": "https://lobste.rs/s/6rwldo/jira_is_turing_complete",
+      "by": "",
+      "score": 19,
+      "commentCount": 1,
+      "createdUtc": 1779562505,
+      "ageHours": 2.5869444444444443,
+      "trendingScore": 1.9340530428186178,
+      "tags": [
+        "compsci"
+      ],
+      "description": "",
       "linkedRepos": []
     },
     {
@@ -559,23 +576,6 @@
           "confidence": 1
         }
       ]
-    },
-    {
-      "shortId": "6rwldo",
-      "title": "Jira is Turing-Complete",
-      "url": "https://seriot.ch/computation/jira.html",
-      "commentsUrl": "https://lobste.rs/s/6rwldo/jira_is_turing_complete",
-      "by": "",
-      "score": 8,
-      "commentCount": 1,
-      "createdUtc": 1779562505,
-      "ageHours": 1.5680555555555555,
-      "trendingScore": 1.1869777420626098,
-      "tags": [
-        "compsci"
-      ],
-      "description": "",
-      "linkedRepos": []
     },
     {
       "shortId": "msrczi",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26344018534

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.