### PR TITLE
chore(data): refresh lobsters signals 2026-05-24T20:33:42Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-24T18:44:27.932Z",
+  "ts": "2026-05-24T20:33:42.160Z",
   "count": 1,
-  "durationMs": 3906,
+  "durationMs": 3234,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-24T18:44:24.047Z",
+  "fetchedAt": "2026-05-24T20:33:38.948Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-24T18:44:24.047Z",
+  "fetchedAt": "2026-05-24T20:33:38.948Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26372025328

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.