### PR TITLE
feat(funding): broaden keyword regex + add vb-enterprise, e27 to AI_TAGGED_SOURCES

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/funding-news/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/funding-news/index.ts
@@ -118,8 +118,11 @@ const AI_TAGGED_SOURCES = new Set<string>([
   'import-ai',
 ]);
 
+// Wave-5 (2026-05-24): added `closes`, `bags`, `lands` to catch common
+// headline phrasings the prior regex missed. Mirror of regex in
+// scripts/scrape-funding-news.mjs:651 — keep both in sync.
 const FUNDING_KEYWORDS =
-  /\braises?\b|\braised\b|\bsecures?\b|\bsecured\b|\bfunding\b|\binvestment\b|\bround\b|\bmillion\b|\bbillion\b|\bacquired\b|\bacquisition\b/i;
+  /\braises?\b|\braised\b|\bsecures?\b|\bsecured\b|\bcloses\b|\bbags\b|\blands\b|\bfunding\b|\binvestment\b|\bround\b|\bmillion\b|\bbillion\b|\bacquired\b|\bacquisition\b/i;
 
 /**
  * AI-funding gate. Operator scope is AI funding only — non-AI rounds add

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -123,6 +123,12 @@ const AI_TAGGED_SOURCES = new Set([
   "tech-funding-news",
   "alleywatch",
   "yc-blog",
+  // Wave-5 (2026-05-24): general tech/business — AI gate over-filtered
+  // these in the first run (0 funding-matched items each). Categorized
+  // as funding-dense so they bypass the gate; funding-keyword regex still
+  // applies after.
+  "vb-enterprise",
+  "e27",
 ]);
 
 // AI-funding-only mode: non-AI-tagged feeds must show an AI marker in
@@ -642,9 +648,13 @@ async function main() {
         continue;
       }
 
-      // Only keep funding-related headlines
+      // Only keep funding-related headlines.
+      // Wave-5 (2026-05-24): added `closes`, `bags`, `lands` to catch
+      // common headline phrasings that the prior regex missed
+      // ("X closes Series B", "Y bags $5M", "Z lands seed"). 7 sources
+      // added Wave-4 produced 0 funding-matched items in the first run.
       const fundingKeywords =
-        /\braises?\b|\braised\b|\bsecures?\b|\bsecured\b|\bfunding\b|\binvestment\b|\bround\b|\bmillion\b|\bbillion\b|\bacquired\b|\bacquisition\b/i;
+        /\braises?\b|\braised\b|\bsecures?\b|\bsecured\b|\bcloses\b|\bbags\b|\blands\b|\bfunding\b|\binvestment\b|\bround\b|\bmillion\b|\bbillion\b|\bacquired\b|\bacquisition\b/i;
       if (!fundingKeywords.test(item.headline)) {
         continue;
       }


### PR DESCRIPTION
## Summary
Wave-4 (2026-05-23) added 12 RSS sources; 7 produced **0 funding-matched items** in the first run. Two root causes:

- **5 sources** (\`tc-seed\`, \`tc-series-a\`, \`yc-blog\`, \`tech-funding-news\`, \`term-sheet\`) — already in \`AI_TAGGED_SOURCES\`, but fail the \`FUNDING_KEYWORDS\` regex because they use phrasings like "closes Series A", "bags \$5M", "lands seed funding".
- **2 sources** (\`vb-enterprise\`, \`e27\`) — fail the AI gate. They're general tech/business publications; the AI gate is over-filtering.

## Changes
1. **\`scripts/scrape-funding-news.mjs:651\`** (was 647) — add \`closes\`, \`bags\`, \`lands\` to \`fundingKeywords\` regex. Plural-only \`closes\` chosen (not \`closes?\`) to avoid false positives like "close call".
2. **\`apps/trendingrepo-worker/src/fetchers/funding-news/index.ts:122\`** — mirror the same regex change, per the in-line "keep in sync" directive.
3. **\`scripts/scrape-funding-news.mjs:127\`** — add \`vb-enterprise\` and \`e27\` to \`AI_TAGGED_SOURCES\` set.

## Known drift (out of scope)
The worker fetcher's \`AI_TAGGED_SOURCES\` set (line 104) is currently behind Wave-4 — missing \`crunchbase-news\`, \`tc-venture\`, \`tc-fundraising\`, \`tc-seed\`, \`tc-series-a\`, \`term-sheet\`, \`tech-funding-news\`, \`alleywatch\`, \`yc-blog\`. If the worker fetcher path is still routing these sources, this drift will cause the AI gate to fire there even after this PR lands. Flagging for a follow-up sync PR.

## Test plan
- [ ] CI green
- [ ] After F.2 (#2439) and this merge: \`gh workflow run collect-funding.yml --ref main\` (no \`-f sources=\`)
- [ ] At least one of \`tc-seed\`/\`tc-series-a\`/\`yc-blog\`/\`tech-funding-news\`/\`term-sheet\`/\`vb-enterprise\`/\`e27\` produces ≥1 item in \`data/funding-news.json\` over the next 4h
- [ ] \`tb_signals.funding.startup\` count over 24h continues > yesterday's 98 baseline

Memory: \`feedback_keep_n_cap_silently_filters_sources\` (related Wave-4 work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)