### PR TITLE
chore(data): refresh scoring shadow report 2026-05-24T05:53:58Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-23T05:33:15.676Z",
+  "generatedAt": "2026-05-24T05:53:57.493Z",
   "reports": [],
   "skipped": [
     {
@@ -10,7 +10,7 @@
     {
       "domainKey": "skill",
       "slug": "trending-skill-sh",
-      "reason": "ranking extraction yielded zero items"
+      "reason": "no data found in Redis or file"
     },
     {
       "domainKey": "mcp",


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26353360785

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.