### PR TITLE
chore(data): refresh mcp liveness 2026-05-25T05:13:18Z

### DIFF
--- a/data/mcp-liveness.json
+++ b/data/mcp-liveness.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-24T19:56:13.450Z",
+  "fetchedAt": "2026-05-25T05:13:16.538Z",
   "summary": {},
   "counts": {
     "total": 0,


### PR DESCRIPTION
Automated data refresh from `Ping MCP liveness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26384418817

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.