### PR TITLE
chore(data): refresh lobsters signals 2026-05-25T01:36:36Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-24T23:37:20.088Z",
+  "ts": "2026-05-25T01:36:36.787Z",
   "count": 1,
-  "durationMs": 2812,
+  "durationMs": 3403,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T23:37:17.293Z",
+  "fetchedAt": "2026-05-25T01:36:33.403Z",
   "windowDays": 7,
   "scannedStories": 77,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T23:37:17.293Z",
+  "fetchedAt": "2026-05-25T01:36:33.403Z",
   "windowHours": 72,
   "scannedTotal": 77,
   "stories": [
@@ -535,6 +535,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "nkrgmr",
+      "title": "JS Crossword - a crossword where the clue = eval(answer)",
+      "url": "https://lyra.horse/fun/jscrossword/",
+      "commentsUrl": "https://lobste.rs/s/nkrgmr/js_crossword_crossword_where_clue_eval",
+      "by": "",
+      "score": 10,
+      "commentCount": 1,
+      "createdUtc": 1779665892,
+      "ageHours": 1.9725,
+      "trendingScore": 1.2630022992716048,
+      "tags": [
+        "javascript",
+        "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ynxkj6",
       "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
       "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
@@ -880,23 +898,6 @@
         "programming"
       ],
       "description": "<p>Curious what others think about this recently popular lifestyle shift. I love my coding, selfhosting, and useful tools but I’ve found myself moving towards “low” tech solutions such as pen and paper or just micro, iPod, a physical calendar versus all these different SaaS and selfhosted services.</p>\n",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "kkzpdd",
-      "title": "Ploopy Bean - external trackpoint",
-      "url": "https://ploopy.co/bean/",
-      "commentsUrl": "https://lobste.rs/s/kkzpdd/ploopy_bean_external_trackpoint",
-      "by": "",
-      "score": 15,
-      "commentCount": 7,
-      "createdUtc": 1778174641,
-      "ageHours": 4.1497222222222225,
-      "trendingScore": 0.9835761964030627,
-      "tags": [
-        "hardware"
-      ],
-      "description": "<p>AFAIU this is a wired device even if promotional images seem to suggest different.</p>\n",
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26378705422

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.