### PR TITLE
chore(data): refresh trustmrr overlays 2026-05-26T08:48:51Z

### DIFF
--- a/data/revenue-overlays.json
+++ b/data/revenue-overlays.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-26T04:41:47.642Z",
+  "generatedAt": "2026-05-26T08:48:51.230Z",
   "version": 1,
   "source": "trustmrr",
   "catalogGeneratedAt": "2026-04-24T01:59:01.837Z",
@@ -36,9 +36,9 @@
       "matchConfidence": "host",
       "sourceUrl": "https://trustmrr.com/startup/muapi"
     },
-    "AChep/keyguard-app": {
+    "Karna14314/Pdf_Tools": {
       "tier": "verified_trustmrr",
-      "fullName": "AChep/keyguard-app",
+      "fullName": "Karna14314/Pdf_Tools",
       "trustmrrSlug": "habits-garden",
       "mrrCents": 5896,
       "last30DaysCents": 16264,


### PR DESCRIPTION
Automated data refresh from `Sync TrustMRR revenue overlays`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26442140204

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.