### PR TITLE
chore(data): refresh huggingface space signals 2026-05-24T19:49:54Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-24T14:10:57.828Z",
+  "ts": "2026-05-24T19:49:54.747Z",
   "count": 1,
-  "durationMs": 4297,
+  "durationMs": 4030,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T14:10:53.533Z",
+  "fetchedAt": "2026-05-24T19:49:50.718Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -148,8 +148,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 81,
-      "trendingScore": 79,
+      "likes": 82,
+      "trendingScore": 80,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -329,8 +329,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 78,
-      "trendingScore": 49,
+      "likes": 79,
+      "trendingScore": 50,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -772,6 +772,26 @@
     },
     {
       "rank": 47,
+      "id": "mrfakename/anima-v1",
+      "author": "mrfakename",
+      "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
+      "likes": 34,
+      "trendingScore": 23,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "text-to-image",
+        "anima",
+        "zerogpu",
+        "anime",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T02:42:26.000Z",
+      "lastModified": "2026-05-22T03:20:51.000Z",
+      "models": []
+    },
+    {
+      "rank": 48,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -787,27 +807,23 @@
       "models": []
     },
     {
-      "rank": 48,
-      "id": "mrfakename/anima-v1",
-      "author": "mrfakename",
-      "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
-      "likes": 33,
+      "rank": 49,
+      "id": "ibuildproducts/wan22-i2v-v4-demo",
+      "author": "ibuildproducts",
+      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
+      "likes": 27,
       "trendingScore": 22,
       "sdk": "gradio",
       "tags": [
         "gradio",
-        "text-to-image",
-        "anima",
-        "zerogpu",
-        "anime",
         "region:us"
       ],
-      "createdAt": "2026-05-15T02:42:26.000Z",
-      "lastModified": "2026-05-22T03:20:51.000Z",
+      "createdAt": "2026-05-17T23:34:01.000Z",
+      "lastModified": "2026-05-18T00:16:12.000Z",
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2026-05-06T17:25:59.000Z",
       "lastModified": "2026-05-07T18:52:54.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "Overworld/waypoint-1-5",
-      "author": "Overworld",
-      "url": "https://huggingface.co/spaces/Overworld/waypoint-1-5",
-      "likes": 58,
-      "trendingScore": 21,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T15:28:17.000Z",
-      "lastModified": "2026-04-29T16:48:42.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26371059567

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.