### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-25T06:52:09Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T01:31:32.584Z",
+  "generatedAt": "2026-05-25T06:52:09.526Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
@@ -52,22 +52,6 @@
       "matchConfidence": "host",
       "sourceUrl": "https://trustmrr.com/startup/capgo"
     },
-    "jasperdevs/odd-snap": {
-      "tier": "verified_trustmrr",
-      "fullName": "jasperdevs/odd-snap",
-      "trustmrrSlug": "cutiq",
-      "mrrCents": 417,
-      "last30DaysCents": 4999,
-      "totalCents": 4999,
-      "growthMrr30d": 0,
-      "customers": 1,
-      "activeSubscriptions": 1,
-      "paymentProvider": "superwall",
-      "category": "Artificial Intelligence",
-      "asOf": "2026-04-24T01:59:01.837Z",
-      "matchConfidence": "host",
-      "sourceUrl": "https://trustmrr.com/startup/cutiq"
-    },
     "AChep/keyguard-app": {
       "tier": "verified_trustmrr",
       "fullName": "AChep/keyguard-app",
@@ -99,6 +83,22 @@
       "asOf": "2026-04-24T01:59:01.837Z",
       "matchConfidence": "exact",
       "sourceUrl": "https://trustmrr.com/startup/postiz"
+    },
+    "jasperdevs/odd-snap": {
+      "tier": "verified_trustmrr",
+      "fullName": "jasperdevs/odd-snap",
+      "trustmrrSlug": "cutiq",
+      "mrrCents": 417,
+      "last30DaysCents": 4999,
+      "totalCents": 4999,
+      "growthMrr30d": 0,
+      "customers": 1,
+      "activeSubscriptions": 1,
+      "paymentProvider": "superwall",
+      "category": "Artificial Intelligence",
+      "asOf": "2026-04-24T01:59:01.837Z",
+      "matchConfidence": "host",
+      "sourceUrl": "https://trustmrr.com/startup/cutiq"
     }
   }
 }


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26387528543

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.