### PR TITLE
chore(data): refresh arxiv signals 2026-05-24T09:12:14Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-24T04:53:39.401Z",
+  "ts": "2026-05-24T09:10:54.980Z",
   "count": 1,
-  "durationMs": 61116,
+  "durationMs": 61531,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T04:53:39.488Z",
+  "fetchedAt": "2026-05-24T09:10:55.100Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -13,6 +13,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22823v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22820v1",
@@ -36,6 +43,13 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22817v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22816v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -43,11 +57,25 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22812v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22809v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22800v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22795v1",
@@ -64,11 +92,25 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22786v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22781v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22779v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22777v1",
@@ -99,6 +141,20 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22773v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22771v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22769v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -118,6 +174,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22763v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22759v1",
@@ -232,6 +295,20 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22719v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22718v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22716v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -281,11 +358,32 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22697v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22693v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22691v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22684v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22681v1",
@@ -344,6 +442,20 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22664v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22660v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22658v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -351,11 +463,25 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22654v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22651v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22650v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22649v1",
@@ -386,11 +512,25 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22642v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22641v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22634v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22631v1",
@@ -405,6 +545,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22621v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22620v1",
@@ -426,6 +573,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22613v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22612v1",
@@ -496,6 +650,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22581v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22579v1",
@@ -603,11 +764,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22511v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22509v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22504v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22501v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22492v1",
@@ -722,6 +904,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22391v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22389v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -785,6 +974,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22217v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22204v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -799,39 +995,11 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
-      "arxivId": "2605.22823v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22817v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22814v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22812v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22800v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22794v1",
@@ -841,46 +1009,11 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22786v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22785v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22779v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22773v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22771v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22763v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22740v1",
@@ -897,32 +1030,11 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22719v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22718v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22717v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22697v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22695v1",
@@ -932,116 +1044,46 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22691v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22684v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22666v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22664v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22662v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22660v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22654v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22653v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22650v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22642v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22635v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22634v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22629v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22621v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22613v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22596v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
       "arxivId": "2605.22593v1",
@@ -1051,53 +1093,11 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22581v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22578v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22511v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22509v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22501v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22391v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22217v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T04:52:38.305Z",
+  "fetchedAt": "2026-05-24T09:09:53.470Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26357162173

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.