### PR TITLE
chore(data): refresh arxiv signals 2026-05-24T04:56:16Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-23T19:50:20.366Z",
+  "ts": "2026-05-24T04:53:39.401Z",
   "count": 1,
-  "durationMs": 61267,
+  "durationMs": 61116,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T19:50:20.452Z",
+  "fetchedAt": "2026-05-24T04:53:39.488Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -15,11 +15,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22820v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22819v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22818v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22816v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22809v1",
@@ -29,11 +50,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22795v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22791v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22781v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22777v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22776v1",
@@ -50,11 +92,46 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22774v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22769v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22767v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22765v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22759v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22756v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22751v1",
@@ -78,6 +155,27 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22746v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22743v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22738v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22737v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -85,11 +183,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22736v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22734v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22733v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22732v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22731v1",
@@ -113,6 +232,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22716v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22715v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -127,6 +253,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22711v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22707v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -139,6 +272,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22703v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22693v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22681v1",
@@ -169,6 +316,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22675v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22672v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -181,6 +335,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22668v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22658v1",
@@ -197,11 +358,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22649v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22645v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22644v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22643v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22641v1",
@@ -218,6 +400,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22622v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22620v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -225,11 +414,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22619v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22616v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22612v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22611v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22608v1",
@@ -253,6 +463,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22604v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22602v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -260,11 +477,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22597v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22591v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22586v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22579v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22572v1",
@@ -281,11 +519,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22568v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22567v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22564v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22563v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22558v1",
@@ -302,6 +561,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22550v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22547v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -316,6 +582,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22542v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22538v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -328,6 +601,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22504v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22492v1",
@@ -349,6 +629,34 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22478v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22476v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22469v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22467v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22465v1",
@@ -379,11 +687,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22446v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22435v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
       "arxivId": "2605.22425v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22423v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22411v1",
@@ -412,6 +741,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22356v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22355v1",
@@ -467,35 +803,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22820v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22818v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22817v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22816v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22814v1",
@@ -509,21 +824,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22800v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22795v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22794v1",
@@ -537,7 +845,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22785v1",
@@ -547,95 +855,32 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22781v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22779v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22777v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22774v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22773v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22771v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22769v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22767v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22765v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22763v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22756v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22746v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22743v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22740v1",
@@ -643,34 +888,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22738v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22736v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22734v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22732v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22724v1",
@@ -684,14 +901,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22718v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22717v1",
@@ -701,32 +918,11 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22716v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22711v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22703v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22697v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22695v1",
@@ -736,39 +932,18 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22693v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22691v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22684v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22675v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22668v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22666v1",
@@ -782,7 +957,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22662v1",
@@ -796,14 +971,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22654v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22653v1",
@@ -817,35 +992,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22649v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22644v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22643v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22642v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22635v1",
@@ -859,7 +1013,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22629v1",
@@ -869,60 +1023,18 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22622v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22621v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22619v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22616v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22613v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22611v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22604v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22597v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22596v1",
@@ -939,25 +1051,11 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22591v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22581v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22579v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22578v1",
@@ -967,137 +1065,39 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22568v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22567v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22563v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22550v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22542v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22511v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22509v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22504v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22501v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22478v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22476v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22469v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22467v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22446v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22435v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22423v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22391v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22356v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22217v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T19:49:19.121Z",
+  "fetchedAt": "2026-05-24T04:52:38.305Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26352273748

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.