### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-26T00:15:50Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-25T20:41:33.105Z",
+  "ts": "2026-05-26T00:15:50.605Z",
   "count": 1,
-  "durationMs": 12465,
+  "durationMs": 9264,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-25T20:41:31.059Z",
+  "lastFetchedAt": "2026-05-26T00:15:49.009Z",
   "windowDays": 7,
   "launches": [
     {
@@ -147,6 +147,83 @@
       "aiAdjacent": true
     },
     {
+      "id": "1140898",
+      "name": "Unabyss",
+      "tagline": "MCP-native self-updating context layer for your AI",
+      "description": "Set it up once and never re-explain yourself to AI again. Connect the apps you use daily - Unabyss will extract, structure, and update your context automatically. Share it with any AI tool via MCP, with granular control over what each tool can see.",
+      "url": "https://www.producthunt.com/products/unabyss?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3EY2VAEXSWTXAR",
+      "votesCount": 452,
+      "commentsCount": 113,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/c35d380b-1508-44ae-a273-b0bea7db4969.gif?auto=format",
+      "topics": [
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1152782",
+      "name": "own.page",
+      "tagline": "Make your own personal website with bento tiles",
+      "description": "own.page helps creators and founders build a beautiful link-in-bio that feels alive - more like a personal website than just a list of links. Build a page in under a minute, customize it your way, add powerful widgets and integrations, understand your visitors, and grow your audience from one place.",
+      "url": "https://www.producthunt.com/products/own-page?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/MG5MNTMYZSEPJI",
+      "votesCount": 446,
+      "commentsCount": 63,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/883004fc-b791-49de-9ae9-188f378b62bf.png?auto=format",
+      "topics": [
+        "social-network",
+        "social-media",
+        "website-builder"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1134267",
       "name": "mailX by mailwarm",
       "tagline": "Email deliverability toolkit for humans and AI agents",
@@ -279,53 +356,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1140898",
-      "name": "Unabyss",
-      "tagline": "MCP-native self-updating context layer for your AI",
-      "description": "Set it up once and never re-explain yourself to AI again. Connect the apps you use daily - Unabyss will extract, structure, and update your context automatically. Share it with any AI tool via MCP, with granular control over what each tool can see.",
-      "url": "https://www.producthunt.com/products/unabyss?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/3EY2VAEXSWTXAR",
-      "votesCount": 421,
-      "commentsCount": 93,
-      "createdAt": "2026-05-25T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/c35d380b-1508-44ae-a273-b0bea7db4969.gif?auto=format",
-      "topics": [
-        "productivity",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1139974",
       "name": "Kelviq",
       "tagline": "Payments, tax, and billing for SaaS & AI companies",
@@ -372,36 +402,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
-      "id": "1152782",
-      "name": "own.page",
-      "tagline": "Make your own personal website with bento tiles",
-      "description": "own.page helps creators and founders build a beautiful link-in-bio that feels alive - more like a personal website than just a list of links. Build a page in under a minute, customize it your way, add powerful widgets and integrations, understand your visitors, and grow your audience from one place.",
-      "url": "https://www.producthunt.com/products/own-page?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/MG5MNTMYZSEPJI",
-      "votesCount": 408,
-      "commentsCount": 55,
-      "createdAt": "2026-05-25T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/883004fc-b791-49de-9ae9-188f378b62bf.png?auto=format",
-      "topics": [
-        "social-network",
-        "social-media",
-        "website-builder"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1363,7 +1363,7 @@
       "description": "Yanshu learns from the work you already do. It spots repeated tasks across files, messages, and workflows, then turns the best patterns into apps and automations. No process mapping or blank canvas—just the routines worth systemizing. Use it to automate recurring work, build lightweight internal tools, and speed up daily ops without writing code.",
       "url": "https://www.producthunt.com/products/yansu?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
       "website": "https://www.producthunt.com/r/YAPEOVBKBZUMNZ",
-      "votesCount": 283,
+      "votesCount": 286,
       "commentsCount": 84,
       "createdAt": "2026-05-25T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/6802da95-e58c-47d9-88a4-31160f9d9c81.png?auto=format",
@@ -1802,6 +1802,72 @@
       "aiAdjacent": false
     },
     {
+      "id": "1145066",
+      "name": "Supaboard 3.0",
+      "tagline": "AI data analysts that understand your business",
+      "description": "Supaboard helps your team turn business data into answers faster. Skip SQL, dashboard digging, and report delays. Ask questions in plain English, analyze data, and generate dashboards in minutes.",
+      "url": "https://www.producthunt.com/products/supaboard-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/AV6HLWXM6B3HLF",
+      "votesCount": 256,
+      "commentsCount": 29,
+      "createdAt": "2026-05-25T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/ffe53c6b-fa95-4c57-9dbc-d05419657288.png?auto=format",
+      "topics": [
+        "saas",
+        "data-analytics",
+        "data-visualization"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1113430",
       "name": "Mantle Chat",
       "tagline": "Collaboration platform where teams work with AI together",
@@ -1907,72 +1973,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
-    },
-    {
-      "id": "1145066",
-      "name": "Supaboard 3.0",
-      "tagline": "AI data analysts that understand your business",
-      "description": "Supaboard helps your team turn business data into answers faster. Skip SQL, dashboard digging, and report delays. Ask questions in plain English, analyze data, and generate dashboards in minutes.",
-      "url": "https://www.producthunt.com/products/supaboard-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/AV6HLWXM6B3HLF",
-      "votesCount": 249,
-      "commentsCount": 27,
-      "createdAt": "2026-05-25T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/ffe53c6b-fa95-4c57-9dbc-d05419657288.png?auto=format",
-      "topics": [
-        "saas",
-        "data-analytics",
-        "data-visualization"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
     },
     {
       "id": "1151355",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26425074795

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.