### PR TITLE
chore(data): refresh awesome-skills index 2026-05-26T08:04:46Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-25T08:43:01.587Z",
+  "ts": "2026-05-26T08:04:46.930Z",
   "count": 1,
-  "durationMs": 2602,
+  "durationMs": 3100,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-25T08:42:58.987Z",
+  "fetchedAt": "2026-05-26T08:04:43.831Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",
@@ -169,6 +169,15 @@
     "coreyhaines31/marketingskills": [
       "sickn33/antigravity-awesome-skills"
     ],
+    "iradoweck/antigravity-awesome-skills": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "heyneuron/flowhunt-skill": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "intelligent-internet/ii-commons-skills": [
+      "sickn33/antigravity-awesome-skills"
+    ],
     "agricidaniel/claude-seo": [
       "sickn33/antigravity-awesome-skills"
     ],
@@ -211,6 +220,9 @@
     "rafsilva85/credit-optimizer-v5": [
       "sickn33/antigravity-awesome-skills",
       "punkpeye/awesome-mcp-servers"
+    ],
+    "ndesv21/socialclaw": [
+      "sickn33/antigravity-awesome-skills"
     ],
     "wittlesus/cursorrules-pro": [
       "sickn33/antigravity-awesome-skills"
@@ -1904,6 +1916,9 @@
     "iunera/druid-mcp-server": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "janadasroor/pg-mnemosyne-mcp": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "javimaligno/postgres_mcp": [
       "punkpeye/awesome-mcp-servers"
@@ -8120,6 +8135,6 @@
   "counts": {
     "lists": 4,
     "listsAttempted": 5,
-    "uniqueSkills": 2628
+    "uniqueSkills": 2633
   }
 }


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26440125854

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.