### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-24T00:08:32Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-23T20:12:09.250Z",
+  "ts": "2026-05-24T00:08:32.644Z",
   "count": 1,
-  "durationMs": 9713,
+  "durationMs": 10947,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-23T20:12:07.619Z",
+  "lastFetchedAt": "2026-05-24T00:08:30.503Z",
   "windowDays": 7,
   "launches": [
     {
@@ -2178,6 +2178,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151353",
+      "name": "Google Antigravity CLI",
+      "tagline": "Run coding agents directly from your terminal",
+      "description": "Antigravity CLI brings multi-step reasoning, multi-file editing, tool calling, and persistent history to the terminal. Optimised for SSH sessions and keyboard-first workflows. For developers who live in the command line.",
+      "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/2VVOKDD4COMAK2",
+      "votesCount": 206,
+      "commentsCount": 13,
+      "createdAt": "2026-05-23T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence",
+        "tech"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1149049",
       "name": "ReactVision Studio",
       "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
@@ -2302,40 +2344,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1141872",
-      "name": "How AI-pilled are you?",
-      "tagline": "Curious how AI-fluent your organization is?",
-      "description": "The P9 AI Fluency Index gives you an explainable grade in ~12 minutes, along with clear recommendations on how to reach the next level. Based on benchmarks from some of the most forward-thinking companies like Ramp, Fin, Shopify, Zapier and Jobber.",
-      "url": "https://www.producthunt.com/products/how-ai-pilled-are-you?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/VMYGQWTHUUE2CR",
-      "votesCount": 197,
-      "commentsCount": 11,
-      "createdAt": "2026-05-09T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/aabbacbc-1ad1-4f5f-ac42-58a53a116cd5.png?auto=format",
-      "topics": [
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26347071648

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.