### PR TITLE
chore(data): promote unknown mentions 2026-05-24T07:38:27Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-23T07:17:18.404Z",
-  "totalUnknownMentions": 246245,
-  "distinctRepos": 22467,
+  "generatedAt": "2026-05-24T07:38:26.950Z",
+  "totalUnknownMentions": 257329,
+  "distinctRepos": 23153,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 185,
+      "totalCount": 194,
       "sourceCount": 5,
       "sources": [
         "bluesky",
@@ -17,11 +17,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 94,
+      "totalCount": 99,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -31,11 +31,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "trycua/cua",
-      "totalCount": 39,
+      "totalCount": 40,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -45,11 +45,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 211,
+      "totalCount": 224,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -58,7 +58,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "vercel/next.js",
@@ -101,7 +101,7 @@
     },
     {
       "fullName": "facebook/react",
-      "totalCount": 93,
+      "totalCount": 97,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -110,7 +110,7 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "antirez/ds4",
@@ -127,7 +127,7 @@
     },
     {
       "fullName": "kolapsis/maintenant",
-      "totalCount": 56,
+      "totalCount": 58,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -136,7 +136,7 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-01T17:15:27.672Z",
-      "lastSeenAt": "2026-05-13T08:53:46.257Z"
+      "lastSeenAt": "2026-05-23T22:09:08.211Z"
     },
     {
       "fullName": "aattaran/deepclaude",
@@ -153,7 +153,7 @@
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 180,
+      "totalCount": 189,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -161,7 +161,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "onyks-os/transparenttorproxy",
@@ -201,7 +201,7 @@
     },
     {
       "fullName": "naver/lispe",
-      "totalCount": 111,
+      "totalCount": 116,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -209,7 +209,19 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 112,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-24T04:39:37.308Z"
     },
     {
       "fullName": "minishlab/semble",
@@ -236,6 +248,18 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 105,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+    },
+    {
       "fullName": "scosman/cursed_browser",
       "totalCount": 103,
       "sourceCount": 3,
@@ -258,30 +282,6 @@
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 100,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
-    },
-    {
-      "fullName": "andyyyy64/whichllm",
-      "totalCount": 100,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-23T06:46:01.193Z"
     },
     {
       "fullName": "reviewstage/stage-cli",
@@ -332,6 +332,18 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
+      "fullName": "snyk/agent-scan",
+      "totalCount": 94,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T18:13:43.732Z",
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+    },
+    {
       "fullName": "nvlabs/cuda-oxide",
       "totalCount": 93,
       "sourceCount": 3,
@@ -342,6 +354,18 @@
       ],
       "firstSeenAt": "2026-05-07T21:45:14.561Z",
       "lastSeenAt": "2026-05-11T00:07:14.314Z"
+    },
+    {
+      "fullName": "fsnotify/fsnotify",
+      "totalCount": 92,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T07:20:32.729Z",
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "bring-shrubbery/ml-sharp-web",
@@ -368,20 +392,8 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
-      "fullName": "snyk/agent-scan",
-      "totalCount": 90,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T18:13:43.732Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
-    },
-    {
       "fullName": "sifter-ai/sifter",
-      "totalCount": 89,
+      "totalCount": 90,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -389,7 +401,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "shadcn-ui/ui",
@@ -402,18 +414,6 @@
       ],
       "firstSeenAt": "2026-05-02T09:42:50.173Z",
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
-    },
-    {
-      "fullName": "fsnotify/fsnotify",
-      "totalCount": 88,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
     },
     {
       "fullName": "run-llama/llama_index",
@@ -452,6 +452,18 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
+      "fullName": "h4ckf0r0day/obscura",
+      "totalCount": 82,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+    },
+    {
       "fullName": "waybarrios/opencode-power-pack",
       "totalCount": 81,
       "sourceCount": 3,
@@ -464,20 +476,8 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
-      "fullName": "h4ckf0r0day/obscura",
-      "totalCount": 78,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
-    },
-    {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 77,
+      "totalCount": 78,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -485,11 +485,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "jnuyens/modulejail",
-      "totalCount": 73,
+      "totalCount": 78,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -497,11 +497,11 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "ollama/ollama",
-      "totalCount": 72,
+      "totalCount": 76,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -509,11 +509,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "n8n-io/n8n",
-      "totalCount": 71,
+      "totalCount": 75,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -521,7 +521,19 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+    },
+    {
+      "fullName": "vllm-project/vllm",
+      "totalCount": 67,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T19:21:26.285Z",
+      "lastSeenAt": "2026-05-24T04:39:37.308Z"
     },
     {
       "fullName": "statewright/statewright",
@@ -572,6 +584,18 @@
       "lastSeenAt": "2026-05-10T12:05:20.661Z"
     },
     {
+      "fullName": "genymobile/scrcpy",
+      "totalCount": 65,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T08:45:16.184Z",
+      "lastSeenAt": "2026-05-24T04:39:37.308Z"
+    },
+    {
       "fullName": "rust-lang/rust",
       "totalCount": 64,
       "sourceCount": 3,
@@ -596,16 +620,16 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
-      "fullName": "genymobile/scrcpy",
-      "totalCount": 64,
+      "fullName": "redis/redis",
+      "totalCount": 63,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-02T08:45:16.184Z",
-      "lastSeenAt": "2026-05-19T18:33:33.494Z"
+      "firstSeenAt": "2026-05-03T08:09:15.267Z",
+      "lastSeenAt": "2026-05-23T19:37:59.807Z"
     },
     {
       "fullName": "angular/angular",
@@ -644,18 +668,6 @@
       "lastSeenAt": "2026-05-07T12:21:38.823Z"
     },
     {
-      "fullName": "vllm-project/vllm",
-      "totalCount": 62,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
-    },
-    {
       "fullName": "localsend/localsend",
       "totalCount": 62,
       "sourceCount": 3,
@@ -692,16 +704,16 @@
       "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
-      "fullName": "redis/redis",
-      "totalCount": 60,
+      "fullName": "junegunn/fzf",
+      "totalCount": 59,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "hackernews"
+        "twitter"
       ],
