### PR TITLE
chore(data): refresh huggingface signals 2026-05-25T10:51:01Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-25T04:53:59.323Z",
+  "ts": "2026-05-25T10:51:01.100Z",
   "count": 1,
-  "durationMs": 6090,
+  "durationMs": 10886,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T04:53:53.235Z",
+  "fetchedAt": "2026-05-25T10:50:50.216Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -8,9 +8,9 @@
       "id": "bytedance-research/Lance",
       "author": "bytedance-research",
       "url": "https://huggingface.co/bytedance-research/Lance",
-      "downloads": 1474,
-      "likes": 771,
-      "trendingScore": 718,
+      "downloads": 1679,
+      "likes": 782,
+      "trendingScore": 721,
       "pipelineTag": "any-to-any",
       "libraryName": "Lance",
       "tags": [
@@ -33,43 +33,12 @@
     },
     {
       "rank": 2,
-      "id": "openbmb/MiniCPM-V-4.6",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6",
-      "downloads": 80586,
-      "likes": 761,
-      "trendingScore": 662,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "minicpmv4_6",
-        "image-text-to-text",
-        "minicpm-v",
-        "multimodal",
-        "On-Device Model",
-        "lightweight",
-        "conversational",
-        "arxiv:2604.27393",
-        "arxiv:2509.18154",
-        "arxiv:2408.01800",
-        "arxiv:2605.08985",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-13T09:12:47.000Z",
-      "lastModified": "2026-05-18T12:58:20.000Z"
-    },
-    {
-      "rank": 3,
       "id": "tencent/Hy-MT2-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
-      "downloads": 4534,
-      "likes": 641,
-      "trendingScore": 611,
+      "downloads": 5552,
+      "likes": 702,
+      "trendingScore": 665,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -106,6 +75,37 @@
       ],
       "createdAt": "2026-05-11T08:22:10.000Z",
       "lastModified": "2026-05-22T05:09:24.000Z"
+    },
+    {
+      "rank": 3,
+      "id": "openbmb/MiniCPM-V-4.6",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6",
+      "downloads": 80586,
+      "likes": 761,
+      "trendingScore": 662,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "minicpmv4_6",
+        "image-text-to-text",
+        "minicpm-v",
+        "multimodal",
+        "On-Device Model",
+        "lightweight",
+        "conversational",
+        "arxiv:2604.27393",
+        "arxiv:2509.18154",
+        "arxiv:2408.01800",
+        "arxiv:2605.08985",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-13T09:12:47.000Z",
+      "lastModified": "2026-05-18T12:58:20.000Z"
     },
     {
       "rank": 4,
@@ -275,9 +275,9 @@
       "id": "NemoStation/Marlin-2B",
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
-      "downloads": 6032,
-      "likes": 312,
-      "trendingScore": 304,
+      "downloads": 7291,
+      "likes": 322,
+      "trendingScore": 311,
       "pipelineTag": "video-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -310,9 +310,9 @@
       "id": "tencent/Hy-MT2-30B-A3B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
-      "downloads": 1243,
-      "likes": 314,
-      "trendingScore": 298,
+      "downloads": 1494,
+      "likes": 318,
+      "trendingScore": 302,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -352,6 +352,36 @@
     },
     {
       "rank": 12,
+      "id": "sapientinc/HRM-Text-1B",
+      "author": "sapientinc",
+      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
+      "downloads": 90026,
+      "likes": 275,
+      "trendingScore": 272,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hrm_text",
+        "text-generation",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "en",
+        "arxiv:2605.20613",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T15:13:02.000Z",
+      "lastModified": "2026-05-21T05:57:38.000Z"
+    },
+    {
+      "rank": 13,
       "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
@@ -377,36 +407,6 @@
       ],
       "createdAt": "2026-05-11T12:57:11.000Z",
       "lastModified": "2026-05-18T05:58:01.000Z"
-    },
-    {
-      "rank": 13,
-      "id": "sapientinc/HRM-Text-1B",
-      "author": "sapientinc",
-      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 84346,
-      "likes": 272,
-      "trendingScore": 269,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hrm_text",
-        "text-generation",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "en",
-        "arxiv:2605.20613",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-21T05:57:38.000Z"
     },
     {
       "rank": 14,
@@ -569,9 +569,9 @@
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
-      "downloads": 5627,
-      "likes": 190,
-      "trendingScore": 187,
+      "downloads": 7449,
+      "likes": 193,
+      "trendingScore": 190,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -629,6 +629,34 @@
     },
     {
       "rank": 22,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 171,
+      "trendingScore": 168,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-22T02:58:39.000Z"
+    },
+    {
+      "rank": 23,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
@@ -671,7 +699,7 @@
       "lastModified": "2026-05-19T23:41:58.000Z"
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "froggeric/Qwen-Fixed-Chat-Templates",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
@@ -699,42 +727,13 @@
       "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
-      "rank": 24,
-      "id": "XiaomiMiMo/MiMo-V2.5-Pro",
-      "author": "XiaomiMiMo",
-      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
-      "downloads": 20905,
-      "likes": 467,
-      "trendingScore": 142,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "mimo_v2",
-        "text-generation",
-        "agent",
-        "long-context",
-        "code",
-        "conversational",
-        "custom_code",
-        "en",
-        "zh",
-        "license:mit",
-        "eval-results",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T12:52:53.000Z",
-      "lastModified": "2026-04-28T07:01:37.000Z"
-    },
-    {
       "rank": 25,
       "id": "tencent/Hy-MT2-7B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 2407,
-      "likes": 149,
-      "trendingScore": 142,
+      "downloads": 3060,
+      "likes": 152,
+      "trendingScore": 145,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -774,6 +773,35 @@
     },
     {
       "rank": 26,
+      "id": "XiaomiMiMo/MiMo-V2.5-Pro",
+      "author": "XiaomiMiMo",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
+      "downloads": 20905,
+      "likes": 467,
+      "trendingScore": 142,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "mimo_v2",
+        "text-generation",
+        "agent",
+        "long-context",
+        "code",
+        "conversational",
+        "custom_code",
+        "en",
+        "zh",
+        "license:mit",
+        "eval-results",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T12:52:53.000Z",
+      "lastModified": "2026-04-28T07:01:37.000Z"
+    },
+    {
+      "rank": 27,
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/TencentARC/Pixal3D",
@@ -792,35 +820,39 @@
       "lastModified": "2026-05-12T23:37:47.000Z"
     },
     {
-      "rank": 27,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
-      "downloads": 0,
-      "likes": 138,
-      "trendingScore": 137,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
+      "rank": 28,
+      "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 1392596,
+      "likes": 810,
+      "trendingScore": 134,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
       "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
-        "transformers",
-        "avatar",
-        "video-generation",
+        "gguf",
+        "uncensored",
+        "qwen3.6",
+        "moe",
+        "vision",
+        "multimodal",
+        "image-text-to-text",
         "en",
         "zh",
-        "license:mit",
-        "region:us"
+        "multilingual",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-22T02:58:39.000Z"
+      "createdAt": "2026-04-17T00:15:26.000Z",
+      "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "Qwen/Qwen3.6-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
@@ -845,7 +877,7 @@
       "lastModified": "2026-04-24T02:39:16.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "mistralai/Mistral-Medium-3.5-128B",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B",
@@ -890,7 +922,7 @@
       "lastModified": "2026-05-04T14:16:22.000Z"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "Qwen/Qwen3.6-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
@@ -915,7 +947,7 @@
       "lastModified": "2026-04-24T02:53:42.000Z"
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "google/gemma-4-26B-A4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-assistant",
@@ -938,7 +970,7 @@
       "lastModified": "2026-05-11T07:50:08.000Z"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -980,58 +1012,13 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 33,
-      "id": "CohereLabs/command-a-plus-05-2026-bf16",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
-      "downloads": 12362,
-      "likes": 113,
-      "trendingScore": 112,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere2_vision",
-        "image-text-to-text",
-        "conversational",
-        "chat",
-        "en",
-        "ar",
-        "bg",
-        "bn",
-        "ca",
-        "cs",
-        "da",
-        "de",
-        "el",
-        "es",
-        "et",
-        "fa",
-        "fi",
-        "fil",
-        "fr",
-        "ga",
-        "he",
-        "hi",
-        "hr",
-        "hu",
-        "id",
-        "is",
-        "it",
-        "ja"
-      ],
-      "createdAt": "2026-05-11T12:31:04.000Z",
-      "lastModified": "2026-05-22T14:40:13.000Z"
-    },
-    {
       "rank": 34,
       "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "downloads": 8300,
-      "likes": 117,
-      "trendingScore": 110,
+      "downloads": 12677,
+      "likes": 121,
+      "trendingScore": 114,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1070,38 +1057,88 @@
     },
     {
       "rank": 35,
-      "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 1220114,
-      "likes": 783,
-      "trendingScore": 109,
+      "id": "CohereLabs/command-a-plus-05-2026-bf16",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
+      "downloads": 12824,
+      "likes": 114,
+      "trendingScore": 113,
       "pipelineTag": "image-text-to-text",
-      "libraryName": null,
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.6",
-        "moe",
-        "vision",
-        "multimodal",
+        "transformers",
+        "safetensors",
+        "cohere2_vision",
         "image-text-to-text",
+        "conversational",
+        "chat",
         "en",
-        "zh",
-        "multilingual",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
+        "ar",
+        "bg",
+        "bn",
+        "ca",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fil",
+        "fr",
+        "ga",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "is",
+        "it",
+        "ja"
       ],
-      "createdAt": "2026-04-17T00:15:26.000Z",
-      "lastModified": "2026-04-17T02:59:21.000Z"
+      "createdAt": "2026-05-11T12:31:04.000Z",
+      "lastModified": "2026-05-22T14:40:13.000Z"
     },
     {
       "rank": 36,
+      "id": "numind/NuExtract3",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3",
+      "downloads": 17501,
+      "likes": 115,
+      "trendingScore": 112,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "image-to-text",
+        "base_model:Qwen/Qwen3.5-4B",
+        "base_model:finetune:Qwen/Qwen3.5-4B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T07:46:41.000Z",
+      "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 37,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -1134,7 +1171,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -1158,43 +1195,6 @@
       ],
       "createdAt": "2026-04-22T06:04:20.000Z",
       "lastModified": "2026-05-06T04:18:09.000Z"
