### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-25T00:12:01Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-24T20:15:34.087Z",
+  "ts": "2026-05-25T00:12:01.313Z",
   "count": 1,
-  "durationMs": 10895,
+  "durationMs": 11589,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-24T20:15:31.925Z",
+  "lastFetchedAt": "2026-05-25T00:11:59.016Z",
   "windowDays": 7,
   "launches": [
     {
@@ -465,6 +465,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1151377",
+      "name": "Stitch 3.0 by Google",
+      "tagline": "Generate and iterate UI screens with AI on a live canvas",
+      "description": "Stitch generates UI screens for mobile and web from text prompts, with streaming edits, in-place AI changes, and one-click export to Figma, Netlify, Lovable, and Bolt. For product designers and developers prototyping fast.",
+      "url": "https://www.producthunt.com/products/stitch-by-google?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/2WIQLRJ4DNSJF5",
+      "votesCount": 371,
+      "commentsCount": 11,
+      "createdAt": "2026-05-24T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/2704ac79-abf6-42dc-a56f-b8ae1cb13896.jpeg?auto=format",
+      "topics": [
+        "design-tools",
+        "user-experience",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1124409",
       "name": "SocLeads 3.0",
       "tagline": "Scrape emails from socials and maps by location",
@@ -619,48 +661,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1151377",
-      "name": "Stitch 3.0 by Google",
-      "tagline": "Generate and iterate UI screens with AI on a live canvas",
-      "description": "Stitch generates UI screens for mobile and web from text prompts, with streaming edits, in-place AI changes, and one-click export to Figma, Netlify, Lovable, and Bolt. For product designers and developers prototyping fast.",
-      "url": "https://www.producthunt.com/products/stitch-by-google?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/2WIQLRJ4DNSJF5",
-      "votesCount": 343,
-      "commentsCount": 10,
-      "createdAt": "2026-05-24T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2704ac79-abf6-42dc-a56f-b8ae1cb13896.jpeg?auto=format",
-      "topics": [
-        "design-tools",
-        "user-experience",
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2036,56 +2036,14 @@
       "aiAdjacent": true
     },
     {
-      "id": "1142238",
-      "name": "InvestorFinder",
-      "tagline": "Find investors who've backed founders just like you",
-      "description": "Finally, real data on how every VC partner actually invests - founder backgrounds, universities and prior companies. Paste your profile and find your best matches in seconds.",
-      "url": "https://www.producthunt.com/products/investorfinder?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RYYTMN5NZ76UMA",
-      "votesCount": 218,
-      "commentsCount": 16,
-      "createdAt": "2026-05-10T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/43973f52-c69a-4d2c-b5fa-23e738090a32.jpeg?auto=format",
-      "topics": [
-        "investing",
-        "venture-capital",
-        "tech"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
       "id": "1153508",
       "name": "ModelHub",
       "tagline": "The missing menu bar app for local LLMs on Mac.",
       "description": "ModelHub is a native macOS menu bar app for developers working with local LLMs. It helps you discover models from Hugging Face, download the right local build, manage your model library, and use Hugging Face models with Ollama, MLX, LM Studio, llama.cpp, and the tools you already have without bouncing between browser tabs, terminal commands, model cards, and local folders. Ollama, MLX, and LM Studio are great tools. ModelHub is the missing discovery and management layer around them.",
       "url": "https://www.producthunt.com/products/modelhub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
       "website": "https://www.producthunt.com/r/VKVZCCO3WNW46P",
-      "votesCount": 214,
-      "commentsCount": 26,
+      "votesCount": 230,
+      "commentsCount": 27,
       "createdAt": "2026-05-24T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/289a32f1-5f2b-49ef-9eb7-2aae920bb5e5.png?auto=format",
       "topics": [
@@ -2131,6 +2089,48 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
+    },
+    {
+      "id": "1142238",
+      "name": "InvestorFinder",
+      "tagline": "Find investors who've backed founders just like you",
+      "description": "Finally, real data on how every VC partner actually invests - founder backgrounds, universities and prior companies. Paste your profile and find your best matches in seconds.",
+      "url": "https://www.producthunt.com/products/investorfinder?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RYYTMN5NZ76UMA",
+      "votesCount": 218,
+      "commentsCount": 16,
+      "createdAt": "2026-05-10T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/43973f52-c69a-4d2c-b5fa-23e738090a32.jpeg?auto=format",
+      "topics": [
+        "investing",
+        "venture-capital",
+        "tech"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
     },
     {
       "id": "1137047",
@@ -2317,6 +2317,37 @@
       "aiAdjacent": true
     },
     {
+      "id": "1150296",
+      "name": "Freu AI",
+      "tagline": "Automate any Mac app with $0 recurring run cost",
+      "description": "Freu AI is an AI agent for Mac that automates any desktop app with natural language. It “sees” your UI to compile a cross‑app workflow once, then runs it locally via a deterministic DSL—no brittle coordinates/selectors and no recurring token bills. Bonus: we’re open‑sourcing freu-cli (our browser automation engine) today.",
+      "url": "https://www.producthunt.com/products/freu-cli?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/OOZSQ3C37HINID",
+      "votesCount": 205,
+      "commentsCount": 13,
+      "createdAt": "2026-05-24T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/fc1882f5-e334-45b1-9a9c-a274b0592ed3.png?auto=format",
+      "topics": [
+        "artificial-intelligence",
+        "github",
+        "business-intelligence",
+        "marketing-automation"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1149049",
       "name": "ReactVision Studio",
       "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
@@ -2340,29 +2371,6 @@
           "websiteUrl": null
         }
       ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1139772",
-      "name": "Claude Agents for Financial Services",
-      "tagline": "Finance agent templates for pitches, KYC, and closing books",
-      "description": "Ten pre-built Claude agent templates for investment research, KYC screening, and month-end close. Each ships with connectors and subagents. For analysts and ops teams at banks, funds, and insurers.",
-      "url": "https://www.producthunt.com/products/claude-code?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/S6IM5WTBU4BUVH",
-      "votesCount": 203,
-      "commentsCount": 3,
-      "createdAt": "2026-05-07T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/f9c97c9f-1744-4a04-a01b-1f99cec85f8d.jpeg?auto=format",
-      "topics": [
-        "fintech",
-        "investing",
-        "artificial-intelligence"
-      ],
-      "makers": [],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26376647248

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.