### PR TITLE
chore(data): refresh ai rss signals 2026-05-26T04:42:19Z

### DIFF
--- a/data/_meta/claude-rss.json
+++ b/data/_meta/claude-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "claude-rss",
   "reason": "ok",
-  "ts": "2026-05-25T20:08:48.930Z",
+  "ts": "2026-05-26T04:42:17.850Z",
   "count": 1,
-  "durationMs": 4207,
+  "durationMs": 5333,
   "extra": {}
 }

--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-25T20:08:50.659Z",
+  "ts": "2026-05-26T04:42:19.496Z",
   "count": 1,
-  "durationMs": 1609,
+  "durationMs": 1488,
   "extra": {}
 }

--- a/data/claude-rss.json
+++ b/data/claude-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T20:08:44.727Z",
+  "fetchedAt": "2026-05-26T04:42:12.522Z",
   "source": "claude",
   "feedUrl": "https://www.anthropic.com/news",
   "error": null,

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T20:08:49.053Z",
+  "fetchedAt": "2026-05-26T04:42:18.012Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh AI RSS signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26432645372

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.