### PR TITLE
fix(funding-workflow): empty default unblocks 39-source fallback

### DIFF
--- a/.github/workflows/collect-funding.yml
+++ b/.github/workflows/collect-funding.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       sources:
-        description: 'Comma-separated source list (techcrunch,venturebeat,sifted)'
-        default: 'techcrunch,venturebeat,sifted'
+        description: 'Comma-separated source list. Leave EMPTY to use the full 39-source list from the run step. Example: techcrunch,venturebeat,sifted'
+        default: ''
       dry_run:
         description: 'Dry run'
         default: 'false'


### PR DESCRIPTION
## Summary
- `workflow_dispatch.inputs.sources.default` was `'techcrunch,venturebeat,sifted'`. The run step uses `${{ github.event.inputs.sources || '<full 39-source list>' }}`. Because the default was non-empty, `inputs.sources` was always populated, so `||` never fell through to the 39-source list — every manual `gh workflow run collect-funding.yml --ref main` quietly ran with only 3 sources.
- Setting `default: ''` lets the fallback fire. Scheduled cron tick unaffected (no inputs at all).
- Memory: \`feedback_workflow_dispatch_input_default_bug\` — never combine \`default:\` with \`\${{ X || fallback }}\`.

## Test plan
- [ ] CI green
- [ ] After merge: \`gh workflow run collect-funding.yml --ref main\` (no \`-f sources=\`) → run logs show all 39 sources in the scrape command
- [ ] Next 2h cron tick continues as before (39 sources via the fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)