-      "firstSeenAt": "2026-05-03T08:09:15.267Z",
-      "lastSeenAt": "2026-05-18T12:48:24.691Z"
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "manankharwar/fusioncore",
@@ -716,6 +728,18 @@
       "lastSeenAt": "2026-05-19T12:20:48.337Z"
     },
     {
+      "fullName": "open-webui/open-webui",
+      "totalCount": 58,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-23T18:50:39.307Z"
+    },
+    {
       "fullName": "uw-syfi/vibe-serve",
       "totalCount": 56,
       "sourceCount": 3,
@@ -726,30 +750,6 @@
       ],
       "firstSeenAt": "2026-05-08T16:57:07.580Z",
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
-    },
-    {
-      "fullName": "junegunn/fzf",
-      "totalCount": 55,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
-    },
-    {
-      "fullName": "open-webui/open-webui",
-      "totalCount": 54,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-07T04:53:38.982Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "minio/minio",
@@ -765,7 +765,7 @@
     },
     {
       "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 51,
+      "totalCount": 52,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -773,7 +773,7 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "cline/cline",
@@ -788,6 +788,30 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
+      "fullName": "anishathalye/ai-agent-security-lecture",
+      "totalCount": 50,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
+      "fullName": "yt-dlp/yt-dlp",
+      "totalCount": 50,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-08T11:47:27.264Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "emarkou/grokfeed",
       "totalCount": 49,
       "sourceCount": 3,
@@ -798,6 +822,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-07T14:30:15.363Z"
+    },
+    {
+      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
+      "totalCount": 48,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-15T06:43:54.808Z",
+      "lastSeenAt": "2026-05-23T12:08:40.983Z"
     },
     {
       "fullName": "jamesyc/timecapsulesmb",
@@ -824,6 +860,30 @@
       "lastSeenAt": "2026-05-07T10:14:50.031Z"
     },
     {
+      "fullName": "0xmassi/webclaw",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+    },
+    {
+      "fullName": "kuberwastaken/claurst",
+      "totalCount": 47,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T09:04:08.589Z",
+      "lastSeenAt": "2026-05-23T08:24:13.060Z"
+    },
+    {
       "fullName": "anthropics/claude-for-legal",
       "totalCount": 47,
       "sourceCount": 3,
@@ -848,16 +908,16 @@
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
     },
     {
-      "fullName": "0xmassi/webclaw",
+      "fullName": "zed-industries/zed",
       "totalCount": 46,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
-        "devto",
-        "reddit"
+        "bluesky",
+        "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "iliaal/fastchart",
@@ -884,42 +944,6 @@
       "lastSeenAt": "2026-05-11T01:25:31.639Z"
     },
     {
-      "fullName": "zed-industries/zed",
-      "totalCount": 45,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
-    },
-    {
-      "fullName": "anishathalye/ai-agent-security-lecture",
-      "totalCount": 45,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T16:34:28.470Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
-    },
-    {
-      "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-      "totalCount": 45,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:43:54.808Z",
-      "lastSeenAt": "2026-05-21T23:40:25.563Z"
-    },
-    {
       "fullName": "mage0535/hermes-memory-installer",
       "totalCount": 45,
       "sourceCount": 3,
@@ -944,6 +968,18 @@
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
+      "fullName": "sander110419/lightroom-cc-on-linux",
+      "totalCount": 42,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "stardockcorp/wireloom",
       "totalCount": 41,
       "sourceCount": 3,
@@ -956,8 +992,20 @@
       "lastSeenAt": "2026-05-20T12:39:36.429Z"
     },
     {
+      "fullName": "xataio/deltax",
+      "totalCount": 40,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-19T19:17:55.212Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "awslabs/mcp",
-      "totalCount": 38,
+      "totalCount": 39,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -965,31 +1013,19 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
-      "fullName": "yt-dlp/yt-dlp",
-      "totalCount": 38,
+      "fullName": "nrwl/nx-console",
+      "totalCount": 39,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-08T11:47:27.264Z",
-      "lastSeenAt": "2026-05-23T06:46:01.193Z"
-    },
-    {
-      "fullName": "sander110419/lightroom-cc-on-linux",
-      "totalCount": 37,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T12:48:24.691Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "firstSeenAt": "2026-05-18T20:04:30.386Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "tabularisdb/tabularis",
@@ -1016,44 +1052,8 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "xataio/deltax",
-      "totalCount": 35,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-19T19:17:55.212Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
-    },
-    {
-      "fullName": "nrwl/nx-console",
-      "totalCount": 34,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-18T20:04:30.386Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
-    },
-    {
-      "fullName": "pydantic/pydantic-ai",
-      "totalCount": 28,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
-    },
-    {
       "fullName": "nodejs/node",
-      "totalCount": 27,
+      "totalCount": 32,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -1061,7 +1061,31 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T03:48:07.888Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
+      "fullName": "pydantic/pydantic-ai",
+      "totalCount": 29,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+    },
+    {
+      "fullName": "anthropics/claude-cookbooks",
+      "totalCount": 26,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -1076,20 +1100,20 @@
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
-      "fullName": "anthropics/claude-cookbooks",
-      "totalCount": 25,
+      "fullName": "multica-ai/andrej-karpathy-skills",
+      "totalCount": 22,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
         "bluesky",
         "devto"
       ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "firstSeenAt": "2026-05-17T19:15:02.265Z",
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "duriantaco/skylos",
-      "totalCount": 19,
+      "totalCount": 20,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -1097,7 +1121,19 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+    },
+    {
+      "fullName": "brethofai/brethof-mind",
+      "totalCount": 19,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-22T17:36:35.165Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -1148,18 +1184,6 @@
       "lastSeenAt": "2026-05-22T22:22:35.106Z"
     },
     {
-      "fullName": "brethofai/brethof-mind",
-      "totalCount": 10,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-22T17:36:35.165Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
-    },
-    {
       "fullName": "simstudioai/sim",
       "totalCount": 4,
       "sourceCount": 3,
@@ -1173,25 +1197,25 @@
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 179,
+      "totalCount": 192,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-23T07:11:34.227Z"
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 139,
+      "totalCount": 143,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -1206,14 +1230,14 @@
     },
     {
       "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 130,
+      "totalCount": 135,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
     },
     {
       "fullName": "nexu-io/open-design",
@@ -1247,6 +1271,17 @@
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
       "lastSeenAt": "2026-05-09T16:11:39.536Z"
+    },
+    {
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 119,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-24T04:39:37.308Z"
     },
     {
       "fullName": "drcathicks/learning-opportunities",
@@ -1293,17 +1328,6 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 109,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-23T06:46:01.193Z"
-    },
-    {
       "fullName": "jossephus/chuchu",
       "totalCount": 109,
       "sourceCount": 2,
@@ -1348,6 +1372,17 @@
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
+      "fullName": "yamafaktory/hypergraphz",
+      "totalCount": 103,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:12:41.505Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "facebookresearch/tuna-2",
       "totalCount": 102,
       "sourceCount": 2,
@@ -1379,17 +1414,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
-    },
-    {
-      "fullName": "yamafaktory/hypergraphz",
-      "totalCount": 98,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T21:12:41.505Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "mekickdemons-creator/mnemara",
@@ -1425,6 +1449,28 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
+      "fullName": "chojs23/concord",
+      "totalCount": 93,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
+      "fullName": "kiamehr5/kmri",
+      "totalCount": 92,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-03T10:34:44.583Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "facebook/pyrefly",
       "totalCount": 92,
       "sourceCount": 2,
@@ -1445,6 +1491,39 @@
       ],
       "firstSeenAt": "2026-05-07T15:15:06.916Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "comfyanonymous/comfyui",