-    },
-    {
-      "rank": 38,
-      "id": "numind/NuExtract3",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 10998,
-      "likes": 108,
-      "trendingScore": 106,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "image-to-text",
-        "base_model:Qwen/Qwen3.5-4B",
-        "base_model:finetune:Qwen/Qwen3.5-4B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T07:46:41.000Z",
-      "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
       "rank": 39,
@@ -1278,8 +1278,8 @@
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
       "downloads": 0,
-      "likes": 99,
-      "trendingScore": 97,
+      "likes": 100,
+      "trendingScore": 98,
       "pipelineTag": "image-to-video",
       "libraryName": "diffusers",
       "tags": [
@@ -1475,6 +1475,32 @@
     },
     {
       "rank": 49,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 5195,
+      "likes": 93,
+      "trendingScore": 90,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-23T01:01:26.000Z"
+    },
+    {
+      "rank": 50,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1499,7 +1525,7 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 50,
+      "rank": 51,
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
@@ -1523,64 +1549,13 @@
       "lastModified": "2026-05-19T08:01:07.000Z"
     },
     {
-      "rank": 51,
-      "id": "inclusionAI/Ring-2.6-1T",
-      "author": "inclusionAI",
-      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
-      "downloads": 3752,
-      "likes": 89,
-      "trendingScore": 88,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "bailing_hybrid",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:mit",
-        "eval-results",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T08:10:02.000Z",
-      "lastModified": "2026-05-18T09:47:28.000Z"
-    },
-    {
       "rank": 52,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 4071,
-      "likes": 91,
-      "trendingScore": 88,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-23T01:01:26.000Z"
-    },
-    {
-      "rank": 53,
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
-      "downloads": 33197,
-      "likes": 89,
-      "trendingScore": 86,
+      "downloads": 37628,
+      "likes": 92,
+      "trendingScore": 89,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1616,6 +1591,31 @@
       ],
       "createdAt": "2026-05-18T05:48:32.000Z",
       "lastModified": "2026-05-19T23:43:59.000Z"
+    },
+    {
+      "rank": 53,
+      "id": "inclusionAI/Ring-2.6-1T",
+      "author": "inclusionAI",
+      "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
+      "downloads": 3752,
+      "likes": 89,
+      "trendingScore": 88,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "bailing_hybrid",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:mit",
+        "eval-results",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:10:02.000Z",
+      "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
       "rank": 54,
@@ -1729,89 +1729,12 @@
     },
     {
       "rank": 57,
-      "id": "RuneXX/LTX-2.3-Workflows",
-      "author": "RuneXX",
-      "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
-      "downloads": 0,
-      "likes": 565,
-      "trendingScore": 80,
-      "pipelineTag": "image-to-video",
-      "libraryName": null,
-      "tags": [
-        "ltx",
-        "ltx-2",
-        "comfyui",
-        "comfy",
-        "gguf",
-        "ltx-video",
-        "ltx-2-3",
-        "ltxv",
-        "text-to-video",
-        "image-to-video",
-        "audio-to-video",
-        "video-to-video",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T19:01:16.000Z",
-      "lastModified": "2026-05-13T05:49:49.000Z"
-    },
-    {
-      "rank": 58,
-      "id": "facebook/VGGT-Omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/VGGT-Omega",
-      "downloads": 0,
-      "likes": 85,
-      "trendingScore": 80,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "facebook",
-        "meta-pytorch",
-        "en",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-17T20:47:45.000Z",
-      "lastModified": "2026-05-14T21:23:21.000Z"
-    },
-    {
-      "rank": 59,
-      "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
-      "author": "AngelSlim",
-      "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
-      "downloads": 17223,
-      "likes": 159,
-      "trendingScore": 79,
-      "pipelineTag": "translation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "hunyuan_v1_dense",
-        "translation",
-        "hy-mt",
-        "quant",
-        "1.25bit",
-        "sherry",
-        "multilingual",
-        "arxiv:2601.07892",
-        "arxiv:2512.24092",
-        "arxiv:2602.21233",
-        "base_model:tencent/HY-MT1.5-1.8B",
-        "base_model:finetune:tencent/HY-MT1.5-1.8B",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T12:39:12.000Z",
-      "lastModified": "2026-05-09T07:37:22.000Z"
-    },
-    {
-      "rank": 60,
       "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "downloads": 14966,
-      "likes": 81,
-      "trendingScore": 79,
+      "downloads": 23762,
+      "likes": 84,
+      "trendingScore": 82,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1850,68 +1773,89 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 61,
-      "id": "poolside/Laguna-XS.2",
-      "author": "poolside",
-      "url": "https://huggingface.co/poolside/Laguna-XS.2",
-      "downloads": 16792,
-      "likes": 231,
-      "trendingScore": 78,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "rank": 58,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 87,
+      "trendingScore": 82,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
       "tags": [
-        "transformers",
+        "stable-audio-3",
         "safetensors",
-        "laguna",
-        "text-generation",
-        "laguna-xs.2",
-        "vllm",
-        "conversational",
-        "custom_code",
-        "license:apache-2.0",
-        "eval-results",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-04-23T20:50:45.000Z",
-      "lastModified": "2026-05-06T18:58:37.000Z"
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
     },
     {
-      "rank": 62,
-      "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 2733708,
-      "likes": 1000,
-      "trendingScore": 78,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "rank": 59,
+      "id": "RuneXX/LTX-2.3-Workflows",
+      "author": "RuneXX",
+      "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
+      "downloads": 0,
+      "likes": 565,
+      "trendingScore": 80,
+      "pipelineTag": "image-to-video",
+      "libraryName": null,
       "tags": [
-        "transformers",
+        "ltx",
+        "ltx-2",
+        "comfyui",
+        "comfy",
         "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us",
-        "imatrix",
-        "conversational"
+        "ltx-video",
+        "ltx-2-3",
+        "ltxv",
+        "text-to-video",
+        "image-to-video",
+        "audio-to-video",
+        "video-to-video",
+        "region:us"
       ],
-      "createdAt": "2026-04-16T04:31:31.000Z",
-      "lastModified": "2026-04-20T12:42:25.000Z"
+      "createdAt": "2026-03-05T19:01:16.000Z",
+      "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 63,
+      "rank": 60,
+      "id": "facebook/VGGT-Omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/VGGT-Omega",
+      "downloads": 0,
+      "likes": 85,
+      "trendingScore": 80,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "facebook",
+        "meta-pytorch",
+        "en",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-17T20:47:45.000Z",
+      "lastModified": "2026-05-14T21:23:21.000Z"
+    },
+    {
+      "rank": 61,
       "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
-      "downloads": 5298,
-      "likes": 80,
-      "trendingScore": 78,
+      "downloads": 7701,
+      "likes": 82,
+      "trendingScore": 80,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1940,7 +1884,91 @@
       "lastModified": "2026-05-23T20:28:00.000Z"
     },
     {
+      "rank": 62,
+      "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
+      "author": "AngelSlim",
+      "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
+      "downloads": 17223,
+      "likes": 159,
+      "trendingScore": 79,
+      "pipelineTag": "translation",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "hunyuan_v1_dense",
+        "translation",
+        "hy-mt",
+        "quant",
+        "1.25bit",
+        "sherry",
+        "multilingual",
+        "arxiv:2601.07892",
+        "arxiv:2512.24092",
+        "arxiv:2602.21233",
+        "base_model:tencent/HY-MT1.5-1.8B",
+        "base_model:finetune:tencent/HY-MT1.5-1.8B",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T12:39:12.000Z",
+      "lastModified": "2026-05-09T07:37:22.000Z"
+    },
+    {
+      "rank": 63,
+      "id": "poolside/Laguna-XS.2",
+      "author": "poolside",
+      "url": "https://huggingface.co/poolside/Laguna-XS.2",
+      "downloads": 16792,
+      "likes": 231,
+      "trendingScore": 78,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "laguna",
+        "text-generation",
+        "laguna-xs.2",
+        "vllm",
+        "conversational",
+        "custom_code",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T20:50:45.000Z",
+      "lastModified": "2026-05-06T18:58:37.000Z"
+    },
+    {
       "rank": 64,
+      "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
+      "downloads": 2733708,
+      "likes": 1000,
+      "trendingScore": 78,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T04:31:31.000Z",
+      "lastModified": "2026-04-20T12:42:25.000Z"
+    },
+    {
+      "rank": 65,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -1973,35 +2001,30 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 65,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 81,
-      "trendingScore": 76,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
+      "rank": 66,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 695,
+      "likes": 78,
+      "trendingScore": 77,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "stable-audio-3",
+        "diffusers",
         "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
+        "text-to-image",
         "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
     },
     {
-      "rank": 66,
+      "rank": 67,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -2034,7 +2057,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 67,
+      "rank": 68,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2079,7 +2102,7 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 68,
+      "rank": 69,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -2099,13 +2122,13 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 69,
-      "id": "microsoft/Lens-Turbo",
+      "rank": 70,
+      "id": "microsoft/Lens",
       "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 543,
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 512,
       "likes": 74,
-      "trendingScore": 73,
+      "trendingScore": 71,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
@@ -2118,11 +2141,11 @@
         "diffusers:LensPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
-      "rank": 70,
+      "rank": 71,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -2145,7 +2168,25 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 71,
+      "rank": 72,
+      "id": "zhen-nan/L2P",
+      "author": "zhen-nan",
+      "url": "https://huggingface.co/zhen-nan/L2P",
+      "downloads": 0,
+      "likes": 69,
+      "trendingScore": 69,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "arxiv:2605.12013",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-03T13:24:20.000Z",
+      "lastModified": "2026-05-22T07:53:35.000Z"
+    },
+    {
+      "rank": 73,
       "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
@@ -2177,7 +2218,7 @@
       "lastModified": "2026-05-14T17:07:52.000Z"
     },
     {
-      "rank": 72,
+      "rank": 74,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -2209,7 +2250,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 73,
+      "rank": 75,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -2234,30 +2275,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 74,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 434,
-      "likes": 70,
-      "trendingScore": 67,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
-    },
-    {
-      "rank": 75,
+      "rank": 76,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -2300,24 +2318,6 @@
       ],
       "createdAt": "2026-04-29T16:12:36.000Z",
       "lastModified": "2026-05-02T14:32:42.000Z"
-    },
-    {
-      "rank": 76,
-      "id": "zhen-nan/L2P",
-      "author": "zhen-nan",
-      "url": "https://huggingface.co/zhen-nan/L2P",
-      "downloads": 0,
-      "likes": 65,
-      "trendingScore": 65,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "arxiv:2605.12013",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-03T13:24:20.000Z",
-      "lastModified": "2026-05-22T07:53:35.000Z"
     },
     {
       "rank": 77,
@@ -2750,6 +2750,36 @@
     },
     {
       "rank": 92,
+      "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 706534,
+      "likes": 666,
+      "trendingScore": 53,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "abliterated",
+        "vision",
+        "multimodal",
+        "audio",
+        "image-text-to-text",
+        "en",
+        "multilingual",
+        "license:gemma",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-02T22:29:19.000Z",
+      "lastModified": "2026-04-06T03:50:35.000Z"
+    },
+    {
+      "rank": 93,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2794,7 +2824,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2821,7 +2851,29 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 10214,
+      "likes": 52,
+      "trendingScore": 51,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-22T05:15:52.000Z"
+    },
+    {
+      "rank": 96,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2849,37 +2901,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 95,
-      "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 733886,
-      "likes": 663,
-      "trendingScore": 50,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "abliterated",
-        "vision",
-        "multimodal",
-        "audio",
-        "image-text-to-text",
-        "en",
-        "multilingual",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-02T22:29:19.000Z",
-      "lastModified": "2026-04-06T03:50:35.000Z"
-    },
-    {
-      "rank": 96,
+      "rank": 97,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -2913,29 +2935,34 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 97,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 8515,
-      "likes": 50,
+      "rank": 98,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 54,
       "trendingScore": 49,
-      "pipelineTag": null,
+      "pipelineTag": "automatic-speech-recognition",
       "libraryName": null,
       "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "dataset:zhifeixie/Voices-in-the-Wild-2M",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
       ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-22T05:15:52.000Z"
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-24T17:48:46.000Z"
     },
     {
-      "rank": 98,
+      "rank": 99,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -2955,7 +2982,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -2986,7 +3013,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 100,
+      "rank": 101,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -3011,7 +3038,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 101,
+      "rank": 102,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -3048,7 +3075,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -3085,7 +3112,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -3113,7 +3140,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 104,
+      "rank": 105,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
@@ -3137,7 +3164,7 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 105,
+      "rank": 106,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3156,7 +3183,39 @@
       "lastModified": "2026-05-20T20:31:07.000Z"
     },
     {
-      "rank": 106,
+      "rank": 107,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 9919282,
+      "likes": 1956,
+      "trendingScore": 46,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
+    },
+    {
+      "rank": 108,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -3179,7 +3238,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 107,
+      "rank": 109,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -3206,11 +3265,11 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 108,
+      "rank": 110,
       "id": "LatitudeGames/Equinox-31B",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 506,
+      "downloads": 593,
       "likes": 44,
       "trendingScore": 44,
       "pipelineTag": null,
@@ -3228,65 +3287,6 @@
       ],
       "createdAt": "2026-05-18T15:45:53.000Z",
       "lastModified": "2026-05-22T04:55:49.000Z"
-    },
-    {
-      "rank": 109,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 10040330,
-      "likes": 1951,
-      "trendingScore": 44,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
-    },
-    {
-      "rank": 110,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 49,
-      "trendingScore": 44,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
-        "en",
-        "zh",
-        "dataset:zhifeixie/Voices-in-the-Wild-2M",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-24T17:48:46.000Z"
     },
     {
       "rank": 111,
@@ -3370,10 +3370,37 @@
     },
     {
       "rank": 114,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 44,
+      "trendingScore": 43,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 115,
       "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 16266,
+      "downloads": 18187,
       "likes": 41,
       "trendingScore": 41,
       "pipelineTag": "image-text-to-text",
@@ -3394,33 +3421,6 @@
       ],
       "createdAt": "2026-05-19T21:48:29.000Z",
       "lastModified": "2026-05-20T01:46:59.000Z"
-    },
-    {
-      "rank": 115,
-      "id": "stabilityai/stable-audio-3-small-music",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
-      "downloads": 0,
-      "likes": 41,
-      "trendingScore": 40,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
     },
     {
       "rank": 116,
@@ -3669,6 +3669,32 @@
     },
     {
       "rank": 125,
+      "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 753063,
+      "likes": 1399,
+      "trendingScore": 36,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.5",
+        "qwen",
+        "en",
+        "zh",
+        "multilingual",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-04T00:24:31.000Z",
+      "lastModified": "2026-04-05T19:01:05.000Z"
+    },
+    {
+      "rank": 126,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -3700,7 +3726,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -3723,7 +3749,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 127,
+      "rank": 128,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -3752,7 +3778,7 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 128,
+      "rank": 129,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -3781,11 +3807,11 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
       "id": "HuggingFaceBio/Carbon-3B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 3686,
+      "downloads": 3966,
       "likes": 37,
       "trendingScore": 35,
       "pipelineTag": "text-generation",
@@ -3807,7 +3833,7 @@
       "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 130,
+      "rank": 131,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -3847,7 +3873,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -3871,7 +3897,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -3888,7 +3914,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -3910,32 +3936,6 @@
       ],
       "createdAt": "2026-04-30T04:35:06.000Z",
       "lastModified": "2026-05-02T09:06:30.000Z"
