### PR TITLE
chore(data): refresh huggingface space signals 2026-05-25T05:10:11Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-24T19:49:54.747Z",
+  "ts": "2026-05-25T05:10:11.846Z",
   "count": 1,
-  "durationMs": 4030,
+  "durationMs": 4236,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T19:49:50.718Z",
+  "fetchedAt": "2026-05-25T05:10:07.611Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -329,8 +329,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 79,
-      "trendingScore": 50,
+      "likes": 85,
+      "trendingScore": 51,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -456,6 +456,22 @@
     },
     {
       "rank": 28,
+      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
+      "author": "Saravutw",
+      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
+      "likes": 58,
+      "trendingScore": 34,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-09T19:01:39.000Z",
+      "lastModified": "2026-03-13T17:12:16.000Z",
+      "models": []
+    },
+    {
+      "rank": 29,
       "id": "suraj291/Survival_Island_Game",
       "author": "suraj291",
       "url": "https://huggingface.co/spaces/suraj291/Survival_Island_Game",
@@ -472,7 +488,7 @@
       "models": []
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "r3gm/wan2-2-fp8da-aoti-previewG",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewG",
@@ -489,7 +505,7 @@
       "models": []
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -505,7 +521,39 @@
       "models": []
     },
     {
-      "rank": 31,
+      "rank": 32,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 33,
+      "trendingScore": 33,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-22T21:24:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 33,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 33,
+      "trendingScore": 33,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-23T11:14:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 34,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -522,7 +570,7 @@
       "models": []
     },
     {
-      "rank": 32,
+      "rank": 35,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -539,7 +587,7 @@
       "models": []
     },
     {
-      "rank": 33,
+      "rank": 36,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -555,7 +603,7 @@
       "models": []
     },
     {
-      "rank": 34,
+      "rank": 37,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -571,7 +619,7 @@
       "models": []
     },
     {
-      "rank": 35,
+      "rank": 38,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -587,7 +635,7 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 39,
       "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
@@ -604,23 +652,7 @@
       "models": []
     },
     {
-      "rank": 37,
-      "id": "stabilityai/stable-audio-3",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 30,
-      "trendingScore": 30,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T15:54:00.000Z",
-      "lastModified": "2026-05-22T21:24:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 38,
+      "rank": 40,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -636,23 +668,7 @@
       "models": []
     },
     {
-      "rank": 39,
-      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
-      "author": "Saravutw",
-      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 53,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-09T19:01:39.000Z",
-      "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 40,
+      "rank": 41,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -669,12 +685,12 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 27,
-      "trendingScore": 27,
+      "likes": 28,
+      "trendingScore": 28,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -685,7 +701,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -701,7 +717,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -721,7 +737,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -738,7 +754,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -755,7 +771,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -771,7 +787,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
@@ -791,7 +807,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -807,11 +823,11 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "ibuildproducts/wan22-i2v-v4-demo",
       "author": "ibuildproducts",
       "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
-      "likes": 27,
+      "likes": 29,
       "trendingScore": 22,
       "sdk": "gradio",
       "tags": [
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2026-05-17T23:34:01.000Z",
       "lastModified": "2026-05-18T00:16:12.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "build-small-hackathon/registration",
-      "author": "build-small-hackathon",
-      "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
-      "likes": 22,
-      "trendingScore": 22,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T17:25:59.000Z",
-      "lastModified": "2026-05-07T18:52:54.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26384324517

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.