### PR TITLE
chore(data): refresh bluesky signals 2026-05-24T22:10:39Z

### DIFF
--- a/data/_meta/bluesky.json
+++ b/data/_meta/bluesky.json
@@ -1,8 +1,8 @@
 {
   "source": "bluesky",
   "reason": "ok",
-  "ts": "2026-05-24T21:12:01.728Z",
+  "ts": "2026-05-24T22:10:39.660Z",
   "count": 1,
-  "durationMs": 12720,
+  "durationMs": 12915,
   "extra": {}
 }

--- a/data/bluesky-mentions.json
+++ b/data/bluesky-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-24T21:11:49.284Z",
+  "fetchedAt": "2026-05-24T22:10:27.327Z",
   "windowDays": 7,
-  "scannedPosts": 299,
+  "scannedPosts": 300,
   "searchQuery": "github.com",
   "pagesFetched": 3,
   "mentions": {
@@ -3619,7 +3619,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:54:08.000Z",
-        "hoursSincePosted": 1.29
+        "hoursSincePosted": 2.27
       },
       "posts": [
         {
@@ -3669,7 +3669,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:54:08.000Z",
           "createdUtc": 1779652448,
-          "ageHours": 1.29,
+          "ageHours": 2.27,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -3697,7 +3697,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:53:41.000Z",
           "createdUtc": 1779652421,
-          "ageHours": 1.3,
+          "ageHours": 2.28,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -9631,23 +9631,51 @@
       "count7d": 1,
       "likesSum7d": 1,
       "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:2pbcv2hgynjwwxnpu633n23w/app.bsky.feed.post/3mmehz4fslb2q",
-        "cid": "bafyreidq2fob4npt2r3atjbgofaown7gy3sf77vzyfojswfvj7oqjstza4",
-        "bskyUrl": "https://bsky.app/profile/jordbastin.bsky.social/post/3mmehz4fslb2q",
-        "text": "Le futur du dev avec agents ne sera pas “prompt au hasard → code”. Ce sera plutôt : spec claire → plan → tâches → implémentation. GitHub pousse cette approche avec Spec Kit. github.com/github/spec...",
+        "uri": "at://did:plc:pfpiq75iixyg7n4jimhgiwu2/app.bsky.feed.post/3mmmv2xe6whc2",
+        "cid": "bafyreibuhqluo5eangu2ne2bghnsxqfvucfnwao57gyz7tsdr3laxls45y",
+        "bskyUrl": "https://bsky.app/profile/manlycoffee.techhub.social.ap.brid.gy/post/3mmmv2xe6whc2",
+        "text": "Just found out about this. https://github.com/github/spec-kit",
         "author": {
-          "handle": "jordbastin.bsky.social",
-          "displayName": "Jordan Bastin 🇫🇷"
+          "handle": "manlycoffee.techhub.social.ap.brid.gy",
+          "displayName": "Sal Rahman"
         },
         "likeCount": 1,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-21T13:00:12.267849Z",
-        "hoursSincePosted": 0.54
+        "replyCount": 0,
+        "createdAt": "2026-05-24T21:15:06.000Z",
+        "hoursSincePosted": 0.92
       },
       "posts": [
+        {
+          "uri": "at://did:plc:pfpiq75iixyg7n4jimhgiwu2/app.bsky.feed.post/3mmmv2xe6whc2",
+          "cid": "bafyreibuhqluo5eangu2ne2bghnsxqfvucfnwao57gyz7tsdr3laxls45y",
+          "bskyUrl": "https://bsky.app/profile/manlycoffee.techhub.social.ap.brid.gy/post/3mmmv2xe6whc2",
+          "text": "Just found out about this. https://github.com/github/spec-kit",
+          "author": {
+            "handle": "manlycoffee.techhub.social.ap.brid.gy",
+            "displayName": "Sal Rahman"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-24T21:15:06.000Z",
+          "createdUtc": 1779657306,
+          "ageHours": 0.92,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "github/spec-kit",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:2pbcv2hgynjwwxnpu633n23w/app.bsky.feed.post/3mmehz4fslb2q",
           "cid": "bafyreidq2fob4npt2r3atjbgofaown7gy3sf77vzyfojswfvj7oqjstza4",
@@ -18977,21 +19005,49 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:2ow4s6cci5ylwwdedvx3qtkx/app.bsky.feed.post/3mmicqdwgbe2z",
-        "cid": "bafyreiftpcho4vcv7ejsldj3mrjvhzp776e5ygc3pdbrkhrpn76wthlbc4",
-        "bskyUrl": "https://bsky.app/profile/tech-trending.bsky.social/post/3mmicqdwgbe2z",
-        "text": "GitHub - domcyrus/rustnet: Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed. https://github.com/domcyrus/rustnet",
+        "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmmv6nmax22c",
+        "cid": "bafyreidm6eeo7m4mmtv4fsrd6onjd33goi6ave2taaehe25bdrpntqgqh4",
+        "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmmv6nmax22c",
+        "text": "domcyrus / rustnet: Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed. ★3923 https://github.com/domcyrus/rustnet",
         "author": {
-          "handle": "tech-trending.bsky.social",
-          "displayName": "Tech Trending"
+          "handle": "rusttrending.bsky.social",
+          "displayName": "RustTrending"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-23T01:36:28.480Z",
-        "hoursSincePosted": 2.53
+        "createdAt": "2026-05-24T21:17:14.656372Z",
+        "hoursSincePosted": 0.89
       },
       "posts": [
+        {
+          "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmmv6nmax22c",
+          "cid": "bafyreidm6eeo7m4mmtv4fsrd6onjd33goi6ave2taaehe25bdrpntqgqh4",
+          "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmmv6nmax22c",
+          "text": "domcyrus / rustnet: Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed. ★3923 https://github.com/domcyrus/rustnet",
+          "author": {
+            "handle": "rusttrending.bsky.social",
+            "displayName": "RustTrending"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-24T21:17:14.656372Z",
+          "createdUtc": 1779657434,
+          "ageHours": 0.89,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "domcyrus/rustnet",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:2ow4s6cci5ylwwdedvx3qtkx/app.bsky.feed.post/3mmicqdwgbe2z",
           "cid": "bafyreiftpcho4vcv7ejsldj3mrjvhzp776e5ygc3pdbrkhrpn76wthlbc4",
@@ -26584,7 +26640,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T17:17:04.688203Z",
-        "hoursSincePosted": 3.91
+        "hoursSincePosted": 4.89
       },
       "posts": [
         {
@@ -26601,7 +26657,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T17:17:04.688203Z",
           "createdUtc": 1779643024,
-          "ageHours": 3.91,
+          "ageHours": 4.89,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -26635,7 +26691,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:01:47.183Z",
-        "hoursSincePosted": 2.17
+        "hoursSincePosted": 3.14
       },
       "posts": [
         {
@@ -26652,7 +26708,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:01:47.183Z",
           "createdUtc": 1779649307,
-          "ageHours": 2.17,
+          "ageHours": 3.14,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -26686,7 +26742,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:01:28.795Z",
-        "hoursSincePosted": 2.17
+        "hoursSincePosted": 3.15
       },
       "posts": [
         {
@@ -26703,7 +26759,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:01:28.795Z",
           "createdUtc": 1779649288,
-          "ageHours": 2.17,
+          "ageHours": 3.15,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -26737,7 +26793,7 @@
         "repostCount": 0,
         "replyCount": 2,
         "createdAt": "2026-05-24T18:36:41.731262Z",
-        "hoursSincePosted": 2.59
+        "hoursSincePosted": 3.56
       },
       "posts": [
         {
@@ -26754,7 +26810,7 @@
           "replyCount": 2,
           "createdAt": "2026-05-24T18:36:41.731262Z",
           "createdUtc": 1779647801,
-          "ageHours": 2.59,
+          "ageHours": 3.56,
           "trendingScore": 4,
           "content_tags": [
             "has-github-repo"
@@ -26788,7 +26844,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T18:23:46Z",
-        "hoursSincePosted": 2.8
+        "hoursSincePosted": 3.78
       },
       "posts": [
         {
@@ -26805,7 +26861,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T18:23:46Z",
           "createdUtc": 1779647026,
-          "ageHours": 2.8,
+          "ageHours": 3.78,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -26839,7 +26895,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:51:06.082Z",
-        "hoursSincePosted": 1.35
+        "hoursSincePosted": 2.32
       },
       "posts": [
         {
@@ -26856,7 +26912,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:51:06.082Z",
           "createdUtc": 1779652266,
-          "ageHours": 1.35,
+          "ageHours": 2.32,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -30488,7 +30544,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:54:08.000Z",
-        "hoursSincePosted": 1.29
+        "hoursSincePosted": 2.27
       },
       "posts": [
         {
@@ -30538,7 +30594,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:54:08.000Z",
           "createdUtc": 1779652448,
-          "ageHours": 1.29,
+          "ageHours": 2.27,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -30566,7 +30622,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:53:41.000Z",
           "createdUtc": 1779652421,
-          "ageHours": 1.3,
+          "ageHours": 2.28,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -36500,23 +36556,51 @@
       "count7d": 1,
       "likesSum7d": 1,
       "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:2pbcv2hgynjwwxnpu633n23w/app.bsky.feed.post/3mmehz4fslb2q",
-        "cid": "bafyreidq2fob4npt2r3atjbgofaown7gy3sf77vzyfojswfvj7oqjstza4",
-        "bskyUrl": "https://bsky.app/profile/jordbastin.bsky.social/post/3mmehz4fslb2q",
-        "text": "Le futur du dev avec agents ne sera pas “prompt au hasard → code”. Ce sera plutôt : spec claire → plan → tâches → implémentation. GitHub pousse cette approche avec Spec Kit. github.com/github/spec...",
+        "uri": "at://did:plc:pfpiq75iixyg7n4jimhgiwu2/app.bsky.feed.post/3mmmv2xe6whc2",
+        "cid": "bafyreibuhqluo5eangu2ne2bghnsxqfvucfnwao57gyz7tsdr3laxls45y",
+        "bskyUrl": "https://bsky.app/profile/manlycoffee.techhub.social.ap.brid.gy/post/3mmmv2xe6whc2",
+        "text": "Just found out about this. https://github.com/github/spec-kit",
         "author": {
-          "handle": "jordbastin.bsky.social",
-          "displayName": "Jordan Bastin 🇫🇷"
+          "handle": "manlycoffee.techhub.social.ap.brid.gy",
+          "displayName": "Sal Rahman"
         },
         "likeCount": 1,
         "repostCount": 0,
-        "replyCount": 1,
-        "createdAt": "2026-05-21T13:00:12.267849Z",
-        "hoursSincePosted": 0.54
+        "replyCount": 0,
+        "createdAt": "2026-05-24T21:15:06.000Z",
+        "hoursSincePosted": 0.92
       },
       "posts": [
+        {
+          "uri": "at://did:plc:pfpiq75iixyg7n4jimhgiwu2/app.bsky.feed.post/3mmmv2xe6whc2",
+          "cid": "bafyreibuhqluo5eangu2ne2bghnsxqfvucfnwao57gyz7tsdr3laxls45y",
+          "bskyUrl": "https://bsky.app/profile/manlycoffee.techhub.social.ap.brid.gy/post/3mmmv2xe6whc2",
+          "text": "Just found out about this. https://github.com/github/spec-kit",
+          "author": {
+            "handle": "manlycoffee.techhub.social.ap.brid.gy",
+            "displayName": "Sal Rahman"
+          },
+          "likeCount": 1,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-24T21:15:06.000Z",
+          "createdUtc": 1779657306,
+          "ageHours": 0.92,
+          "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "github/spec-kit",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:2pbcv2hgynjwwxnpu633n23w/app.bsky.feed.post/3mmehz4fslb2q",
           "cid": "bafyreidq2fob4npt2r3atjbgofaown7gy3sf77vzyfojswfvj7oqjstza4",
@@ -45846,21 +45930,49 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:2ow4s6cci5ylwwdedvx3qtkx/app.bsky.feed.post/3mmicqdwgbe2z",
-        "cid": "bafyreiftpcho4vcv7ejsldj3mrjvhzp776e5ygc3pdbrkhrpn76wthlbc4",
-        "bskyUrl": "https://bsky.app/profile/tech-trending.bsky.social/post/3mmicqdwgbe2z",
-        "text": "GitHub - domcyrus/rustnet: Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed. https://github.com/domcyrus/rustnet",
+        "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmmv6nmax22c",
+        "cid": "bafyreidm6eeo7m4mmtv4fsrd6onjd33goi6ave2taaehe25bdrpntqgqh4",
+        "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmmv6nmax22c",
+        "text": "domcyrus / rustnet: Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed. ★3923 https://github.com/domcyrus/rustnet",
         "author": {
-          "handle": "tech-trending.bsky.social",
-          "displayName": "Tech Trending"
+          "handle": "rusttrending.bsky.social",
+          "displayName": "RustTrending"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-23T01:36:28.480Z",
-        "hoursSincePosted": 2.53
+        "createdAt": "2026-05-24T21:17:14.656372Z",
+        "hoursSincePosted": 0.89
       },
       "posts": [
+        {
+          "uri": "at://did:plc:lontmsdex36tfjyxjlznnea7/app.bsky.feed.post/3mmmv6nmax22c",
+          "cid": "bafyreidm6eeo7m4mmtv4fsrd6onjd33goi6ave2taaehe25bdrpntqgqh4",
+          "bskyUrl": "https://bsky.app/profile/rusttrending.bsky.social/post/3mmmv6nmax22c",
+          "text": "domcyrus / rustnet: Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed. ★3923 https://github.com/domcyrus/rustnet",
+          "author": {
+            "handle": "rusttrending.bsky.social",
+            "displayName": "RustTrending"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-24T21:17:14.656372Z",
+          "createdUtc": 1779657434,
+          "ageHours": 0.89,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "domcyrus/rustnet",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:2ow4s6cci5ylwwdedvx3qtkx/app.bsky.feed.post/3mmicqdwgbe2z",
           "cid": "bafyreiftpcho4vcv7ejsldj3mrjvhzp776e5ygc3pdbrkhrpn76wthlbc4",
@@ -53453,7 +53565,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T17:17:04.688203Z",
-        "hoursSincePosted": 3.91
+        "hoursSincePosted": 4.89
       },
       "posts": [
         {
@@ -53470,7 +53582,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T17:17:04.688203Z",
           "createdUtc": 1779643024,
-          "ageHours": 3.91,
+          "ageHours": 4.89,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -53504,7 +53616,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:01:47.183Z",
-        "hoursSincePosted": 2.17
+        "hoursSincePosted": 3.14
       },
       "posts": [
         {
@@ -53521,7 +53633,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:01:47.183Z",
           "createdUtc": 1779649307,
-          "ageHours": 2.17,
+          "ageHours": 3.14,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -53555,7 +53667,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:01:28.795Z",
-        "hoursSincePosted": 2.17
+        "hoursSincePosted": 3.15
       },
       "posts": [
         {
@@ -53572,7 +53684,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:01:28.795Z",
           "createdUtc": 1779649288,
-          "ageHours": 2.17,
+          "ageHours": 3.15,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -53606,7 +53718,7 @@
         "repostCount": 0,
         "replyCount": 2,
         "createdAt": "2026-05-24T18:36:41.731262Z",
-        "hoursSincePosted": 2.59
+        "hoursSincePosted": 3.56
       },
       "posts": [
         {
@@ -53623,7 +53735,7 @@
           "replyCount": 2,
           "createdAt": "2026-05-24T18:36:41.731262Z",
           "createdUtc": 1779647801,
-          "ageHours": 2.59,
+          "ageHours": 3.56,
           "trendingScore": 4,
           "content_tags": [
             "has-github-repo"
@@ -53657,7 +53769,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T18:23:46Z",
-        "hoursSincePosted": 2.8
+        "hoursSincePosted": 3.78
       },
       "posts": [
         {
@@ -53674,7 +53786,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T18:23:46Z",
           "createdUtc": 1779647026,
-          "ageHours": 2.8,
+          "ageHours": 3.78,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -53708,7 +53820,7 @@
         "repostCount": 0,
         "replyCount": 0,
         "createdAt": "2026-05-24T19:51:06.082Z",
-        "hoursSincePosted": 1.35
+        "hoursSincePosted": 2.32
       },
       "posts": [
         {
@@ -53725,7 +53837,7 @@
           "replyCount": 0,
           "createdAt": "2026-05-24T19:51:06.082Z",
           "createdUtc": 1779652266,
-          "ageHours": 1.35,
+          "ageHours": 2.32,
           "trendingScore": 0,
           "content_tags": [
             "has-github-repo"
@@ -53749,23 +53861,13 @@
       "likesSum7d": 3
     },
     {
-      "fullName": "anthropics/knowledge-work-plugins",
+      "fullName": "github/spec-kit",
       "count7d": 1,
-      "likesSum7d": 2
-    },
-    {
-      "fullName": "imputnet/helium-linux",
-      "count7d": 1,
-      "likesSum7d": 2
+      "likesSum7d": 1
     },
     {
       "fullName": "garrytan/gstack",
       "count7d": 2,
-      "likesSum7d": 0
-    },
-    {
-      "fullName": "AKS-Labs/CircleToSearch",
-      "count7d": 1,
       "likesSum7d": 0
     },
     {
@@ -53775,6 +53877,11 @@
     },
     {
       "fullName": "BloopAI/vibe-kanban",
+      "count7d": 1,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "domcyrus/rustnet",
       "count7d": 1,
       "likesSum7d": 0
     },

--- a/data/bluesky-trending.json
+++ b/data/bluesky-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T21:11:49.284Z",
+  "fetchedAt": "2026-05-24T22:10:27.327Z",
   "discoveryVersion": "2026-04-21",
   "keywords": [
     "AI agents",
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "scannedPosts": 663,
+  "scannedPosts": 664,
   "posts": [
     {
       "uri": "at://did:plc:oijtzlibd7mlf56jbfohssdz/app.bsky.feed.post/3ml46o7m5rs2b",
@@ -264,7 +264,7 @@
       "replyCount": 32,
       "createdAt": "2026-05-22T20:45:27.265Z",
       "createdUtc": 1779482727,
-      "ageHours": 48.44,
+      "ageHours": 49.42,
       "trendingScore": 3084,
       "content_tags": [],
       "value_score": 0,
@@ -336,7 +336,7 @@
       "replyCount": 124,
       "createdAt": "2026-05-22T01:16:23.287Z",
       "createdUtc": 1779412583,
-      "ageHours": 67.92,
+      "ageHours": 68.9,
       "trendingScore": 2504,
       "content_tags": [],
       "value_score": 0,
@@ -504,7 +504,7 @@
       "replyCount": 29,
       "createdAt": "2026-05-21T00:02:07.549Z",
       "createdUtc": 1779321727,
-      "ageHours": 93.16,
+      "ageHours": 94.14,
       "trendingScore": 1226.5,
       "content_tags": [],
       "value_score": 0,
@@ -513,6 +513,30 @@
       "matchedQuery": "lang:en workflow",
       "matchedTopicId": "workflow",
       "matchedTopicLabel": "Workflow and automation"
+    },
+    {
+      "uri": "at://did:plc:p2evpzo36m3pn6xuib6rneiz/app.bsky.feed.post/3mmm4wdcfis2p",
+      "cid": "bafyreibnooxy6snslwznp2ryoosc2ayqsv6gowngmvxi6i4wzwdn7n6vna",
+      "bskyUrl": "https://bsky.app/profile/omelette-vore.bsky.social/post/3mmm4wdcfis2p",
+      "text": "Sweat rag",
+      "author": {
+        "handle": "omelette-vore.bsky.social",
+        "displayName": "🔞Omelette 🍳 {NO RP}"
+      },
+      "likeCount": 859,
+      "repostCount": 179,
+      "replyCount": 18,
+      "createdAt": "2026-05-24T14:03:05.726Z",
+      "createdUtc": 1779631385,
+      "ageHours": 8.12,
+      "trendingScore": 1226,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "RAG and retrieval",
+      "matchedQuery": "lang:en rag",
+      "matchedTopicId": "retrieval",
+      "matchedTopicLabel": "RAG and retrieval"
     },
     {
       "uri": "at://did:plc:z4llsx425l4htoylyyx6iam3/app.bsky.feed.post/3mlwgb5ao7k23",
@@ -563,30 +587,6 @@
       "matchedTopicLabel": "Workflow and automation"
     },
     {
-      "uri": "at://did:plc:p2evpzo36m3pn6xuib6rneiz/app.bsky.feed.post/3mmm4wdcfis2p",
-      "cid": "bafyreibnooxy6snslwznp2ryoosc2ayqsv6gowngmvxi6i4wzwdn7n6vna",
-      "bskyUrl": "https://bsky.app/profile/omelette-vore.bsky.social/post/3mmm4wdcfis2p",
-      "text": "Sweat rag",
-      "author": {
-        "handle": "omelette-vore.bsky.social",
-        "displayName": "🔞Omelette 🍳 {NO RP}"
-      },
-      "likeCount": 827,
-      "repostCount": 175,
-      "replyCount": 18,
-      "createdAt": "2026-05-24T14:03:05.726Z",
-      "createdUtc": 1779631385,
-      "ageHours": 7.15,
-      "trendingScore": 1186,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "RAG and retrieval",
-      "matchedQuery": "lang:en rag",
-      "matchedTopicId": "retrieval",
-      "matchedTopicLabel": "RAG and retrieval"
-    },
-    {
       "uri": "at://did:plc:allu5vs3gnm2wm7jzf4rad3r/app.bsky.feed.post/3ml4at5hshs2s",
       "cid": "bafyreifzp4wbcby6osa6blcfi2gkiaszzmekqpiqoty3uqoscjtur5jzoe",
       "bskyUrl": "https://bsky.app/profile/isolyth.dev/post/3ml4at5hshs2s",
@@ -624,7 +624,7 @@
       "replyCount": 5,
       "createdAt": "2026-05-20T16:37:23.343Z",
       "createdUtc": 1779295043,
-      "ageHours": 100.57,
+      "ageHours": 101.55,
       "trendingScore": 1094.5,
       "content_tags": [],
       "value_score": 0,
@@ -672,7 +672,7 @@
       "replyCount": 23,
       "createdAt": "2026-05-22T15:14:50.942Z",
       "createdUtc": 1779462890,
-      "ageHours": 53.95,
+      "ageHours": 54.93,
       "trendingScore": 993.5,
       "content_tags": [],
       "value_score": 0,
@@ -936,7 +936,7 @@
       "replyCount": 18,
       "createdAt": "2026-05-22T04:16:35.871Z",
       "createdUtc": 1779423395,
-      "ageHours": 64.92,
+      "ageHours": 65.9,
       "trendingScore": 702,
       "content_tags": [],
       "value_score": 0,
@@ -984,7 +984,7 @@
       "replyCount": 2,
       "createdAt": "2026-04-21T03:38:29.785Z",
       "createdUtc": 1776742709,
-      "ageHours": 809.56,
+      "ageHours": 810.53,
       "trendingScore": 689,
       "content_tags": [],
       "value_score": 0,
@@ -1080,7 +1080,7 @@
       "replyCount": 2,
       "createdAt": "2026-05-22T16:18:34.387Z",
       "createdUtc": 1779466714,
-      "ageHours": 52.89,
+      "ageHours": 53.86,
       "trendingScore": 647,
       "content_tags": [],
       "value_score": 0,
@@ -1200,7 +1200,7 @@
       "replyCount": 1,
       "createdAt": "2026-05-21T01:34:58.982Z",
       "createdUtc": 1779327298,
-      "ageHours": 91.61,
+      "ageHours": 92.59,
       "trendingScore": 588.5,
       "content_tags": [],
       "value_score": 0,


### PR DESCRIPTION
Automated data refresh from `Refresh Bluesky signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26374094711

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.