-    },
-    {
-      "rank": 134,
-      "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 1050175,
-      "likes": 1332,
-      "trendingScore": 34,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.5",
-        "qwen",
-        "en",
-        "zh",
-        "multilingual",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-04T00:24:31.000Z",
-      "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
       "rank": 135,
@@ -4001,6 +4001,58 @@
     },
     {
       "rank": 138,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2585622,
+      "likes": 2049,
+      "trendingScore": 34,
+      "pipelineTag": "mask-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
+    },
+    {
+      "rank": 139,
+      "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
+      "author": "Phr00t",
+      "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
+      "downloads": 0,
+      "likes": 2052,
+      "trendingScore": 34,
+      "pipelineTag": "text-to-image",
+      "libraryName": "comfyUI",
+      "tags": [
+        "comfyUI",
+        "qwen",
+        "qwen-edit",
+        "t2i",
+        "i2i",
+        "text-to-image",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:finetune:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-10-02T03:43:15.000Z",
+      "lastModified": "2026-02-03T02:10:35.000Z"
+    },
+    {
+      "rank": 140,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -4045,7 +4097,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 139,
+      "rank": 141,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -4090,7 +4142,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 140,
+      "rank": 142,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -4134,7 +4186,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 141,
+      "rank": 143,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -4160,11 +4212,11 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 142,
+      "rank": 144,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
-      "downloads": 1566,
+      "downloads": 1648,
       "likes": 34,
       "trendingScore": 33,
       "pipelineTag": "text-generation",
@@ -4185,7 +4237,7 @@
       "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 143,
+      "rank": 145,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -4229,7 +4281,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 144,
+      "rank": 146,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -4272,58 +4324,6 @@
       ],
       "createdAt": "2026-03-09T05:48:58.000Z",
       "lastModified": "2026-03-11T15:32:58.000Z"
-    },
-    {
-      "rank": 145,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2624571,
-      "likes": 2045,
-      "trendingScore": 32,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 146,
-      "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
-      "author": "Phr00t",
-      "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
-      "downloads": 0,
-      "likes": 2050,
-      "trendingScore": 32,
-      "pipelineTag": "text-to-image",
-      "libraryName": "comfyUI",
-      "tags": [
-        "comfyUI",
-        "qwen",
-        "qwen-edit",
-        "t2i",
-        "i2i",
-        "text-to-image",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:finetune:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-10-02T03:43:15.000Z",
-      "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
       "rank": 147,
@@ -4556,6 +4556,33 @@
     },
     {
       "rank": 154,
+      "id": "stabilityai/stable-audio-3-small-sfx",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
+      "downloads": 0,
+      "likes": 32,
+      "trendingScore": 31,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-sfx-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:16.000Z",
+      "lastModified": "2026-05-19T20:02:45.000Z"
+    },
+    {
+      "rank": 155,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4581,7 +4608,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 155,
+      "rank": 156,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4613,7 +4640,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 156,
+      "rank": 157,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4640,7 +4667,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 157,
+      "rank": 158,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4674,7 +4701,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 158,
+      "rank": 159,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4694,33 +4721,6 @@
       ],
       "createdAt": "2026-05-13T09:22:55.000Z",
       "lastModified": "2026-05-13T19:23:38.000Z"
-    },
-    {
-      "rank": 159,
-      "id": "stabilityai/stable-audio-3-small-sfx",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
-      "downloads": 0,
-      "likes": 31,
-      "trendingScore": 30,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-sfx-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-sfx-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:16.000Z",
-      "lastModified": "2026-05-19T20:02:45.000Z"
     },
     {
       "rank": 160,
@@ -4868,7 +4868,7 @@
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
-      "downloads": 1500,
+      "downloads": 1706,
       "likes": 30,
       "trendingScore": 29,
       "pipelineTag": "image-text-to-text",
@@ -4913,8 +4913,8 @@
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 48007,
-      "likes": 1338,
+      "downloads": 49515,
+      "likes": 1342,
       "trendingScore": 29,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -4945,7 +4945,7 @@
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "downloads": 1762,
+      "downloads": 1869,
       "likes": 29,
       "trendingScore": 29,
       "pipelineTag": "text-generation",
@@ -5645,6 +5645,32 @@
     },
     {
       "rank": 190,
+      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
+      "downloads": 27984,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T17:45:13.000Z",
+      "lastModified": "2026-05-23T00:38:45.000Z"
+    },
+    {
+      "rank": 191,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -5682,7 +5708,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 191,
+      "rank": 192,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -5700,7 +5726,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 192,
+      "rank": 193,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -5726,7 +5752,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -5746,7 +5772,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -5773,7 +5799,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -5799,7 +5825,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -5825,7 +5851,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -5862,7 +5888,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -5878,7 +5904,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -5901,7 +5927,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -5943,7 +5969,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -5982,7 +6008,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 202,
+      "rank": 203,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6027,11 +6053,11 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 203,
+      "rank": 204,
       "id": "tencent/Hy-MT2-7B-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 10037,
+      "downloads": 13330,
       "likes": 26,
       "trendingScore": 25,
       "pipelineTag": null,
@@ -6049,7 +6075,49 @@
       "lastModified": "2026-05-22T05:16:12.000Z"
     },
     {
-      "rank": 204,
+      "rank": 205,
+      "id": "Comfy-Org/Lens",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/Lens",
+      "downloads": 0,
+      "likes": 25,
+      "trendingScore": 25,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T14:51:51.000Z",
+      "lastModified": "2026-05-24T13:34:38.000Z"
+    },
+    {
+      "rank": 206,
+      "id": "openbmb/BitCPM-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
+      "downloads": 789,
+      "likes": 29,
+      "trendingScore": 25,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-23T18:12:57.000Z"
+    },
+    {
+      "rank": 207,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -6081,7 +6149,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 205,
+      "rank": 208,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -6105,7 +6173,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 206,
+      "rank": 209,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -6132,7 +6200,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 207,
+      "rank": 210,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -6157,7 +6225,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 208,
+      "rank": 211,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -6193,7 +6261,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 209,
+      "rank": 212,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -6209,7 +6277,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 210,
+      "rank": 213,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -6230,11 +6298,11 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 211,
+      "rank": 214,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 1597,
+      "downloads": 1766,
       "likes": 28,
       "trendingScore": 24,
       "pipelineTag": "text-generation",
@@ -6256,7 +6324,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 212,
+      "rank": 215,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -6278,51 +6346,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 213,
-      "id": "nvidia/Nemotron-Labs-Diffusion-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 27346,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T17:45:13.000Z",
-      "lastModified": "2026-05-23T00:38:45.000Z"
-    },
-    {
-      "rank": 214,
-      "id": "Comfy-Org/Lens",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/Lens",
-      "downloads": 0,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T14:51:51.000Z",
-      "lastModified": "2026-05-24T13:34:38.000Z"
-    },
-    {
-      "rank": 215,
+      "rank": 216,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -6349,7 +6373,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 216,
+      "rank": 217,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -6378,7 +6402,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 217,
+      "rank": 218,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -6395,7 +6419,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 218,
+      "rank": 219,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -6416,7 +6440,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 219,
+      "rank": 220,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -6437,7 +6461,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 220,
+      "rank": 221,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6458,7 +6482,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 221,
+      "rank": 222,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -6490,7 +6514,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 222,
+      "rank": 223,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6521,11 +6545,11 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 223,
+      "rank": 224,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "downloads": 2247,
+      "downloads": 2670,
       "likes": 24,
       "trendingScore": 23,
       "pipelineTag": null,
@@ -6543,7 +6567,33 @@
       "lastModified": "2026-05-22T05:15:40.000Z"
     },
     {
-      "rank": 224,
+      "rank": 225,
+      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
+      "downloads": 19496,
+      "likes": 25,
+      "trendingScore": 23,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T17:12:28.000Z",
+      "lastModified": "2026-05-23T01:01:21.000Z"
+    },
+    {
+      "rank": 226,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6574,7 +6624,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 225,
+      "rank": 227,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6603,7 +6653,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 226,
+      "rank": 228,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6648,7 +6698,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 227,
+      "rank": 229,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6675,7 +6725,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 228,
+      "rank": 230,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6701,7 +6751,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 229,
+      "rank": 231,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -6725,7 +6775,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 230,
+      "rank": 232,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -6763,7 +6813,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 231,
+      "rank": 233,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -6780,7 +6830,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 232,
+      "rank": 234,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -6808,7 +6858,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 233,
+      "rank": 235,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -6831,7 +6881,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 234,
+      "rank": 236,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -6848,33 +6898,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 235,
-      "id": "nvidia/Nemotron-Labs-Diffusion-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
-      "downloads": 15720,
-      "likes": 24,
-      "trendingScore": 22,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T17:12:28.000Z",
-      "lastModified": "2026-05-23T01:01:21.000Z"
-    },
-    {
-      "rank": 236,
+      "rank": 237,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -6901,7 +6925,38 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 237,
+      "rank": 238,
+      "id": "pyannote/segmentation-3.0",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/segmentation-3.0",
+      "downloads": 9222261,
+      "likes": 1021,
+      "trendingScore": 22,
+      "pipelineTag": "voice-activity-detection",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pytorch",
+        "pyannote",
+        "pyannote-audio-model",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "speaker-segmentation",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "resegmentation",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2023-09-22T12:03:10.000Z",
+      "lastModified": "2024-05-10T19:35:46.000Z"
+    },
+    {
+      "rank": 239,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -6946,7 +7001,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 238,
+      "rank": 240,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -6974,7 +7029,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 239,
+      "rank": 241,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -7010,7 +7065,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 240,
+      "rank": 242,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -7037,7 +7092,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 241,
+      "rank": 243,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -7062,7 +7117,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 242,
+      "rank": 244,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -7090,7 +7145,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 243,
+      "rank": 245,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -7123,7 +7178,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 244,
+      "rank": 246,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -7148,7 +7203,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 245,
+      "rank": 247,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -7185,7 +7240,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 246,
+      "rank": 248,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -7228,7 +7283,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 247,
+      "rank": 249,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -7252,7 +7307,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 248,
+      "rank": 250,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -7276,7 +7331,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 249,
+      "rank": 251,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -7305,38 +7360,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 250,
-      "id": "pyannote/segmentation-3.0",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/segmentation-3.0",
-      "downloads": 9410234,
-      "likes": 1019,
-      "trendingScore": 20,
-      "pipelineTag": "voice-activity-detection",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pytorch",
-        "pyannote",
-        "pyannote-audio-model",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "speaker-segmentation",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "resegmentation",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2023-09-22T12:03:10.000Z",
-      "lastModified": "2024-05-10T19:35:46.000Z"
-    },
-    {
-      "rank": 251,
+      "rank": 252,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -7354,7 +7378,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7399,7 +7423,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7444,12 +7468,12 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
-      "downloads": 7969576,
-      "likes": 4631,
+      "downloads": 8082595,
+      "likes": 4638,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -7473,7 +7497,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -7497,7 +7521,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7526,7 +7550,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -7550,11 +7574,11 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2850738,
+      "downloads": 2838518,
       "likes": 403,
       "trendingScore": 20,
       "pipelineTag": "automatic-speech-recognition",
@@ -7583,7 +7607,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -7628,7 +7652,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -7661,7 +7685,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -7683,7 +7707,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -7710,7 +7734,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -7726,7 +7750,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -7749,7 +7773,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7774,7 +7798,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 266,
+      "rank": 267,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -7810,7 +7834,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -7839,7 +7863,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -7869,7 +7893,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 269,
+      "rank": 270,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -7914,7 +7938,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 270,
+      "rank": 271,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -7941,7 +7965,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 271,
+      "rank": 272,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -7967,7 +7991,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 272,
+      "rank": 273,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -7995,7 +8019,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 273,
+      "rank": 274,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -8024,11 +8048,11 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 274,
+      "rank": 275,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 12890,
+      "downloads": 14355,
       "likes": 19,
       "trendingScore": 19,
       "pipelineTag": "image-text-to-text",
@@ -8050,11 +8074,11 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 275,
+      "rank": 276,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
-      "downloads": 8364,
+      "downloads": 9223,
       "likes": 19,
       "trendingScore": 19,
       "pipelineTag": null,
@@ -8077,7 +8101,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 276,
+      "rank": 277,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -8099,7 +8123,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 277,
+      "rank": 278,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -8133,7 +8157,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 278,
+      "rank": 279,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -8157,7 +8181,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 279,
+      "rank": 280,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -8183,7 +8207,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 280,
+      "rank": 281,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -8205,7 +8229,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 281,
+      "rank": 282,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -8234,7 +8258,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 282,
+      "rank": 283,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8266,7 +8290,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 283,
+      "rank": 284,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8284,7 +8308,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 284,
+      "rank": 285,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8313,7 +8337,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 285,
+      "rank": 286,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8331,7 +8355,78 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 286,
+      "rank": 287,
+      "id": "Jackrong/Qwopus3.6-27B-v2",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
+      "downloads": 3125,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:20:50.000Z",
+      "lastModified": "2026-05-23T00:38:29.000Z"
+    },
+    {
+      "rank": 288,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 10,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-25T02:16:53.000Z"
+    },
+    {
+      "rank": 289,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -8376,7 +8471,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 287,
+      "rank": 290,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -8405,7 +8500,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 288,
+      "rank": 291,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -8434,7 +8529,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 289,
+      "rank": 292,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -8466,7 +8561,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 290,
+      "rank": 293,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -8496,7 +8591,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 291,
+      "rank": 294,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -8517,7 +8612,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 292,
+      "rank": 295,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -8562,7 +8657,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 293,
+      "rank": 296,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -8591,7 +8686,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 294,
+      "rank": 297,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -8619,7 +8714,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 295,
+      "rank": 298,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -8644,7 +8739,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 296,
+      "rank": 299,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -8667,7 +8762,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 297,
+      "rank": 300,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -8694,7 +8789,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 298,
+      "rank": 301,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -8720,7 +8815,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 299,
+      "rank": 302,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -8749,7 +8844,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 300,
+      "rank": 303,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -8781,11 +8876,11 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 301,
+      "rank": 304,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
-      "downloads": 14154,
+      "downloads": 15765,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
@@ -8809,7 +8904,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 302,
+      "rank": 305,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -8828,11 +8923,11 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 303,
+      "rank": 306,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
-      "downloads": 18380264,
+      "downloads": 18822463,
       "likes": 1268,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -8856,7 +8951,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 304,
+      "rank": 307,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -8874,51 +8969,33 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 305,
-      "id": "Jackrong/Qwopus3.6-27B-v2",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
-      "downloads": 1534,
+      "rank": 308,
+      "id": "stabilityai/stable-audio-3-medium-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
+      "downloads": 0,
       "likes": 17,
       "trendingScore": 17,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
       "tags": [
-        "transformers",
+        "stable-audio-3",
         "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "image",
-        "conversational",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
         "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
+        "arxiv:2605.17991",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-14T08:20:50.000Z",
-      "lastModified": "2026-05-23T00:38:29.000Z"
+      "createdAt": "2026-05-17T01:44:44.000Z",
+      "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 306,
+      "rank": 309,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -8943,7 +9020,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 307,
+      "rank": 310,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -8978,7 +9055,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 308,
+      "rank": 311,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -9023,7 +9100,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 309,
+      "rank": 312,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -9050,7 +9127,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 310,
+      "rank": 313,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -9079,7 +9156,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 311,
+      "rank": 314,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -9102,7 +9179,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 312,
+      "rank": 315,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -9146,7 +9223,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 313,
+      "rank": 316,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -9191,7 +9268,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 314,
+      "rank": 317,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -9209,7 +9286,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 315,
+      "rank": 318,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -9254,7 +9331,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 316,
+      "rank": 319,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -9292,7 +9369,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 317,
+      "rank": 320,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -9312,7 +9389,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 318,
+      "rank": 321,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -9345,7 +9422,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 319,
+      "rank": 322,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -9375,7 +9452,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 320,
+      "rank": 323,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -9407,7 +9484,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 321,
+      "rank": 324,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -9432,12 +9509,12 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 322,
+      "rank": 325,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
-      "downloads": 167125,
-      "likes": 94,
+      "downloads": 163672,
+      "likes": 96,
       "trendingScore": 16,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -9455,7 +9532,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 323,
+      "rank": 326,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9479,7 +9556,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 324,
+      "rank": 327,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9509,7 +9586,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 325,
+      "rank": 328,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -9533,7 +9610,7 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 326,
+      "rank": 329,
       "id": "openbmb/BitCPM-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
@@ -9558,33 +9635,85 @@
       "lastModified": "2026-05-24T10:43:34.000Z"
     },
     {
-      "rank": 327,
-      "id": "stabilityai/stable-audio-3-medium-base",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
-      "downloads": 0,
-      "likes": 16,
+      "rank": 330,
+      "id": "openai/whisper-large-v3-turbo",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
+      "downloads": 7794649,
+      "likes": 3032,
       "trendingScore": 16,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
       "tags": [
-        "stable-audio-3",
+        "transformers",
         "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
+        "whisper",
+        "automatic-speech-recognition",
+        "audio",
         "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
+        "zh",
+        "de",
+        "es",
+        "ru",
+        "ko",
+        "fr",
+        "ja",
+        "pt",
+        "tr",
+        "pl",
+        "ca",
+        "nl",
+        "ar",
+        "sv",
+        "it",
+        "id",
+        "hi",
+        "fi",
+        "vi",
+        "he",
+        "uk",
+        "el",
+        "ms",
+        "cs"
       ],
-      "createdAt": "2026-05-17T01:44:44.000Z",
-      "lastModified": "2026-05-19T20:02:40.000Z"
+      "createdAt": "2024-10-01T07:39:28.000Z",
+      "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 328,
+      "rank": 331,
+      "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
+      "author": "LuffyTheFox",
+      "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
+      "downloads": 21205,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.6",
+        "moe",
+        "vision",
+        "multimodal",
+        "genesis",
+        "image-text-to-text",
+        "conversational",
+        "en",
+        "zh",
+        "multilingual",
+        "base_model:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "base_model:quantized:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix"
+      ],
+      "createdAt": "2026-05-21T12:23:23.000Z",
+      "lastModified": "2026-05-24T17:32:37.000Z"
+    },
+    {
+      "rank": 332,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -9611,7 +9740,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 329,
+      "rank": 333,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -9656,7 +9785,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 330,
+      "rank": 334,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -9686,7 +9815,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 331,
+      "rank": 335,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -9716,7 +9845,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 332,
+      "rank": 336,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -9761,7 +9890,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 333,
+      "rank": 337,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -9796,7 +9925,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 334,
+      "rank": 338,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -9825,7 +9954,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 335,
+      "rank": 339,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -9850,7 +9979,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 336,
+      "rank": 340,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -9878,7 +10007,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 337,
+      "rank": 341,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -9906,7 +10035,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 338,
+      "rank": 342,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -9937,7 +10066,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 339,
+      "rank": 343,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -9982,7 +10111,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 340,
+      "rank": 344,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -10014,7 +10143,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 341,
+      "rank": 345,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -10041,7 +10170,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 342,
+      "rank": 346,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -10064,7 +10193,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 343,
+      "rank": 347,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -10091,7 +10220,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 344,
+      "rank": 348,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -10114,7 +10243,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 345,
+      "rank": 349,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -10140,7 +10269,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 346,
+      "rank": 350,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -10170,7 +10299,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 347,
+      "rank": 351,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -10197,12 +10326,12 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 348,
+      "rank": 352,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
-      "downloads": 106074,
-      "likes": 79,
+      "downloads": 105320,
+      "likes": 83,
       "trendingScore": 15,
       "pipelineTag": "any-to-any",
       "libraryName": "transformers",
@@ -10228,7 +10357,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 349,
+      "rank": 353,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -10256,7 +10385,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 350,
+      "rank": 354,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10288,7 +10417,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 351,
+      "rank": 355,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10333,7 +10462,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 352,
+      "rank": 356,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -10366,7 +10495,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 353,
+      "rank": 357,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -10406,11 +10535,11 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 354,
+      "rank": 358,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
-      "downloads": 221708,
+      "downloads": 223156,
       "likes": 441,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -10447,7 +10576,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 355,
+      "rank": 359,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -10470,11 +10599,11 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 356,
+      "rank": 360,
       "id": "netease-youdao/Confucius4",
       "author": "netease-youdao",
       "url": "https://huggingface.co/netease-youdao/Confucius4",
-      "downloads": 465,
+      "downloads": 474,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": null,
@@ -10488,7 +10617,7 @@
       "lastModified": "2026-05-20T08:42:10.000Z"
     },
     {
-      "rank": 357,
+      "rank": 361,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -10526,12 +10655,12 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 358,
+      "rank": 362,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
-      "downloads": 723728,
-      "likes": 293,
+      "downloads": 723421,
+      "likes": 295,
       "trendingScore": 15,
       "pipelineTag": "image-feature-extraction",
       "libraryName": "transformers",
@@ -10554,7 +10683,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 359,
+      "rank": 363,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -10577,7 +10706,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 360,
+      "rank": 364,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -10604,7 +10733,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 361,
+      "rank": 365,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -10635,12 +10764,12 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 362,
+      "rank": 366,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 444428,
-      "likes": 1402,
+      "downloads": 405806,
+      "likes": 1403,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
@@ -10666,11 +10795,11 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 363,
+      "rank": 367,
       "id": "syvai/cohere-transcribe-diarize",
       "author": "syvai",
       "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
-      "downloads": 135,
+      "downloads": 170,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "automatic-speech-recognition",
@@ -10711,76 +10840,7 @@
       "lastModified": "2026-05-22T20:56:30.000Z"
     },
     {
-      "rank": 364,
-      "id": "openai/whisper-large-v3-turbo",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
-      "downloads": 7710286,
-      "likes": 3030,
-      "trendingScore": 15,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "whisper",
-        "automatic-speech-recognition",
-        "audio",
-        "en",
-        "zh",
-        "de",
-        "es",
-        "ru",
-        "ko",
-        "fr",
-        "ja",
-        "pt",
-        "tr",
-        "pl",
-        "ca",
-        "nl",
-        "ar",
-        "sv",
-        "it",
-        "id",
-        "hi",
-        "fi",
-        "vi",
-        "he",
-        "uk",
-        "el",
-        "ms",
-        "cs"
-      ],
-      "createdAt": "2024-10-01T07:39:28.000Z",
-      "lastModified": "2024-10-04T14:51:11.000Z"
-    },
-    {
-      "rank": 365,
-      "id": "openbmb/BitCPM-CANN-8B-gguf",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
-      "downloads": 452,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T06:18:55.000Z",
-      "lastModified": "2026-05-23T18:12:57.000Z"
-    },
-    {
-      "rank": 366,
+      "rank": 368,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -10804,7 +10864,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 367,
+      "rank": 369,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -10831,7 +10891,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 368,
+      "rank": 370,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -10859,7 +10919,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 369,
+      "rank": 371,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -10878,7 +10938,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 370,
+      "rank": 372,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -10910,7 +10970,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 371,
+      "rank": 373,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -10939,7 +10999,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 372,
+      "rank": 374,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -10965,7 +11025,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 373,
+      "rank": 375,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -10993,7 +11053,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 374,
+      "rank": 376,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -11027,7 +11087,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 375,
+      "rank": 377,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -11053,7 +11113,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 376,
+      "rank": 378,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -11095,7 +11155,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 377,
+      "rank": 379,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -11133,7 +11193,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 378,
+      "rank": 380,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -11152,7 +11212,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 379,
+      "rank": 381,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -11172,7 +11232,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 380,
+      "rank": 382,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -11199,7 +11259,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 381,
+      "rank": 383,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -11225,7 +11285,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 382,
+      "rank": 384,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -11250,7 +11310,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 383,
+      "rank": 385,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -11279,7 +11339,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 384,
+      "rank": 386,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -11324,7 +11384,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 385,
+      "rank": 387,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -11351,11 +11411,11 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 386,
+      "rank": 388,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
-      "downloads": 1294,
+      "downloads": 1421,
       "likes": 37,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
@@ -11380,7 +11440,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 387,
+      "rank": 389,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -11417,11 +11477,11 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 388,
+      "rank": 390,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
-      "downloads": 17179621,
+      "downloads": 16982782,
       "likes": 3259,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
@@ -11443,14 +11503,14 @@
         "license:mit",
         "text-generation-inference",
         "endpoints_compatible",
-        "region:us",
-        "deploy:azure"
+        "deploy:azure",
+        "region:us"
       ],
       "createdAt": "2022-03-02T23:29:04.000Z",
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 389,
+      "rank": 391,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -11479,40 +11539,119 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 390,
-      "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "author": "LuffyTheFox",
-      "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "downloads": 11222,
+      "rank": 392,
+      "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
+      "downloads": 912,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
-      "libraryName": null,
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.6",
-        "moe",
-        "vision",
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion_vlm",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
         "multimodal",
