### PR TITLE
chore(data): refresh scoring shadow report 2026-05-26T05:58:54Z

### DIFF
--- a/data/scoring-shadow-report.json
+++ b/data/scoring-shadow-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T06:17:20.186Z",
+  "generatedAt": "2026-05-26T05:58:53.610Z",
   "reports": [],
   "skipped": [
     {


### PR DESCRIPTION
Automated data refresh from `Run shadow scoring`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26435097138

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.