### PR TITLE
chore(data): refresh lobsters signals 2026-05-24T05:43:13Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-24T01:33:14.512Z",
+  "ts": "2026-05-24T05:43:13.924Z",
   "count": 1,
-  "durationMs": 3737,
+  "durationMs": 2798,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T01:33:10.796Z",
+  "fetchedAt": "2026-05-24T05:43:11.148Z",
   "windowDays": 7,
   "scannedStories": 77,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T01:33:10.796Z",
+  "fetchedAt": "2026-05-24T05:43:11.148Z",
   "windowHours": 72,
   "scannedTotal": 77,
   "stories": [


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26353167563

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.