### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-24T20:15:34Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-24T16:11:48.710Z",
+  "ts": "2026-05-24T20:15:34.087Z",
   "count": 1,
-  "durationMs": 11183,
+  "durationMs": 10895,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-24T16:11:46.461Z",
+  "lastFetchedAt": "2026-05-24T20:15:31.925Z",
   "windowDays": 7,
   "launches": [
     {
@@ -645,6 +645,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151377",
+      "name": "Stitch 3.0 by Google",
+      "tagline": "Generate and iterate UI screens with AI on a live canvas",
+      "description": "Stitch generates UI screens for mobile and web from text prompts, with streaming edits, in-place AI changes, and one-click export to Figma, Netlify, Lovable, and Bolt. For product designers and developers prototyping fast.",
+      "url": "https://www.producthunt.com/products/stitch-by-google?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/2WIQLRJ4DNSJF5",
+      "votesCount": 343,
+      "commentsCount": 10,
+      "createdAt": "2026-05-24T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2704ac79-abf6-42dc-a56f-b8ae1cb13896.jpeg?auto=format",
+      "topics": [
+        "design-tools",
+        "user-experience",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1138927",
       "name": "articuler.ai",
       "tagline": "Describe your goal. Meet the right professional.",
@@ -1224,48 +1266,6 @@
         "video"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1151377",
-      "name": "Stitch 3.0 by Google",
-      "tagline": "Generate and iterate UI screens with AI on a live canvas",
-      "description": "Stitch generates UI screens for mobile and web from text prompts, with streaming edits, in-place AI changes, and one-click export to Figma, Netlify, Lovable, and Bolt. For product designers and developers prototyping fast.",
-      "url": "https://www.producthunt.com/products/stitch-by-google?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/2WIQLRJ4DNSJF5",
-      "votesCount": 282,
-      "commentsCount": 9,
-      "createdAt": "2026-05-24T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2704ac79-abf6-42dc-a56f-b8ae1cb13896.jpeg?auto=format",
-      "topics": [
-        "design-tools",
-        "user-experience",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2078,6 +2078,61 @@
       "aiAdjacent": false
     },
     {
+      "id": "1153508",
+      "name": "ModelHub",
+      "tagline": "The missing menu bar app for local LLMs on Mac.",
+      "description": "ModelHub is a native macOS menu bar app for developers working with local LLMs. It helps you discover models from Hugging Face, download the right local build, manage your model library, and use Hugging Face models with Ollama, MLX, LM Studio, llama.cpp, and the tools you already have without bouncing between browser tabs, terminal commands, model cards, and local folders. Ollama, MLX, and LM Studio are great tools. ModelHub is the missing discovery and management layer around them.",
+      "url": "https://www.producthunt.com/products/modelhub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/VKVZCCO3WNW46P",
+      "votesCount": 214,
+      "commentsCount": 26,
+      "createdAt": "2026-05-24T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/289a32f1-5f2b-49ef-9eb7-2aae920bb5e5.png?auto=format",
+      "topics": [
+        "open-source",
+        "developer-tools",
+        "github",
+        "menu-bar-apps"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1137047",
       "name": "Theneo",
       "tagline": "The API management platform for humans and agents",
@@ -2308,48 +2363,6 @@
         "artificial-intelligence"
       ],
       "makers": [],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1148531",
-      "name": "CtrlOps",
-      "tagline": "Deploy, Debug & Manage Linux Servers with AI.",
-      "description": "Most devs manage servers from a spreadsheet of IPs and commands nobody remembers. CtrlOps gives you AI-powered server management without DevOps expertise. AI terminal that generates commands with your approval. Scripts library. One-click deploys from any GitHub repo. Visual file manager. Real-time server monitoring. Zero agents on servers. Deployments that took 60 minutes now take 5. 100% local. Your credentials never leave your machine. Mac. Windows. Linux.",
-      "url": "https://www.producthunt.com/products/ctrlops?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H64HE7ZK3MVBJN",
-      "votesCount": 203,
-      "commentsCount": 50,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2a1eb160-e2ce-4652-975c-4d715270bde7.png?auto=format",
-      "topics": [
-        "linux",
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26371616991

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.