### PR TITLE
chore(data): refresh awesome-skills index 2026-05-24T07:33:32Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-23T07:11:34.230Z",
+  "ts": "2026-05-24T07:33:32.202Z",
   "count": 1,
-  "durationMs": 3595,
+  "durationMs": 2676,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-23T07:11:30.637Z",
+  "fetchedAt": "2026-05-24T07:33:29.527Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",
@@ -71,6 +71,9 @@
       "wong2/awesome-mcp-servers"
     ],
     "scopeblind/scopeblind-gateway": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "multica-ai/andrej-karpathy-skills": [
       "sickn33/antigravity-awesome-skills"
     ],
     "adelaidasofia/ai-brain-starter": [
@@ -8117,6 +8120,6 @@
   "counts": {
     "lists": 4,
     "listsAttempted": 5,
-    "uniqueSkills": 2627
+    "uniqueSkills": 2628
   }
 }


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26355228959

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.