### PR TITLE
chore(data): refresh lobsters signals 2026-05-25T19:07:40Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-25T16:40:51.094Z",
+  "ts": "2026-05-25T19:07:40.035Z",
   "count": 1,
-  "durationMs": 2962,
+  "durationMs": 3266,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-25T16:40:48.154Z",
+  "fetchedAt": "2026-05-25T19:07:36.790Z",
   "windowDays": 7,
-  "scannedStories": 75,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-25T16:40:48.154Z",
+  "fetchedAt": "2026-05-25T19:07:36.790Z",
   "windowHours": 72,
-  "scannedTotal": 75,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -283,6 +283,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "kgem4b",
+      "title": "The social contract of writing",
+      "url": "https://jola.dev/posts/the-social-contract-of-writing",
+      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
+      "by": "",
+      "score": 55,
+      "commentCount": 9,
+      "createdUtc": 1779710964,
+      "ageHours": 6.97,
+      "trendingScore": 2.0472648261527193,
+      "tags": [
+        "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "03djyt",
       "title": "New design for the FreeBSD website",
       "url": "https://www.freebsd.org/",
@@ -347,23 +364,6 @@
       "trendingScore": 1.65427236943472,
       "tags": [
         "web"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "kgem4b",
-      "title": "The social contract of writing",
-      "url": "https://jola.dev/posts/the-social-contract-of-writing",
-      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
-      "by": "",
-      "score": 27,
-      "commentCount": 2,
-      "createdUtc": 1779710964,
-      "ageHours": 4.523333333333333,
-      "trendingScore": 1.6205387033418106,
-      "tags": [
-        "philosophy"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26415755381

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.