### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-25T17:15:13Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-25T14:17:24.263Z",
+  "ts": "2026-05-25T17:15:13.885Z",
   "count": 1,
-  "durationMs": 13801,
+  "durationMs": 12365,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-25T14:17:18.826Z",
+  "lastFetchedAt": "2026-05-25T17:15:11.989Z",
   "windowDays": 7,
   "launches": [
     {
@@ -375,6 +375,53 @@
       "aiAdjacent": true
     },
     {
+      "id": "1140898",
+      "name": "Unabyss",
+      "tagline": "MCP-native self-updating context layer for your AI",
+      "description": "Set it up once and never re-explain yourself to AI again. Connect the apps you use daily - Unabyss will extract, structure, and update your context automatically. Share it with any AI tool via MCP, with granular control over what each tool can see.",
+      "url": "https://www.producthunt.com/products/unabyss?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3EY2VAEXSWTXAR",
+      "votesCount": 388,
+      "commentsCount": 90,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/c35d380b-1508-44ae-a273-b0bea7db4969.gif?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1135604",
       "name": "PollyReach",
       "tagline": "Give your agent a real number and voice to make calls.",
@@ -687,6 +734,36 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152782",
+      "name": "own.page",
+      "tagline": "Make your own personal website with bento tiles",
+      "description": "own.page helps creators and founders build a beautiful link-in-bio that feels alive - more like a personal website than just a list of links. Build a page in under a minute, customize it your way, add powerful widgets and integrations, understand your visitors, and grow your audience from one place.",
+      "url": "https://www.producthunt.com/products/own-page?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/MG5MNTMYZSEPJI",
+      "votesCount": 345,
+      "commentsCount": 47,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/883004fc-b791-49de-9ae9-188f378b62bf.png?auto=format",
+      "topics": [
+        "social-network",
+        "social-media",
+        "website-builder"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1138927",
       "name": "articuler.ai",
       "tagline": "Describe your goal. Meet the right professional.",
@@ -900,53 +977,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1140898",
-      "name": "Unabyss",
-      "tagline": "MCP-native self-updating context layer for your AI",
-      "description": "Set it up once and never re-explain yourself to AI again. Connect the apps you use daily - Unabyss will extract, structure, and update your context automatically. Share it with any AI tool via MCP, with granular control over what each tool can see.",
-      "url": "https://www.producthunt.com/products/unabyss?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/3EY2VAEXSWTXAR",
-      "votesCount": 311,
-      "commentsCount": 76,
-      "createdAt": "2026-05-25T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/c35d380b-1508-44ae-a273-b0bea7db4969.gif?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1424,36 +1454,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1152782",
-      "name": "own.page",
-      "tagline": "Make your own personal website with bento tiles",
-      "description": "own.page helps creators and founders build a beautiful link-in-bio that feels alive - more like a personal website than just a list of links. Build a page in under a minute, customize it your way, add powerful widgets and integrations, understand your visitors, and grow your audience from one place.",
-      "url": "https://www.producthunt.com/products/own-page?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/MG5MNTMYZSEPJI",
-      "votesCount": 277,
-      "commentsCount": 36,
-      "createdAt": "2026-05-25T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/883004fc-b791-49de-9ae9-188f378b62bf.png?auto=format",
-      "topics": [
-        "social-network",
-        "social-media",
-        "website-builder"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
       "id": "1137008",
       "name": "OpenJobs AI",
       "tagline": "End-to-End Autonomous AI Recruiter",
@@ -1752,6 +1752,54 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
+    },
+    {
+      "id": "1154343",
+      "name": "Yansu",
+      "tagline": "AI that learns how you work and turns it into software",
+      "description": "Yanshu learns from the work you already do. It spots repeated tasks across files, messages, and workflows, then turns the best patterns into apps and automations. No process mapping or blank canvas—just the routines worth systemizing. Use it to automate recurring work, build lightweight internal tools, and speed up daily ops without writing code.",
+      "url": "https://www.producthunt.com/products/yansu?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/YAPEOVBKBZUMNZ",
+      "votesCount": 259,
+      "commentsCount": 82,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/6802da95-e58c-47d9-88a4-31160f9d9c81.png?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence",
+        "maker-tools"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
     },
     {
       "id": "1113430",
@@ -2168,22 +2216,40 @@
       "aiAdjacent": true
     },
     {
-      "id": "1154343",
-      "name": "Yansu",
-      "tagline": "AI that learns how you work and turns it into software",
-      "description": "Yanshu learns from the work you already do. It spots repeated tasks across files, messages, and workflows, then turns the best patterns into apps and automations. No process mapping or blank canvas—just the routines worth systemizing. Use it to automate recurring work, build lightweight internal tools, and speed up daily ops without writing code.",
-      "url": "https://www.producthunt.com/products/yansu?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/YAPEOVBKBZUMNZ",
-      "votesCount": 225,
-      "commentsCount": 80,
+      "id": "1145066",
+      "name": "Supaboard 3.0",
+      "tagline": "AI data analysts that understand your business",
+      "description": "Supaboard helps your team turn business data into answers faster. Skip SQL, dashboard digging, and report delays. Ask questions in plain English, analyze data, and generate dashboards in minutes.",
+      "url": "https://www.producthunt.com/products/supaboard-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/AV6HLWXM6B3HLF",
+      "votesCount": 226,
+      "commentsCount": 26,
       "createdAt": "2026-05-25T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/6802da95-e58c-47d9-88a4-31160f9d9c81.png?auto=format",
+      "thumbnail": "https://ph-files.imgix.net/ffe53c6b-fa95-4c57-9dbc-d05419657288.png?auto=format",
       "topics": [
-        "productivity",
-        "artificial-intelligence",
-        "maker-tools"
+        "saas",
+        "data-analytics",
+        "data-visualization"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2213,7 +2279,7 @@
       "xUrl": null,
       "linkedRepo": null,
       "daysSinceLaunch": 0,
-      "aiAdjacent": true
+      "aiAdjacent": false
     },
     {
       "id": "1142238",
@@ -2356,48 +2422,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1151120",
-      "name": "Runtime",
-      "tagline": "Sandboxed coding agents for everyone on your team",
-      "description": "Turn coding agents into teammates anyone can use from Slack, Linear, CLI, API or your browser. Ship features, query data, build dashboards, automate workflows. All within your company's context, skills, integrations, and security guardrails.",
-      "url": "https://www.producthunt.com/products/runtime?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/TOZOGOJYMEHTNQ",
-      "votesCount": 206,
-      "commentsCount": 46,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/67ea30b8-1bf6-44ba-99db-09c8498841d9.png?auto=format",
-      "topics": [
-        "slack",
-        "developer-tools",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26411842903

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.