### PR TITLE
chore(data): refresh lobsters signals 2026-05-24T14:51:22Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-24T12:44:14.404Z",
+  "ts": "2026-05-24T14:51:22.261Z",
   "count": 1,
-  "durationMs": 4710,
+  "durationMs": 2834,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-24T12:44:09.727Z",
+  "fetchedAt": "2026-05-24T14:51:19.445Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 81,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-24T12:44:09.727Z",
+  "fetchedAt": "2026-05-24T14:51:19.445Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 81,
   "stories": [
     {
       "shortId": "29pm2f",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26364385284

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.