### PR TITLE
chore(data): refresh lobsters signals 2026-05-23T22:29:12Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-23T21:30:21.379Z",
+  "ts": "2026-05-23T22:29:12.700Z",
   "count": 1,
-  "durationMs": 2806,
+  "durationMs": 3142,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T21:30:18.593Z",
+  "fetchedAt": "2026-05-23T22:29:09.579Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-23T21:30:18.593Z",
+  "fetchedAt": "2026-05-23T22:29:09.579Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "29pm2f",
@@ -230,6 +230,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "6rwldo",
+      "title": "Jira is Turing-Complete",
+      "url": "https://seriot.ch/computation/jira.html",
+      "commentsUrl": "https://lobste.rs/s/6rwldo/jira_is_turing_complete",
+      "by": "",
+      "score": 27,
+      "commentCount": 1,
+      "createdUtc": 1779562505,
+      "ageHours": 3.5677777777777777,
+      "trendingScore": 2.05513769085182,
+      "tags": [
+        "compsci"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "03djyt",
       "title": "New design for the FreeBSD website",
       "url": "https://www.freebsd.org/",
@@ -245,23 +262,6 @@
         "freebsd"
       ],
       "description": "<p>The commit introducing the new design: <a href=\"https://cgit.freebsd.org/doc/commit/?id=c9c518d9dbb70240c23810f300ce4a5ba60442c6\" rel=\"ugc\">https://cgit.freebsd.org/doc/commit/?id=c9c518d9dbb70240c23810f300ce4a5ba60442c6</a></p>\n",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "6rwldo",
-      "title": "Jira is Turing-Complete",
-      "url": "https://seriot.ch/computation/jira.html",
-      "commentsUrl": "https://lobste.rs/s/6rwldo/jira_is_turing_complete",
-      "by": "",
-      "score": 19,
-      "commentCount": 1,
-      "createdUtc": 1779562505,
-      "ageHours": 2.5869444444444443,
-      "trendingScore": 1.9340530428186178,
-      "tags": [
-        "compsci"
-      ],
-      "description": "",
       "linkedRepos": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26345200612

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.