### PR TITLE
chore(data): promote unknown mentions 2026-05-25T08:47:16Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-24T07:38:26.950Z",
-  "totalUnknownMentions": 257329,
-  "distinctRepos": 23153,
+  "generatedAt": "2026-05-25T08:47:15.965Z",
+  "totalUnknownMentions": 271998,
+  "distinctRepos": 23970,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 194,
+      "totalCount": 204,
       "sourceCount": 5,
       "sources": [
         "bluesky",
@@ -17,11 +17,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 99,
+      "totalCount": 104,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -31,11 +31,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "trycua/cua",
-      "totalCount": 40,
+      "totalCount": 41,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -45,11 +45,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 224,
+      "totalCount": 232,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -58,7 +58,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
       "fullName": "vercel/next.js",
@@ -87,6 +87,19 @@
       "lastSeenAt": "2026-05-15T06:46:20.813Z"
     },
     {
+      "fullName": "facebook/react",
+      "totalCount": 101,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "npm"
+      ],
+      "firstSeenAt": "2026-05-01T10:45:39.581Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
       "fullName": "vitejs/vite",
       "totalCount": 98,
       "sourceCount": 4,
@@ -98,19 +111,6 @@
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
       "lastSeenAt": "2026-05-22T19:51:38.224Z"
-    },
-    {
-      "fullName": "facebook/react",
-      "totalCount": 97,
-      "sourceCount": 4,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "antirez/ds4",
@@ -153,7 +153,7 @@
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 189,
+      "totalCount": 204,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -161,7 +161,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "onyks-os/transparenttorproxy",
@@ -188,6 +188,30 @@
       "lastSeenAt": "2026-05-20T05:57:56.260Z"
     },
     {
+      "fullName": "naver/lispe",
+      "totalCount": 127,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "andyyyy64/whichllm",
+      "totalCount": 125,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T10:12:27.167Z",
+      "lastSeenAt": "2026-05-25T04:51:10.028Z"
+    },
+    {
       "fullName": "ninjahawk/hollow-agentos",
       "totalCount": 117,
       "sourceCount": 3,
@@ -198,30 +222,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-20T09:58:14.460Z"
-    },
-    {
-      "fullName": "naver/lispe",
-      "totalCount": 116,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
-    },
-    {
-      "fullName": "andyyyy64/whichllm",
-      "totalCount": 112,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-24T04:39:37.308Z"
     },
     {
       "fullName": "minishlab/semble",
@@ -236,6 +236,18 @@
       "lastSeenAt": "2026-05-18T04:41:26.919Z"
     },
     {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 110,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+    },
+    {
       "fullName": "manojmallick/sigmap",
       "totalCount": 106,
       "sourceCount": 3,
@@ -246,18 +258,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:47:49.694Z",
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
-    },
-    {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 105,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "scosman/cursed_browser",
@@ -296,6 +296,18 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
+      "fullName": "snyk/agent-scan",
+      "totalCount": 98,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T18:13:43.732Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
       "fullName": "leaningtech/browsercode",
       "totalCount": 98,
       "sourceCount": 3,
@@ -332,16 +344,16 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "snyk/agent-scan",
-      "totalCount": 94,
+      "fullName": "fsnotify/fsnotify",
+      "totalCount": 96,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T18:13:43.732Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+      "firstSeenAt": "2026-05-07T07:20:32.729Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
       "fullName": "nvlabs/cuda-oxide",
@@ -356,18 +368,6 @@
       "lastSeenAt": "2026-05-11T00:07:14.314Z"
     },
     {
-      "fullName": "fsnotify/fsnotify",
-      "totalCount": 92,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
-    },
-    {
       "fullName": "bring-shrubbery/ml-sharp-web",
       "totalCount": 92,
       "sourceCount": 3,
@@ -378,6 +378,18 @@
       ],
       "firstSeenAt": "2026-05-03T10:35:18.415Z",
       "lastSeenAt": "2026-05-21T05:20:28.559Z"
