### PR TITLE
chore(data): refresh huggingface space signals 2026-05-24T04:50:50Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-23T19:47:31.956Z",
+  "ts": "2026-05-24T04:50:49.965Z",
   "count": 1,
-  "durationMs": 6686,
+  "durationMs": 6399,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T19:47:25.272Z",
+  "fetchedAt": "2026-05-24T04:50:43.568Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -162,6 +162,22 @@
     },
     {
       "rank": 10,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 78,
+      "trendingScore": 76,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-20T10:03:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 11,
       "id": "HiDream-ai/HiDream-O1-Image",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image",
@@ -174,22 +190,6 @@
       ],
       "createdAt": "2026-05-09T15:30:47.000Z",
       "lastModified": "2026-05-09T18:48:40.000Z",
-      "models": []
-    },
-    {
-      "rank": 11,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 76,
-      "trendingScore": 74,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-20T10:03:33.000Z",
       "models": []
     },
     {
@@ -342,6 +342,23 @@
     },
     {
       "rank": 21,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 73,
+      "trendingScore": 46,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 22,
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
@@ -357,7 +374,7 @@
       "models": []
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "FrameAI4687/Omni-Video-Factory",
       "author": "FrameAI4687",
       "url": "https://huggingface.co/spaces/FrameAI4687/Omni-Video-Factory",
@@ -370,23 +387,6 @@
       ],
       "createdAt": "2026-02-15T06:09:12.000Z",
       "lastModified": "2026-03-06T11:12:22.000Z",
-      "models": []
-    },
-    {
-      "rank": 23,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 71,
-      "trendingScore": 44,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -588,6 +588,23 @@
     },
     {
       "rank": 36,
+      "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
+      "author": "r3gm",
+      "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
+      "likes": 33,
+      "trendingScore": 30,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T22:11:49.000Z",
+      "lastModified": "2026-05-16T22:14:21.000Z",
+      "models": []
+    },
+    {
+      "rank": 37,
       "id": "stabilityai/stable-audio-3",
       "author": "stabilityai",
       "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
@@ -603,7 +620,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -619,7 +636,7 @@
       "models": []
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -636,29 +653,12 @@
       "models": []
     },
     {
-      "rank": 39,
-      "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
-      "author": "r3gm",
-      "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
-      "likes": 31,
-      "trendingScore": 28,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T22:11:49.000Z",
-      "lastModified": "2026-05-16T22:14:21.000Z",
-      "models": []
-    },
-    {
       "rank": 40,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 46,
-      "trendingScore": 27,
+      "likes": 50,
+      "trendingScore": 28,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -775,7 +775,7 @@
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
-      "likes": 32,
+      "likes": 33,
       "trendingScore": 22,
       "sdk": "gradio",
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26352243708

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.