### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-25T14:17:24Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-25T00:12:01.313Z",
+  "ts": "2026-05-25T14:17:24.263Z",
   "count": 1,
-  "durationMs": 11589,
+  "durationMs": 13801,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-25T00:11:59.016Z",
+  "lastFetchedAt": "2026-05-25T14:17:18.826Z",
   "windowDays": 7,
   "launches": [
     {
@@ -932,6 +932,53 @@
       "aiAdjacent": true
     },
     {
+      "id": "1140898",
+      "name": "Unabyss",
+      "tagline": "MCP-native self-updating context layer for your AI",
+      "description": "Set it up once and never re-explain yourself to AI again. Connect the apps you use daily - Unabyss will extract, structure, and update your context automatically. Share it with any AI tool via MCP, with granular control over what each tool can see.",
+      "url": "https://www.producthunt.com/products/unabyss?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3EY2VAEXSWTXAR",
+      "votesCount": 311,
+      "commentsCount": 76,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/c35d380b-1508-44ae-a273-b0bea7db4969.gif?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1136169",
       "name": "Fere AI",
       "tagline": "AI agents that turn signals into crypto + Polymarket trades",
@@ -1375,6 +1422,36 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
+    },
+    {
+      "id": "1152782",
+      "name": "own.page",
+      "tagline": "Make your own personal website with bento tiles",
+      "description": "own.page helps creators and founders build a beautiful link-in-bio that feels alive - more like a personal website than just a list of links. Build a page in under a minute, customize it your way, add powerful widgets and integrations, understand your visitors, and grow your audience from one place.",
+      "url": "https://www.producthunt.com/products/own-page?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/MG5MNTMYZSEPJI",
+      "votesCount": 277,
+      "commentsCount": 36,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/883004fc-b791-49de-9ae9-188f378b62bf.png?auto=format",
+      "topics": [
+        "social-network",
+        "social-media",
+        "website-builder"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
     },
     {
       "id": "1137008",
@@ -2091,6 +2168,54 @@
       "aiAdjacent": true
     },
     {
+      "id": "1154343",
+      "name": "Yansu",
+      "tagline": "AI that learns how you work and turns it into software",
+      "description": "Yanshu learns from the work you already do. It spots repeated tasks across files, messages, and workflows, then turns the best patterns into apps and automations. No process mapping or blank canvas—just the routines worth systemizing. Use it to automate recurring work, build lightweight internal tools, and speed up daily ops without writing code.",
+      "url": "https://www.producthunt.com/products/yansu?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/YAPEOVBKBZUMNZ",
+      "votesCount": 225,
+      "commentsCount": 80,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/6802da95-e58c-47d9-88a4-31160f9d9c81.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "maker-tools"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1142238",
       "name": "InvestorFinder",
       "tagline": "Find investors who've backed founders just like you",
@@ -2261,109 +2386,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1151353",
-      "name": "Google Antigravity CLI",
-      "tagline": "Run coding agents directly from your terminal",
-      "description": "Antigravity CLI brings multi-step reasoning, multi-file editing, tool calling, and persistent history to the terminal. Optimised for SSH sessions and keyboard-first workflows. For developers who live in the command line.",
-      "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/2VVOKDD4COMAK2",
-      "votesCount": 206,
-      "commentsCount": 13,
-      "createdAt": "2026-05-23T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
-      "topics": [
-        "developer-tools",
-        "artificial-intelligence",
-        "tech"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1150296",
-      "name": "Freu AI",
-      "tagline": "Automate any Mac app with $0 recurring run cost",
-      "description": "Freu AI is an AI agent for Mac that automates any desktop app with natural language. It “sees” your UI to compile a cross‑app workflow once, then runs it locally via a deterministic DSL—no brittle coordinates/selectors and no recurring token bills. Bonus: we’re open‑sourcing freu-cli (our browser automation engine) today.",
-      "url": "https://www.producthunt.com/products/freu-cli?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/OOZSQ3C37HINID",
-      "votesCount": 205,
-      "commentsCount": 13,
-      "createdAt": "2026-05-24T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/fc1882f5-e334-45b1-9a9c-a274b0592ed3.png?auto=format",
-      "topics": [
-        "artificial-intelligence",
-        "github",
-        "business-intelligence",
-        "marketing-automation"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1149049",
-      "name": "ReactVision Studio",
-      "tagline": "Build AR/VR Apps in React Native + ship directly to devices",
-      "description": "A browser-based visual editor for building AR & VR scenes. Drag and drop 3D objects, generate assets with AI, then ship natively to iOS, Android, and Meta Quest from a single React Native codebase. Open source renderer, Expo-compatible, 100K+ npm installs.",
-      "url": "https://www.producthunt.com/products/reactvision-studio?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/NULQJX32QZRBB6",
-      "votesCount": 204,
-      "commentsCount": 14,
-      "createdAt": "2026-05-18T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2392e869-311a-4527-8875-bd658e17a404.png?auto=format",
-      "topics": [
-        "virtual-reality",
-        "developer-tools",
-        "augmented-reality"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26404963799

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.