### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-24T16:11:48Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-24T12:09:20.185Z",
+  "ts": "2026-05-24T16:11:48.710Z",
   "count": 1,
-  "durationMs": 11145,
+  "durationMs": 11183,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-24T12:09:18.716Z",
+  "lastFetchedAt": "2026-05-24T16:11:46.461Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1238,6 +1238,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151377",
+      "name": "Stitch 3.0 by Google",
+      "tagline": "Generate and iterate UI screens with AI on a live canvas",
+      "description": "Stitch generates UI screens for mobile and web from text prompts, with streaming edits, in-place AI changes, and one-click export to Figma, Netlify, Lovable, and Bolt. For product designers and developers prototyping fast.",
+      "url": "https://www.producthunt.com/products/stitch-by-google?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/2WIQLRJ4DNSJF5",
+      "votesCount": 282,
+      "commentsCount": 9,
+      "createdAt": "2026-05-24T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2704ac79-abf6-42dc-a56f-b8ae1cb13896.jpeg?auto=format",
+      "topics": [
+        "design-tools",
+        "user-experience",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1052099",
       "name": "Graphbit PRFlow",
       "tagline": "AI code reviewer that catches what others miss",
@@ -2313,37 +2355,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
-    },
-    {
-      "id": "1139500",
-      "name": "deepsec",
-      "tagline": "Open-source coding security harness",
-      "description": "Vercel is open sourcing deepsec, an AI security harness that runs on your infrastructure, with your keys, against your code.",
-      "url": "https://www.producthunt.com/products/vercel?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/T5UPS2CJT3MEUS",
-      "votesCount": 198,
-      "commentsCount": 3,
-      "createdAt": "2026-05-10T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/593ff5e2-9d11-491c-ab63-9e929e894214.jpeg?auto=format",
-      "topics": [
-        "open-source",
-        "developer-tools",
-        "github",
-        "security"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26366202028

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.