### PR TITLE
chore(data): refresh lobsters signals 2026-05-25T16:40:51Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-25T14:22:59.138Z",
+  "ts": "2026-05-25T16:40:51.094Z",
   "count": 1,
-  "durationMs": 3396,
+  "durationMs": 2962,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T14:22:55.764Z",
+  "fetchedAt": "2026-05-25T16:40:48.154Z",
   "windowDays": 7,
   "scannedStories": 75,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T14:22:55.764Z",
+  "fetchedAt": "2026-05-25T16:40:48.154Z",
   "windowHours": 72,
   "scannedTotal": 75,
   "stories": [
@@ -352,6 +352,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "kgem4b",
+      "title": "The social contract of writing",
+      "url": "https://jola.dev/posts/the-social-contract-of-writing",
+      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
+      "by": "",
+      "score": 27,
+      "commentCount": 2,
+      "createdUtc": 1779710964,
+      "ageHours": 4.523333333333333,
+      "trendingScore": 1.6205387033418106,
+      "tags": [
+        "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ij94sb",
       "title": "Ratty: A terminal emulator with inline 3D graphics",
       "url": "https://ratty-term.org/",
@@ -530,23 +547,6 @@
       "tags": [
         "concatenative",
         "web"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "kgem4b",
-      "title": "The social contract of writing",
-      "url": "https://jola.dev/posts/the-social-contract-of-writing",
-      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
-      "by": "",
-      "score": 11,
-      "commentCount": 0,
-      "createdUtc": 1779710964,
-      "ageHours": 2.225277777777778,
-      "trendingScore": 1.266513393355767,
-      "tags": [
-        "philosophy"
       ],
       "description": "",
       "linkedRepos": []
@@ -738,6 +738,41 @@
       "linkedRepos": []
     },
     {
+      "shortId": "lkv0sh",
+      "title": "Using AI to write better code more slowly",
+      "url": "https://nolanlawson.com/2026/05/25/using-ai-to-write-better-code-more-slowly/",
+      "commentsUrl": "https://lobste.rs/s/lkv0sh/using_ai_write_better_code_more_slowly",
+      "by": "",
+      "score": 4,
+      "commentCount": 0,
+      "createdUtc": 1779725954,
+      "ageHours": 0.35944444444444446,
+      "trendingScore": 1.1036855523080105,
+      "tags": [
+        "practices",
+        "vibecoding"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "3izfup",
+      "title": "Switching to Colemak",
+      "url": "https://pta2002.com/blog/colemak/",
+      "commentsUrl": "https://lobste.rs/s/3izfup/switching_colemak",
+      "by": "",
+      "score": 21,
+      "commentCount": 25,
+      "createdUtc": 1779708204,
+      "ageHours": 5.29,
+      "trendingScore": 1.066910531931108,
+      "tags": [
+        "a11y"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "r87zln",
       "title": "Internships for early university / no former employment",
       "url": "",
@@ -859,43 +894,6 @@
       "trendingScore": 1.001564536980598,
       "tags": [
         "security"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "b8gee9",
-      "title": "taken",
-      "url": "https://sinceyouarrived.world/taken",
-      "commentsUrl": "https://lobste.rs/s/b8gee9/taken",
-      "by": "",
-      "score": 47,
-      "commentCount": 32,
-      "createdUtc": 1778552487,
-      "ageHours": 11.011944444444444,
-      "trendingScore": 1.0013468994071215,
-      "tags": [
-        "privacy",
-        "web"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ptvaan",
-      "title": "Gnutella: A Protocol Outliving the World That Created It",
-      "url": "https://rickcarlino.com/notes/p2p/gnutella-explanation.html",
-      "commentsUrl": "https://lobste.rs/s/ptvaan/gnutella_protocol_outliving_world",
-      "by": "",
-      "score": 42,
-      "commentCount": 3,
-      "createdUtc": 1779417426,
-      "ageHours": 10.08,
-      "trendingScore": 1.0003428882961223,
-      "tags": [
-        "distributed",
-        "historical",
-        "networking"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26410620774

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.