### PR TITLE
chore(data): refresh huggingface space signals 2026-05-24T09:08:31Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-24T04:50:49.965Z",
+  "ts": "2026-05-24T09:08:31.908Z",
   "count": 1,
-  "durationMs": 6399,
+  "durationMs": 4270,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T04:50:43.568Z",
+  "fetchedAt": "2026-05-24T09:08:27.639Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -145,6 +145,22 @@
     },
     {
       "rank": 9,
+      "id": "HuggingFaceBio/carbon-demo",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
+      "likes": 81,
+      "trendingScore": 79,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T14:18:55.000Z",
+      "lastModified": "2026-05-20T10:03:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 10,
       "id": "prithivMLmods/FireRed-Image-Edit-1.0-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/FireRed-Image-Edit-1.0-Fast",
@@ -158,22 +174,6 @@
       ],
       "createdAt": "2026-02-19T15:30:29.000Z",
       "lastModified": "2026-03-23T09:13:07.000Z",
-      "models": []
-    },
-    {
-      "rank": 10,
-      "id": "HuggingFaceBio/carbon-demo",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 78,
-      "trendingScore": 76,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T14:18:55.000Z",
-      "lastModified": "2026-05-20T10:03:33.000Z",
       "models": []
     },
     {
@@ -345,8 +345,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 73,
-      "trendingScore": 46,
+      "likes": 76,
+      "trendingScore": 48,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -637,6 +637,22 @@
     },
     {
       "rank": 39,
+      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
+      "author": "Saravutw",
+      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
+      "likes": 51,
+      "trendingScore": 29,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-09T19:01:39.000Z",
+      "lastModified": "2026-03-13T17:12:16.000Z",
+      "models": []
+    },
+    {
+      "rank": 40,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -650,22 +666,6 @@
       ],
       "createdAt": "2026-03-28T19:57:45.000Z",
       "lastModified": "2026-05-15T03:44:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 40,
-      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
-      "author": "Saravutw",
-      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 50,
-      "trendingScore": 28,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-09T19:01:39.000Z",
-      "lastModified": "2026-03-13T17:12:16.000Z",
       "models": []
     },
     {
@@ -723,6 +723,22 @@
     },
     {
       "rank": 44,
+      "id": "multimodalart/z-image-6b-pixel-space",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
+      "likes": 24,
+      "trendingScore": 24,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T12:46:34.000Z",
+      "lastModified": "2026-05-22T19:37:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 45,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -739,7 +755,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -755,7 +771,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -771,7 +787,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
@@ -791,7 +807,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -807,7 +823,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "Overworld/waypoint-1-5",
       "author": "Overworld",
       "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
@@ -820,26 +836,6 @@
       ],
       "createdAt": "2026-03-18T15:28:17.000Z",
       "lastModified": "2026-04-29T16:48:42.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "carlofkl/DreamLite",
-      "author": "carlofkl",
-      "url": "https://huggingface.co/spaces/carlofkl/DreamLite",
-      "likes": 29,
-      "trendingScore": 21,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "image-generation",
-        "image-editing",
-        "on-device",
-        "diffusion",
-        "region:us"
-      ],
-      "createdAt": "2026-04-26T10:19:51.000Z",
-      "lastModified": "2026-04-28T15:12:34.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26357133527

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.