### PR TITLE
chore(data): refresh profile-completion queue 2026-05-25T22:52:41Z

### DIFF
--- a/data/_meta/profile-completion-check.json
+++ b/data/_meta/profile-completion-check.json
@@ -1,9 +1,9 @@
 {
   "source": "profile-completion-check",
   "reason": "ok",
-  "ts": "2026-05-25T21:41:00.246Z",
+  "ts": "2026-05-25T22:52:41.800Z",
   "count": 66,
-  "durationMs": 891,
+  "durationMs": 869,
   "extra": {
     "mode": "top",
     "totalChecked": 100,

--- a/data/profile-completion-queue.json
+++ b/data/profile-completion-queue.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T21:41:00.085Z",
+  "generatedAt": "2026-05-25T22:52:41.569Z",
   "version": 1,
   "mode": "top",
   "totalChecked": 100,


### PR DESCRIPTION
Automated data refresh from `Profile completion check`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26422895617

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.