### PR TITLE
chore(data): refresh lobsters signals 2026-05-26T08:52:18Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-26T04:48:07.290Z",
+  "ts": "2026-05-26T08:52:18.409Z",
   "count": 1,
-  "durationMs": 3346,
+  "durationMs": 2594,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-26T04:48:03.968Z",
+  "fetchedAt": "2026-05-26T08:52:15.835Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-26T04:48:03.968Z",
+  "fetchedAt": "2026-05-26T08:52:15.835Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -607,6 +607,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "dw02ye",
+      "title": "The pressure",
+      "url": "https://daniel.haxx.se/blog/2026/05/26/the-pressure/",
+      "commentsUrl": "https://lobste.rs/s/dw02ye/pressure",
+      "by": "",
+      "score": 10,
+      "commentCount": 0,
+      "createdUtc": 1779778058,
+      "ageHours": 2.0769444444444445,
+      "trendingScore": 1.2147804941787144,
+      "tags": [
+        "culture",
+        "programming"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "eedsds",
       "title": "Encyclical Letter of His Holiness Leo XIV Magnifica Humanitas",
       "url": "http://www.vatican.va/content/leo-xiv/en/encyclicals/documents/20260515-magnifica-humanitas.html",
@@ -876,25 +894,6 @@
       "tags": [
         "programming",
         "ruby"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "7zppv1",
-      "title": "Behind the Scenes Hardening Firefox with Claude Mythos Preview",
-      "url": "https://hacks.mozilla.org/2026/05/behind-the-scenes-hardening-firefox/",
-      "commentsUrl": "https://lobste.rs/s/7zppv1/behind_scenes_hardening_firefox_with",
-      "by": "",
-      "score": 25,
-      "commentCount": 5,
-      "createdUtc": 1778170184,
-      "ageHours": 6.4686111111111115,
-      "trendingScore": 1.0144291578205202,
-      "tags": [
-        "browsers",
-        "security",
-        "vibecoding"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26442292597

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.