### PR TITLE
chore(data): refresh staleness report 2026-05-24T06:05:58Z

### DIFF
--- a/data/staleness-report.json
+++ b/data/staleness-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-23T05:42:48.744Z",
+  "generatedAt": "2026-05-24T06:05:57.576Z",
   "sources": [
     {
       "slug": "trending",


### PR DESCRIPTION
Automated data refresh from `Sweep staleness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26353587813

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.