-        "genesis",
+        "vlm",
+        "diffusion-language-model",
         "image-text-to-text",
         "conversational",
-        "en",
-        "zh",
-        "multilingual",
-        "base_model:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-        "base_model:quantized:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix"
+        "custom_code",
+        "license:other",
+        "region:us"
       ],
-      "createdAt": "2026-05-21T12:23:23.000Z",
-      "lastModified": "2026-05-24T17:32:37.000Z"
+      "createdAt": "2026-05-08T17:45:40.000Z",
+      "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 391,
+      "rank": 393,
+      "id": "CohereLabs/cohere-transcribe-03-2026",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
+      "downloads": 305090,
+      "likes": 958,
+      "trendingScore": 14,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere_asr",
+        "automatic-speech-recognition",
+        "audio",
+        "hf-asr-leaderboard",
+        "speech-recognition",
+        "transcription",
+        "custom_code",
+        "ar",
+        "de",
+        "el",
+        "en",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "vi",
+        "zh",
+        "doi:10.57967/hf/8653",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-03-24T10:35:54.000Z",
+      "lastModified": "2026-05-04T13:29:45.000Z"
+    },
+    {
+      "rank": 394,
+      "id": "SupraLabs/Supra-50M-Instruct",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
+      "downloads": 1045,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "dataset:yahma/alpaca-cleaned",
+        "base_model:SupraLabs/Supra-50M-Base",
+        "base_model:quantized:SupraLabs/Supra-50M-Base",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-21T12:06:17.000Z",
+      "lastModified": "2026-05-23T08:10:17.000Z"
+    },
+    {
+      "rank": 395,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -11541,7 +11680,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 392,
+      "rank": 396,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -11586,7 +11725,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 393,
+      "rank": 397,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -11615,7 +11754,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 394,
+      "rank": 398,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -11642,7 +11781,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 395,
+      "rank": 399,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -11669,7 +11808,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 396,
+      "rank": 400,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -11700,7 +11839,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 397,
+      "rank": 401,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -11724,7 +11863,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 398,
+      "rank": 402,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -11769,7 +11908,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 399,
+      "rank": 403,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -11796,7 +11935,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 400,
+      "rank": 404,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -11832,7 +11971,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 401,
+      "rank": 405,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -11863,7 +12002,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 402,
+      "rank": 406,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -11894,7 +12033,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 403,
+      "rank": 407,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -11927,7 +12066,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 404,
+      "rank": 408,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -11956,7 +12095,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 405,
+      "rank": 409,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -11982,7 +12121,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 406,
+      "rank": 410,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -12012,7 +12151,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 407,
+      "rank": 411,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -12030,7 +12169,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 408,
+      "rank": 412,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -12061,7 +12200,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 409,
+      "rank": 413,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -12082,7 +12221,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 410,
+      "rank": 414,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -12102,7 +12241,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -12129,7 +12268,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -12159,7 +12298,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -12176,7 +12315,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -12203,7 +12342,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12228,7 +12367,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 416,
+      "rank": 420,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -12271,36 +12410,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 417,
-      "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
-      "downloads": 658,
-      "likes": 13,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion_vlm",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "multimodal",
-        "vlm",
-        "diffusion-language-model",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T17:45:40.000Z",
-      "lastModified": "2026-05-19T18:52:46.000Z"
-    },
-    {
-      "rank": 418,
+      "rank": 421,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -12329,12 +12439,12 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 419,
+      "rank": 422,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
-      "downloads": 9229,
-      "likes": 608,
+      "downloads": 9144,
+      "likes": 611,
       "trendingScore": 13,
       "pipelineTag": "text-to-video",
       "libraryName": "wan2.2",
@@ -12354,11 +12464,11 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 420,
+      "rank": 423,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
-      "downloads": 154,
+      "downloads": 181,
       "likes": 14,
       "trendingScore": 13,
       "pipelineTag": "text-to-image",
@@ -12377,11 +12487,11 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 421,
+      "rank": 424,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "downloads": 5233,
+      "downloads": 7191,
       "likes": 14,
       "trendingScore": 13,
       "pipelineTag": null,
@@ -12407,11 +12517,11 @@
       "lastModified": "2026-05-25T00:33:13.000Z"
     },
     {
-      "rank": 422,
+      "rank": 425,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "downloads": 11042,
+      "downloads": 12882,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
@@ -12435,51 +12545,7 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 423,
-      "id": "CohereLabs/cohere-transcribe-03-2026",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
-      "downloads": 301847,
-      "likes": 954,
-      "trendingScore": 13,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere_asr",
-        "automatic-speech-recognition",
-        "audio",
-        "hf-asr-leaderboard",
-        "speech-recognition",
-        "transcription",
-        "custom_code",
-        "ar",
-        "de",
-        "el",
-        "en",
-        "es",
-        "fr",
-        "it",
-        "ja",
-        "ko",
-        "nl",
-        "pl",
-        "pt",
-        "vi",
-        "zh",
-        "doi:10.57967/hf/8653",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-03-24T10:35:54.000Z",
-      "lastModified": "2026-05-04T13:29:45.000Z"
-    },
-    {
-      "rank": 424,
+      "rank": 426,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -12524,7 +12590,33 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 425,
+      "rank": 427,
+      "id": "stabilityai/stable-audio-3-optimized",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
+      "downloads": 0,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "onnx",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T19:38:34.000Z",
+      "lastModified": "2026-05-20T20:49:04.000Z"
+    },
+    {
+      "rank": 428,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -12551,7 +12643,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -12579,7 +12671,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -12612,7 +12704,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -12628,7 +12720,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -12651,7 +12743,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -12685,7 +12777,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -12705,7 +12797,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 432,
+      "rank": 435,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -12740,7 +12832,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 433,
+      "rank": 436,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -12770,7 +12862,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 434,
+      "rank": 437,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -12791,7 +12883,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 435,
+      "rank": 438,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -12820,7 +12912,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 436,
+      "rank": 439,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -12850,7 +12942,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 437,
+      "rank": 440,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -12878,7 +12970,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 438,
+      "rank": 441,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -12907,7 +12999,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -12939,7 +13031,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -12974,7 +13066,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -12996,7 +13088,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 442,
+      "rank": 445,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -13034,7 +13126,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 443,
+      "rank": 446,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -13073,7 +13165,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 444,
+      "rank": 447,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -13110,7 +13202,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 445,
+      "rank": 448,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -13134,7 +13226,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 446,
+      "rank": 449,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -13152,7 +13244,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 447,
+      "rank": 450,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -13171,7 +13263,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 448,
+      "rank": 451,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -13199,11 +13291,11 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 449,
+      "rank": 452,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
-      "downloads": 34451,
+      "downloads": 35224,
       "likes": 635,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -13240,7 +13332,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 450,
+      "rank": 453,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -13262,7 +13354,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 451,
+      "rank": 454,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -13299,7 +13391,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 452,
+      "rank": 455,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -13329,7 +13421,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 453,
+      "rank": 456,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -13358,7 +13450,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 454,
+      "rank": 457,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -13386,7 +13478,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 455,
+      "rank": 458,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -13412,7 +13504,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 456,
+      "rank": 459,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -13437,7 +13529,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 457,
+      "rank": 460,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -13464,7 +13556,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 458,
+      "rank": 461,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -13489,7 +13581,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 459,
+      "rank": 462,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -13518,7 +13610,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 460,
+      "rank": 463,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -13543,12 +13635,12 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 461,
+      "rank": 464,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13114,
-      "likes": 523,
+      "downloads": 13062,
+      "likes": 524,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -13570,11 +13662,11 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 462,
+      "rank": 465,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
-      "downloads": 291,
+      "downloads": 355,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "text-to-image",
@@ -13596,76 +13688,11 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 463,
-      "id": "stabilityai/stable-audio-3-optimized",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
-      "downloads": 0,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "onnx",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T19:38:34.000Z",
-      "lastModified": "2026-05-20T20:49:04.000Z"
-    },
-    {
-      "rank": 464,
-      "id": "SupraLabs/Supra-50M-Instruct",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
-      "downloads": 822,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "llama",
-        "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "dataset:yahma/alpaca-cleaned",
-        "base_model:SupraLabs/Supra-50M-Base",
-        "base_model:quantized:SupraLabs/Supra-50M-Base",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-21T12:06:17.000Z",
-      "lastModified": "2026-05-23T08:10:17.000Z"
-    },
-    {
-      "rank": 465,
+      "rank": 466,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "downloads": 1280299,
+      "downloads": 1261358,
       "likes": 860,
       "trendingScore": 12,
       "pipelineTag": "automatic-speech-recognition",
@@ -13700,11 +13727,11 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 466,
+      "rank": 467,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
-      "downloads": 1671206,
+      "downloads": 1693872,
       "likes": 4539,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
@@ -13723,18 +13750,18 @@
         "license:llama3",
         "text-generation-inference",
         "endpoints_compatible",
-        "region:us",
-        "deploy:azure"
+        "deploy:azure",
+        "region:us"
       ],
       "createdAt": "2024-04-17T09:35:12.000Z",
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 467,
+      "rank": 468,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 10772,
+      "downloads": 11621,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -13758,11 +13785,11 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 468,
+      "rank": 469,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
-      "downloads": 700,
+      "downloads": 883,
       "likes": 24,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
@@ -13784,11 +13811,11 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 469,
+      "rank": 470,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
-      "downloads": 12644300,
+      "downloads": 12733226,
       "likes": 999,
       "trendingScore": 12,
       "pipelineTag": "text-classification",
