### PR TITLE
chore(data): refresh lobsters signals 2026-05-25T20:51:30Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-25T19:07:40.035Z",
+  "ts": "2026-05-25T20:51:30.485Z",
   "count": 1,
-  "durationMs": 3266,
+  "durationMs": 2690,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-25T19:07:36.790Z",
+  "fetchedAt": "2026-05-25T20:51:27.816Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-25T19:07:36.790Z",
+  "fetchedAt": "2026-05-25T20:51:27.816Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -215,6 +215,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "kgem4b",
+      "title": "The social contract of writing",
+      "url": "https://jola.dev/posts/the-social-contract-of-writing",
+      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
+      "by": "",
+      "score": 79,
+      "commentCount": 13,
+      "createdUtc": 1779710964,
+      "ageHours": 8.700833333333334,
+      "trendingScore": 2.256839588407484,
+      "tags": [
+        "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "k21pdb",
       "title": "Aggressive AI scrapers are making it kinda suck to run wikis",
       "url": "https://weirdgloop.org/blog/clankers",
@@ -278,23 +295,6 @@
       "trendingScore": 2.05513769085182,
       "tags": [
         "compsci"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "kgem4b",
-      "title": "The social contract of writing",
-      "url": "https://jola.dev/posts/the-social-contract-of-writing",
-      "commentsUrl": "https://lobste.rs/s/kgem4b/social_contract_writing",
-      "by": "",
-      "score": 55,
-      "commentCount": 9,
-      "createdUtc": 1779710964,
-      "ageHours": 6.97,
-      "trendingScore": 2.0472648261527193,
-      "tags": [
-        "philosophy"
       ],
       "description": "",
       "linkedRepos": []
@@ -845,6 +845,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "eedsds",
+      "title": "Encyclical Letter of His Holiness Leo XIV Magnifica Humanitas",
+      "url": "http://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html",
+      "commentsUrl": "https://lobste.rs/s/eedsds/encyclical_letter_his_holiness_leo_xiv",
+      "by": "",
+      "score": 14,
+      "commentCount": 4,
+      "createdUtc": 1779728868,
+      "ageHours": 3.7275,
+      "trendingScore": 1.0213636299883524,
+      "tags": [
+        "ai",
+        "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "n1gytv",
       "title": "Why Ruby Still Feels Like Home After All These Years",
       "url": "https://caio.ca/blog/why-ruby-still-feels-like-home",
@@ -877,23 +895,6 @@
         "browsers",
         "security",
         "vibecoding"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "k8mkgs",
-      "title": "XSS Is Deadly for Passkeys: The Hidden Risk of Attestation None",
-      "url": "https://scotthelme.co.uk/xss-is-deadly-for-passkeys-the-hidden-risk-of-attestation-none/",
-      "commentsUrl": "https://lobste.rs/s/k8mkgs/xss_is_deadly_for_passkeys_hidden_risk",
-      "by": "",
-      "score": 8,
-      "commentCount": 1,
-      "createdUtc": 1779304832,
-      "ageHours": 1.9958333333333333,
-      "trendingScore": 1.001564536980598,
-      "tags": [
-        "security"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26419252831

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.