### PR TITLE
chore(data): refresh arxiv signals 2026-05-24T14:13:54Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-24T04:53:39.401Z",
+  "ts": "2026-05-24T14:13:12.082Z",
   "count": 1,
-  "durationMs": 61116,
+  "durationMs": 60575,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T04:53:39.488Z",
+  "fetchedAt": "2026-05-24T14:13:12.147Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -13,6 +13,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22823v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22820v1",
@@ -36,6 +43,13 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22817v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22816v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -43,11 +57,32 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22814v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
+      "arxivId": "2605.22812v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22809v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22800v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22795v1",
@@ -64,11 +99,25 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22786v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22781v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22779v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22777v1",
@@ -99,6 +148,20 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22773v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22771v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22769v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -118,6 +181,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22763v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22759v1",
@@ -232,6 +302,20 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22719v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22718v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22716v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -281,11 +365,32 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22697v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22693v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22691v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22684v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22681v1",
@@ -344,6 +449,34 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22666v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
+      "arxivId": "2605.22664v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22662v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
+      "arxivId": "2605.22660v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22658v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -351,11 +484,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22654v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22653v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
       "arxivId": "2605.22651v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22650v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22649v1",
@@ -386,11 +540,32 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22642v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22641v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22635v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
+      "arxivId": "2605.22634v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22631v1",
@@ -400,11 +575,25 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22629v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
       "arxivId": "2605.22622v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22621v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22620v1",
@@ -426,6 +615,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22613v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22612v1",
@@ -484,6 +680,13 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22596v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
       "arxivId": "2605.22591v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -496,6 +699,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22581v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22579v1",
@@ -603,11 +813,32 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22511v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22509v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22504v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22501v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
       "arxivId": "2605.22492v1",
@@ -722,6 +953,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22391v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22389v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -785,6 +1023,13 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
+      "arxivId": "2605.22217v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
       "arxivId": "2605.22204v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -799,95 +1044,25 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
-      "arxivId": "2605.22823v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22817v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22814v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22812v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22800v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22794v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22786v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22785v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22779v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22773v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22771v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22763v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22740v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22724v1",
@@ -897,20 +1072,6 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22719v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22718v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22717v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -918,130 +1079,11 @@
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     },
     {
-      "arxivId": "2605.22697v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22695v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22691v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22684v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22666v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22664v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22662v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22660v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22654v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22653v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22650v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22642v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22635v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22634v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22629v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22621v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22613v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22596v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22593v1",
@@ -1051,53 +1093,11 @@
       "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
-      "arxivId": "2605.22581v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22578v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22511v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22509v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22501v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22391v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22217v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T04:52:38.305Z",
+  "fetchedAt": "2026-05-24T14:12:11.529Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26363506693

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.