### PR TITLE
chore(data): refresh lobsters signals 2026-05-25T14:22:59Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-25T10:58:52.766Z",
+  "ts": "2026-05-25T14:22:59.138Z",
   "count": 1,
-  "durationMs": 4230,
+  "durationMs": 3396,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-25T10:58:48.552Z",
+  "fetchedAt": "2026-05-25T14:22:55.764Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 75,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-25T10:58:48.552Z",
+  "fetchedAt": "2026-05-25T14:22:55.764Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 75,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -535,6 +535,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "kgem4b",
+      "title": "The social contract of writing",
+      "url": "https://jola.dev/posts/the-social-contract-of-writing",
+      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
+      "by": "",
+      "score": 11,
+      "commentCount": 0,
+      "createdUtc": 1779710964,
+      "ageHours": 2.225277777777778,
+      "trendingScore": 1.266513393355767,
+      "tags": [
+        "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "nkrgmr",
       "title": "JS Crossword - a crossword where the clue = eval(answer)",
       "url": "https://lyra.horse/fun/jscrossword/",
@@ -879,23 +896,6 @@
         "distributed",
         "historical",
         "networking"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "tbizqg",
-      "title": "The mysterious XF86AudioPlay issue",
-      "url": "https://michael-prokop.at/blog/2026/05/20/the-mysterious-xf86audioplay-issue/",
-      "commentsUrl": "https://lobste.rs/s/tbizqg/mysterious_xf86audioplay_issue",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1779483275,
-      "ageHours": 0.9283333333333333,
-      "trendingScore": 0.997790208170548,
-      "tags": [
-        "linux"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26405208164

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.