@@ -13812,7 +13839,38 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 470,
+      "rank": 471,
+      "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
+      "author": "YTan2000",
+      "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
+      "downloads": 730,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "llama.cpp",
+        "qwen",
+        "qwopus",
+        "quantization",
+        "turboquant",
+        "tq3_4s",
+        "multimodal",
+        "image-text-to-text",
+        "en",
+        "base_model:Jackrong/Qwopus3.6-27B-v2",
+        "base_model:quantized:Jackrong/Qwopus3.6-27B-v2",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T07:56:16.000Z",
+      "lastModified": "2026-05-23T08:47:41.000Z"
+    },
+    {
+      "rank": 472,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -13857,7 +13915,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 471,
+      "rank": 473,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -13899,7 +13957,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 472,
+      "rank": 474,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -13925,7 +13983,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 473,
+      "rank": 475,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -13950,7 +14008,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 474,
+      "rank": 476,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -13967,7 +14025,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 475,
+      "rank": 477,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -13995,7 +14053,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 476,
+      "rank": 478,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -14021,7 +14079,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 477,
+      "rank": 479,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -14048,7 +14106,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 478,
+      "rank": 480,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -14076,7 +14134,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 479,
+      "rank": 481,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -14109,7 +14167,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 480,
+      "rank": 482,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -14143,7 +14201,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 481,
+      "rank": 483,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -14172,7 +14230,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 482,
+      "rank": 484,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -14201,7 +14259,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 483,
+      "rank": 485,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -14234,7 +14292,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 484,
+      "rank": 486,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -14261,7 +14319,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 485,
+      "rank": 487,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -14291,7 +14349,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 486,
+      "rank": 488,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -14317,7 +14375,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 487,
+      "rank": 489,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -14341,7 +14399,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 488,
+      "rank": 490,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -14368,7 +14426,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 489,
+      "rank": 491,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -14402,7 +14460,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 490,
+      "rank": 492,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -14418,7 +14476,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 491,
+      "rank": 493,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -14449,7 +14507,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 492,
+      "rank": 494,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -14471,7 +14529,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 493,
+      "rank": 495,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -14491,7 +14549,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 494,
+      "rank": 496,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -14513,7 +14571,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 495,
+      "rank": 497,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -14542,7 +14600,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 496,
+      "rank": 498,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -14567,7 +14625,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 497,
+      "rank": 499,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -14592,7 +14650,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 498,
+      "rank": 500,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -14627,7 +14685,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 499,
+      "rank": 501,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -14651,7 +14709,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 500,
+      "rank": 502,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -14682,7 +14740,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 501,
+      "rank": 503,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -14708,7 +14766,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 502,
+      "rank": 504,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -14738,7 +14796,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 503,
+      "rank": 505,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -14764,11 +14822,11 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 504,
+      "rank": 506,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
-      "downloads": 2074583,
+      "downloads": 2060444,
       "likes": 1597,
       "trendingScore": 11,
       "pipelineTag": "text-to-speech",
@@ -14809,7 +14867,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 505,
+      "rank": 507,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -14836,7 +14894,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 506,
+      "rank": 508,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -14863,7 +14921,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 507,
+      "rank": 509,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -14908,7 +14966,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 508,
+      "rank": 510,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -14934,7 +14992,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 509,
+      "rank": 511,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -14963,11 +15021,11 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 510,
+      "rank": 512,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
-      "downloads": 390754,
+      "downloads": 412749,
       "likes": 13,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15008,7 +15066,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 511,
+      "rank": 513,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15040,7 +15098,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 512,
+      "rank": 514,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -15075,11 +15133,11 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 513,
+      "rank": 515,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
-      "downloads": 44,
+      "downloads": 78,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15106,42 +15164,11 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 514,
-      "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
-      "author": "YTan2000",
-      "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
-      "downloads": 536,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "llama.cpp",
-        "qwen",
-        "qwopus",
-        "quantization",
-        "turboquant",
-        "tq3_4s",
-        "multimodal",
-        "image-text-to-text",
-        "en",
-        "base_model:Jackrong/Qwopus3.6-27B-v2",
-        "base_model:quantized:Jackrong/Qwopus3.6-27B-v2",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T07:56:16.000Z",
-      "lastModified": "2026-05-23T08:47:41.000Z"
-    },
-    {
-      "rank": 515,
+      "rank": 516,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "downloads": 9168,
+      "downloads": 9547,
       "likes": 156,
       "trendingScore": 11,
       "pipelineTag": "text-to-image",
@@ -15157,11 +15184,11 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 516,
+      "rank": 517,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "downloads": 16381,
+      "downloads": 18616,
       "likes": 13,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15187,11 +15214,11 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 517,
+      "rank": 518,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
-      "downloads": 18686,
+      "downloads": 19660,
       "likes": 142,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15232,7 +15259,112 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 518,
+      "rank": 519,
+      "id": "unsloth/Z-Image-Turbo-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
+      "downloads": 55944,
+      "likes": 190,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-image",
+      "libraryName": "ggml",
+      "tags": [
+        "ggml",
+        "gguf",
+        "quantized",
+        "unsloth",
+        "text-to-image",
+        "en",
+        "arxiv:2511.22699",
+        "arxiv:2511.22677",
+        "arxiv:2511.13649",
+        "base_model:Tongyi-MAI/Z-Image-Turbo",
+        "base_model:quantized:Tongyi-MAI/Z-Image-Turbo",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-21T22:47:59.000Z",
+      "lastModified": "2026-01-08T02:11:45.000Z"
+    },
+    {
+      "rank": 520,
+      "id": "NousResearch/Hermes-4.3-36B",
+      "author": "NousResearch",
+      "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
+      "downloads": 6263,
+      "likes": 212,
+      "trendingScore": 11,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "seed_oss",
+        "text-generation",
+        "Bytedance Seed",
+        "instruct",
+        "finetune",
+        "reasoning",
+        "hybrid-mode",
+        "chatml",
+        "function calling",
+        "tool use",
+        "json mode",
+        "structured outputs",
+        "atropos",
+        "dataforge",
+        "long context",
+        "roleplaying",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2508.18255",
+        "base_model:ByteDance-Seed/Seed-OSS-36B-Base",
+        "base_model:finetune:ByteDance-Seed/Seed-OSS-36B-Base",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-17T19:48:42.000Z",
+      "lastModified": "2025-12-06T15:04:17.000Z"
+    },
+    {
+      "rank": 521,
+      "id": "SupraLabs/Supra-50M-Base",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
+      "downloads": 397,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:00:44.000Z",
+      "lastModified": "2026-05-23T07:46:11.000Z"
+    },
+    {
+      "rank": 522,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -15261,7 +15393,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 519,
+      "rank": 523,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -15295,7 +15427,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 520,
+      "rank": 524,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -15340,7 +15472,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 521,
+      "rank": 525,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -15369,7 +15501,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 522,
+      "rank": 526,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -15394,7 +15526,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 523,
+      "rank": 527,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -15429,7 +15561,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 524,
+      "rank": 528,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -15456,7 +15588,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 525,
+      "rank": 529,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -15501,7 +15633,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 526,
+      "rank": 530,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -15523,7 +15655,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 527,
+      "rank": 531,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -15555,7 +15687,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 528,
+      "rank": 532,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -15580,7 +15712,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -15604,35 +15736,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 530,
-      "id": "unsloth/Z-Image-Turbo-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
-      "downloads": 58980,
-      "likes": 189,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-image",
-      "libraryName": "ggml",
-      "tags": [
-        "ggml",
-        "gguf",
-        "quantized",
-        "unsloth",
-        "text-to-image",
-        "en",
-        "arxiv:2511.22699",
-        "arxiv:2511.22677",
-        "arxiv:2511.13649",
-        "base_model:Tongyi-MAI/Z-Image-Turbo",
-        "base_model:quantized:Tongyi-MAI/Z-Image-Turbo",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-21T22:47:59.000Z",
-      "lastModified": "2026-01-08T02:11:45.000Z"
-    },
-    {
-      "rank": 531,
+      "rank": 534,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -15675,7 +15779,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 532,
+      "rank": 535,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -15699,7 +15803,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 533,
+      "rank": 536,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -15728,7 +15832,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 534,
+      "rank": 537,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -15760,7 +15864,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 535,
+      "rank": 538,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -15784,7 +15888,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 536,
+      "rank": 539,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -15806,7 +15910,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 537,
+      "rank": 540,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -15831,7 +15935,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 538,
+      "rank": 541,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -15859,7 +15963,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 539,
+      "rank": 542,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -15883,7 +15987,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 540,
+      "rank": 543,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -15910,7 +16014,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 541,
+      "rank": 544,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -15927,7 +16031,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 542,
+      "rank": 545,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -15951,7 +16055,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 543,
+      "rank": 546,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -15975,7 +16079,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 544,
+      "rank": 547,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -16008,7 +16112,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 545,
+      "rank": 548,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -16042,7 +16146,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 546,
+      "rank": 549,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -16064,7 +16168,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 547,
+      "rank": 550,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -16087,7 +16191,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 548,
+      "rank": 551,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -16107,7 +16211,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 549,
+      "rank": 552,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -16139,7 +16243,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 550,
+      "rank": 553,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -16178,7 +16282,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 551,
+      "rank": 554,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -16212,7 +16316,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 552,
+      "rank": 555,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -16236,7 +16340,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 553,
+      "rank": 556,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -16256,7 +16360,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 554,
+      "rank": 557,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -16285,7 +16389,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 555,
+      "rank": 558,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -16307,7 +16411,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 556,
+      "rank": 559,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -16339,7 +16443,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 557,
+      "rank": 560,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -16366,7 +16470,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 558,
+      "rank": 561,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -16410,7 +16514,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 559,
+      "rank": 562,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -16428,7 +16532,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 560,
+      "rank": 563,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -16467,7 +16571,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 561,
+      "rank": 564,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -16506,7 +16610,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 562,
+      "rank": 565,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -16540,7 +16644,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 563,
+      "rank": 566,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -16568,7 +16672,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 564,
+      "rank": 567,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -16590,7 +16694,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 565,
+      "rank": 568,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -16618,7 +16722,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 566,
+      "rank": 569,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -16636,7 +16740,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 567,
+      "rank": 570,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -16664,7 +16768,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 568,
+      "rank": 571,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -16695,7 +16799,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 569,
+      "rank": 572,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -16711,7 +16815,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 570,
+      "rank": 573,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -16738,7 +16842,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 571,
+      "rank": 574,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -16767,7 +16871,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 572,
+      "rank": 575,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -16795,7 +16899,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 573,
+      "rank": 576,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -16824,7 +16928,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 574,
+      "rank": 577,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -16845,7 +16949,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 575,
+      "rank": 578,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -16866,11 +16970,11 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 576,
+      "rank": 579,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "downloads": 224,
+      "downloads": 340,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -16893,12 +16997,12 @@
       "lastModified": "2026-05-21T02:10:38.000Z"
     },
     {
-      "rank": 577,
+      "rank": 580,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 2090260,
-      "likes": 2145,
+      "downloads": 2092362,
+      "likes": 2147,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -16931,7 +17035,7 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 578,
+      "rank": 581,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -16961,50 +17065,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 579,
-      "id": "NousResearch/Hermes-4.3-36B",
-      "author": "NousResearch",
-      "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
-      "downloads": 6159,
-      "likes": 211,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "seed_oss",
-        "text-generation",
-        "Bytedance Seed",
-        "instruct",
-        "finetune",
-        "reasoning",
-        "hybrid-mode",
-        "chatml",
-        "function calling",
-        "tool use",
-        "json mode",
-        "structured outputs",
-        "atropos",
-        "dataforge",
-        "long context",
-        "roleplaying",
-        "chat",
-        "conversational",
-        "en",
-        "arxiv:2508.18255",
-        "base_model:ByteDance-Seed/Seed-OSS-36B-Base",
-        "base_model:finetune:ByteDance-Seed/Seed-OSS-36B-Base",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-17T19:48:42.000Z",
-      "lastModified": "2025-12-06T15:04:17.000Z"
-    },
-    {
-      "rank": 580,
+      "rank": 582,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -17028,12 +17089,12 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 581,
+      "rank": 583,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
-      "downloads": 971087,
-      "likes": 414,
+      "downloads": 1050219,
+      "likes": 415,
       "trendingScore": 10,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -17058,41 +17119,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 582,
-      "id": "SupraLabs/Supra-50M-Base",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
-      "downloads": 341,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T05:00:44.000Z",
-      "lastModified": "2026-05-23T07:46:11.000Z"
-    },
-    {
-      "rank": 583,
+      "rank": 584,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -17117,11 +17144,11 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 584,
+      "rank": 585,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
-      "downloads": 1201,
+      "downloads": 1245,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -17139,12 +17166,12 @@
       "lastModified": "2026-05-22T05:16:00.000Z"
     },
     {
-      "rank": 585,
+      "rank": 586,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
-      "downloads": 951361,
-      "likes": 2777,
+      "downloads": 940426,
+      "likes": 2778,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -17178,11 +17205,11 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 586,
+      "rank": 587,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
-      "downloads": 129969,
+      "downloads": 133945,
       "likes": 172,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -17209,11 +17236,11 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 587,
+      "rank": 588,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
-      "downloads": 334,
+      "downloads": 379,
       "likes": 15,
       "trendingScore": 10,
       "pipelineTag": "other",
@@ -17242,11 +17269,11 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 588,
+      "rank": 589,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
-      "downloads": 1400,
+      "downloads": 1520,
       "likes": 481,
       "trendingScore": 10,
       "pipelineTag": "text-to-video",
@@ -17268,7 +17295,69 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 589,
+      "rank": 590,
+      "id": "meta-llama/Llama-3.1-8B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
+      "downloads": 1241077,
+      "likes": 2206,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "license:llama3.1",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-14T22:20:15.000Z",
+      "lastModified": "2024-10-16T22:00:37.000Z"
+    },
+    {
+      "rank": 591,
+      "id": "black-forest-labs/FLUX.2-klein-base-9B",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
+      "downloads": 83796,
+      "likes": 233,
+      "trendingScore": 10,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-generation",
+        "image-editing",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "license:other",
+        "diffusers:Flux2KleinPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-01-14T13:40:35.000Z",
+      "lastModified": "2026-02-24T00:19:46.000Z"
+    },
+    {
+      "rank": 592,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -17295,7 +17384,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 590,
+      "rank": 593,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -17321,7 +17410,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 591,
+      "rank": 594,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -17349,7 +17438,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 592,
+      "rank": 595,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -17375,7 +17464,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 593,
+      "rank": 596,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -17415,7 +17504,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 594,
+      "rank": 597,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -17451,7 +17540,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 595,
+      "rank": 598,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -17495,7 +17584,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 596,
+      "rank": 599,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -17520,7 +17609,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 597,
+      "rank": 600,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -17565,7 +17654,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 598,
+      "rank": 601,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -17584,7 +17673,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 599,
+      "rank": 602,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -17609,7 +17698,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 600,
+      "rank": 603,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -17648,7 +17737,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 601,
+      "rank": 604,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -17665,7 +17754,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 602,
+      "rank": 605,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -17693,7 +17782,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 603,
+      "rank": 606,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -17722,7 +17811,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 604,
+      "rank": 607,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -17747,7 +17836,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 605,
+      "rank": 608,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -17782,7 +17871,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 606,
+      "rank": 609,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -17812,7 +17901,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 607,
+      "rank": 610,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -17848,7 +17937,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 608,
+      "rank": 611,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -17871,7 +17960,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 609,
+      "rank": 612,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -17888,7 +17977,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 610,
+      "rank": 613,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -17908,7 +17997,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 611,
+      "rank": 614,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -17935,7 +18024,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 612,
+      "rank": 615,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -17959,7 +18048,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 613,
+      "rank": 616,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -17981,7 +18070,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 614,
+      "rank": 617,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -18013,7 +18102,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 615,
+      "rank": 618,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -18041,7 +18130,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 616,
+      "rank": 619,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -18059,7 +18148,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 617,
+      "rank": 620,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -18084,7 +18173,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 618,
+      "rank": 621,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -18107,7 +18196,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 619,
+      "rank": 622,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -18125,7 +18214,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 620,
+      "rank": 623,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -18160,7 +18249,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 621,
+      "rank": 624,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -18188,7 +18277,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 622,
+      "rank": 625,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -18210,7 +18299,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 623,
+      "rank": 626,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -18237,7 +18326,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 624,
+      "rank": 627,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -18262,7 +18351,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 625,
+      "rank": 628,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -18296,7 +18385,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 626,
+      "rank": 629,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -18323,7 +18412,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 627,
+      "rank": 630,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -18350,7 +18439,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 628,
+      "rank": 631,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -18391,7 +18480,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 629,
+      "rank": 632,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -18421,7 +18510,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 630,
+      "rank": 633,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -18458,7 +18547,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 631,
+      "rank": 634,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -18490,7 +18579,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 632,
+      "rank": 635,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -18532,7 +18621,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 633,
+      "rank": 636,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -18562,7 +18651,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 634,
+      "rank": 637,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -18607,7 +18696,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 635,
+      "rank": 638,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -18634,7 +18723,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 636,
+      "rank": 639,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -18666,7 +18755,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 637,
+      "rank": 640,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -18700,7 +18789,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 638,
+      "rank": 641,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -18730,7 +18819,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 639,
+      "rank": 642,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -18755,7 +18844,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 640,
+      "rank": 643,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -18782,7 +18871,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 641,
+      "rank": 644,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -18814,7 +18903,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 642,
+      "rank": 645,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -18859,7 +18948,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 643,
+      "rank": 646,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -18887,7 +18976,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 644,
+      "rank": 647,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -18913,11 +19002,11 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 645,
+      "rank": 648,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
-      "downloads": 1007,
+      "downloads": 1036,
       "likes": 408,
       "trendingScore": 9,
       "pipelineTag": "audio-to-audio",
@@ -18942,7 +19031,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 646,
+      "rank": 649,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -18984,12 +19073,12 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 647,
+      "rank": 650,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
-      "downloads": 181591,
-      "likes": 994,
+      "downloads": 212884,
+      "likes": 997,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -19012,7 +19101,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 648,
+      "rank": 651,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -19041,7 +19130,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 649,
+      "rank": 652,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -19071,7 +19160,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 650,
+      "rank": 653,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -19098,7 +19187,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 651,
+      "rank": 654,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -19127,7 +19216,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 652,
+      "rank": 655,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -19154,7 +19243,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 653,
+      "rank": 656,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -19183,7 +19272,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 654,
+      "rank": 657,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -19223,43 +19312,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 655,
-      "id": "meta-llama/Llama-3.1-8B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
-      "downloads": 1252436,
-      "likes": 2205,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "license:llama3.1",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-14T22:20:15.000Z",
-      "lastModified": "2024-10-16T22:00:37.000Z"
-    },
-    {
-      "rank": 656,
+      "rank": 658,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -19277,7 +19330,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 657,
+      "rank": 659,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -19295,11 +19348,11 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 658,
+      "rank": 660,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
-      "downloads": 71306,
+      "downloads": 69277,
       "likes": 181,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -19320,12 +19373,12 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 659,
+      "rank": 661,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
-      "downloads": 8401031,
-      "likes": 1080,
+      "downloads": 8315098,
+      "likes": 1081,
       "trendingScore": 9,
       "pipelineTag": "image-classification",
       "libraryName": "transformers",
@@ -19345,11 +19398,11 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 660,
+      "rank": 662,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
-      "downloads": 129,
+      "downloads": 166,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -19361,11 +19414,11 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 661,
+      "rank": 663,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
-      "downloads": 1740,
+      "downloads": 2177,
       "likes": 10,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -19398,37 +19451,11 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 662,
-      "id": "black-forest-labs/FLUX.2-klein-base-9B",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
-      "downloads": 87280,
-      "likes": 232,
-      "trendingScore": 9,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-generation",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "license:other",
-        "diffusers:Flux2KleinPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-01-14T13:40:35.000Z",
-      "lastModified": "2026-02-24T00:19:46.000Z"
-    },
-    {
-      "rank": 663,
+      "rank": 664,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
-      "downloads": 37,
+      "downloads": 47,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -19464,11 +19491,11 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 664,
+      "rank": 665,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
-      "downloads": 18603,
+      "downloads": 19977,
       "likes": 17,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -19497,11 +19524,11 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 665,
+      "rank": 666,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
-      "downloads": 1340,
+      "downloads": 1722,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -19524,11 +19551,11 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 666,
+      "rank": 667,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
-      "downloads": 136178,
+      "downloads": 138163,
       "likes": 341,
       "trendingScore": 9,
       "pipelineTag": "text-to-image",
@@ -19558,7 +19585,77 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 667,
+      "rank": 668,
+      "id": "google/gemma-7b",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-7b",
+      "downloads": 104595,
+      "likes": 3329,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "gemma",
+        "text-generation",
+        "arxiv:2305.14314",
+        "arxiv:2312.11805",
+        "arxiv:2009.03300",
+        "arxiv:1905.07830",
+        "arxiv:1911.11641",
+        "arxiv:1904.09728",
+        "arxiv:1905.10044",
+        "arxiv:1907.10641",
+        "arxiv:1811.00937",
+        "arxiv:1809.02789",
+        "arxiv:1911.01547",
+        "arxiv:1705.03551",
+        "arxiv:2107.03374",
+        "arxiv:2108.07732",
+        "arxiv:2110.14168",
+        "arxiv:2304.06364",
+        "arxiv:2206.04615",
+        "arxiv:1804.06876",
+        "arxiv:2110.08193",
+        "arxiv:2009.11462",
+        "arxiv:2101.11718",
+        "arxiv:1804.09301",
+        "arxiv:2109.07958",
+        "arxiv:2203.09509",
+        "license:gemma"
+      ],
+      "createdAt": "2024-02-08T22:36:43.000Z",
+      "lastModified": "2024-06-27T14:09:40.000Z"
+    },
+    {
+      "rank": 669,
+      "id": "stabilityai/stable-audio-3-small-music-base",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T23:40:30.000Z",
+      "lastModified": "2026-05-20T15:19:54.000Z"
+    },
+    {
+      "rank": 670,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -19585,7 +19682,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 668,
+      "rank": 671,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -19609,7 +19706,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 669,
+      "rank": 672,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -19629,7 +19726,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 670,
+      "rank": 673,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -19648,7 +19745,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 671,
+      "rank": 674,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -19682,7 +19779,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 672,
+      "rank": 675,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -19714,7 +19811,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 673,
+      "rank": 676,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -19736,7 +19833,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 674,
+      "rank": 677,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -19781,7 +19878,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 675,
+      "rank": 678,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -19800,7 +19897,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 676,
+      "rank": 679,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -19834,7 +19931,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 677,
+      "rank": 680,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -19862,7 +19959,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 678,
+      "rank": 681,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -19890,7 +19987,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 679,
+      "rank": 682,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -19913,7 +20010,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 680,
+      "rank": 683,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -19940,7 +20037,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 681,
+      "rank": 684,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -19985,7 +20082,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 682,
+      "rank": 685,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -20021,7 +20118,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 683,
+      "rank": 686,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -20061,7 +20158,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 684,
+      "rank": 687,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -20090,7 +20187,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 685,
+      "rank": 688,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -20118,7 +20215,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 686,
+      "rank": 689,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -20137,7 +20234,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 687,
+      "rank": 690,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -20156,7 +20253,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 688,
+      "rank": 691,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -20188,7 +20285,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 689,
+      "rank": 692,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -20215,7 +20312,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 690,
+      "rank": 693,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -20237,7 +20334,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 691,
+      "rank": 694,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -20255,7 +20352,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 692,
+      "rank": 695,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -20284,7 +20381,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 693,
+      "rank": 696,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -20305,7 +20402,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 694,
+      "rank": 697,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -20333,7 +20430,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 695,
+      "rank": 698,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -20354,7 +20451,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 696,
+      "rank": 699,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -20390,52 +20487,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 697,
-      "id": "google/gemma-7b",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-7b",
-      "downloads": 104689,
-      "likes": 3328,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "gemma",
-        "text-generation",
-        "arxiv:2305.14314",
-        "arxiv:2312.11805",
-        "arxiv:2009.03300",
-        "arxiv:1905.07830",
-        "arxiv:1911.11641",
-        "arxiv:1904.09728",
-        "arxiv:1905.10044",
-        "arxiv:1907.10641",
-        "arxiv:1811.00937",
-        "arxiv:1809.02789",
-        "arxiv:1911.01547",
-        "arxiv:1705.03551",
-        "arxiv:2107.03374",
-        "arxiv:2108.07732",
-        "arxiv:2110.14168",
-        "arxiv:2304.06364",
-        "arxiv:2206.04615",
-        "arxiv:1804.06876",
-        "arxiv:2110.08193",
-        "arxiv:2009.11462",
-        "arxiv:2101.11718",
-        "arxiv:1804.09301",
-        "arxiv:2109.07958",
-        "arxiv:2203.09509",
-        "license:gemma"
-      ],
-      "createdAt": "2024-02-08T22:36:43.000Z",
-      "lastModified": "2024-06-27T14:09:40.000Z"
-    },
-    {
-      "rank": 698,
+      "rank": 700,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -20461,7 +20513,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 699,
+      "rank": 701,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -20484,7 +20536,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 700,
+      "rank": 702,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -20509,7 +20561,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 701,
+      "rank": 703,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -20544,7 +20596,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 702,
+      "rank": 704,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -20589,7 +20641,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 703,
+      "rank": 705,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -20616,7 +20668,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 704,
+      "rank": 706,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -20645,7 +20697,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 705,
+      "rank": 707,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -20664,7 +20716,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 706,
+      "rank": 708,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -20685,7 +20737,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 707,
+      "rank": 709,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -20711,7 +20763,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 708,
+      "rank": 710,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -20737,7 +20789,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 709,
+      "rank": 711,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -20774,7 +20826,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 710,
+      "rank": 712,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -20819,7 +20871,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 711,
+      "rank": 713,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -20844,7 +20896,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 712,
+      "rank": 714,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -20861,7 +20913,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 713,
+      "rank": 715,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -20888,7 +20940,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 714,
+      "rank": 716,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -20906,7 +20958,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 715,
+      "rank": 717,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -20931,7 +20983,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 716,
+      "rank": 718,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -20963,7 +21015,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 717,
+      "rank": 719,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -20984,7 +21036,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 718,
+      "rank": 720,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -21003,7 +21055,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 719,
+      "rank": 721,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -21034,7 +21086,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 720,
+      "rank": 722,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -21057,7 +21109,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 721,
+      "rank": 723,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -21074,7 +21126,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 722,
+      "rank": 724,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -21102,7 +21154,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 723,
+      "rank": 725,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -21119,7 +21171,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 724,
+      "rank": 726,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -21155,7 +21207,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 725,
+      "rank": 727,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -21185,7 +21237,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 726,
+      "rank": 728,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -21208,7 +21260,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 727,
+      "rank": 729,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -21241,7 +21293,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 728,
+      "rank": 730,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -21272,7 +21324,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 729,
+      "rank": 731,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -21295,7 +21347,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 730,
+      "rank": 732,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -21328,7 +21380,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 731,
+      "rank": 733,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -21351,7 +21403,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 732,
+      "rank": 734,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -21381,7 +21433,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 733,
+      "rank": 735,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -21410,7 +21462,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 734,
+      "rank": 736,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -21439,7 +21491,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 735,
+      "rank": 737,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -21475,7 +21527,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 736,
+      "rank": 738,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -21498,7 +21550,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 737,
+      "rank": 739,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -21523,7 +21575,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 738,
+      "rank": 740,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -21553,7 +21605,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 739,
+      "rank": 741,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -21589,7 +21641,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 740,
+      "rank": 742,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -21626,7 +21678,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 741,
+      "rank": 743,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -21653,7 +21705,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 742,
+      "rank": 744,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -21686,32 +21738,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 743,
-      "id": "stabilityai/stable-audio-3-small-music-base",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
-      "downloads": 0,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T23:40:30.000Z",
-      "lastModified": "2026-05-20T15:19:54.000Z"
-    },
-    {
-      "rank": 744,
+      "rank": 745,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -21748,7 +21775,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 745,
+      "rank": 746,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -21776,7 +21803,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 746,
+      "rank": 747,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -21796,11 +21823,11 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 747,
+      "rank": 748,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
-      "downloads": 14245,
+      "downloads": 14290,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -21822,11 +21849,11 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 748,
+      "rank": 749,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
-      "downloads": 4145,
+      "downloads": 4362,
       "likes": 10,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -21867,7 +21894,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 749,
+      "rank": 750,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -21899,11 +21926,11 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 750,
+      "rank": 751,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
-      "downloads": 173,
+      "downloads": 206,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -21924,7 +21951,7 @@
       "lastModified": "2026-05-22T04:33:05.000Z"
     },
     {
-      "rank": 751,
+      "rank": 752,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -21946,7 +21973,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 752,
+      "rank": 753,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -21974,11 +22001,11 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 753,
+      "rank": 754,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
-      "downloads": 1182,
+      "downloads": 1426,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22003,7 +22030,7 @@
       "lastModified": "2026-05-22T20:32:34.000Z"
     },
     {
-      "rank": 754,
+      "rank": 755,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -22027,11 +22054,11 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 755,
+      "rank": 756,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
-      "downloads": 1211,
+      "downloads": 1553,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22062,7 +22089,7 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 756,
+      "rank": 757,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
@@ -22080,11 +22107,11 @@
       "lastModified": "2026-05-23T05:40:30.000Z"
     },
     {
-      "rank": 757,
+      "rank": 758,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
-      "downloads": 1579,
+      "downloads": 1962,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22102,11 +22129,11 @@
       "lastModified": "2026-05-22T05:15:45.000Z"
     },
     {
-      "rank": 758,
+      "rank": 759,
       "id": "Anbeeld/Qwen3.6-27B-DFlash-GGUF",
       "author": "Anbeeld",
       "url": "https://huggingface.co/Anbeeld/Qwen3.6-27B-DFlash-GGUF",
-      "downloads": 2929,
+      "downloads": 3734,
       "likes": 9,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22123,11 +22150,11 @@
       "lastModified": "2026-05-22T17:31:30.000Z"
     },
     {
-      "rank": 759,
+      "rank": 760,
       "id": "nvidia/GLM-5.1-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
-      "downloads": 3798,
+      "downloads": 4561,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22155,11 +22182,11 @@
       "lastModified": "2026-05-20T21:18:02.000Z"
     },
     {
-      "rank": 760,
+      "rank": 761,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
-      "downloads": 8462,
+      "downloads": 8450,
       "likes": 546,
       "trendingScore": 8,
       "pipelineTag": "automatic-speech-recognition",
@@ -22200,11 +22227,11 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 761,
+      "rank": 762,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
-      "downloads": 11085922,
+      "downloads": 11612224,
       "likes": 465,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22230,11 +22257,11 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 762,
+      "rank": 763,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
-      "downloads": 2394,
+      "downloads": 3674,
       "likes": 9,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22252,11 +22279,11 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 763,
+      "rank": 764,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
-      "downloads": 2041,
+      "downloads": 1935,
       "likes": 33,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22268,11 +22295,11 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 764,
+      "rank": 765,
       "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
-      "downloads": 155,
+      "downloads": 863,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -22313,7 +22340,141 @@
       "lastModified": "2026-05-24T04:55:49.000Z"
     },
     {
-      "rank": 765,
+      "rank": 766,
+      "id": "joyfox/LTX-2.3-Transition-LORA",
+      "author": "joyfox",
+      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
+      "downloads": 36708,
+      "likes": 113,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ValiantCat",
+        "Lightricks",
+        "LTX-2.3",
+        "image-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-20T10:25:10.000Z",
+      "lastModified": "2026-03-30T03:28:58.000Z"
+    },
+    {
+      "rank": 767,
+      "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
+      "author": "cyberneurova",
+      "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "any-to-any",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "abliterated",
+        "uncensored",
+        "lance",
+        "bytedance",
+        "multimodal",
+        "vision-language",
+        "text-to-image",
+        "text-to-video",
+        "vqa",
+        "research",
+        "transferability",
+        "any-to-any",
+        "en",
+        "base_model:bytedance-research/Lance",
+        "base_model:finetune:bytedance-research/Lance",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T10:33:00.000Z",
+      "lastModified": "2026-05-20T10:40:41.000Z"
+    },
+    {
+      "rank": 768,
+      "id": "zeroentropy/zerank-2-reranker",
+      "author": "zeroentropy",
+      "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
+      "downloads": 150076,
+      "likes": 79,
+      "trendingScore": 8,
+      "pipelineTag": "text-ranking",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3",
+        "finance",
+        "legal",
+        "code",
+        "stem",
+        "medical",
+        "text-ranking",
+        "en",
+        "arxiv:2509.12541",
+        "base_model:Qwen/Qwen3-4B",
+        "base_model:finetune:Qwen/Qwen3-4B",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-11-19T05:19:06.000Z",
+      "lastModified": "2026-05-05T17:47:28.000Z"
+    },
+    {
+      "rank": 769,
+      "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
+      "downloads": 2865,
+      "likes": 9,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T07:13:09.000Z",
+      "lastModified": "2026-05-23T14:54:50.000Z"
+    },
+    {
+      "rank": 770,
+      "id": "Abiray/L2P-model-1k-merge-INT8",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "image-generation",
+        "text-to-image",
+        "int8",
+        "comfyui",
+        "quantized",
+        "arxiv:2605.12013",
+        "base_model:zhen-nan/L2P",
+        "base_model:quantized:zhen-nan/L2P",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T17:12:49.000Z",
+      "lastModified": "2026-05-23T17:24:01.000Z"
+    },
+    {
+      "rank": 771,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -22339,7 +22500,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 766,
+      "rank": 772,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -22356,7 +22517,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 767,
+      "rank": 773,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -22384,7 +22545,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 768,
+      "rank": 774,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -22419,7 +22580,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 769,
+      "rank": 775,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -22444,7 +22605,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 770,
+      "rank": 776,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -22474,7 +22635,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 771,
+      "rank": 777,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -22503,7 +22664,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 772,
+      "rank": 778,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -22530,7 +22691,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 773,
+      "rank": 779,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -22556,7 +22717,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 774,
+      "rank": 780,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -22587,7 +22748,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 775,
+      "rank": 781,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -22605,7 +22766,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 776,
+      "rank": 782,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -22634,7 +22795,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 777,
+      "rank": 783,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -22657,7 +22818,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 778,
+      "rank": 784,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -22702,7 +22863,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 779,
+      "rank": 785,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -22728,7 +22889,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 780,
+      "rank": 786,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -22756,7 +22917,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 781,
+      "rank": 787,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -22794,7 +22955,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 782,
+      "rank": 788,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -22821,7 +22982,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 783,
+      "rank": 789,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -22847,7 +23008,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 784,
+      "rank": 790,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -22865,7 +23026,7 @@
       "lastModified": "2026-05-20T22:18:31.000Z"
     },
     {
-      "rank": 785,
+      "rank": 791,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -22891,7 +23052,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 786,
+      "rank": 792,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -22915,7 +23076,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 787,
+      "rank": 793,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -22956,7 +23117,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 788,
+      "rank": 794,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -22973,7 +23134,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 789,
+      "rank": 795,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -23006,7 +23167,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 790,
+      "rank": 796,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -23040,7 +23201,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 791,
+      "rank": 797,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -23079,7 +23240,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 792,
+      "rank": 798,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -23109,7 +23270,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 793,
+      "rank": 799,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -23135,7 +23296,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 794,
+      "rank": 800,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -23171,7 +23332,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 795,
+      "rank": 801,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -23201,7 +23362,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 796,
+      "rank": 802,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -23239,7 +23400,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 797,
+      "rank": 803,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -23274,7 +23435,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 798,
+      "rank": 804,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -23291,7 +23452,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 799,
+      "rank": 805,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -23333,7 +23494,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 800,
+      "rank": 806,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -23363,7 +23524,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 801,
+      "rank": 807,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -23388,7 +23549,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 802,
+      "rank": 808,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -23416,7 +23577,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 803,
+      "rank": 809,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -23433,7 +23594,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 804,
+      "rank": 810,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -23460,7 +23621,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 805,
+      "rank": 811,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -23503,7 +23664,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 806,
+      "rank": 812,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -23543,7 +23704,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 807,
+      "rank": 813,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -23567,7 +23728,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 808,
+      "rank": 814,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -23596,7 +23757,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 809,
+      "rank": 815,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -23622,7 +23783,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 810,
+      "rank": 816,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -23661,7 +23822,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 811,
+      "rank": 817,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -23685,7 +23846,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 812,
+      "rank": 818,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -23713,7 +23874,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 813,
+      "rank": 819,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -23745,7 +23906,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 814,
+      "rank": 820,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -23775,7 +23936,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 815,
+      "rank": 821,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -23804,7 +23965,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 816,
+      "rank": 822,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -23833,7 +23994,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 817,
+      "rank": 823,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -23853,7 +24014,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 818,
+      "rank": 824,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -23877,7 +24038,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 819,
+      "rank": 825,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -23907,7 +24068,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 820,
+      "rank": 826,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -23937,7 +24098,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 821,
+      "rank": 827,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -23955,7 +24116,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 822,
+      "rank": 828,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -23972,7 +24133,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 823,
+      "rank": 829,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -24008,7 +24169,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 824,
+      "rank": 830,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -24039,7 +24200,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 825,
+      "rank": 831,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -24070,7 +24231,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 826,
+      "rank": 832,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -24103,7 +24264,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 827,
+      "rank": 833,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -24131,7 +24292,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 828,
+      "rank": 834,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -24156,7 +24317,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 829,
+      "rank": 835,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -24179,7 +24340,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 830,
+      "rank": 836,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -24207,7 +24368,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 831,
+      "rank": 837,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -24240,7 +24401,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 832,
+      "rank": 838,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -24270,7 +24431,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 833,
+      "rank": 839,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -24305,7 +24466,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 834,
+      "rank": 840,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -24337,7 +24498,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 835,
+      "rank": 841,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -24362,7 +24523,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 836,
+      "rank": 842,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -24385,7 +24546,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 837,
+      "rank": 843,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -24412,7 +24573,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 838,
+      "rank": 844,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -24435,7 +24596,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 839,
+      "rank": 845,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -24480,7 +24641,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 840,
+      "rank": 846,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -24512,7 +24673,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 841,
+      "rank": 847,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -24539,7 +24700,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 842,
+      "rank": 848,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -24565,7 +24726,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 843,
+      "rank": 849,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -24597,7 +24758,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 844,
+      "rank": 850,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -24626,7 +24787,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 845,
+      "rank": 851,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -24658,7 +24819,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 846,
+      "rank": 852,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -24688,7 +24849,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 847,
+      "rank": 853,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -24705,7 +24866,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 848,
+      "rank": 854,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -24725,7 +24886,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 849,
+      "rank": 855,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -24764,7 +24925,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 850,
+      "rank": 856,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -24802,7 +24963,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 851,
+      "rank": 857,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -24830,7 +24991,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 852,
+      "rank": 858,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -24875,7 +25036,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 853,
+      "rank": 859,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -24905,7 +25066,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 854,
+      "rank": 860,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -24932,7 +25093,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 855,
+      "rank": 861,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -24958,7 +25119,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 856,
+      "rank": 862,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -24987,7 +25148,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 857,
+      "rank": 863,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -25005,7 +25166,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 858,
+      "rank": 864,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -25037,7 +25198,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 859,
+      "rank": 865,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -25064,7 +25225,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 860,
+      "rank": 866,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -25082,7 +25243,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 861,
+      "rank": 867,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -25109,7 +25270,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 862,
+      "rank": 868,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -25133,7 +25294,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 863,
+      "rank": 869,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -25178,7 +25339,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 864,
+      "rank": 870,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -25209,7 +25370,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 865,
+      "rank": 871,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -25234,7 +25395,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 866,
+      "rank": 872,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -25268,12 +25429,12 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 867,
+      "rank": 873,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
-      "downloads": 52,
-      "likes": 7,
+      "downloads": 85,
+      "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
       "libraryName": "transformers",
@@ -25313,7 +25474,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 868,
+      "rank": 874,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -25354,7 +25515,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 869,
+      "rank": 875,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -25381,11 +25542,11 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 870,
+      "rank": 876,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
-      "downloads": 80,
+      "downloads": 108,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -25410,37 +25571,11 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 871,
-      "id": "joyfox/LTX-2.3-Transition-LORA",
-      "author": "joyfox",
-      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 36864,
-      "likes": 112,
-      "trendingScore": 7,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ValiantCat",
-        "Lightricks",
-        "LTX-2.3",
-        "image-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-20T10:25:10.000Z",
-      "lastModified": "2026-03-30T03:28:58.000Z"
-    },
-    {
-      "rank": 872,
+      "rank": 877,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
-      "downloads": 139643,
+      "downloads": 144051,
       "likes": 254,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -25468,7 +25603,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 873,
+      "rank": 878,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -25492,40 +25627,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 874,
-      "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
-      "author": "cyberneurova",
-      "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "any-to-any",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "abliterated",
-        "uncensored",
-        "lance",
-        "bytedance",
-        "multimodal",
-        "vision-language",
-        "text-to-image",
-        "text-to-video",
-        "vqa",
-        "research",
-        "transferability",
-        "any-to-any",
-        "en",
-        "base_model:bytedance-research/Lance",
-        "base_model:finetune:bytedance-research/Lance",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T10:33:00.000Z",
-      "lastModified": "2026-05-20T10:40:41.000Z"
-    },
-    {
-      "rank": 875,
+      "rank": 879,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -25552,7 +25654,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 876,
+      "rank": 880,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -25591,11 +25693,11 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 877,
+      "rank": 881,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
-      "downloads": 534,
+      "downloads": 461,
       "likes": 177,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -25621,11 +25723,11 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 878,
+      "rank": 882,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
-      "downloads": 7438,
+      "downloads": 7520,
       "likes": 15,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -25653,11 +25755,11 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 879,
+      "rank": 883,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
-      "downloads": 331680,
+      "downloads": 347563,
       "likes": 961,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -25687,12 +25789,12 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 880,
+      "rank": 884,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
       "downloads": 0,
-      "likes": 564,
+      "likes": 565,
       "trendingScore": 7,
       "pipelineTag": null,
       "libraryName": null,
@@ -25704,7 +25806,7 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 881,
+      "rank": 885,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
@@ -25731,7 +25833,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 882,
+      "rank": 886,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -25756,14 +25858,14 @@
         "region:us"
       ],
       "createdAt": "2026-05-19T17:02:04.000Z",
