### PR TITLE
chore(data): refresh staleness report 2026-05-26T06:11:51Z

### DIFF
--- a/data/staleness-report.json
+++ b/data/staleness-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-25T06:39:59.847Z",
+  "generatedAt": "2026-05-26T06:11:50.245Z",
   "sources": [
     {
       "slug": "trending",


### PR DESCRIPTION
Automated data refresh from `Sweep staleness`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26435555953

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.