### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-25T20:07:48Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T18:07:09.847Z",
+  "generatedAt": "2026-05-25T20:07:48.006Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
@@ -35,22 +35,6 @@
       "asOf": "2026-04-24T01:59:01.837Z",
       "matchConfidence": "host",
       "sourceUrl": "https://trustmrr.com/startup/muapi"
-    },
-    "Cap-go/capacitor-uploader": {
-      "tier": "verified_trustmrr",
-      "fullName": "Cap-go/capacitor-uploader",
-      "trustmrrSlug": "capgo",
-      "mrrCents": 1721362,
-      "last30DaysCents": 2316981,
-      "totalCents": 38621707,
-      "growthMrr30d": 13.312707424778559,
-      "customers": 448,
-      "activeSubscriptions": 526,
-      "paymentProvider": "stripe",
-      "category": "Developer Tools",
-      "asOf": "2026-04-24T01:59:01.837Z",
-      "matchConfidence": "host",
-      "sourceUrl": "https://trustmrr.com/startup/capgo"
     },
     "AChep/keyguard-app": {
       "tier": "verified_trustmrr",


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26417792610

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.