-      "lastModified": "2026-05-24T01:09:24.000Z"
+      "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 883,
+      "rank": 887,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
-      "downloads": 74,
+      "downloads": 76,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -25779,7 +25881,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 884,
+      "rank": 888,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -25807,11 +25909,11 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 885,
+      "rank": 889,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
-      "downloads": 1367,
+      "downloads": 1337,
       "likes": 45,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -25834,11 +25936,11 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 886,
+      "rank": 890,
       "id": "huytd189/Qwen3.6-27B-pure-GGUF",
       "author": "huytd189",
       "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
-      "downloads": 1490,
+      "downloads": 2078,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -25856,37 +25958,7 @@
       "lastModified": "2026-05-23T00:41:53.000Z"
     },
     {
-      "rank": 887,
-      "id": "zeroentropy/zerank-2-reranker",
-      "author": "zeroentropy",
-      "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
-      "downloads": 164012,
-      "likes": 78,
-      "trendingScore": 7,
-      "pipelineTag": "text-ranking",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3",
-        "finance",
-        "legal",
-        "code",
-        "stem",
-        "medical",
-        "text-ranking",
-        "en",
-        "arxiv:2509.12541",
-        "base_model:Qwen/Qwen3-4B",
-        "base_model:finetune:Qwen/Qwen3-4B",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-11-19T05:19:06.000Z",
-      "lastModified": "2026-05-05T17:47:28.000Z"
-    },
-    {
-      "rank": 888,
+      "rank": 891,
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
@@ -25915,11 +25987,11 @@
       "lastModified": "2025-12-17T05:12:35.000Z"
     },
     {
-      "rank": 889,
+      "rank": 892,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
-      "downloads": 9175,
+      "downloads": 7380,
       "likes": 103,
       "trendingScore": 7,
       "pipelineTag": "image-to-text",
@@ -25944,11 +26016,11 @@
       "lastModified": "2026-05-13T07:13:52.000Z"
     },
     {
-      "rank": 890,
+      "rank": 893,
       "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
-      "downloads": 5248,
+      "downloads": 4843,
       "likes": 197,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -25989,11 +26061,11 @@
       "lastModified": "2026-05-15T06:27:56.000Z"
     },
     {
-      "rank": 891,
+      "rank": 894,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
-      "downloads": 14107,
+      "downloads": 14021,
       "likes": 26,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26015,11 +26087,11 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 892,
+      "rank": 895,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
-      "downloads": 1466,
+      "downloads": 1878,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-ranking",
@@ -26050,7 +26122,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 893,
+      "rank": 896,
       "id": "openbmb/BitCPM-CANN-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-1B",
@@ -26076,7 +26148,7 @@
       "lastModified": "2026-05-23T18:13:08.000Z"
     },
     {
-      "rank": 894,
+      "rank": 897,
       "id": "openbmb/BitCPM-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-3B",
@@ -26102,11 +26174,11 @@
       "lastModified": "2026-05-23T18:13:14.000Z"
     },
     {
-      "rank": 895,
+      "rank": 898,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
-      "downloads": 447,
+      "downloads": 480,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-to-image",
@@ -26135,52 +26207,76 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 896,
-      "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "downloads": 1431,
-      "likes": 8,
+      "rank": 899,
+      "id": "UofTCSSLab/Maia3-79M",
+      "author": "UofTCSSLab",
+      "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
+      "downloads": 0,
+      "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "gguf",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T07:13:09.000Z",
-      "lastModified": "2026-05-23T14:54:50.000Z"
-    },
-    {
-      "rank": 897,
-      "id": "Abiray/L2P-model-1k-merge-INT8",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "image-generation",
-        "text-to-image",
-        "int8",
-        "comfyui",
-        "quantized",
-        "arxiv:2605.12013",
-        "base_model:zhen-nan/L2P",
-        "base_model:quantized:zhen-nan/L2P",
-        "license:apache-2.0",
+        "chess",
+        "maia",
+        "maia3",
+        "chessformer",
+        "move-prediction",
+        "human-ai",
+        "interpretability",
+        "en",
         "region:us"
       ],
