### PR TITLE
chore(data): refresh arxiv signals 2026-05-24T20:00:24Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-24T14:13:12.082Z",
+  "ts": "2026-05-24T19:52:07.899Z",
   "count": 1,
-  "durationMs": 60575,
+  "durationMs": 61441,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T14:13:12.147Z",
+  "fetchedAt": "2026-05-24T19:52:08.028Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -8,13 +8,6 @@
   "count": 156,
   "papers": [
     {
-      "arxivId": "2605.22821v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
       "arxivId": "2605.22823v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -22,39 +15,11 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22820v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22819v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22818v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22817v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22816v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22814v1",
@@ -71,13 +36,6 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22809v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
       "arxivId": "2605.22800v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -85,18 +43,11 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22795v1",
+      "arxivId": "2605.22794v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22791v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22786v1",
@@ -106,11 +57,11 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22781v1",
+      "arxivId": "2605.22785v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22779v1",
@@ -118,34 +69,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22777v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22776v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22775v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22774v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22773v1",
@@ -162,27 +85,6 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22769v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22767v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22765v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22763v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -190,116 +92,11 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22759v1",
+      "arxivId": "2605.22740v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22756v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22751v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22749v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22748v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22746v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22743v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22738v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22737v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22736v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22734v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22733v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22732v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22731v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22723v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22720v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22719v1",
@@ -316,55 +113,6 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22716v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22715v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22714v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22711v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22707v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22705v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22703v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22697v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -372,11 +120,11 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22693v1",
+      "arxivId": "2605.22695v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
     },
     {
       "arxivId": "2605.22691v1",
@@ -391,62 +139,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22681v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22679v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22678v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22677v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22675v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22672v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22671v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22668v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
       "arxivId": "2605.22666v1",
@@ -477,13 +169,6 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22658v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
       "arxivId": "2605.22654v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -498,13 +183,6 @@
       "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
-      "arxivId": "2605.22651v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
       "arxivId": "2605.22650v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -512,46 +190,11 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22649v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22645v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22644v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22643v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
       "arxivId": "2605.22642v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22641v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
       "arxivId": "2605.22635v1",
@@ -568,13 +211,6 @@
       "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
     },
     {
-      "arxivId": "2605.22631v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
       "arxivId": "2605.22629v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -582,18 +218,480 @@
       "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
     },
     {
-      "arxivId": "2605.22622v1",
+      "arxivId": "2605.22621v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22613v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22596v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+    },
+    {
+      "arxivId": "2605.22581v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22511v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22509v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22501v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22391v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22217v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+    },
+    {
+      "arxivId": "2605.22821v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22820v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22819v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22818v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22816v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
-      "arxivId": "2605.22621v1",
+      "arxivId": "2605.22809v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22795v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22791v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22781v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22777v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22776v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22775v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22774v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22769v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22767v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22765v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22759v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22756v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22751v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22749v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22748v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22746v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22743v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22738v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22737v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22736v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22734v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22733v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22732v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22731v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22724v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
+    },
+    {
+      "arxivId": "2605.22723v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22720v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22717v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22716v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22715v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22714v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22711v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22707v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22705v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22703v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22693v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22681v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22679v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22678v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22677v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22675v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22672v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22671v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22668v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22658v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22651v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22649v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+    },
+    {
+      "arxivId": "2605.22645v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22644v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22643v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22641v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
+      "arxivId": "2605.22631v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+    },
+    {
+      "arxivId": "2605.22622v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22620v1",
@@ -607,91 +705,84 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22616v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22613v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22612v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22611v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22608v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22607v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22605v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22604v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22602v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22597v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
-      "arxivId": "2605.22596v1",
+      "arxivId": "2605.22593v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T09:10:55.100Z"
+      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
     },
     {
       "arxivId": "2605.22591v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22586v1",
@@ -701,13 +792,6 @@
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
     },
     {
-      "arxivId": "2605.22581v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
       "arxivId": "2605.22579v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -715,11 +799,18 @@
       "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
     },
     {
+      "arxivId": "2605.22578v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
+    },
+    {
       "arxivId": "2605.22572v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22570v1",
@@ -740,14 +831,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22564v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22563v1",
@@ -768,35 +859,35 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22550v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22547v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22544v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22542v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22538v1",
@@ -810,42 +901,21 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22511v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
-    },
-    {
-      "arxivId": "2605.22509v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22504v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
-    },
-    {
-      "arxivId": "2605.22501v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22492v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22487v1",
@@ -866,21 +936,21 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22476v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22469v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22467v1",
@@ -915,7 +985,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22446v1",
@@ -936,35 +1006,28 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22423v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22411v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22391v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22389v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22380v1",
@@ -978,14 +1041,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22356v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T19:50:20.452Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22355v1",
@@ -999,14 +1062,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22258v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22247v1",
@@ -1020,21 +1083,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22217v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T04:53:39.488Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22204v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
+      "lastEnrichedAt": "2026-05-24T19:52:08.028Z"
     },
     {
       "arxivId": "2605.22203v1",
@@ -1042,62 +1098,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-23T14:15:27.848Z"
-    },
-    {
-      "arxivId": "2605.22794v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
-    },
-    {
-      "arxivId": "2605.22785v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
-    },
-    {
-      "arxivId": "2605.22740v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
-    },
-    {
-      "arxivId": "2605.22724v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22717v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
-    },
-    {
-      "arxivId": "2605.22695v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-24T14:13:12.147Z"
-    },
-    {
-      "arxivId": "2605.22593v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T15:42:48.351Z"
-    },
-    {
-      "arxivId": "2605.22578v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-22T10:06:20.604Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T14:12:11.529Z",
+  "fetchedAt": "2026-05-24T19:51:06.479Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26371083202

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.