### PR TITLE
chore(data): refresh huggingface space signals 2026-05-24T14:10:57Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-24T09:08:31.908Z",
+  "ts": "2026-05-24T14:10:57.828Z",
   "count": 1,
-  "durationMs": 4270,
+  "durationMs": 4297,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T09:08:27.639Z",
+  "fetchedAt": "2026-05-24T14:10:53.533Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -326,6 +326,23 @@
     },
     {
       "rank": 20,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 78,
+      "trendingScore": 49,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-13T17:12:57.000Z",
+      "models": []
+    },
+    {
+      "rank": 21,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -338,23 +355,6 @@
       ],
       "createdAt": "2026-01-27T14:05:13.000Z",
       "lastModified": "2026-05-08T10:48:11.000Z",
-      "models": []
-    },
-    {
-      "rank": 21,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 76,
-      "trendingScore": 48,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
       "models": []
     },
     {
@@ -640,7 +640,7 @@
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 51,
+      "likes": 53,
       "trendingScore": 29,
       "sdk": "gradio",
       "tags": [
@@ -670,6 +670,22 @@
     },
     {
       "rank": 41,
+      "id": "multimodalart/z-image-6b-pixel-space",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
+      "likes": 27,
+      "trendingScore": 27,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T12:46:34.000Z",
+      "lastModified": "2026-05-22T19:37:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 42,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -685,7 +701,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -705,7 +721,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -719,22 +735,6 @@
       ],
       "createdAt": "2025-12-28T08:15:28.000Z",
       "lastModified": "2025-12-29T13:46:27.000Z",
-      "models": []
-    },
-    {
-      "rank": 44,
-      "id": "multimodalart/z-image-6b-pixel-space",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 24,
-      "trendingScore": 24,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T12:46:34.000Z",
-      "lastModified": "2026-05-22T19:37:35.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26363478161

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.