-      "createdAt": "2026-05-23T17:12:49.000Z",
-      "lastModified": "2026-05-23T17:24:01.000Z"
+      "createdAt": "2026-05-17T23:34:19.000Z",
+      "lastModified": "2026-05-24T16:12:28.000Z"
     },
     {
-      "rank": 898,
+      "rank": 900,
+      "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
+      "author": "DavidAU",
+      "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
+      "downloads": 570,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "unsloth",
+        "heretic",
+        "uncensored",
+        "abliterated",
+        "fine tune",
+        "creative",
+        "creative writing",
+        "fiction writing",
+        "plot generation",
+        "sub-plot generation",
+        "story generation",
+        "scene continue",
+        "storytelling",
+        "fiction story",
+        "science fiction",
+        "romance",
+        "all genres",
+        "story",
+        "writing",
+        "vivid prosing",
+        "vivid writing",
+        "fiction",
+        "roleplaying",
+        "bfloat16",
+        "all use cases",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T02:06:58.000Z",
+      "lastModified": "2026-05-20T02:34:32.000Z"
+    },
+    {
+      "rank": 901,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -26213,7 +26309,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 899,
+      "rank": 902,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -26242,7 +26338,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 900,
+      "rank": 903,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -26287,7 +26383,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 901,
+      "rank": 904,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -26316,7 +26412,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 902,
+      "rank": 905,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -26361,7 +26457,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 903,
+      "rank": 906,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -26405,7 +26501,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 904,
+      "rank": 907,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -26431,7 +26527,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 905,
+      "rank": 908,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -26457,7 +26553,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 906,
+      "rank": 909,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -26489,7 +26585,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 907,
+      "rank": 910,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -26512,7 +26608,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 908,
+      "rank": 911,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -26555,7 +26651,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 909,
+      "rank": 912,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -26600,7 +26696,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 910,
+      "rank": 913,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -26645,7 +26741,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 911,
+      "rank": 914,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -26672,7 +26768,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 912,
+      "rank": 915,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -26699,7 +26795,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 913,
+      "rank": 916,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -26724,7 +26820,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 914,
+      "rank": 917,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -26763,7 +26859,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 915,
+      "rank": 918,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -26788,7 +26884,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 916,
+      "rank": 919,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -26816,7 +26912,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 917,
+      "rank": 920,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -26841,7 +26937,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 918,
+      "rank": 921,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -26857,7 +26953,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 919,
+      "rank": 922,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -26884,7 +26980,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 920,
+      "rank": 923,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -26916,7 +27012,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 921,
+      "rank": 924,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -26946,7 +27042,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 922,
+      "rank": 925,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -26978,7 +27074,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 923,
+      "rank": 926,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -27006,7 +27102,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 924,
+      "rank": 927,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -27032,12 +27128,12 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 925,
+      "rank": 928,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
-      "downloads": 871825,
-      "likes": 539,
+      "downloads": 820911,
+      "likes": 549,
       "trendingScore": 6,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -27057,7 +27153,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 926,
+      "rank": 929,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -27086,7 +27182,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 927,
+      "rank": 930,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -27128,7 +27224,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 928,
+      "rank": 931,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -27155,7 +27251,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 929,
+      "rank": 932,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -27200,7 +27296,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 930,
+      "rank": 933,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -27226,7 +27322,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 931,
+      "rank": 934,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -27246,7 +27342,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 932,
+      "rank": 935,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -27273,7 +27369,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 933,
+      "rank": 936,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -27315,7 +27411,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 934,
+      "rank": 937,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -27342,7 +27438,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 935,
+      "rank": 938,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -27371,7 +27467,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 936,
+      "rank": 939,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -27398,7 +27494,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 937,
+      "rank": 940,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -27425,7 +27521,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 938,
+      "rank": 941,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -27452,7 +27548,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 939,
+      "rank": 942,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -27480,11 +27576,11 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 940,
+      "rank": 943,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
-      "downloads": 3808,
+      "downloads": 3941,
       "likes": 15,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -27503,7 +27599,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 941,
+      "rank": 944,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -27534,7 +27630,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 942,
+      "rank": 945,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -27579,7 +27675,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 943,
+      "rank": 946,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -27601,7 +27697,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 944,
+      "rank": 947,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -27627,7 +27723,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 945,
+      "rank": 948,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -27658,7 +27754,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 946,
+      "rank": 949,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -27681,7 +27777,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 947,
+      "rank": 950,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -27711,7 +27807,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 948,
+      "rank": 951,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -27743,7 +27839,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 949,
+      "rank": 952,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -27772,7 +27868,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 950,
+      "rank": 953,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -27804,7 +27900,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 951,
+      "rank": 954,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -27836,7 +27932,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 952,
+      "rank": 955,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -27867,7 +27963,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 953,
+      "rank": 956,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -27898,7 +27994,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 954,
+      "rank": 957,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -27921,7 +28017,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 955,
+      "rank": 958,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -27948,7 +28044,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 956,
+      "rank": 959,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -27993,7 +28089,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 957,
+      "rank": 960,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -28011,7 +28107,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 958,
+      "rank": 961,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -28034,7 +28130,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 959,
+      "rank": 962,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -28064,7 +28160,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 960,
+      "rank": 963,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -28103,7 +28199,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 961,
+      "rank": 964,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -28141,7 +28237,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 962,
+      "rank": 965,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -28186,7 +28282,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 963,
+      "rank": 966,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -28211,7 +28307,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 964,
+      "rank": 967,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -28236,7 +28332,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 965,
+      "rank": 968,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -28269,7 +28365,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 966,
+      "rank": 969,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -28296,7 +28392,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 967,
+      "rank": 970,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -28326,7 +28422,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 968,
+      "rank": 971,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -28358,7 +28454,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 969,
+      "rank": 972,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -28391,7 +28487,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 970,
+      "rank": 973,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -28409,7 +28505,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 971,
+      "rank": 974,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -28432,7 +28528,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 972,
+      "rank": 975,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -28464,7 +28560,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 973,
+      "rank": 976,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -28509,7 +28605,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 974,
+      "rank": 977,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -28548,7 +28644,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 975,
+      "rank": 978,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -28575,7 +28671,7 @@
       "lastModified": "2026-05-10T03:41:04.000Z"
     },
     {
-      "rank": 976,
+      "rank": 979,
       "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
       "author": "Ngixdev",
       "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
@@ -28612,7 +28708,7 @@
       "lastModified": "2026-04-02T18:56:12.000Z"
     },
     {
-      "rank": 977,
+      "rank": 980,
       "id": "BAAI/bge-base-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
@@ -28648,7 +28744,7 @@
       "lastModified": "2024-02-21T03:00:19.000Z"
     },
     {
-      "rank": 978,
+      "rank": 981,
       "id": "Comfy-Org/sam3.1",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/sam3.1",
@@ -28666,7 +28762,7 @@
       "lastModified": "2026-05-06T13:59:05.000Z"
     },
     {
-      "rank": 979,
+      "rank": 982,
       "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
       "author": "Max-and-Omnis",
       "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
@@ -28705,7 +28801,7 @@
       "lastModified": "2026-04-24T08:34:29.000Z"
     },
     {
-      "rank": 980,
+      "rank": 983,
       "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
       "author": "TinyLlama",
       "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -28734,7 +28830,7 @@
       "lastModified": "2024-03-17T05:07:08.000Z"
     },
     {
-      "rank": 981,
+      "rank": 984,
       "id": "Camais03/camie-tagger-v2",
       "author": "Camais03",
       "url": "https://huggingface.co/Camais03/camie-tagger-v2",
@@ -28761,7 +28857,7 @@
       "lastModified": "2026-01-01T16:37:32.000Z"
     },
     {
-      "rank": 982,
+      "rank": 985,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-TalkVid-3K",
@@ -28788,7 +28884,7 @@
       "lastModified": "2026-03-18T20:01:19.000Z"
     },
     {
-      "rank": 983,
+      "rank": 986,
       "id": "TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-31B-it-Claude-Opus-Distill-v2-GGUF",
@@ -28818,7 +28914,7 @@
       "lastModified": "2026-05-08T07:10:22.000Z"
     },
     {
-      "rank": 984,
+      "rank": 987,
       "id": "birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
       "author": "birder-project",
       "url": "https://huggingface.co/birder-project/vit_reg4_so150m_p14_ls_dino-v2-bio",
@@ -28845,7 +28941,7 @@
       "lastModified": "2026-05-10T15:29:20.000Z"
     },
     {
-      "rank": 985,
+      "rank": 988,
       "id": "pyannote/wespeaker-voxceleb-resnet34-LM",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM",
@@ -28876,7 +28972,7 @@
       "lastModified": "2024-05-10T19:36:24.000Z"
     },
     {
-      "rank": 986,
+      "rank": 989,
       "id": "Comfy-Org/flux2-dev",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/flux2-dev",
@@ -28895,7 +28991,7 @@
       "lastModified": "2026-01-10T04:45:01.000Z"
     },
     {
-      "rank": 987,
+      "rank": 990,
       "id": "unsloth/FLUX.2-dev-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-dev-GGUF",
@@ -28922,7 +29018,7 @@
       "lastModified": "2025-12-10T16:47:58.000Z"
     },
     {
-      "rank": 988,
+      "rank": 991,
       "id": "lilylilith/AnyPose",
       "author": "lilylilith",
       "url": "https://huggingface.co/lilylilith/AnyPose",
@@ -28947,7 +29043,7 @@
       "lastModified": "2026-01-02T18:22:54.000Z"
     },
     {
-      "rank": 989,
+      "rank": 992,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-14B-Diffusers",
@@ -28977,7 +29073,7 @@
       "lastModified": "2026-05-14T07:09:21.000Z"
     },
     {
-      "rank": 990,
+      "rank": 993,
       "id": "stabilityai/sdxl-turbo",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/sdxl-turbo",
@@ -28999,7 +29095,7 @@
       "lastModified": "2024-07-10T11:33:43.000Z"
     },
     {
-      "rank": 991,
+      "rank": 994,
       "id": "zhuhz22/Causal-Forcing",
       "author": "zhuhz22",
       "url": "https://huggingface.co/zhuhz22/Causal-Forcing",
@@ -29020,7 +29116,7 @@
       "lastModified": "2026-05-11T05:58:45.000Z"
     },
     {
-      "rank": 992,
+      "rank": 995,
       "id": "FrontiersMind/Nandi-Mini-150M-Instruct",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Instruct",
@@ -29056,7 +29152,7 @@
       "lastModified": "2026-05-18T12:20:56.000Z"
     },
     {
-      "rank": 993,
+      "rank": 996,
       "id": "CompactAI-O/Glint-1.3",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1.3",
@@ -29079,7 +29175,7 @@
       "lastModified": "2026-05-13T22:59:07.000Z"
     },
     {
-      "rank": 994,
+      "rank": 997,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -29124,7 +29220,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 995,
+      "rank": 998,
       "id": "fastino/gliner2-base-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-base-v1",
@@ -29154,7 +29250,7 @@
       "lastModified": "2026-04-17T20:14:27.000Z"
     },
     {
-      "rank": 996,
+      "rank": 999,
       "id": "fancyfeast/llama-joycaption-beta-one-hf-llava",
       "author": "fancyfeast",
       "url": "https://huggingface.co/fancyfeast/llama-joycaption-beta-one-hf-llava",
@@ -29179,7 +29275,7 @@
       "lastModified": "2025-05-16T04:12:26.000Z"
     },
     {
-      "rank": 997,
+      "rank": 1000,
       "id": "FrontiersMind/Nandi-Mini-150M",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M",
@@ -29210,94 +29306,6 @@
       ],
       "createdAt": "2026-04-01T13:19:41.000Z",
       "lastModified": "2026-05-15T09:58:44.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "NeoQuasar/Kronos-base",
