### PR TITLE
chore(data): refresh huggingface space signals 2026-05-25T20:14:12Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-25T15:40:19.228Z",
+  "ts": "2026-05-25T20:14:12.364Z",
   "count": 1,
-  "durationMs": 4731,
+  "durationMs": 6404,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T15:40:14.498Z",
+  "fetchedAt": "2026-05-25T20:14:05.963Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -226,6 +226,22 @@
     },
     {
       "rank": 14,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 73,
+      "trendingScore": 70,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-23T11:14:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 15,
       "id": "r3gm/wan2-2-fp8da-aoti-preview",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview",
@@ -242,7 +258,7 @@
       "models": []
     },
     {
-      "rank": 15,
+      "rank": 16,
       "id": "kulkas2pintu/wan222",
       "author": "kulkas2pintu",
       "url": "https://huggingface.co/spaces/kulkas2pintu/wan222",
@@ -259,7 +275,7 @@
       "models": []
     },
     {
-      "rank": 16,
+      "rank": 17,
       "id": "ysharma/fast-image-studio",
       "author": "ysharma",
       "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
@@ -272,22 +288,6 @@
       ],
       "createdAt": "2026-04-29T14:15:57.000Z",
       "lastModified": "2026-04-30T12:10:32.000Z",
-      "models": []
-    },
-    {
-      "rank": 17,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 65,
-      "trendingScore": 63,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-23T11:14:35.000Z",
       "models": []
     },
     {
@@ -423,6 +423,22 @@
     },
     {
       "rank": 26,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 44,
+      "trendingScore": 44,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-22T21:24:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 27,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -435,22 +451,6 @@
       ],
       "createdAt": "2025-12-10T03:50:25.000Z",
       "lastModified": "2025-12-17T06:32:54.000Z",
-      "models": []
-    },
-    {
-      "rank": 27,
-      "id": "stabilityai/stable-audio-3",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 40,
-      "trendingScore": 40,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T15:54:00.000Z",
-      "lastModified": "2026-05-22T21:24:33.000Z",
       "models": []
     },
     {
@@ -554,6 +554,22 @@
     },
     {
       "rank": 34,
+      "id": "multimodalart/z-image-6b-pixel-space",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
+      "likes": 33,
+      "trendingScore": 33,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T12:46:34.000Z",
+      "lastModified": "2026-05-22T19:37:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 35,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -570,7 +586,7 @@
       "models": []
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -587,7 +603,7 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -603,7 +619,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -619,7 +635,7 @@
       "models": []
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -632,22 +648,6 @@
       ],
       "createdAt": "2026-05-13T16:06:55.000Z",
       "lastModified": "2026-05-19T00:50:26.000Z",
-      "models": []
-    },
-    {
-      "rank": 39,
-      "id": "multimodalart/z-image-6b-pixel-space",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 31,
-      "trendingScore": 31,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T12:46:34.000Z",
-      "lastModified": "2026-05-22T19:37:35.000Z",
       "models": []
     },
     {
@@ -705,7 +705,7 @@
       "id": "ibuildproducts/wan22-i2v-v4-demo",
       "author": "ibuildproducts",
       "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
-      "likes": 35,
+      "likes": 36,
       "trendingScore": 28,
       "sdk": "gradio",
       "tags": [
@@ -824,18 +824,18 @@
     },
     {
       "rank": 50,
-      "id": "linoyts/Flux2-Klein-Face-Swap",
-      "author": "linoyts",
-      "url": "https://huggingface.co/spaces/linoyts/Flux2-Klein-Face-Swap",
-      "likes": 386,
-      "trendingScore": 22,
+      "id": "CohereLabs/command-a-plus-05-2026",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
+      "likes": 24,
+      "trendingScore": 23,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
-      "createdAt": "2026-02-03T14:43:29.000Z",
-      "lastModified": "2026-03-10T10:33:23.000Z",
+      "createdAt": "2026-05-11T12:07:16.000Z",
+      "lastModified": "2026-05-20T13:50:45.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26417999887

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.