### PR TITLE
chore(data): refresh huggingface space signals 2026-05-25T10:59:27Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-25T05:10:11.846Z",
+  "ts": "2026-05-25T10:59:27.339Z",
   "count": 1,
-  "durationMs": 4236,
+  "durationMs": 4045,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T05:10:07.611Z",
+  "fetchedAt": "2026-05-25T10:59:23.297Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -148,8 +148,8 @@
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 82,
-      "trendingScore": 80,
+      "likes": 83,
+      "trendingScore": 81,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -326,6 +326,22 @@
     },
     {
       "rank": 20,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 54,
+      "trendingScore": 53,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-23T11:14:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 21,
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
@@ -342,7 +358,7 @@
       "models": []
     },
     {
-      "rank": 21,
+      "rank": 22,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -358,7 +374,7 @@
       "models": []
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
@@ -374,7 +390,7 @@
       "models": []
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "FrameAI4687/Omni-Video-Factory",
       "author": "FrameAI4687",
       "url": "https://huggingface.co/spaces/FrameAI4687/Omni-Video-Factory",
@@ -390,7 +406,7 @@
       "models": []
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
       "author": "akhaliq",
       "url": "https://huggingface.co/spaces/akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
@@ -406,7 +422,7 @@
       "models": []
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -422,7 +438,7 @@
       "models": []
     },
     {
-      "rank": 26,
+      "rank": 27,
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
@@ -439,7 +455,23 @@
       "models": []
     },
     {
-      "rank": 27,
+      "rank": 28,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 35,
+      "trendingScore": 35,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-22T21:24:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 29,
       "id": "multimodalart/qwen-image-multiple-angles-3d-camera",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/qwen-image-multiple-angles-3d-camera",
@@ -455,11 +487,11 @@
       "models": []
     },
     {
-      "rank": 28,
+      "rank": 30,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 58,
+      "likes": 59,
       "trendingScore": 34,
       "sdk": "gradio",
       "tags": [
@@ -471,7 +503,7 @@
       "models": []
     },
     {
-      "rank": 29,
+      "rank": 31,
       "id": "suraj291/Survival_Island_Game",
       "author": "suraj291",
       "url": "https://huggingface.co/spaces/suraj291/Survival_Island_Game",
@@ -488,7 +520,7 @@
       "models": []
     },
     {
-      "rank": 30,
+      "rank": 32,
       "id": "r3gm/wan2-2-fp8da-aoti-previewG",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewG",
@@ -505,7 +537,7 @@
       "models": []
     },
     {
-      "rank": 31,
+      "rank": 33,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -518,38 +550,6 @@
       ],
       "createdAt": "2026-05-09T15:35:22.000Z",
       "lastModified": "2026-05-09T18:21:38.000Z",
-      "models": []
-    },
-    {
-      "rank": 32,
-      "id": "stabilityai/stable-audio-3",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 33,
-      "trendingScore": 33,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T15:54:00.000Z",
-      "lastModified": "2026-05-22T21:24:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 33,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 33,
-      "trendingScore": 33,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-23T11:14:35.000Z",
       "models": []
     },
     {
@@ -689,8 +689,8 @@
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 28,
-      "trendingScore": 28,
+      "likes": 29,
+      "trendingScore": 29,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -808,6 +808,22 @@
     },
     {
       "rank": 49,
+      "id": "ibuildproducts/wan22-i2v-v4-demo",
+      "author": "ibuildproducts",
+      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
+      "likes": 30,
+      "trendingScore": 23,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:34:01.000Z",
+      "lastModified": "2026-05-18T00:16:12.000Z",
+      "models": []
+    },
+    {
+      "rank": 50,
       "id": "linoyts/Flux2-Klein-Face-Swap",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
@@ -820,22 +836,6 @@
       ],
       "createdAt": "2026-02-03T14:43:29.000Z",
       "lastModified": "2026-03-10T10:33:23.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "ibuildproducts/wan22-i2v-v4-demo",
-      "author": "ibuildproducts",
-      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
-      "likes": 29,
-      "trendingScore": 22,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:34:01.000Z",
-      "lastModified": "2026-05-18T00:16:12.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26396987013

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.