### PR TITLE
chore(data): refresh ai rss signals 2026-05-25T05:01:35Z

### DIFF
--- a/data/_meta/claude-rss.json
+++ b/data/_meta/claude-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "claude-rss",
   "reason": "ok",
-  "ts": "2026-05-24T19:47:23.901Z",
+  "ts": "2026-05-25T05:01:33.309Z",
   "count": 1,
-  "durationMs": 894,
+  "durationMs": 1600,
   "extra": {}
 }

--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-24T19:47:26.357Z",
+  "ts": "2026-05-25T05:01:35.048Z",
   "count": 1,
-  "durationMs": 2312,
+  "durationMs": 1586,
   "extra": {}
 }

--- a/data/claude-rss.json
+++ b/data/claude-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T19:47:23.014Z",
+  "fetchedAt": "2026-05-25T05:01:31.713Z",
   "source": "claude",
   "feedUrl": "https://www.anthropic.com/news",
   "error": null,

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T19:47:24.050Z",
+  "fetchedAt": "2026-05-25T05:01:33.466Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh AI RSS signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26384080710

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.