### PR TITLE
chore(ci): add timeout-minutes to 10 workflows (sync-trustmrr cron already deduped)

### DIFF
--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -16,6 +16,7 @@ jobs:
   auto-merge:
     if: contains(github.event.pull_request.labels.*.name, 'auto-merge')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/health-watch.yml
+++ b/.github/workflows/health-watch.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint-no-secret-env-in-client.yml
+++ b/.github/workflows/lint-no-secret-env-in-client.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/lint-no-secret-fields-in-response-types.yml
+++ b/.github/workflows/lint-no-secret-fields-in-response-types.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/no-gabagool.yml
+++ b/.github/workflows/no-gabagool.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   lint:
     runs-on: [self-hosted, toolbox]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Forbid legacy gabagool* literals

--- a/.github/workflows/refresh-star-activity.yml
+++ b/.github/workflows/refresh-star-activity.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   append:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scrape-npm-daily.yml
+++ b/.github/workflows/scrape-npm-daily.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   scrape:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sentry-fix-bot.yml
+++ b/.github/workflows/sentry-fix-bot.yml
@@ -36,6 +36,7 @@ jobs:
   dispatch-agent:
     if: github.event.label.name == 'sentry-error'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Plant @claude prompt with stack-trace context
         env:

--- a/.github/workflows/trendingrepo-worker.yml
+++ b/.github/workflows/trendingrepo-worker.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: apps/trendingrepo-worker


### PR DESCRIPTION
## Summary

Adds `timeout-minutes` to the job level of 10 workflows that previously
relied on GitHub Actions' 360-minute default. A hung external call
(npm registry, GitHub API, dependency install) could otherwise stall
a runner for 6 hours.

Picked values per the audit principle: typical scrapers/builders get
30 min, fast cron/lint/auto-merge jobs get 10 min.

## Workflows changed

| File | Job | Timeout | Rationale |
|---|---|---|---|
| `trendingrepo-worker.yml` | test | 30 | npm ci + typecheck + build + vitest |
| `scrape-npm-daily.yml` | scrape | 30 | rate-limited npm registry scraper, every 6h |
| `refresh-star-activity.yml` | append | 30 | per-tracked-repo GitHub API calls, daily |
| `sentry-fix-bot.yml` | dispatch-agent | 10 | single `gh issue comment` shell |
| `health-watch.yml` | check | 10 | every-30min cron, single source-health check |
| `no-gabagool.yml` | lint | 10 | grep over tree |
| `lint-no-secret-fields-in-response-types.yml` | lint | 10 | linter script |
| `lint-no-secret-env-in-client.yml` | lint | 10 | linter script |
| `dependabot-auto-merge.yml` | auto-merge | 10 | metadata fetch + `gh pr merge --auto` |
| `auto-merge-bot.yml` | auto-merge | 10 | `gh pr merge --auto` only |

Diff is exactly 10 lines added across 10 files; no behavioral change
on the happy path, only bounded failure mode.

## Note on the audit's Q13 (sync-trustmrr double cron)

Punch-list audit P3-F flagged `sync-trustmrr.yml` as having a redundant
double `cron:` entry. On inspection, the file currently only has one
cron line (`- cron: "27 * * * *"`). The audit item is stale — already
deduped in an earlier PR. No change needed.

## Known CI failure mode

Main CI ("Typecheck, guards, tests, build, e2e") will fail with 5
pre-existing test failures (OSS Insight 24h stars, Twitter agent
ingestion ×2, scan idempotency ×2) — these are **not** regressions
from this PR (workflow YAML edits don't affect those tests).
Tracked as punch-list item C.7. Admin-merge is the expected path.

## Test plan
- [x] `git diff main..chore/ci-timeout-guards-2026-05-24 --stat` shows
      only `.github/workflows/*.yml` files
- [x] `git diff` shows only `+timeout-minutes:` additions, no removals
- [ ] Wait for CI to run — actions/workflow YAML validation should pass
- [ ] Mirko admin-merges past the 5 unrelated C.7 failures