+      "totalCount": 90,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-23T23:11:29.877Z"
+    },
+    {
+      "fullName": "eleutherai/lm-evaluation-harness",
+      "totalCount": 89,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+    },
+    {
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 89,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "gfernandf/agent-skills",
@@ -1491,28 +1570,6 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "chojs23/concord",
-      "totalCount": 88,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
-    },
-    {
-      "fullName": "kiamehr5/kmri",
-      "totalCount": 87,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T10:34:44.583Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
-    },
-    {
       "fullName": "scottgl9/skelm",
       "totalCount": 87,
       "sourceCount": 2,
@@ -1535,6 +1592,17 @@
       "lastSeenAt": "2026-05-08T19:48:01.671Z"
     },
     {
+      "fullName": "npm/cli",
+      "totalCount": 86,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-24T04:39:37.308Z"
+    },
+    {
       "fullName": "arriemeijer-creator/aerojax",
       "totalCount": 86,
       "sourceCount": 2,
@@ -1544,28 +1612,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-21T09:46:35.015Z"
-    },
-    {
-      "fullName": "enmanuelmag/heimdall-mcp",
-      "totalCount": 85,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-23T03:28:28.888Z"
-    },
-    {
-      "fullName": "eleutherai/lm-evaluation-harness",
-      "totalCount": 85,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-22T19:51:38.224Z"
     },
     {
       "fullName": "v4bel/dirtyfrag",
@@ -1676,17 +1722,6 @@
       ],
       "firstSeenAt": "2026-05-01T23:17:38.392Z",
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
-    },
-    {
-      "fullName": "comfyanonymous/comfyui",
-      "totalCount": 80,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-23T06:46:01.193Z"
     },
     {
       "fullName": "tsirysndr/rockbox-zig",
@@ -1810,6 +1845,17 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
+      "fullName": "tanrikuluozlem/burn",
+      "totalCount": 77,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T08:44:17.194Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1865,6 +1911,17 @@
       "lastSeenAt": "2026-05-10T16:09:01.639Z"
     },
     {
+      "fullName": "zakirullin/files.md",
+      "totalCount": 75,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
       "fullName": "davesimoes/crustai",
       "totalCount": 75,
       "sourceCount": 2,
@@ -1907,17 +1964,6 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "npm/cli",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-23T06:46:01.193Z"
     },
     {
       "fullName": "phel-lang/phel-lang",
@@ -2017,17 +2063,6 @@
       ],
       "firstSeenAt": "2026-05-02T21:01:52.519Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "tanrikuluozlem/burn",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T08:44:17.194Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
     },
     {
       "fullName": "pion/rtwatch",
@@ -2195,15 +2230,26 @@
       "lastSeenAt": "2026-05-12T19:09:34.978Z"
     },
     {
-      "fullName": "zakirullin/files.md",
+      "fullName": "mistralai/client-python",
       "totalCount": 70,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-23T05:06:35.642Z"
+      "firstSeenAt": "2026-05-12T04:18:11.270Z",
+      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+    },
+    {
+      "fullName": "mukundakatta/hermes-agentmemory",
+      "totalCount": 70,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T19:47:32.538Z",
+      "lastSeenAt": "2026-05-23T16:24:08.531Z"
     },
     {
       "fullName": "webstonehq/tuxedo",
@@ -2239,6 +2285,17 @@
       "lastSeenAt": "2026-05-12T14:51:56.628Z"
     },
     {
+      "fullName": "modelcontextprotocol/servers",
+      "totalCount": 69,
+      "sourceCount": 2,
+      "sources": [
+        "awesome-skills",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+    },
+    {
       "fullName": "openclaw/peekaboo",
       "totalCount": 69,
       "sourceCount": 2,
@@ -2259,61 +2316,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-16T08:13:18.750Z"
-    },
-    {
-      "fullName": "iandchasse/de-link",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "obdev/littlesnitch-linux",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-12T12:19:51.467Z"
-    },
-    {
-      "fullName": "raine/claude-code-proxy",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T06:50:23.685Z",
-      "lastSeenAt": "2026-05-11T04:22:55.038Z"
-    },
-    {
-      "fullName": "federico-busato/modern-cpp-programming",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T17:16:19.580Z",
-      "lastSeenAt": "2026-05-09T15:42:37.217Z"
-    },
-    {
-      "fullName": "whohas/whohas",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T15:17:55.542Z",
-      "lastSeenAt": "2026-05-08T11:33:06.098Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26355328790

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.