+    },
+    {
+      "fullName": "sifter-ai/sifter",
+      "totalCount": 91,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "luce-org/lucebox-hub",
@@ -392,16 +404,16 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
-      "fullName": "sifter-ai/sifter",
-      "totalCount": 90,
+      "fullName": "jnuyens/modulejail",
+      "totalCount": 89,
       "sourceCount": 3,
       "sources": [
-        "awesome-skills",
-        "devto",
-        "reddit"
+        "bluesky",
+        "hackernews",
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "shadcn-ui/ui",
@@ -428,6 +440,18 @@
       "lastSeenAt": "2026-05-22T18:04:56.157Z"
     },
     {
+      "fullName": "h4ckf0r0day/obscura",
+      "totalCount": 86,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
       "fullName": "tanstack/router",
       "totalCount": 85,
       "sourceCount": 3,
@@ -452,18 +476,6 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
-      "fullName": "h4ckf0r0day/obscura",
-      "totalCount": 82,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
-    },
-    {
       "fullName": "waybarrios/opencode-power-pack",
       "totalCount": 81,
       "sourceCount": 3,
@@ -476,8 +488,20 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
+      "fullName": "ollama/ollama",
+      "totalCount": 80,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
       "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 78,
+      "totalCount": 79,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -485,35 +509,11 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
-    },
-    {
-      "fullName": "jnuyens/modulejail",
-      "totalCount": 78,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
-    },
-    {
-      "fullName": "ollama/ollama",
-      "totalCount": 76,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "n8n-io/n8n",
-      "totalCount": 75,
+      "totalCount": 79,
       "sourceCount": 3,
       "sources": [
         "devto",
@@ -521,11 +521,23 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
+      "fullName": "rust-lang/rust",
+      "totalCount": 72,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "vllm-project/vllm",
-      "totalCount": 67,
+      "totalCount": 72,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -533,7 +545,19 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-24T04:39:37.308Z"
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
+      "fullName": "rahilp/second-brain-cloudflare",
+      "totalCount": 69,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T08:16:23.224Z",
+      "lastSeenAt": "2026-05-25T04:51:10.028Z"
     },
     {
       "fullName": "statewright/statewright",
@@ -572,6 +596,18 @@
       "lastSeenAt": "2026-05-20T22:44:07.574Z"
     },
     {
+      "fullName": "genymobile/scrcpy",
+      "totalCount": 66,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-02T08:45:16.184Z",
+      "lastSeenAt": "2026-05-24T08:01:37.173Z"
+    },
+    {
       "fullName": "sambigeara/pollen",
       "totalCount": 66,
       "sourceCount": 3,
@@ -584,30 +620,6 @@
       "lastSeenAt": "2026-05-10T12:05:20.661Z"
     },
     {
-      "fullName": "genymobile/scrcpy",
-      "totalCount": 65,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T08:45:16.184Z",
-      "lastSeenAt": "2026-05-24T04:39:37.308Z"
-    },
-    {
-      "fullName": "rust-lang/rust",
-      "totalCount": 64,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-23T01:34:24.128Z"
-    },
-    {
       "fullName": "vercel/ai",
       "totalCount": 64,
       "sourceCount": 3,
@@ -618,6 +630,30 @@
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
+    },
+    {
+      "fullName": "yt-dlp/yt-dlp",
+      "totalCount": 63,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-08T11:47:27.264Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "junegunn/fzf",
+      "totalCount": 63,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
       "fullName": "redis/redis",
@@ -704,16 +740,16 @@
       "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
-      "fullName": "junegunn/fzf",
-      "totalCount": 59,
+      "fullName": "anishathalye/ai-agent-security-lecture",
+      "totalCount": 61,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "devto",
-        "twitter"
+        "hackernews",
+        "lobsters"
       ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+      "firstSeenAt": "2026-05-18T16:34:28.470Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "manankharwar/fusioncore",
@@ -765,7 +801,7 @@
     },
     {
       "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 52,
+      "totalCount": 53,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -773,7 +809,43 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+    },
+    {
+      "fullName": "sander110419/lightroom-cc-on-linux",
+      "totalCount": 53,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "antoinezambelli/forge",
+      "totalCount": 52,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-19T20:52:58.618Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "xataio/deltax",
+      "totalCount": 51,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-19T19:17:55.212Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "cline/cline",
@@ -788,19 +860,7 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
-      "fullName": "anishathalye/ai-agent-security-lecture",
-      "totalCount": 50,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T16:34:28.470Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
-    },
-    {
-      "fullName": "yt-dlp/yt-dlp",
+      "fullName": "nrwl/nx-console",
       "totalCount": 50,
       "sourceCount": 3,
       "sources": [
@@ -808,8 +868,8 @@
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-08T11:47:27.264Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-18T20:04:30.386Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -822,6 +882,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-07T14:30:15.363Z"
+    },
+    {
+      "fullName": "0xmassi/webclaw",
+      "totalCount": 48,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
@@ -860,16 +932,16 @@
       "lastSeenAt": "2026-05-07T10:14:50.031Z"
     },
     {
-      "fullName": "0xmassi/webclaw",
+      "fullName": "zed-industries/zed",
       "totalCount": 47,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
-        "devto",
-        "reddit"
+        "bluesky",
+        "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "kuberwastaken/claurst",
@@ -906,18 +978,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
-    },
-    {
-      "fullName": "zed-industries/zed",
-      "totalCount": 46,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
     },
     {
       "fullName": "iliaal/fastchart",
@@ -968,16 +1028,16 @@
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
     },
     {
-      "fullName": "sander110419/lightroom-cc-on-linux",
-      "totalCount": 42,
+      "fullName": "nodejs/node",
+      "totalCount": 43,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-18T12:48:24.691Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-03T03:48:07.888Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "stardockcorp/wireloom",
@@ -992,20 +1052,8 @@
       "lastSeenAt": "2026-05-20T12:39:36.429Z"
     },
     {
-      "fullName": "xataio/deltax",
-      "totalCount": 40,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-19T19:17:55.212Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
-    },
-    {
       "fullName": "awslabs/mcp",
-      "totalCount": 39,
+      "totalCount": 40,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -1013,19 +1061,7 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
-    },
-    {
-      "fullName": "nrwl/nx-console",
-      "totalCount": 39,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-18T20:04:30.386Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "tabularisdb/tabularis",
@@ -1052,20 +1088,20 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "nodejs/node",
-      "totalCount": 32,
+      "fullName": "brethofai/brethof-mind",
+      "totalCount": 34,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T03:48:07.888Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-22T17:36:35.165Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "pydantic/pydantic-ai",
-      "totalCount": 29,
+      "totalCount": 30,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -1073,11 +1109,11 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "anthropics/claude-cookbooks",
-      "totalCount": 26,
+      "totalCount": 27,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -1085,7 +1121,19 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+    },
+    {
+      "fullName": "multica-ai/andrej-karpathy-skills",
+      "totalCount": 27,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-17T19:15:02.265Z",
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -1100,20 +1148,8 @@
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
-      "fullName": "multica-ai/andrej-karpathy-skills",
-      "totalCount": 22,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-17T19:15:02.265Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
-    },
-    {
-      "fullName": "duriantaco/skylos",
-      "totalCount": 20,
+      "fullName": "achiya-automation/safari-mcp",
+      "totalCount": 25,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
@@ -1121,19 +1157,31 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
-      "fullName": "brethofai/brethof-mind",
-      "totalCount": 19,
+      "fullName": "perplexityai/bumblebee",
+      "totalCount": 23,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-22T17:36:35.165Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-22T18:04:56.157Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "duriantaco/skylos",
+      "totalCount": 21,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -1197,25 +1245,36 @@
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 192,
+      "totalCount": 206,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
     },
     {
       "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 143,
+      "totalCount": 147,
       "sourceCount": 2,
       "sources": [
         "devto",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+    },
+    {
+      "fullName": "raiyanyahya/how-to-train-your-gpt",
+      "totalCount": 146,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -1229,26 +1288,26 @@
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
-      "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 135,
+      "fullName": "nixos/nixpkgs",
+      "totalCount": 131,
       "sourceCount": 2,
       "sources": [
         "bluesky",
-        "hackernews"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-25T00:14:30.458Z"
     },
     {
       "fullName": "nexu-io/open-design",
-      "totalCount": 129,
+      "totalCount": 130,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-02T13:50:45.195Z",
-      "lastSeenAt": "2026-05-11T19:17:39.871Z"
+      "lastSeenAt": "2026-05-24T15:22:19.669Z"
     },
     {
       "fullName": "warwickwood-cell/gengeo-agent-registry",
@@ -1271,17 +1330,6 @@
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
       "lastSeenAt": "2026-05-09T16:11:39.536Z"
-    },
-    {
-      "fullName": "nixos/nixpkgs",
-      "totalCount": 119,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-24T04:39:37.308Z"
     },
     {
       "fullName": "drcathicks/learning-opportunities",
@@ -1328,6 +1376,28 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
+      "fullName": "yamafaktory/hypergraphz",
+      "totalCount": 114,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:12:41.505Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "clickhouse/silk",
+      "totalCount": 111,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
       "fullName": "jossephus/chuchu",
       "totalCount": 109,
       "sourceCount": 2,
@@ -1372,15 +1442,26 @@
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
-      "fullName": "yamafaktory/hypergraphz",
+      "fullName": "chojs23/concord",
+      "totalCount": 104,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "kiamehr5/kmri",
       "totalCount": 103,
       "sourceCount": 2,
       "sources": [
-        "devto",
-        "hackernews"
+        "hackernews",
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-03T21:12:41.505Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-03T10:34:44.583Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "facebookresearch/tuna-2",
@@ -1416,6 +1497,17 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
+      "fullName": "npm/cli",
+      "totalCount": 99,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-25T04:51:10.028Z"
+    },
+    {
       "fullName": "mekickdemons-creator/mnemara",
       "totalCount": 98,
       "sourceCount": 2,
@@ -1449,26 +1541,26 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "chojs23/concord",
+      "fullName": "eleutherai/lm-evaluation-harness",
       "totalCount": 93,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
-      "fullName": "kiamehr5/kmri",
-      "totalCount": 92,
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 93,
       "sourceCount": 2,
       "sources": [
-        "hackernews",
-        "reddit"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T10:34:44.583Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
       "fullName": "facebook/pyrefly",
@@ -1502,28 +1594,6 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-23T23:11:29.877Z"
-    },
-    {
-      "fullName": "eleutherai/lm-evaluation-harness",
-      "totalCount": 89,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
-    },
-    {
-      "fullName": "enmanuelmag/heimdall-mcp",
-      "totalCount": 89,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-24T03:46:15.164Z"
     },
     {
       "fullName": "gfernandf/agent-skills",
@@ -1570,6 +1640,17 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
+      "fullName": "tanrikuluozlem/burn",
+      "totalCount": 88,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T08:44:17.194Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
       "fullName": "scottgl9/skelm",
       "totalCount": 87,
       "sourceCount": 2,
@@ -1592,15 +1673,15 @@
       "lastSeenAt": "2026-05-08T19:48:01.671Z"
     },
     {
-      "fullName": "npm/cli",
+      "fullName": "zakirullin/files.md",
       "totalCount": 86,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-24T04:39:37.308Z"
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "arriemeijer-creator/aerojax",
@@ -1700,6 +1781,17 @@
       ],
       "firstSeenAt": "2026-05-08T15:06:30.276Z",
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
+    },
+    {
+      "fullName": "mistralai/client-python",
+      "totalCount": 81,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T04:18:11.270Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
@@ -1845,17 +1937,6 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "tanrikuluozlem/burn",
-      "totalCount": 77,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T08:44:17.194Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
-    },
-    {
       "fullName": "wiaahmarketplace/typerion-oss",
       "totalCount": 77,
       "sourceCount": 2,
@@ -1876,6 +1957,17 @@
       ],
       "firstSeenAt": "2026-05-03T10:34:44.583Z",
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
+    },
+    {
+      "fullName": "aendrix03/graft",
+      "totalCount": 76,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T00:21:52.545Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "yaelwrites/big-ass-data-broker-opt-out-list",
@@ -1911,15 +2003,26 @@
       "lastSeenAt": "2026-05-10T16:09:01.639Z"
     },
     {
-      "fullName": "zakirullin/files.md",
+      "fullName": "mikemiol17/bugtalk",
+      "totalCount": 75,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-18T12:12:25.407Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+    },
+    {
+      "fullName": "openosint/openosint",
       "totalCount": 75,
       "sourceCount": 2,
       "sources": [
         "bluesky",
-        "hackernews"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
+      "firstSeenAt": "2026-05-08T16:47:08.670Z",
+      "lastSeenAt": "2026-05-25T04:51:10.028Z"
     },
     {
       "fullName": "davesimoes/crustai",
@@ -1964,6 +2067,28 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "modelcontextprotocol/servers",
+      "totalCount": 74,
+      "sourceCount": 2,
+      "sources": [
+        "awesome-skills",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+    },
+    {
+      "fullName": "zoharbabin/due-diligence-agents",
+      "totalCount": 74,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-17T17:37:10.554Z",
+      "lastSeenAt": "2026-05-24T13:41:56.965Z"
     },
     {
       "fullName": "phel-lang/phel-lang",
@@ -2063,6 +2188,17 @@
       ],
       "firstSeenAt": "2026-05-02T21:01:52.519Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "raindrop-ai/workshop",
+      "totalCount": 72,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "producthunt"
+      ],
+      "firstSeenAt": "2026-05-15T06:21:09.173Z",
+      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "pion/rtwatch",
@@ -2184,138 +2320,6 @@
       ],
       "firstSeenAt": "2026-05-03T06:15:18.005Z",
       "lastSeenAt": "2026-05-10T04:11:37.463Z"
-    },
-    {
-      "fullName": "microsoft/lib0xc",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T19:52:26.619Z",
-      "lastSeenAt": "2026-05-08T17:55:29.602Z"
-    },
-    {
-      "fullName": "c2sp/wycheproof",
-      "totalCount": 71,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-02T10:30:24.305Z",
-      "lastSeenAt": "2026-05-21T00:00:52.233Z"
-    },
-    {
-      "fullName": "cloudflare/workers-sdk",
-      "totalCount": 71,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "npm"
-      ],
-      "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-15T06:45:21.575Z"
-    },
-    {
-      "fullName": "alikamp/parks-kpbm-scaling",
-      "totalCount": 71,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-12T19:09:34.978Z"
-    },
-    {
-      "fullName": "mistralai/client-python",
-      "totalCount": 70,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T04:18:11.270Z",
-      "lastSeenAt": "2026-05-24T04:31:39.804Z"
-    },
-    {
-      "fullName": "mukundakatta/hermes-agentmemory",
-      "totalCount": 70,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-15T19:47:32.538Z",
-      "lastSeenAt": "2026-05-23T16:24:08.531Z"
-    },
-    {
-      "fullName": "webstonehq/tuxedo",
-      "totalCount": 70,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T22:43:47.823Z",
-      "lastSeenAt": "2026-05-15T21:22:38.595Z"
-    },
-    {
-      "fullName": "robertdfrench/ifuncd-up",
-      "totalCount": 70,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T01:31:05.817Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "davireisvieira/stackport",
-      "totalCount": 70,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-12T14:51:56.628Z"
-    },
-    {
-      "fullName": "modelcontextprotocol/servers",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "awesome-skills",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-24T07:33:32.199Z"
-    },
-    {
-      "fullName": "openclaw/peekaboo",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-12T20:52:08.570Z",
-      "lastSeenAt": "2026-05-22T00:16:33.857Z"
-    },
-    {
-      "fullName": "sudarshan8417/tfdrift",
-      "totalCount": 69,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-16T08:13:18.750Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26391886043

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.