-      "author": "NeoQuasar",
-      "url": "https://huggingface.co/NeoQuasar/Kronos-base",
-      "downloads": 1264622,
-      "likes": 156,
-      "trendingScore": 6,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "Finance",
-        "Candlestick",
-        "K-line",
-        "time-series-forecasting",
-        "arxiv:2508.02739",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-06-30T17:11:20.000Z",
-      "lastModified": "2025-09-09T14:08:15.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
-      "author": "Novice25",
-      "url": "https://huggingface.co/Novice25/Qwen-Image-Edit-Rapid-AIO-GGUF",
-      "downloads": 66759,
-      "likes": 233,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "image-text-to-image",
-        "base_model:Phr00t/Qwen-Image-Edit-Rapid-AIO",
-        "base_model:quantized:Phr00t/Qwen-Image-Edit-Rapid-AIO",
-        "region:us"
-      ],
-      "createdAt": "2025-11-22T08:13:58.000Z",
-      "lastModified": "2026-01-25T11:06:55.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/gemma-4-E4B-it-The-DECKARD-Expresso-Universe-HERETIC-UNCENSORED-Thinking",
-      "downloads": 1025,
-      "likes": 21,
-      "trendingScore": 6,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "heretic",
-        "uncensored",
-        "aliterated",
-        "finetune",
-        "unsloth",
-        "all use cases",
-        "coder",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying",
-        "bfloat16"
-      ],
-      "createdAt": "2026-04-08T08:16:51.000Z",
-      "lastModified": "2026-04-14T05:57:02.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26396652480

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.