### PR TITLE
chore(data): refresh huggingface signals 2026-05-26T10:20:20Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-26T04:36:25.836Z",
+  "ts": "2026-05-26T10:20:20.057Z",
   "count": 1,
-  "durationMs": 6916,
+  "durationMs": 6154,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T04:36:18.922Z",
+  "fetchedAt": "2026-05-26T10:20:13.904Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -8,9 +8,9 @@
       "id": "tencent/Hy-MT2-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B",
-      "downloads": 5552,
-      "likes": 918,
-      "trendingScore": 854,
+      "downloads": 7471,
+      "likes": 972,
+      "trendingScore": 875,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -46,7 +46,7 @@
         "gu"
       ],
       "createdAt": "2026-05-11T08:22:10.000Z",
-      "lastModified": "2026-05-22T05:09:24.000Z"
+      "lastModified": "2026-05-26T09:05:58.000Z"
     },
     {
       "rank": 2,
@@ -180,9 +180,9 @@
       "id": "tencent/Hy-MT2-30B-A3B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B",
-      "downloads": 1494,
-      "likes": 378,
-      "trendingScore": 361,
+      "downloads": 2091,
+      "likes": 386,
+      "trendingScore": 369,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -218,7 +218,7 @@
         "gu"
       ],
       "createdAt": "2026-05-11T07:43:51.000Z",
-      "lastModified": "2026-05-22T05:15:55.000Z"
+      "lastModified": "2026-05-26T09:05:48.000Z"
     },
     {
       "rank": 8,
@@ -293,36 +293,12 @@
     },
     {
       "rank": 10,
-      "id": "HiDream-ai/HiDream-O1-Image",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
-      "downloads": 11725,
-      "likes": 342,
-      "trendingScore": 332,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:06:04.000Z",
-      "lastModified": "2026-05-15T10:40:00.000Z"
-    },
-    {
-      "rank": 11,
       "id": "NemoStation/Marlin-2B",
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
-      "downloads": 7291,
-      "likes": 348,
-      "trendingScore": 332,
+      "downloads": 9144,
+      "likes": 352,
+      "trendingScore": 334,
       "pipelineTag": "video-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -351,13 +327,37 @@
       "lastModified": "2026-05-20T07:54:57.000Z"
     },
     {
+      "rank": 11,
+      "id": "HiDream-ai/HiDream-O1-Image",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+      "downloads": 11725,
+      "likes": 342,
+      "trendingScore": 332,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T13:06:04.000Z",
+      "lastModified": "2026-05-15T10:40:00.000Z"
+    },
+    {
       "rank": 12,
       "id": "sapientinc/HRM-Text-1B",
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 90026,
-      "likes": 321,
-      "trendingScore": 278,
+      "downloads": 103033,
+      "likes": 361,
+      "trendingScore": 292,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -414,8 +414,8 @@
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
       "downloads": 0,
-      "likes": 239,
-      "trendingScore": 233,
+      "likes": 258,
+      "trendingScore": 251,
       "pipelineTag": null,
       "libraryName": "diffusers",
       "tags": [
@@ -438,6 +438,46 @@
     },
     {
       "rank": 15,
+      "id": "openbmb/MiniCPM5-1B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
+      "downloads": 2409,
+      "likes": 271,
+      "trendingScore": 236,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "minicpm",
+        "minicpm5",
+        "long-context",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "conversational",
+        "en",
+        "zh",
+        "dataset:openbmb/Ultra-FineWeb",
+        "dataset:openbmb/Ultra-FineWeb-L3",
+        "dataset:openbmb/UltraData-Math",
+        "dataset:openbmb/UltraData-SFT-2605",
+        "arxiv:2506.07900",
+        "arxiv:2602.09003",
+        "arxiv:2512.16649",
+        "arxiv:2604.13016",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T07:27:59.000Z",
+      "lastModified": "2026-05-26T04:24:04.000Z"
+    },
+    {
+      "rank": 16,
       "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -465,7 +505,7 @@
       "lastModified": "2026-05-18T03:25:15.000Z"
     },
     {
-      "rank": 16,
+      "rank": 17,
       "id": "circlestone-labs/Anima",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima",
@@ -484,7 +524,7 @@
       "lastModified": "2026-05-14T17:13:39.000Z"
     },
     {
-      "rank": 17,
+      "rank": 18,
       "id": "openai/privacy-filter",
       "author": "openai",
       "url": "https://huggingface.co/openai/privacy-filter",
@@ -508,7 +548,7 @@
       "lastModified": "2026-04-22T16:50:17.000Z"
     },
     {
-      "rank": 18,
+      "rank": 19,
       "id": "google/gemma-4-31B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B-it-assistant",
@@ -531,13 +571,13 @@
       "lastModified": "2026-05-11T07:51:37.000Z"
     },
     {
-      "rank": 19,
+      "rank": 20,
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
-      "downloads": 7449,
-      "likes": 202,
-      "trendingScore": 199,
+      "downloads": 7769,
+      "likes": 203,
+      "trendingScore": 200,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -576,7 +616,7 @@
       "lastModified": "2026-05-22T14:39:44.000Z"
     },
     {
-      "rank": 20,
+      "rank": 21,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/Dramabox",
@@ -605,7 +645,7 @@
       "lastModified": "2026-05-13T16:39:38.000Z"
     },
     {
-      "rank": 21,
+      "rank": 22,
       "id": "SeeSee21/Z-Anime",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Anime",
@@ -638,31 +678,13 @@
       "lastModified": "2026-04-27T01:13:30.000Z"
     },
     {
-      "rank": 22,
-      "id": "TenStrip/LTX2.3-10Eros",
-      "author": "TenStrip",
-      "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
-      "downloads": 51779,
-      "likes": 190,
-      "trendingScore": 182,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "image-to-video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T17:08:26.000Z",
-      "lastModified": "2026-05-07T01:24:09.000Z"
-    },
-    {
       "rank": 23,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 1392596,
-      "likes": 866,
-      "trendingScore": 178,
+      "downloads": 1598473,
+      "likes": 885,
+      "trendingScore": 190,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -689,6 +711,24 @@
     },
     {
       "rank": 24,
+      "id": "TenStrip/LTX2.3-10Eros",
+      "author": "TenStrip",
+      "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
+      "downloads": 51779,
+      "likes": 190,
+      "trendingScore": 182,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "image-to-video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T17:08:26.000Z",
+      "lastModified": "2026-05-07T01:24:09.000Z"
+    },
+    {
+      "rank": 25,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
@@ -731,7 +771,7 @@
       "lastModified": "2026-05-19T23:41:58.000Z"
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "froggeric/Qwen-Fixed-Chat-Templates",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
@@ -759,13 +799,13 @@
       "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
-      "rank": 26,
+      "rank": 27,
       "id": "tencent/Hy-MT2-7B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B",
-      "downloads": 3060,
-      "likes": 163,
-      "trendingScore": 156,
+      "downloads": 3600,
+      "likes": 168,
+      "trendingScore": 161,
       "pipelineTag": "translation",
       "libraryName": "transformers",
       "tags": [
@@ -801,85 +841,16 @@
         "gu"
       ],
       "createdAt": "2026-05-11T14:56:58.000Z",
-      "lastModified": "2026-05-22T05:16:06.000Z"
-    },
-    {
-      "rank": 27,
-      "id": "openbmb/MiniCPM5-1B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
-      "downloads": 2,
-      "likes": 168,
-      "trendingScore": 154,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "minicpm",
-        "minicpm5",
-        "long-context",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "conversational",
-        "en",
-        "zh",
-        "dataset:openbmb/Ultra-FineWeb",
-        "dataset:openbmb/Ultra-FineWeb-L3",
-        "dataset:openbmb/UltraData-Math",
-        "dataset:openbmb/UltraData-SFT-2605",
-        "arxiv:2506.07900",
-        "arxiv:2602.09003",
-        "arxiv:2512.16649",
-        "arxiv:2604.13016",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T07:27:59.000Z",
-      "lastModified": "2026-05-26T04:24:04.000Z"
+      "lastModified": "2026-05-26T09:05:54.000Z"
     },
     {
       "rank": 28,
-      "id": "XiaomiMiMo/MiMo-V2.5-Pro",
-      "author": "XiaomiMiMo",
-      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
-      "downloads": 20905,
-      "likes": 467,
-      "trendingScore": 142,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "mimo_v2",
-        "text-generation",
-        "agent",
-        "long-context",
-        "code",
-        "conversational",
-        "custom_code",
-        "en",
-        "zh",
-        "license:mit",
-        "eval-results",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T12:52:53.000Z",
-      "lastModified": "2026-04-28T07:01:37.000Z"
-    },
-    {
-      "rank": 29,
       "id": "numind/NuExtract3",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3",
-      "downloads": 17501,
-      "likes": 144,
-      "trendingScore": 140,
+      "downloads": 20350,
+      "likes": 148,
+      "trendingScore": 143,
       "pipelineTag": "image-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -908,6 +879,35 @@
       ],
       "createdAt": "2026-04-29T07:46:41.000Z",
       "lastModified": "2026-05-20T09:24:47.000Z"
+    },
+    {
+      "rank": 29,
+      "id": "XiaomiMiMo/MiMo-V2.5-Pro",
+      "author": "XiaomiMiMo",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
+      "downloads": 20905,
+      "likes": 467,
+      "trendingScore": 142,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "mimo_v2",
+        "text-generation",
+        "agent",
+        "long-context",
+        "code",
+        "conversational",
+        "custom_code",
+        "en",
+        "zh",
+        "license:mit",
+        "eval-results",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T12:52:53.000Z",
+      "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
       "rank": 30,
@@ -1003,9 +1003,9 @@
       "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "downloads": 12677,
-      "likes": 129,
-      "trendingScore": 122,
+      "downloads": 16379,
+      "likes": 134,
+      "trendingScore": 127,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1047,9 +1047,9 @@
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
-      "downloads": 12824,
-      "likes": 121,
-      "trendingScore": 120,
+      "downloads": 13869,
+      "likes": 126,
+      "trendingScore": 125,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1266,204 +1266,12 @@
     },
     {
       "rank": 41,
-      "id": "jackxinning/Leanly_AI",
-      "author": "jackxinning",
-      "url": "https://huggingface.co/jackxinning/Leanly_AI",
-      "downloads": 10822,
-      "likes": 111,
-      "trendingScore": 99,
-      "pipelineTag": "question-answering",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "medical",
-        "question-answering",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-16T10:43:03.000Z",
-      "lastModified": "2026-05-04T07:50:46.000Z"
-    },
-    {
-      "rank": 42,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
-      "downloads": 3819,
-      "likes": 99,
-      "trendingScore": 99,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:09:29.000Z",
-      "lastModified": "2026-05-15T10:40:24.000Z"
-    },
-    {
-      "rank": 43,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 100,
-      "trendingScore": 98,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
-    },
-    {
-      "rank": 44,
-      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
-      "downloads": 5195,
-      "likes": 101,
-      "trendingScore": 98,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_labs_diffusion",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T23:06:08.000Z",
-      "lastModified": "2026-05-23T01:01:26.000Z"
-    },
-    {
-      "rank": 45,
-      "id": "google/gemma-4-31B-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-31B-it",
-      "downloads": 8731301,
-      "likes": 2568,
-      "trendingScore": 94,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "conversational",
-        "base_model:google/gemma-4-31B",
-        "base_model:finetune:google/gemma-4-31B",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-03-11T18:22:36.000Z",
-      "lastModified": "2026-05-07T07:39:17.000Z"
-    },
-    {
-      "rank": 46,
-      "id": "ScenemaAI/scenema-audio",
-      "author": "ScenemaAI",
-      "url": "https://huggingface.co/ScenemaAI/scenema-audio",
-      "downloads": 237,
-      "likes": 97,
-      "trendingScore": 94,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "scenema-audio",
-      "tags": [
-        "scenema-audio",
-        "audio-generation",
-        "diffusion",
-        "text-to-audio",
-        "voice-cloning",
-        "speech-generation",
-        "expressive-speech",
-        "voice-acting",
-        "text-to-speech",
-        "en",
-        "de",
-        "fr",
-        "es",
-        "it",
-        "pt",
-        "ja",
-        "zh",
-        "ko",
-        "ru",
-        "ar",
-        "hi",
-        "sw",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-26T01:37:45.000Z",
-      "lastModified": "2026-05-14T03:19:58.000Z"
-    },
-    {
-      "rank": 47,
-      "id": "microsoft/Fara-7B",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Fara-7B",
-      "downloads": 15175,
-      "likes": 590,
-      "trendingScore": 94,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_5_vl",
-        "image-text-to-text",
-        "multimodal",
-        "conversational",
-        "en",
-        "arxiv:2511.19663",
-        "license:mit",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-10-30T18:56:59.000Z",
-      "lastModified": "2026-05-19T15:37:05.000Z"
-    },
-    {
-      "rank": 48,
       "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "downloads": 23762,
-      "likes": 96,
-      "trendingScore": 94,
+      "downloads": 31597,
+      "likes": 104,
+      "trendingScore": 102,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1502,7 +1310,250 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
+      "rank": 42,
+      "id": "nvidia/Nemotron-Labs-Diffusion-14B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
+      "downloads": 5453,
+      "likes": 104,
+      "trendingScore": 101,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_labs_diffusion",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T23:06:08.000Z",
+      "lastModified": "2026-05-23T01:01:26.000Z"
+    },
+    {
+      "rank": 43,
+      "id": "jackxinning/Leanly_AI",
+      "author": "jackxinning",
+      "url": "https://huggingface.co/jackxinning/Leanly_AI",
+      "downloads": 10822,
+      "likes": 111,
+      "trendingScore": 99,
+      "pipelineTag": "question-answering",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "medical",
+        "question-answering",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T10:43:03.000Z",
+      "lastModified": "2026-05-04T07:50:46.000Z"
+    },
+    {
+      "rank": 44,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+      "downloads": 3819,
+      "likes": 99,
+      "trendingScore": 99,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T13:09:29.000Z",
+      "lastModified": "2026-05-15T10:40:24.000Z"
+    },
+    {
+      "rank": 45,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 100,
+      "trendingScore": 98,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
+    },
+    {
+      "rank": 46,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 908,
+      "likes": 98,
+      "trendingScore": 96,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "diffusers:LensPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
+    },
+    {
+      "rank": 47,
+      "id": "google/gemma-4-31B-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-31B-it",
+      "downloads": 8731301,
+      "likes": 2568,
+      "trendingScore": 94,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "conversational",
+        "base_model:google/gemma-4-31B",
+        "base_model:finetune:google/gemma-4-31B",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-03-11T18:22:36.000Z",
+      "lastModified": "2026-05-07T07:39:17.000Z"
+    },
+    {
+      "rank": 48,
+      "id": "ScenemaAI/scenema-audio",
+      "author": "ScenemaAI",
+      "url": "https://huggingface.co/ScenemaAI/scenema-audio",
+      "downloads": 237,
+      "likes": 97,
+      "trendingScore": 94,
+      "pipelineTag": "text-to-speech",
+      "libraryName": "scenema-audio",
+      "tags": [
+        "scenema-audio",
+        "audio-generation",
+        "diffusion",
+        "text-to-audio",
+        "voice-cloning",
+        "speech-generation",
+        "expressive-speech",
+        "voice-acting",
+        "text-to-speech",
+        "en",
+        "de",
+        "fr",
+        "es",
+        "it",
+        "pt",
+        "ja",
+        "zh",
+        "ko",
+        "ru",
+        "ar",
+        "hi",
+        "sw",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-26T01:37:45.000Z",
+      "lastModified": "2026-05-14T03:19:58.000Z"
+    },
+    {
       "rank": 49,
+      "id": "microsoft/Fara-7B",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Fara-7B",
+      "downloads": 15175,
+      "likes": 590,
+      "trendingScore": 94,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_5_vl",
+        "image-text-to-text",
+        "multimodal",
+        "conversational",
+        "en",
+        "arxiv:2511.19663",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-10-30T18:56:59.000Z",
+      "lastModified": "2026-05-19T15:37:05.000Z"
+    },
+    {
+      "rank": 50,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 101,
+      "trendingScore": 94,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "sound-effects",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
+    },
+    {
+      "rank": 51,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
@@ -1531,39 +1582,11 @@
       "lastModified": "2026-05-05T12:57:20.000Z"
     },
     {
-      "rank": 50,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 98,
-      "trendingScore": 92,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
-    },
-    {
-      "rank": 51,
+      "rank": 52,
       "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
-      "downloads": 7701,
+      "downloads": 10015,
       "likes": 96,
       "trendingScore": 92,
       "pipelineTag": "text-generation",
@@ -1594,7 +1617,7 @@
       "lastModified": "2026-05-23T20:28:00.000Z"
     },
     {
-      "rank": 52,
+      "rank": 53,
       "id": "dealignai/Gemma-4-31B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-31B-JANG_4M-CRACK",
@@ -1620,7 +1643,7 @@
       "lastModified": "2026-04-25T21:33:07.000Z"
     },
     {
-      "rank": 53,
+      "rank": 54,
       "id": "unsloth/Qwen3.6-27B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF",
@@ -1648,7 +1671,34 @@
       "lastModified": "2026-04-22T16:01:39.000Z"
     },
     {
-      "rank": 54,
+      "rank": 55,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 117,
+      "likes": 90,
+      "trendingScore": 90,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 56,
       "id": "Cactus-Compute/needle",
       "author": "Cactus-Compute",
       "url": "https://huggingface.co/Cactus-Compute/needle",
@@ -1673,7 +1723,7 @@
       "lastModified": "2026-05-13T09:32:17.000Z"
     },
     {
-      "rank": 55,
+      "rank": 57,
       "id": "internlm/Intern-S2-Preview",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview",
@@ -1697,7 +1747,7 @@
       "lastModified": "2026-05-19T08:01:07.000Z"
     },
     {
-      "rank": 56,
+      "rank": 58,
       "id": "Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-MTP-GGUF",
@@ -1741,7 +1791,7 @@
       "lastModified": "2026-05-19T23:43:59.000Z"
     },
     {
-      "rank": 57,
+      "rank": 59,
       "id": "inclusionAI/Ring-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ring-2.6-1T",
@@ -1766,13 +1816,13 @@
       "lastModified": "2026-05-18T09:47:28.000Z"
     },
     {
-      "rank": 58,
-      "id": "microsoft/Lens-Turbo",
+      "rank": 60,
+      "id": "microsoft/Lens",
       "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 695,
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 673,
       "likes": 90,
-      "trendingScore": 88,
+      "trendingScore": 87,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
@@ -1785,11 +1835,11 @@
         "diffusers:LensPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
-      "rank": 59,
+      "rank": 61,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/k2-fsa/OmniVoice",
@@ -1834,7 +1884,7 @@
       "lastModified": "2026-05-07T15:45:07.000Z"
     },
     {
-      "rank": 60,
+      "rank": 62,
       "id": "havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-27B-MTP-UD-GGUF",
@@ -1861,7 +1911,7 @@
       "lastModified": "2026-05-10T15:43:51.000Z"
     },
     {
-      "rank": 61,
+      "rank": 63,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -1899,30 +1949,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 62,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 512,
-      "likes": 85,
-      "trendingScore": 82,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "diffusers:LensPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
-    },
-    {
-      "rank": 63,
+      "rank": 64,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -1950,7 +1977,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 64,
+      "rank": 65,
       "id": "facebook/VGGT-Omega",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/VGGT-Omega",
@@ -1970,7 +1997,7 @@
       "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
-      "rank": 65,
+      "rank": 66,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -1999,7 +2026,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 66,
+      "rank": 67,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -2025,7 +2052,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 67,
+      "rank": 68,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -2054,7 +2081,7 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 68,
+      "rank": 69,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -2087,7 +2114,7 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 69,
+      "rank": 70,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -2120,7 +2147,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 70,
+      "rank": 71,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2165,33 +2192,6 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 71,
-      "id": "nvidia/PiD",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/PiD",
-      "downloads": 10,
-      "likes": 74,
-      "trendingScore": 74,
-      "pipelineTag": "image-to-image",
-      "libraryName": "pytorch",
-      "tags": [
-        "pytorch",
-        "diffusers",
-        "safetensors",
-        "super-resolution",
-        "diffusion",
-        "pixel-diffusion-decoder",
-        "vae-decoder",
-        "image-to-image",
-        "arxiv:2605.23902",
-        "base_model:Tongyi-MAI/Z-Image",
-        "base_model:finetune:Tongyi-MAI/Z-Image",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T00:41:46.000Z",
-      "lastModified": "2026-05-26T01:17:21.000Z"
-    },
-    {
       "rank": 72,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
@@ -2217,8 +2217,8 @@
       "author": "zhen-nan",
       "url": "https://huggingface.co/zhen-nan/L2P",
       "downloads": 0,
-      "likes": 71,
-      "trendingScore": 71,
+      "likes": 72,
+      "trendingScore": 72,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
@@ -2628,6 +2628,54 @@
     },
     {
       "rank": 87,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 12083,
+      "likes": 59,
+      "trendingScore": 58,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-26T09:06:16.000Z"
+    },
+    {
+      "rank": 88,
+      "id": "openbmb/BitCPM-CANN-8B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
+      "downloads": 1202,
+      "likes": 72,
+      "trendingScore": 58,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "minicpm",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:51.000Z",
+      "lastModified": "2026-05-24T10:43:34.000Z"
+    },
+    {
+      "rank": 89,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2650,7 +2698,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 88,
+      "rank": 90,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2681,7 +2729,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 89,
+      "rank": 91,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2711,29 +2759,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 90,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 10214,
-      "likes": 57,
-      "trendingScore": 56,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-22T05:15:52.000Z"
-    },
-    {
-      "rank": 91,
+      "rank": 92,
       "id": "zhifeixie/Mega-ASR",
       "author": "zhifeixie",
       "url": "https://huggingface.co/zhifeixie/Mega-ASR",
@@ -2760,7 +2786,7 @@
       "lastModified": "2026-05-24T17:48:46.000Z"
     },
     {
-      "rank": 92,
+      "rank": 93,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -2778,7 +2804,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -2805,7 +2831,7 @@
       "lastModified": "2026-05-14T02:37:15.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -2832,7 +2858,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 95,
+      "rank": 96,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -2865,7 +2891,7 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 96,
+      "rank": 97,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -2895,7 +2921,39 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 9929386,
+      "likes": 1979,
+      "trendingScore": 53,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
+    },
+    {
+      "rank": 99,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2940,7 +2998,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 98,
+      "rank": 100,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -2967,7 +3025,7 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 99,
+      "rank": 101,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -2995,39 +3053,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 100,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 9919282,
-      "likes": 1972,
-      "trendingScore": 50,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
-    },
-    {
-      "rank": 101,
+      "rank": 102,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -3061,7 +3087,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -3081,7 +3107,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -3112,7 +3138,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 104,
+      "rank": 105,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -3137,7 +3163,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 105,
+      "rank": 106,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -3174,7 +3200,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 106,
+      "rank": 107,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -3211,7 +3237,51 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 107,
+      "rank": 108,
+      "id": "Kijai/LTX2.3_comfy",
+      "author": "Kijai",
+      "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
+      "downloads": 1722148,
+      "likes": 410,
+      "trendingScore": 47,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
+      "tags": [
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-05T15:20:18.000Z",
+      "lastModified": "2026-05-20T20:31:07.000Z"
+    },
+    {
+      "rank": 109,
+      "id": "black-forest-labs/FLUX.1-dev",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+      "downloads": 710720,
+      "likes": 12910,
+      "trendingScore": 47,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "image-generation",
+        "flux",
+        "en",
+        "license:other",
+        "endpoints_compatible",
+        "diffusers:FluxPipeline",
+        "region:us"
+      ],
+      "createdAt": "2024-07-31T21:13:44.000Z",
+      "lastModified": "2025-06-27T16:22:19.000Z"
+    },
+    {
+      "rank": 110,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -3239,7 +3309,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 108,
+      "rank": 111,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
@@ -3263,30 +3333,11 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 109,
-      "id": "Kijai/LTX2.3_comfy",
-      "author": "Kijai",
-      "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
-      "downloads": 1599401,
-      "likes": 399,
-      "trendingScore": 46,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T15:20:18.000Z",
-      "lastModified": "2026-05-20T20:31:07.000Z"
-    },
-    {
-      "rank": 110,
+      "rank": 112,
       "id": "LatitudeGames/Equinox-31B",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 593,
+      "downloads": 653,
       "likes": 46,
       "trendingScore": 46,
       "pipelineTag": null,
@@ -3306,7 +3357,7 @@
       "lastModified": "2026-05-22T04:55:49.000Z"
     },
     {
-      "rank": 111,
+      "rank": 113,
       "id": "stabilityai/stable-audio-3-small-music",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
@@ -3333,7 +3384,7 @@
       "lastModified": "2026-05-19T20:02:42.000Z"
     },
     {
-      "rank": 112,
+      "rank": 114,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -3356,7 +3407,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 113,
+      "rank": 115,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -3383,32 +3434,7 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 114,
-      "id": "black-forest-labs/FLUX.1-dev",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
-      "downloads": 708162,
-      "likes": 12907,
-      "trendingScore": 45,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "image-generation",
-        "flux",
-        "en",
-        "license:other",
-        "endpoints_compatible",
-        "diffusers:FluxPipeline",
-        "region:us"
-      ],
-      "createdAt": "2024-07-31T21:13:44.000Z",
-      "lastModified": "2025-06-27T16:22:19.000Z"
-    },
-    {
-      "rank": 115,
+      "rank": 116,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -3441,7 +3467,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -3472,7 +3498,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -3488,11 +3514,11 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 18187,
+      "downloads": 20123,
       "likes": 43,
       "trendingScore": 43,
       "pipelineTag": "image-text-to-text",
@@ -3515,7 +3541,39 @@
       "lastModified": "2026-05-20T01:46:59.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
+      "id": "jedisct1/MiMo-V2.5-coder-Q2",
+      "author": "jedisct1",
+      "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
+      "downloads": 1050,
+      "likes": 43,
+      "trendingScore": 42,
+      "pipelineTag": "text-generation",
+      "libraryName": "llama.cpp",
+      "tags": [
+        "llama.cpp",
+        "gguf",
+        "text-generation",
+        "code",
+        "coding",
+        "tool-calling",
+        "agent",
+        "mixture-of-experts",
+        "long-context",
+        "en",
+        "base_model:XiaomiMiMo/MiMo-V2.5",
+        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T21:13:40.000Z",
+      "lastModified": "2026-05-25T23:53:02.000Z"
+    },
+    {
+      "rank": 121,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3541,7 +3599,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 120,
+      "rank": 122,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -3560,7 +3618,7 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 121,
+      "rank": 123,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -3586,32 +3644,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 122,
-      "id": "openbmb/BitCPM-CANN-8B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
-      "downloads": 689,
-      "likes": 53,
-      "trendingScore": 39,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "minicpm",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T13:10:51.000Z",
-      "lastModified": "2026-05-24T10:43:34.000Z"
-    },
-    {
-      "rank": 123,
+      "rank": 124,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3643,7 +3676,33 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 124,
+      "rank": 125,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 4170,
+      "likes": 40,
+      "trendingScore": 38,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-20T13:39:48.000Z"
+    },
+    {
+      "rank": 126,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3670,7 +3729,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 125,
+      "rank": 127,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3697,7 +3756,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 126,
+      "rank": 128,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -3727,64 +3786,6 @@
       ],
       "createdAt": "2026-05-16T19:11:26.000Z",
       "lastModified": "2026-05-21T21:34:50.000Z"
-    },
-    {
-      "rank": 127,
-      "id": "HuggingFaceBio/Carbon-3B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 3966,
-      "likes": 39,
-      "trendingScore": 37,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-20T13:39:48.000Z"
-    },
-    {
-      "rank": 128,
-      "id": "jedisct1/MiMo-V2.5-coder-Q2",
-      "author": "jedisct1",
-      "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
-      "downloads": 4,
-      "likes": 38,
-      "trendingScore": 37,
-      "pipelineTag": "text-generation",
-      "libraryName": "llama.cpp",
-      "tags": [
-        "llama.cpp",
-        "gguf",
-        "text-generation",
-        "code",
-        "coding",
-        "tool-calling",
-        "agent",
-        "mixture-of-experts",
-        "long-context",
-        "en",
-        "base_model:XiaomiMiMo/MiMo-V2.5",
-        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T21:13:40.000Z",
-      "lastModified": "2026-05-25T23:53:02.000Z"
     },
     {
       "rank": 129,
@@ -3848,7 +3849,7 @@
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
-      "downloads": 1648,
+      "downloads": 1727,
       "likes": 37,
       "trendingScore": 36,
       "pipelineTag": "text-generation",
@@ -4102,6 +4103,30 @@
     },
     {
       "rank": 140,
+      "id": "openbmb/BitCPM-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
+      "downloads": 1282,
+      "likes": 39,
+      "trendingScore": 35,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-23T18:12:57.000Z"
+    },
+    {
+      "rank": 141,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -4125,7 +4150,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 141,
+      "rank": 142,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -4142,7 +4167,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 142,
+      "rank": 143,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -4166,7 +4191,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 143,
+      "rank": 144,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -4182,7 +4207,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 144,
+      "rank": 145,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -4209,7 +4234,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 145,
+      "rank": 146,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -4228,7 +4253,46 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 146,
+      "rank": 147,
+      "id": "openbmb/MiniCPM5-1B-GGUF",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
+      "downloads": 1655,
+      "likes": 72,
+      "trendingScore": 33.5,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
+        "long-context",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "en",
+        "zh",
+        "dataset:openbmb/Ultra-FineWeb",
+        "dataset:openbmb/Ultra-FineWeb-L3",
+        "dataset:openbmb/UltraData-Math",
+        "dataset:openbmb/UltraData-SFT-2605",
+        "arxiv:2506.07900",
+        "arxiv:2602.09003",
+        "arxiv:2512.16649",
+        "arxiv:2604.13016",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T09:49:47.000Z",
+      "lastModified": "2026-05-25T10:55:40.000Z"
+    },
+    {
+      "rank": 148,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -4273,7 +4337,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 147,
+      "rank": 149,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -4318,7 +4382,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 148,
+      "rank": 150,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -4362,7 +4426,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 149,
+      "rank": 151,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -4388,31 +4452,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 150,
-      "id": "openbmb/BitCPM-CANN-8B-gguf",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
-      "downloads": 789,
-      "likes": 37,
-      "trendingScore": 33,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T06:18:55.000Z",
-      "lastModified": "2026-05-23T18:12:57.000Z"
-    },
-    {
-      "rank": 151,
+      "rank": 152,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -4456,7 +4496,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 152,
+      "rank": 153,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -4501,7 +4541,7 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 153,
+      "rank": 154,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -4534,7 +4574,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 154,
+      "rank": 155,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -4558,7 +4598,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 155,
+      "rank": 156,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -4585,7 +4625,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 156,
+      "rank": 157,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -4627,7 +4667,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 157,
+      "rank": 158,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -4655,7 +4695,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 158,
+      "rank": 159,
       "id": "ByteDance-Seed/Cola-DLM",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
@@ -4685,7 +4725,7 @@
       "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
-      "rank": 159,
+      "rank": 160,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
@@ -4730,11 +4770,11 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 160,
+      "rank": 161,
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
-      "downloads": 1706,
+      "downloads": 1993,
       "likes": 32,
       "trendingScore": 31,
       "pipelineTag": "image-text-to-text",
@@ -4775,11 +4815,11 @@
       "lastModified": "2026-05-22T14:40:30.000Z"
     },
     {
-      "rank": 161,
+      "rank": 162,
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
-      "downloads": 1869,
+      "downloads": 1932,
       "likes": 31,
       "trendingScore": 31,
       "pipelineTag": "text-generation",
@@ -4803,7 +4843,25 @@
       "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 162,
+      "rank": 163,
+      "id": "Comfy-Org/Lens",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/Lens",
+      "downloads": 0,
+      "likes": 31,
+      "trendingScore": 31,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T14:51:51.000Z",
+      "lastModified": "2026-05-24T13:34:38.000Z"
+    },
+    {
+      "rank": 164,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4829,7 +4887,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 163,
+      "rank": 165,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4861,7 +4919,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 164,
+      "rank": 166,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4888,7 +4946,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 165,
+      "rank": 167,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4922,7 +4980,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 166,
+      "rank": 168,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4944,25 +5002,39 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 167,
-      "id": "Comfy-Org/Lens",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/Lens",
-      "downloads": 0,
-      "likes": 30,
+      "rank": 169,
+      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "author": "fal",
+      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "downloads": 50617,
+      "likes": 1347,
       "trendingScore": 30,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "comfyui",
-        "license:other",
+        "diffusers",
+        "qwen",
+        "qwen-image-edit",
+        "qwen-image-edit-2511",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "camera-control",
+        "image-editing",
+        "image-to-image",
+        "gaussian-splatting",
+        "fal",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-23T14:51:51.000Z",
-      "lastModified": "2026-05-24T13:34:38.000Z"
+      "createdAt": "2026-01-07T17:01:15.000Z",
+      "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
-      "rank": 168,
+      "rank": 170,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -4993,7 +5065,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 169,
+      "rank": 171,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -5016,7 +5088,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 170,
+      "rank": 172,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -5043,7 +5115,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 171,
+      "rank": 173,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -5074,7 +5146,7 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 172,
+      "rank": 174,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -5103,159 +5175,13 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 173,
-      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "author": "fal",
-      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 49515,
-      "likes": 1346,
-      "trendingScore": 29,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "qwen",
-        "qwen-image-edit",
-        "qwen-image-edit-2511",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "camera-control",
-        "image-editing",
-        "image-to-image",
-        "gaussian-splatting",
-        "fal",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T17:01:15.000Z",
-      "lastModified": "2026-01-07T17:06:01.000Z"
-    },
-    {
-      "rank": 174,
-      "id": "dx8152/Flux2-Klein-9B-Consistency",
-      "author": "dx8152",
-      "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
-      "downloads": 29101,
-      "likes": 358,
-      "trendingScore": 28,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "image-to-image",
-        "base_model:black-forest-labs/FLUX.2-klein-9B",
-        "base_model:adapter:black-forest-labs/FLUX.2-klein-9B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-05T16:04:16.000Z",
-      "lastModified": "2026-04-19T02:39:34.000Z"
-    },
-    {
       "rank": 175,
-      "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
-      "downloads": 55366,
-      "likes": 109,
-      "trendingScore": 28,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "nvidia",
-        "unsloth",
-        "nemotron-3",
-        "multimodal",
-        "text-generation",
-        "en",
-        "fr",
-        "es",
-        "it",
-        "de",
-        "ja",
-        "zh",
-        "dataset:nvidia/nemotron-post-training-v3",
-        "dataset:nvidia/nemotron-pre-training-datasets",
-        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-27T21:42:38.000Z",
-      "lastModified": "2026-04-28T16:14:16.000Z"
-    },
-    {
-      "rank": 176,
-      "id": "Alissonerdx/LTX-LoRAs",
-      "author": "Alissonerdx",
-      "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
-      "downloads": 0,
-      "likes": 159,
-      "trendingScore": 28,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "ltx",
-        "lora",
-        "inpaint",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-22T09:30:01.000Z",
-      "lastModified": "2026-04-22T17:46:55.000Z"
-    },
-    {
-      "rank": 177,
-      "id": "zai-org/GLM-OCR",
-      "author": "zai-org",
-      "url": "https://huggingface.co/zai-org/GLM-OCR",
-      "downloads": 7171486,
-      "likes": 1748,
-      "trendingScore": 28,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "glm_ocr",
-        "image-text-to-text",
-        "image-to-text",
-        "zh",
-        "en",
-        "fr",
-        "es",
-        "ru",
-        "de",
-        "ja",
-        "ko",
-        "arxiv:2603.10910",
-        "license:mit",
-        "eval-results",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-01-30T04:24:21.000Z",
-      "lastModified": "2026-04-14T14:46:47.000Z"
-    },
-    {
-      "rank": 178,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
-      "downloads": 260375836,
+      "downloads": 262278076,
       "likes": 4830,
-      "trendingScore": 28,
+      "trendingScore": 29,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
       "tags": [
@@ -5294,7 +5220,121 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
+      "rank": 176,
+      "id": "dx8152/Flux2-Klein-9B-Consistency",
+      "author": "dx8152",
+      "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
+      "downloads": 29101,
+      "likes": 358,
+      "trendingScore": 28,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "image-to-image",
+        "base_model:black-forest-labs/FLUX.2-klein-9B",
+        "base_model:adapter:black-forest-labs/FLUX.2-klein-9B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-05T16:04:16.000Z",
+      "lastModified": "2026-04-19T02:39:34.000Z"
+    },
+    {
+      "rank": 177,
+      "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
+      "downloads": 55366,
+      "likes": 109,
+      "trendingScore": 28,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "nvidia",
+        "unsloth",
+        "nemotron-3",
+        "multimodal",
+        "text-generation",
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "ja",
+        "zh",
+        "dataset:nvidia/nemotron-post-training-v3",
+        "dataset:nvidia/nemotron-pre-training-datasets",
+        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-27T21:42:38.000Z",
+      "lastModified": "2026-04-28T16:14:16.000Z"
+    },
+    {
+      "rank": 178,
+      "id": "Alissonerdx/LTX-LoRAs",
+      "author": "Alissonerdx",
+      "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
+      "downloads": 0,
+      "likes": 159,
+      "trendingScore": 28,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "ltx",
+        "lora",
+        "inpaint",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-22T09:30:01.000Z",
+      "lastModified": "2026-04-22T17:46:55.000Z"
+    },
+    {
       "rank": 179,
+      "id": "zai-org/GLM-OCR",
+      "author": "zai-org",
+      "url": "https://huggingface.co/zai-org/GLM-OCR",
+      "downloads": 7171486,
+      "likes": 1748,
+      "trendingScore": 28,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "glm_ocr",
+        "image-text-to-text",
+        "image-to-text",
+        "zh",
+        "en",
+        "fr",
+        "es",
+        "ru",
+        "de",
+        "ja",
+        "ko",
+        "arxiv:2603.10910",
+        "license:mit",
+        "eval-results",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-01-30T04:24:21.000Z",
+      "lastModified": "2026-04-14T14:46:47.000Z"
+    },
+    {
+      "rank": 180,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5326,11 +5366,11 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 180,
+      "rank": 181,
       "id": "tencent/Hy-MT2-7B-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 13330,
+      "downloads": 14891,
       "likes": 29,
       "trendingScore": 28,
       "pipelineTag": null,
@@ -5340,15 +5380,16 @@
         "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-7B",
         "base_model:quantized:tencent/Hy-MT2-7B",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
       "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-22T05:16:12.000Z"
+      "lastModified": "2026-05-26T09:06:21.000Z"
     },
     {
-      "rank": 181,
+      "rank": 182,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -5388,7 +5429,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 182,
+      "rank": 183,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -5425,7 +5466,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 183,
+      "rank": 184,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -5468,7 +5509,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 184,
+      "rank": 185,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -5488,7 +5529,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 185,
+      "rank": 186,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -5513,7 +5554,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 186,
+      "rank": 187,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5538,11 +5579,11 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 187,
+      "rank": 188,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
-      "downloads": 27984,
+      "downloads": 30473,
       "likes": 27,
       "trendingScore": 27,
       "pipelineTag": "text-generation",
@@ -5564,7 +5605,60 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 188,
+      "rank": 189,
+      "id": "oron1208/OOO_Anima",
+      "author": "oron1208",
+      "url": "https://huggingface.co/oron1208/OOO_Anima",
+      "downloads": 0,
+      "likes": 27,
+      "trendingScore": 27,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "text-to-image",
+        "image-generation",
+        "anime",
+        "illustration",
+        "anima",
+        "safetensors",
+        "ja",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T09:41:37.000Z",
+      "lastModified": "2026-05-21T15:24:20.000Z"
+    },
+    {
+      "rank": 190,
+      "id": "black-forest-labs/FLUX.1-schnell",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
+      "downloads": 580769,
+      "likes": 4934,
+      "trendingScore": 27,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "image-generation",
+        "flux",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "diffusers:FluxPipeline",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-07-31T19:58:05.000Z",
+      "lastModified": "2024-08-16T14:37:56.000Z"
+    },
+    {
+      "rank": 191,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -5609,7 +5703,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 189,
+      "rank": 192,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -5636,7 +5730,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 190,
+      "rank": 193,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -5681,7 +5775,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 191,
+      "rank": 194,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -5707,7 +5801,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 192,
+      "rank": 195,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -5729,7 +5823,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 193,
+      "rank": 196,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -5745,7 +5839,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 194,
+      "rank": 197,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -5781,7 +5875,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 195,
+      "rank": 198,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -5799,7 +5893,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 196,
+      "rank": 199,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -5831,34 +5925,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 197,
-      "id": "oron1208/OOO_Anima",
-      "author": "oron1208",
-      "url": "https://huggingface.co/oron1208/OOO_Anima",
-      "downloads": 0,
-      "likes": 26,
-      "trendingScore": 26,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "text-to-image",
-        "image-generation",
-        "anime",
-        "illustration",
-        "anima",
-        "safetensors",
-        "ja",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T09:41:37.000Z",
-      "lastModified": "2026-05-21T15:24:20.000Z"
-    },
-    {
-      "rank": 198,
+      "rank": 200,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -5896,7 +5963,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 199,
+      "rank": 201,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -5914,7 +5981,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 200,
+      "rank": 202,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -5940,7 +6007,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 201,
+      "rank": 203,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -5960,7 +6027,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 202,
+      "rank": 204,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -5987,7 +6054,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 203,
+      "rank": 205,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -6013,7 +6080,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 204,
+      "rank": 206,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -6039,7 +6106,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 205,
+      "rank": 207,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -6076,7 +6143,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 206,
+      "rank": 208,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -6092,7 +6159,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 207,
+      "rank": 209,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -6115,7 +6182,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 208,
+      "rank": 210,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -6157,7 +6224,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 209,
+      "rank": 211,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -6196,7 +6263,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 210,
+      "rank": 212,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6241,12 +6308,12 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 211,
+      "rank": 213,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
-      "downloads": 9222261,
-      "likes": 1024,
+      "downloads": 9192817,
+      "likes": 1033,
       "trendingScore": 25,
       "pipelineTag": "voice-activity-detection",
       "libraryName": "pyannote-audio",
@@ -6272,11 +6339,11 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 212,
+      "rank": 214,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
-      "downloads": 2670,
+      "downloads": 3055,
       "likes": 26,
       "trendingScore": 25,
       "pipelineTag": null,
@@ -6286,15 +6353,42 @@
         "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-1.8B",
         "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
       "createdAt": "2026-05-20T09:26:32.000Z",
-      "lastModified": "2026-05-22T05:15:40.000Z"
+      "lastModified": "2026-05-26T09:06:32.000Z"
     },
     {
-      "rank": 213,
+      "rank": 215,
+      "id": "HuggingFaceBio/Carbon-500M",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
+      "downloads": 1874,
+      "likes": 29,
+      "trendingScore": 25,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "dna",
+        "genomic",
+        "speculative-decoding",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T16:09:33.000Z",
+      "lastModified": "2026-05-20T13:40:43.000Z"
+    },
+    {
+      "rank": 216,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -6326,7 +6420,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 214,
+      "rank": 217,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -6350,7 +6444,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 215,
+      "rank": 218,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -6377,7 +6471,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 216,
+      "rank": 219,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -6402,7 +6496,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 217,
+      "rank": 220,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -6438,7 +6532,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 218,
+      "rank": 221,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -6454,7 +6548,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 219,
+      "rank": 222,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -6475,33 +6569,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 220,
-      "id": "HuggingFaceBio/Carbon-500M",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
-      "downloads": 1766,
-      "likes": 28,
-      "trendingScore": 24,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "dna",
-        "genomic",
-        "speculative-decoding",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T16:09:33.000Z",
-      "lastModified": "2026-05-20T13:40:43.000Z"
-    },
-    {
-      "rank": 221,
+      "rank": 223,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -6523,11 +6591,11 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 222,
+      "rank": 224,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
-      "downloads": 19496,
+      "downloads": 22203,
       "likes": 26,
       "trendingScore": 24,
       "pipelineTag": "text-generation",
@@ -6549,7 +6617,7 @@
       "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 223,
+      "rank": 225,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -6576,7 +6644,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 224,
+      "rank": 226,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -6603,7 +6671,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 225,
+      "rank": 227,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -6632,7 +6700,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 226,
+      "rank": 228,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -6649,7 +6717,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 227,
+      "rank": 229,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -6670,7 +6738,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 228,
+      "rank": 230,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -6691,7 +6759,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 229,
+      "rank": 231,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6712,7 +6780,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 230,
+      "rank": 232,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -6744,7 +6812,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 231,
+      "rank": 233,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6775,46 +6843,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 232,
-      "id": "openbmb/MiniCPM5-1B-GGUF",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
-      "downloads": 0,
-      "likes": 47,
-      "trendingScore": 23,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "minicpm",
-        "minicpm5",
-        "llama",
-        "text-generation",
-        "long-context",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "en",
-        "zh",
-        "dataset:openbmb/Ultra-FineWeb",
-        "dataset:openbmb/Ultra-FineWeb-L3",
-        "dataset:openbmb/UltraData-Math",
-        "dataset:openbmb/UltraData-SFT-2605",
-        "arxiv:2506.07900",
-        "arxiv:2602.09003",
-        "arxiv:2512.16649",
-        "arxiv:2604.13016",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T09:49:47.000Z",
-      "lastModified": "2026-05-25T10:55:40.000Z"
-    },
-    {
-      "rank": 233,
+      "rank": 234,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6845,7 +6874,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 234,
+      "rank": 235,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6874,7 +6903,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 235,
+      "rank": 236,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6919,7 +6948,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 236,
+      "rank": 237,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6944,32 +6973,6 @@
       ],
       "createdAt": "2026-04-23T15:52:31.000Z",
       "lastModified": "2026-05-06T18:54:03.000Z"
-    },
-    {
-      "rank": 237,
-      "id": "black-forest-labs/FLUX.1-schnell",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
-      "downloads": 660418,
-      "likes": 4879,
-      "trendingScore": 22,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "image-generation",
-        "flux",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "diffusers:FluxPipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-07-31T19:58:05.000Z",
-      "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
       "rank": 238,
@@ -7284,7 +7287,7 @@
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
-      "downloads": 9223,
+      "downloads": 9872,
       "likes": 21,
       "trendingScore": 21,
       "pipelineTag": null,
@@ -7311,7 +7314,7 @@
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
-      "downloads": 14355,
+      "downloads": 15380,
       "likes": 21,
       "trendingScore": 21,
       "pipelineTag": "image-text-to-text",
@@ -7334,6 +7337,39 @@
     },
     {
       "rank": 251,
+      "id": "pyannote/speaker-diarization-community-1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
+      "downloads": 2844915,
+      "likes": 409,
+      "trendingScore": 21,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2104.03603",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "arxiv:2110.07058",
+        "license:cc-by-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-04-15T21:31:35.000Z",
+      "lastModified": "2025-09-29T08:43:24.000Z"
+    },
+    {
+      "rank": 252,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -7361,7 +7397,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -7394,7 +7430,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -7419,7 +7455,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -7456,7 +7492,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -7499,7 +7535,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -7523,7 +7559,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -7547,7 +7583,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -7576,7 +7612,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -7594,7 +7630,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7639,7 +7675,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7684,7 +7720,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -7713,7 +7749,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -7737,7 +7773,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7766,7 +7802,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -7788,39 +7824,6 @@
       ],
       "createdAt": "2025-12-17T05:55:58.000Z",
       "lastModified": "2025-12-23T13:13:52.000Z"
-    },
-    {
-      "rank": 266,
-      "id": "pyannote/speaker-diarization-community-1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2838518,
-      "likes": 405,
-      "trendingScore": 20,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2104.03603",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "arxiv:2110.07058",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-04-15T21:31:35.000Z",
-      "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
       "rank": 267,
@@ -8265,6 +8268,48 @@
     },
     {
       "rank": 282,
+      "id": "netease-youdao/Confucius4",
+      "author": "netease-youdao",
+      "url": "https://huggingface.co/netease-youdao/Confucius4",
+      "downloads": 493,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T10:13:40.000Z",
+      "lastModified": "2026-05-20T08:42:10.000Z"
+    },
+    {
+      "rank": 283,
+      "id": "Tongyi-MAI/Z-Image",
+      "author": "Tongyi-MAI",
+      "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
+      "downloads": 32049,
+      "likes": 1117,
+      "trendingScore": 19,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2511.22699",
+        "license:apache-2.0",
+        "diffusers:ZImagePipeline",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-01-23T10:02:00.000Z",
+      "lastModified": "2026-01-28T14:26:13.000Z"
+    },
+    {
+      "rank": 284,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -8286,7 +8331,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 283,
+      "rank": 285,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -8320,7 +8365,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 284,
+      "rank": 286,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -8344,7 +8389,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 285,
+      "rank": 287,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -8370,7 +8415,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 286,
+      "rank": 288,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -8392,7 +8437,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 287,
+      "rank": 289,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -8421,7 +8466,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 288,
+      "rank": 290,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8453,7 +8498,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 289,
+      "rank": 291,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8471,7 +8516,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 290,
+      "rank": 292,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8500,7 +8545,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 291,
+      "rank": 293,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8518,11 +8563,11 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 292,
+      "rank": 294,
       "id": "Jackrong/Qwopus3.6-27B-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
-      "downloads": 3125,
+      "downloads": 4313,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": "image-text-to-text",
@@ -8562,7 +8607,7 @@
       "lastModified": "2026-05-23T00:38:29.000Z"
     },
     {
-      "rank": 293,
+      "rank": 295,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -8588,7 +8633,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 294,
+      "rank": 296,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -8616,7 +8661,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 295,
+      "rank": 297,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -8648,25 +8693,25 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 296,
-      "id": "netease-youdao/Confucius4",
-      "author": "netease-youdao",
-      "url": "https://huggingface.co/netease-youdao/Confucius4",
-      "downloads": 474,
-      "likes": 18,
+      "rank": 298,
+      "id": "Comfy-Org/stable-audio-3",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
+      "downloads": 0,
+      "likes": 19,
       "trendingScore": 18,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "safetensors",
-        "qwen3_5",
+        "comfyui",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-19T10:13:40.000Z",
-      "lastModified": "2026-05-20T08:42:10.000Z"
+      "createdAt": "2026-05-12T23:23:44.000Z",
+      "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 297,
+      "rank": 299,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -8711,7 +8756,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 298,
+      "rank": 300,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -8740,7 +8785,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 299,
+      "rank": 301,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -8769,7 +8814,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 300,
+      "rank": 302,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -8801,7 +8846,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 301,
+      "rank": 303,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -8831,7 +8876,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 302,
+      "rank": 304,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -8852,7 +8897,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 303,
+      "rank": 305,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -8897,7 +8942,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -8926,7 +8971,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -8954,7 +8999,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 306,
+      "rank": 308,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -8979,7 +9024,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 307,
+      "rank": 309,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -9002,7 +9047,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 308,
+      "rank": 310,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -9029,7 +9074,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 309,
+      "rank": 311,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -9055,7 +9100,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 310,
+      "rank": 312,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -9084,7 +9129,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 311,
+      "rank": 313,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9103,7 +9148,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 312,
+      "rank": 314,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9131,25 +9176,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 313,
-      "id": "Comfy-Org/stable-audio-3",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
-      "downloads": 0,
-      "likes": 18,
-      "trendingScore": 17,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T23:23:44.000Z",
-      "lastModified": "2026-05-20T15:19:38.000Z"
-    },
-    {
-      "rank": 314,
+      "rank": 315,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -9194,11 +9221,11 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 315,
+      "rank": 316,
       "id": "SupraLabs/Supra-50M-Instruct",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
-      "downloads": 1045,
+      "downloads": 1318,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -9233,11 +9260,11 @@
       "lastModified": "2026-05-23T08:10:17.000Z"
     },
     {
-      "rank": 316,
+      "rank": 317,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "downloads": 21205,
+      "downloads": 29218,
       "likes": 18,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
@@ -9266,7 +9293,52 @@
       "lastModified": "2026-05-24T17:32:37.000Z"
     },
     {
-      "rank": 317,
+      "rank": 318,
+      "id": "syvai/cohere-transcribe-diarize",
+      "author": "syvai",
+      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
+      "downloads": 205,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere_asr",
+        "automatic-speech-recognition",
+        "audio",
+        "speech-recognition",
+        "transcription",
+        "diarization",
+        "speaker-diarization",
+        "timestamps",
+        "custom_code",
+        "en",
+        "ar",
+        "de",
+        "el",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "vi",
+        "zh",
+        "base_model:CohereLabs/cohere-transcribe-03-2026",
+        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T03:51:05.000Z",
+      "lastModified": "2026-05-22T20:56:30.000Z"
+    },
+    {
+      "rank": 319,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -9291,7 +9363,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -9326,7 +9398,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 319,
+      "rank": 321,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -9371,7 +9443,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 320,
+      "rank": 322,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -9398,7 +9470,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 321,
+      "rank": 323,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -9427,7 +9499,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 322,
+      "rank": 324,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -9450,7 +9522,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 323,
+      "rank": 325,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -9494,7 +9566,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 324,
+      "rank": 326,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -9539,7 +9611,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 325,
+      "rank": 327,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -9557,7 +9629,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 326,
+      "rank": 328,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -9602,7 +9674,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 327,
+      "rank": 329,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -9640,7 +9712,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 328,
+      "rank": 330,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -9660,7 +9732,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 329,
+      "rank": 331,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -9693,7 +9765,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 330,
+      "rank": 332,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -9723,7 +9795,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 331,
+      "rank": 333,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -9755,7 +9827,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 332,
+      "rank": 334,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -9780,7 +9852,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 333,
+      "rank": 335,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -9803,31 +9875,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 334,
-      "id": "Tongyi-MAI/Z-Image",
-      "author": "Tongyi-MAI",
-      "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
-      "downloads": 31743,
-      "likes": 1114,
-      "trendingScore": 16,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2511.22699",
-        "license:apache-2.0",
-        "diffusers:ZImagePipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-01-23T10:02:00.000Z",
-      "lastModified": "2026-01-28T14:26:13.000Z"
-    },
-    {
-      "rank": 335,
+      "rank": 336,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9857,7 +9905,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 336,
+      "rank": 337,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -9881,52 +9929,34 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 337,
-      "id": "syvai/cohere-transcribe-diarize",
-      "author": "syvai",
-      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
-      "downloads": 170,
-      "likes": 16,
+      "rank": 338,
+      "id": "unsloth/gemma-4-E2B-it-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
+      "downloads": 1249187,
+      "likes": 215,
       "trendingScore": 16,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
       "tags": [
-        "transformers",
-        "safetensors",
-        "cohere_asr",
-        "automatic-speech-recognition",
-        "audio",
-        "speech-recognition",
-        "transcription",
-        "diarization",
-        "speaker-diarization",
-        "timestamps",
-        "custom_code",
-        "en",
-        "ar",
-        "de",
-        "el",
-        "es",
-        "fr",
-        "it",
-        "ja",
-        "ko",
-        "nl",
-        "pl",
-        "pt",
-        "vi",
-        "zh",
-        "base_model:CohereLabs/cohere-transcribe-03-2026",
-        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
+        "gguf",
+        "gemma4",
+        "unsloth",
+        "gemma",
+        "google",
+        "image-text-to-text",
+        "base_model:google/gemma-4-E2B-it",
+        "base_model:quantized:google/gemma-4-E2B-it",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-05-19T03:51:05.000Z",
-      "lastModified": "2026-05-22T20:56:30.000Z"
+      "createdAt": "2026-04-01T14:40:57.000Z",
+      "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 338,
+      "rank": 339,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -9953,7 +9983,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 339,
+      "rank": 340,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -9998,7 +10028,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 340,
+      "rank": 341,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -10028,7 +10058,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 341,
+      "rank": 342,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -10058,7 +10088,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 342,
+      "rank": 343,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -10103,7 +10133,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 343,
+      "rank": 344,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -10138,7 +10168,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 344,
+      "rank": 345,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -10167,7 +10197,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 345,
+      "rank": 346,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -10192,7 +10222,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 346,
+      "rank": 347,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -10220,7 +10250,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 347,
+      "rank": 348,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -10248,7 +10278,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 348,
+      "rank": 349,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -10279,7 +10309,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 349,
+      "rank": 350,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -10324,7 +10354,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 350,
+      "rank": 351,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -10356,7 +10386,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 351,
+      "rank": 352,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -10383,7 +10413,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 352,
+      "rank": 353,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -10406,7 +10436,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 353,
+      "rank": 354,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -10433,11 +10463,11 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 354,
+      "rank": 355,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
-      "downloads": 1944348,
+      "downloads": 1956782,
       "likes": 825,
       "trendingScore": 15,
       "pipelineTag": "automatic-speech-recognition",
@@ -10456,7 +10486,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 355,
+      "rank": 356,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -10482,7 +10512,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 356,
+      "rank": 357,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -10512,7 +10542,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 357,
+      "rank": 358,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -10539,7 +10569,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 358,
+      "rank": 359,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -10570,12 +10600,12 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 359,
+      "rank": 360,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
-      "downloads": 1252435,
-      "likes": 347,
+      "downloads": 1573212,
+      "likes": 353,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -10598,7 +10628,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 360,
+      "rank": 361,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10630,7 +10660,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 361,
+      "rank": 362,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10675,7 +10705,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 362,
+      "rank": 363,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -10708,7 +10738,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 363,
+      "rank": 364,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -10748,7 +10778,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 364,
+      "rank": 365,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -10789,7 +10819,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 365,
+      "rank": 366,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -10812,7 +10842,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 366,
+      "rank": 367,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -10850,12 +10880,12 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 367,
+      "rank": 368,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
-      "downloads": 723421,
-      "likes": 297,
+      "downloads": 728009,
+      "likes": 298,
       "trendingScore": 15,
       "pipelineTag": "image-feature-extraction",
       "libraryName": "transformers",
@@ -10878,12 +10908,12 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 368,
+      "rank": 369,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "downloads": 0,
-      "likes": 1579,
+      "likes": 1580,
       "trendingScore": 15,
       "pipelineTag": "image-to-video",
       "libraryName": "wan2.2",
@@ -10899,33 +10929,6 @@
       ],
       "createdAt": "2025-07-30T16:39:44.000Z",
       "lastModified": "2026-04-06T05:31:09.000Z"
-    },
-    {
-      "rank": 369,
-      "id": "unsloth/gemma-4-E2B-it-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
-      "downloads": 1246974,
-      "likes": 214,
-      "trendingScore": 15,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "gemma4",
-        "unsloth",
-        "gemma",
-        "google",
-        "image-text-to-text",
-        "base_model:google/gemma-4-E2B-it",
-        "base_model:quantized:google/gemma-4-E2B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-01T14:40:57.000Z",
-      "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
       "rank": 370,
@@ -11056,7 +11059,7 @@
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
-      "downloads": 912,
+      "downloads": 1225,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
@@ -11082,6 +11085,50 @@
     },
     {
       "rank": 375,
+      "id": "CohereLabs/cohere-transcribe-03-2026",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
+      "downloads": 308298,
+      "likes": 960,
+      "trendingScore": 15,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere_asr",
+        "automatic-speech-recognition",
+        "audio",
+        "hf-asr-leaderboard",
+        "speech-recognition",
+        "transcription",
+        "custom_code",
+        "ar",
+        "de",
+        "el",
+        "en",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "vi",
+        "zh",
+        "doi:10.57967/hf/8653",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-03-24T10:35:54.000Z",
+      "lastModified": "2026-05-04T13:29:45.000Z"
+    },
+    {
+      "rank": 376,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -11105,7 +11152,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 376,
+      "rank": 377,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -11132,7 +11179,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 377,
+      "rank": 378,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -11160,7 +11207,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 378,
+      "rank": 379,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -11179,7 +11226,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 379,
+      "rank": 380,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -11211,7 +11258,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 380,
+      "rank": 381,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -11240,7 +11287,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 381,
+      "rank": 382,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -11266,7 +11313,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 382,
+      "rank": 383,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -11294,7 +11341,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 383,
+      "rank": 384,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -11328,7 +11375,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 384,
+      "rank": 385,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -11354,7 +11401,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 385,
+      "rank": 386,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -11396,7 +11443,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 386,
+      "rank": 387,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -11434,7 +11481,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 387,
+      "rank": 388,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -11453,7 +11500,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 388,
+      "rank": 389,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -11473,7 +11520,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 389,
+      "rank": 390,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -11500,7 +11547,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 390,
+      "rank": 391,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -11526,7 +11573,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 391,
+      "rank": 392,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -11551,7 +11598,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 392,
+      "rank": 393,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -11580,7 +11627,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 393,
+      "rank": 394,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -11625,7 +11672,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 394,
+      "rank": 395,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -11652,7 +11699,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 395,
+      "rank": 396,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -11681,7 +11728,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 396,
+      "rank": 397,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -11718,50 +11765,6 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 397,
-      "id": "CohereLabs/cohere-transcribe-03-2026",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
-      "downloads": 305090,
-      "likes": 959,
-      "trendingScore": 14,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere_asr",
-        "automatic-speech-recognition",
-        "audio",
-        "hf-asr-leaderboard",
-        "speech-recognition",
-        "transcription",
-        "custom_code",
-        "ar",
-        "de",
-        "el",
-        "en",
-        "es",
-        "fr",
-        "it",
-        "ja",
-        "ko",
-        "nl",
-        "pl",
-        "pt",
-        "vi",
-        "zh",
-        "doi:10.57967/hf/8653",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-03-24T10:35:54.000Z",
-      "lastModified": "2026-05-04T13:29:45.000Z"
-    },
-    {
       "rank": 398,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
@@ -11792,7 +11795,7 @@
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
-      "downloads": 12882,
+      "downloads": 14420,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
@@ -11862,6 +11865,70 @@
     },
     {
       "rank": 401,
+      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "downloads": 8386,
+      "likes": 15,
+      "trendingScore": 14,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "dataset:zerofata/Roleplay-Anime-Characters",
+        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T00:40:03.000Z",
+      "lastModified": "2026-05-25T00:33:13.000Z"
+    },
+    {
+      "rank": 402,
+      "id": "numind/NuMarkdown-8B-Thinking",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
+      "downloads": 51292,
+      "likes": 466,
+      "trendingScore": 14,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_5_vl",
+        "image-text-to-text",
+        "OCR",
+        "vision-language",
+        "VLM",
+        "Reasoning",
+        "document-to-markdown",
+        "qwen2.5",
+        "markdown",
+        "extraction",
+        "RAG",
+        "image-to-text",
+        "license:mit",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-07-29T18:39:08.000Z",
+      "lastModified": "2026-05-19T19:01:34.000Z"
+    },
+    {
+      "rank": 403,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -11890,7 +11957,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 402,
+      "rank": 404,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -11935,7 +12002,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 403,
+      "rank": 405,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -11964,7 +12031,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 404,
+      "rank": 406,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -11991,7 +12058,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 405,
+      "rank": 407,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -12018,7 +12085,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 406,
+      "rank": 408,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -12049,7 +12116,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 407,
+      "rank": 409,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -12073,7 +12140,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 408,
+      "rank": 410,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -12118,7 +12185,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 409,
+      "rank": 411,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -12145,7 +12212,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 410,
+      "rank": 412,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -12181,7 +12248,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 411,
+      "rank": 413,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -12212,7 +12279,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 412,
+      "rank": 414,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -12243,7 +12310,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 413,
+      "rank": 415,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -12276,7 +12343,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 414,
+      "rank": 416,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -12305,7 +12372,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 415,
+      "rank": 417,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -12331,7 +12398,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 416,
+      "rank": 418,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -12361,7 +12428,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 417,
+      "rank": 419,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -12379,7 +12446,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 418,
+      "rank": 420,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -12410,7 +12477,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 419,
+      "rank": 421,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -12431,7 +12498,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 420,
+      "rank": 422,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -12451,7 +12518,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 421,
+      "rank": 423,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -12478,7 +12545,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 422,
+      "rank": 424,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -12508,7 +12575,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 423,
+      "rank": 425,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -12525,7 +12592,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 424,
+      "rank": 426,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -12552,7 +12619,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 425,
+      "rank": 427,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12577,7 +12644,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 426,
+      "rank": 428,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -12620,7 +12687,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 427,
+      "rank": 429,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -12649,12 +12716,12 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 428,
+      "rank": 430,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
-      "downloads": 9144,
-      "likes": 613,
+      "downloads": 9257,
+      "likes": 614,
       "trendingScore": 13,
       "pipelineTag": "text-to-video",
       "libraryName": "wan2.2",
@@ -12674,11 +12741,11 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 429,
+      "rank": 431,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
-      "downloads": 181,
+      "downloads": 215,
       "likes": 14,
       "trendingScore": 13,
       "pipelineTag": "text-to-image",
@@ -12697,37 +12764,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 430,
-      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "downloads": 7191,
-      "likes": 14,
-      "trendingScore": 13,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "dataset:zerofata/Instruct-Anime",
-        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
-        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
-        "dataset:zerofata/Roleplay-Anime-Characters",
-        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T00:40:03.000Z",
-      "lastModified": "2026-05-25T00:33:13.000Z"
-    },
-    {
-      "rank": 431,
+      "rank": 432,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12752,7 +12789,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 432,
+      "rank": 433,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -12779,12 +12816,12 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 433,
+      "rank": 434,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
-      "downloads": 1693872,
-      "likes": 4543,
+      "downloads": 1697520,
+      "likes": 4544,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -12809,7 +12846,33 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 434,
+      "rank": 435,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 47,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-26T07:40:38.000Z"
+    },
+    {
+      "rank": 436,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -12836,7 +12899,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 435,
+      "rank": 437,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -12864,7 +12927,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 436,
+      "rank": 438,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -12897,7 +12960,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 437,
+      "rank": 439,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -12913,7 +12976,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 438,
+      "rank": 440,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -12936,7 +12999,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 439,
+      "rank": 441,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -12970,7 +13033,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 440,
+      "rank": 442,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -12990,7 +13053,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 441,
+      "rank": 443,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -13025,7 +13088,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 442,
+      "rank": 444,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -13055,7 +13118,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 443,
+      "rank": 445,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -13076,7 +13139,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 444,
+      "rank": 446,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -13105,7 +13168,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 445,
+      "rank": 447,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -13135,7 +13198,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 446,
+      "rank": 448,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -13163,7 +13226,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 447,
+      "rank": 449,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -13192,7 +13255,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 448,
+      "rank": 450,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -13224,7 +13287,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 449,
+      "rank": 451,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -13259,12 +13322,12 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 450,
+      "rank": 452,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
-      "downloads": 358908,
-      "likes": 371,
+      "downloads": 514997,
+      "likes": 385,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -13281,7 +13344,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 451,
+      "rank": 453,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -13319,7 +13382,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 452,
+      "rank": 454,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -13358,7 +13421,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 453,
+      "rank": 455,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -13395,7 +13458,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 454,
+      "rank": 456,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -13419,7 +13482,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 455,
+      "rank": 457,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -13437,7 +13500,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 456,
+      "rank": 458,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -13456,7 +13519,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 457,
+      "rank": 459,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -13484,7 +13547,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 458,
+      "rank": 460,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -13525,7 +13588,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 459,
+      "rank": 461,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -13547,7 +13610,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 460,
+      "rank": 462,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -13584,7 +13647,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 461,
+      "rank": 463,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -13614,7 +13677,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 462,
+      "rank": 464,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -13643,7 +13706,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -13671,7 +13734,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -13697,7 +13760,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 465,
+      "rank": 467,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -13724,7 +13787,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 466,
+      "rank": 468,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -13749,7 +13812,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 467,
+      "rank": 469,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -13778,7 +13841,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 468,
+      "rank": 470,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -13803,7 +13866,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 469,
+      "rank": 471,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -13829,7 +13892,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 470,
+      "rank": 472,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -13868,11 +13931,11 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 471,
+      "rank": 473,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 11621,
+      "downloads": 13041,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -13896,7 +13959,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 472,
+      "rank": 474,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -13922,11 +13985,11 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 473,
+      "rank": 475,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
-      "downloads": 12733226,
+      "downloads": 12880672,
       "likes": 999,
       "trendingScore": 12,
       "pipelineTag": "text-classification",
@@ -13950,11 +14013,11 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 474,
+      "rank": 476,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
-      "downloads": 730,
+      "downloads": 779,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -13981,11 +14044,11 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 475,
+      "rank": 477,
       "id": "SupraLabs/Supra-50M-Base",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
-      "downloads": 397,
+      "downloads": 542,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
@@ -14015,11 +14078,11 @@
       "lastModified": "2026-05-23T07:46:11.000Z"
     },
     {
-      "rank": 476,
+      "rank": 478,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
-      "downloads": 1245,
+      "downloads": 1500,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": null,
@@ -14030,18 +14093,19 @@
         "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-30B-A3B",
         "base_model:quantized:tencent/Hy-MT2-30B-A3B",
+        "license:apache-2.0",
         "fp8",
         "region:us"
       ],
       "createdAt": "2026-05-18T06:09:22.000Z",
-      "lastModified": "2026-05-22T05:16:00.000Z"
+      "lastModified": "2026-05-26T09:06:09.000Z"
     },
     {
-      "rank": 477,
+      "rank": 479,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 2092362,
+      "downloads": 2097928,
       "likes": 2151,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
@@ -14075,11 +14139,11 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 478,
+      "rank": 480,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
-      "downloads": 2177,
+      "downloads": 3489,
       "likes": 13,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -14112,41 +14176,136 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 479,
-      "id": "numind/NuMarkdown-8B-Thinking",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
-      "downloads": 54132,
-      "likes": 464,
+      "rank": 481,
+      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "author": "alibaba-pai",
+      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "downloads": 9841,
+      "likes": 157,
       "trendingScore": 12,
-      "pipelineTag": "image-to-text",
+      "pipelineTag": "text-to-image",
+      "libraryName": "videox_fun",
+      "tags": [
+        "videox_fun",
+        "lora",
+        "text-to-image",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-02-02T09:37:39.000Z",
+      "lastModified": "2026-03-02T11:46:41.000Z"
+    },
+    {
+      "rank": 482,
+      "id": "unsloth/Z-Image-Turbo-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
+      "downloads": 55705,
+      "likes": 191,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "ggml",
+      "tags": [
+        "ggml",
+        "gguf",
+        "quantized",
+        "unsloth",
+        "text-to-image",
+        "en",
+        "arxiv:2511.22699",
+        "arxiv:2511.22677",
+        "arxiv:2511.13649",
+        "base_model:Tongyi-MAI/Z-Image-Turbo",
+        "base_model:quantized:Tongyi-MAI/Z-Image-Turbo",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-21T22:47:59.000Z",
+      "lastModified": "2026-01-08T02:11:45.000Z"
+    },
+    {
+      "rank": 483,
+      "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
+      "downloads": 4037,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T07:13:09.000Z",
+      "lastModified": "2026-05-23T14:54:50.000Z"
+    },
+    {
+      "rank": 484,
+      "id": "meta-llama/Llama-3.1-8B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
+      "downloads": 1249949,
+      "likes": 2210,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "qwen2_5_vl",
-        "image-text-to-text",
-        "OCR",
-        "vision-language",
-        "VLM",
-        "Reasoning",
-        "document-to-markdown",
-        "qwen2.5",
-        "markdown",
-        "extraction",
-        "RAG",
-        "image-to-text",
-        "license:mit",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "license:llama3.1",
         "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-14T22:20:15.000Z",
+      "lastModified": "2024-10-16T22:00:37.000Z"
+    },
+    {
+      "rank": 485,
+      "id": "Qwen/Qwen3.5-122B-A10B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
+      "downloads": 833994,
+      "likes": 555,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "conversational",
+        "license:apache-2.0",
+        "eval-results",
         "endpoints_compatible",
         "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2025-07-29T18:39:08.000Z",
-      "lastModified": "2026-05-19T19:01:34.000Z"
+      "createdAt": "2026-02-24T09:43:37.000Z",
+      "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 480,
+      "rank": 486,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -14191,7 +14350,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 481,
+      "rank": 487,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -14233,7 +14392,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 482,
+      "rank": 488,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -14259,7 +14418,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 483,
+      "rank": 489,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -14284,7 +14443,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 484,
+      "rank": 490,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -14301,7 +14460,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 485,
+      "rank": 491,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -14329,7 +14488,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 486,
+      "rank": 492,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -14355,7 +14514,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 487,
+      "rank": 493,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -14382,7 +14541,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 488,
+      "rank": 494,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -14410,7 +14569,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 489,
+      "rank": 495,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -14443,7 +14602,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 490,
+      "rank": 496,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -14477,7 +14636,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 491,
+      "rank": 497,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -14506,7 +14665,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 492,
+      "rank": 498,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -14535,7 +14694,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 493,
+      "rank": 499,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -14568,7 +14727,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 494,
+      "rank": 500,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -14595,7 +14754,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 495,
+      "rank": 501,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -14625,7 +14784,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 496,
+      "rank": 502,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -14651,7 +14810,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 497,
+      "rank": 503,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -14675,7 +14834,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 498,
+      "rank": 504,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -14702,7 +14861,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 499,
+      "rank": 505,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -14736,7 +14895,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 500,
+      "rank": 506,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -14752,7 +14911,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 501,
+      "rank": 507,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -14783,7 +14942,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 502,
+      "rank": 508,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -14805,7 +14964,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 503,
+      "rank": 509,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -14825,7 +14984,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 504,
+      "rank": 510,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -14847,7 +15006,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 505,
+      "rank": 511,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -14876,7 +15035,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 506,
+      "rank": 512,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -14901,7 +15060,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 507,
+      "rank": 513,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -14926,7 +15085,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 508,
+      "rank": 514,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -14961,7 +15120,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 509,
+      "rank": 515,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -14985,7 +15144,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 510,
+      "rank": 516,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -15016,7 +15175,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 511,
+      "rank": 517,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
@@ -15042,7 +15201,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 512,
+      "rank": 518,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -15072,7 +15231,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 513,
+      "rank": 519,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -15098,7 +15257,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 514,
+      "rank": 520,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -15143,7 +15302,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 515,
+      "rank": 521,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -15170,7 +15329,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 516,
+      "rank": 522,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -15197,7 +15356,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 517,
+      "rank": 523,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -15242,7 +15401,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 518,
+      "rank": 524,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -15268,7 +15427,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 519,
+      "rank": 525,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -15297,11 +15456,11 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 520,
+      "rank": 526,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
-      "downloads": 412749,
+      "downloads": 434169,
       "likes": 14,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15342,7 +15501,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 521,
+      "rank": 527,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15374,7 +15533,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 522,
+      "rank": 528,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -15409,11 +15568,11 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 523,
+      "rank": 529,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
-      "downloads": 78,
+      "downloads": 124,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15440,27 +15599,7 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 524,
-      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "author": "alibaba-pai",
-      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "downloads": 9547,
-      "likes": 156,
-      "trendingScore": 11,
-      "pipelineTag": "text-to-image",
-      "libraryName": "videox_fun",
-      "tags": [
-        "videox_fun",
-        "lora",
-        "text-to-image",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-02-02T09:37:39.000Z",
-      "lastModified": "2026-03-02T11:46:41.000Z"
-    },
-    {
-      "rank": 525,
+      "rank": 530,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -15490,7 +15629,7 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 526,
+      "rank": 531,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -15535,39 +15674,11 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 527,
-      "id": "unsloth/Z-Image-Turbo-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
-      "downloads": 55944,
-      "likes": 190,
-      "trendingScore": 11,
-      "pipelineTag": "text-to-image",
-      "libraryName": "ggml",
-      "tags": [
-        "ggml",
-        "gguf",
-        "quantized",
-        "unsloth",
-        "text-to-image",
-        "en",
-        "arxiv:2511.22699",
-        "arxiv:2511.22677",
-        "arxiv:2511.13649",
-        "base_model:Tongyi-MAI/Z-Image-Turbo",
-        "base_model:quantized:Tongyi-MAI/Z-Image-Turbo",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-21T22:47:59.000Z",
-      "lastModified": "2026-01-08T02:11:45.000Z"
-    },
-    {
-      "rank": 528,
+      "rank": 532,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
-      "downloads": 6263,
+      "downloads": 6393,
       "likes": 212,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15606,7 +15717,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 529,
+      "rank": 533,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -15631,11 +15742,11 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 530,
+      "rank": 534,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
-      "downloads": 379,
+      "downloads": 431,
       "likes": 17,
       "trendingScore": 11,
       "pipelineTag": "other",
@@ -15664,31 +15775,11 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 531,
-      "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "downloads": 2865,
-      "likes": 12,
-      "trendingScore": 11,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T07:13:09.000Z",
-      "lastModified": "2026-05-23T14:54:50.000Z"
-    },
-    {
-      "rank": 532,
+      "rank": 535,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
-      "downloads": 940426,
+      "downloads": 944232,
       "likes": 2780,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -15723,7 +15814,81 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 533,
+      "rank": 536,
+      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "author": "opendatalab",
+      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "downloads": 535,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_vl",
+        "image-text-to-text",
+        "conversational",
+        "zh",
+        "en",
+        "arxiv:2604.04771",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T11:00:43.000Z",
+      "lastModified": "2026-05-25T10:58:41.000Z"
+    },
+    {
+      "rank": 537,
+      "id": "Abiray/L2P-model-1k-merge-INT8",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "image-generation",
+        "text-to-image",
+        "int8",
+        "comfyui",
+        "quantized",
+        "arxiv:2605.12013",
+        "base_model:zhen-nan/L2P",
+        "base_model:quantized:zhen-nan/L2P",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T17:12:49.000Z",
+      "lastModified": "2026-05-23T17:24:01.000Z"
+    },
+    {
+      "rank": 538,
+      "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
+      "downloads": 5428,
+      "likes": 12,
+      "trendingScore": 11,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
+        "base_model:quantized:Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-22T05:01:30.000Z",
+      "lastModified": "2026-05-22T10:25:05.000Z"
+    },
+    {
+      "rank": 539,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -15752,7 +15917,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 534,
+      "rank": 540,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -15786,7 +15951,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 535,
+      "rank": 541,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -15831,7 +15996,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 536,
+      "rank": 542,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -15860,7 +16025,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 537,
+      "rank": 543,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -15885,7 +16050,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 538,
+      "rank": 544,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -15920,7 +16085,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 539,
+      "rank": 545,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -15947,7 +16112,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 540,
+      "rank": 546,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -15992,7 +16157,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 541,
+      "rank": 547,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -16014,7 +16179,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 542,
+      "rank": 548,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -16046,7 +16211,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 543,
+      "rank": 549,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -16071,7 +16236,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 544,
+      "rank": 550,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -16095,7 +16260,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 545,
+      "rank": 551,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -16138,7 +16303,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 546,
+      "rank": 552,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -16162,7 +16327,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 547,
+      "rank": 553,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -16191,7 +16356,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 548,
+      "rank": 554,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -16223,7 +16388,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 549,
+      "rank": 555,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -16247,7 +16412,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 550,
+      "rank": 556,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -16269,7 +16434,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 551,
+      "rank": 557,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -16294,7 +16459,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 552,
+      "rank": 558,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -16322,7 +16487,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 553,
+      "rank": 559,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -16346,7 +16511,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 554,
+      "rank": 560,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -16373,7 +16538,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 555,
+      "rank": 561,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -16390,7 +16555,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 556,
+      "rank": 562,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -16414,7 +16579,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 557,
+      "rank": 563,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -16438,7 +16603,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 558,
+      "rank": 564,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -16471,7 +16636,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 559,
+      "rank": 565,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -16505,7 +16670,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 560,
+      "rank": 566,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -16527,7 +16692,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 561,
+      "rank": 567,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -16550,7 +16715,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 562,
+      "rank": 568,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -16570,7 +16735,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 563,
+      "rank": 569,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -16602,7 +16767,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 564,
+      "rank": 570,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -16641,7 +16806,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 565,
+      "rank": 571,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -16675,7 +16840,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 566,
+      "rank": 572,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -16699,7 +16864,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 567,
+      "rank": 573,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -16719,7 +16884,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 568,
+      "rank": 574,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -16748,7 +16913,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 569,
+      "rank": 575,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -16770,7 +16935,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 570,
+      "rank": 576,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -16802,7 +16967,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 571,
+      "rank": 577,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -16829,7 +16994,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 572,
+      "rank": 578,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -16873,7 +17038,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 573,
+      "rank": 579,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -16891,7 +17056,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 574,
+      "rank": 580,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -16930,7 +17095,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 575,
+      "rank": 581,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -16969,7 +17134,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 576,
+      "rank": 582,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -17003,7 +17168,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 577,
+      "rank": 583,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -17031,7 +17196,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 578,
+      "rank": 584,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -17053,7 +17218,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 579,
+      "rank": 585,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -17081,7 +17246,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 580,
+      "rank": 586,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -17099,7 +17264,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 581,
+      "rank": 587,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -17127,7 +17292,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 582,
+      "rank": 588,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -17158,7 +17323,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 583,
+      "rank": 589,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -17174,7 +17339,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 584,
+      "rank": 590,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -17201,7 +17366,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 585,
+      "rank": 591,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -17230,7 +17395,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 586,
+      "rank": 592,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -17258,7 +17423,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 587,
+      "rank": 593,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -17287,7 +17452,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 588,
+      "rank": 594,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -17308,7 +17473,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 589,
+      "rank": 595,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -17329,34 +17494,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 590,
-      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "author": "opendatalab",
-      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "downloads": 340,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_vl",
-        "image-text-to-text",
-        "conversational",
-        "zh",
-        "en",
-        "arxiv:2604.04771",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T11:00:43.000Z",
-      "lastModified": "2026-05-25T10:58:41.000Z"
-    },
-    {
-      "rank": 591,
+      "rank": 596,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -17386,7 +17524,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 592,
+      "rank": 597,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -17410,7 +17548,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 593,
+      "rank": 598,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -17440,7 +17578,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 594,
+      "rank": 599,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -17471,11 +17609,11 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 595,
+      "rank": 600,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
-      "downloads": 1520,
+      "downloads": 1666,
       "likes": 482,
       "trendingScore": 10,
       "pipelineTag": "text-to-video",
@@ -17497,43 +17635,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 596,
-      "id": "meta-llama/Llama-3.1-8B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
-      "downloads": 1241077,
-      "likes": 2207,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "license:llama3.1",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-14T22:20:15.000Z",
-      "lastModified": "2024-10-16T22:00:37.000Z"
-    },
-    {
-      "rank": 597,
+      "rank": 601,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -17559,7 +17661,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 598,
+      "rank": 602,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -17577,11 +17679,11 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 599,
+      "rank": 603,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
-      "downloads": 19977,
+      "downloads": 20962,
       "likes": 18,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
@@ -17610,11 +17712,11 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 600,
+      "rank": 604,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
-      "downloads": 1722,
+      "downloads": 2059,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -17637,7 +17739,7 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 601,
+      "rank": 605,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -17662,7 +17764,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 602,
+      "rank": 606,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -17687,36 +17789,11 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 603,
-      "id": "Abiray/L2P-model-1k-merge-INT8",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "image-generation",
-        "text-to-image",
-        "int8",
-        "comfyui",
-        "quantized",
-        "arxiv:2605.12013",
-        "base_model:zhen-nan/L2P",
-        "base_model:quantized:zhen-nan/L2P",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T17:12:49.000Z",
-      "lastModified": "2026-05-23T17:24:01.000Z"
-    },
-    {
-      "rank": 604,
+      "rank": 607,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
-      "downloads": 138163,
+      "downloads": 140858,
       "likes": 343,
       "trendingScore": 10,
       "pipelineTag": "text-to-image",
@@ -17746,54 +17823,25 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 605,
-      "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
-      "downloads": 3674,
-      "likes": 11,
+      "rank": 608,
+      "id": "Comfy-Org/PixelDiT",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+      "downloads": 0,
+      "likes": 10,
       "trendingScore": 10,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "gguf",
-        "base_model:Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
-        "base_model:quantized:Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
+        "comfyui",
         "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-22T05:01:30.000Z",
-      "lastModified": "2026-05-22T10:25:05.000Z"
-    },
-    {
-      "rank": 606,
-      "id": "Qwen/Qwen3.5-122B-A10B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
-      "downloads": 820911,
-      "likes": 553,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "conversational",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2026-02-24T09:43:37.000Z",
-      "lastModified": "2026-04-24T03:55:23.000Z"
+      "createdAt": "2026-05-25T14:05:48.000Z",
+      "lastModified": "2026-05-26T09:53:38.000Z"
     },
     {
-      "rank": 607,
+      "rank": 609,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -17820,7 +17868,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 608,
+      "rank": 610,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -17846,7 +17894,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 609,
+      "rank": 611,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -17874,7 +17922,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 610,
+      "rank": 612,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -17900,7 +17948,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 611,
+      "rank": 613,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -17940,7 +17988,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 612,
+      "rank": 614,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -17976,7 +18024,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 613,
+      "rank": 615,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -18020,7 +18068,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 614,
+      "rank": 616,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -18045,7 +18093,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 615,
+      "rank": 617,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -18090,7 +18138,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 616,
+      "rank": 618,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -18109,7 +18157,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 617,
+      "rank": 619,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -18134,7 +18182,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 618,
+      "rank": 620,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -18173,7 +18221,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 619,
+      "rank": 621,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -18190,7 +18238,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 620,
+      "rank": 622,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -18218,7 +18266,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 621,
+      "rank": 623,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -18247,7 +18295,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 622,
+      "rank": 624,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -18272,7 +18320,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 623,
+      "rank": 625,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -18307,7 +18355,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 624,
+      "rank": 626,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -18337,7 +18385,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 625,
+      "rank": 627,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -18373,7 +18421,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 626,
+      "rank": 628,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -18396,7 +18444,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 627,
+      "rank": 629,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -18413,7 +18461,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 628,
+      "rank": 630,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -18433,7 +18481,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 629,
+      "rank": 631,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -18460,7 +18508,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 630,
+      "rank": 632,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -18484,7 +18532,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 631,
+      "rank": 633,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -18506,7 +18554,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 632,
+      "rank": 634,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -18538,7 +18586,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 633,
+      "rank": 635,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -18566,7 +18614,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 634,
+      "rank": 636,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -18584,7 +18632,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 635,
+      "rank": 637,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -18609,7 +18657,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 636,
+      "rank": 638,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -18632,7 +18680,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 637,
+      "rank": 639,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -18650,7 +18698,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 638,
+      "rank": 640,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -18685,7 +18733,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 639,
+      "rank": 641,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -18713,7 +18761,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 640,
+      "rank": 642,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -18735,7 +18783,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 641,
+      "rank": 643,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -18762,7 +18810,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 642,
+      "rank": 644,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -18787,7 +18835,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 643,
+      "rank": 645,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -18821,7 +18869,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 644,
+      "rank": 646,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -18848,7 +18896,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 645,
+      "rank": 647,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -18875,7 +18923,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 646,
+      "rank": 648,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -18916,7 +18964,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 647,
+      "rank": 649,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -18946,7 +18994,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 648,
+      "rank": 650,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -18983,7 +19031,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 649,
+      "rank": 651,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -19015,7 +19063,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 650,
+      "rank": 652,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -19057,7 +19105,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 651,
+      "rank": 653,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -19087,7 +19135,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 652,
+      "rank": 654,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -19132,7 +19180,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 653,
+      "rank": 655,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -19159,7 +19207,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 654,
+      "rank": 656,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -19191,7 +19239,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 655,
+      "rank": 657,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -19225,7 +19273,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 656,
+      "rank": 658,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -19255,7 +19303,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 657,
+      "rank": 659,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -19280,7 +19328,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 658,
+      "rank": 660,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -19307,7 +19355,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 659,
+      "rank": 661,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -19339,7 +19387,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 660,
+      "rank": 662,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -19384,7 +19432,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 661,
+      "rank": 663,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -19412,7 +19460,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 662,
+      "rank": 664,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -19438,11 +19486,11 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 663,
+      "rank": 665,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
-      "downloads": 1036,
+      "downloads": 1077,
       "likes": 408,
       "trendingScore": 9,
       "pipelineTag": "audio-to-audio",
@@ -19467,7 +19515,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 664,
+      "rank": 666,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -19509,7 +19557,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 665,
+      "rank": 667,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -19537,7 +19585,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 666,
+      "rank": 668,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -19566,7 +19614,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 667,
+      "rank": 669,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -19596,7 +19644,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 668,
+      "rank": 670,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -19623,7 +19671,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 669,
+      "rank": 671,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -19652,7 +19700,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 670,
+      "rank": 672,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -19679,7 +19727,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 671,
+      "rank": 673,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -19708,7 +19756,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 672,
+      "rank": 674,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -19748,7 +19796,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 673,
+      "rank": 675,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -19766,7 +19814,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 674,
+      "rank": 676,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -19791,11 +19839,11 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 675,
+      "rank": 677,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
-      "downloads": 166,
+      "downloads": 178,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -19807,11 +19855,11 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 676,
+      "rank": 678,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
-      "downloads": 47,
+      "downloads": 97,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -19847,7 +19895,7 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 677,
+      "rank": 679,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -19892,11 +19940,11 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 678,
+      "rank": 680,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
-      "downloads": 1553,
+      "downloads": 1977,
       "likes": 10,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -19927,11 +19975,11 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 679,
+      "rank": 681,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
-      "downloads": 1962,
+      "downloads": 2273,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -19941,19 +19989,20 @@
         "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-1.8B",
         "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
       "createdAt": "2026-05-20T09:26:12.000Z",
-      "lastModified": "2026-05-22T05:15:45.000Z"
+      "lastModified": "2026-05-26T09:06:26.000Z"
     },
     {
-      "rank": 680,
+      "rank": 682,
       "id": "Anbeeld/Qwen3.6-27B-DFlash-GGUF",
       "author": "Anbeeld",
       "url": "https://huggingface.co/Anbeeld/Qwen3.6-27B-DFlash-GGUF",
-      "downloads": 3734,
+      "downloads": 4306,
       "likes": 10,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -19970,11 +20019,11 @@
       "lastModified": "2026-05-22T17:31:30.000Z"
     },
     {
-      "rank": 681,
+      "rank": 683,
       "id": "nvidia/GLM-5.1-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
-      "downloads": 4561,
+      "downloads": 5318,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -20002,7 +20051,7 @@
       "lastModified": "2026-05-20T21:18:02.000Z"
     },
     {
-      "rank": 682,
+      "rank": 684,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -20035,11 +20084,11 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 683,
+      "rank": 685,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
-      "downloads": 1426,
+      "downloads": 1679,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -20064,11 +20113,11 @@
       "lastModified": "2026-05-22T20:32:34.000Z"
     },
     {
-      "rank": 684,
+      "rank": 686,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
-      "downloads": 150076,
+      "downloads": 130412,
       "likes": 80,
       "trendingScore": 9,
       "pipelineTag": "text-ranking",
@@ -20094,7 +20143,114 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 685,
+      "rank": 687,
+      "id": "Qwen/Qwen-Image-Layered",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
+      "downloads": 57322,
+      "likes": 1085,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-text-to-image",
+        "en",
+        "zh",
+        "arxiv:2512.15603",
+        "base_model:Qwen/Qwen-Image",
+        "base_model:finetune:Qwen/Qwen-Image",
+        "license:apache-2.0",
+        "diffusers:QwenImageLayeredPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-12-17T06:02:34.000Z",
+      "lastModified": "2025-12-19T09:11:18.000Z"
+    },
+    {
+      "rank": 688,
+      "id": "UofTCSSLab/Maia3-79M",
+      "author": "UofTCSSLab",
+      "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "chess",
+        "maia",
+        "maia3",
+        "chessformer",
+        "move-prediction",
+        "human-ai",
+        "interpretability",
+        "en",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:34:19.000Z",
+      "lastModified": "2026-05-24T16:12:28.000Z"
+    },
+    {
+      "rank": 689,
+      "id": "nvidia/vgg-ttt",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/vgg-ttt",
+      "downloads": 42,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-3d",
+      "libraryName": "vggttt",
+      "tags": [
+        "vggttt",
+        "safetensors",
+        "vggt",
+        "3d-reconstruction",
+        "pointmap",
+        "depth-estimation",
+        "camera-pose",
+        "image-to-3d",
+        "arxiv:2602.23361",
+        "arxiv:2503.11651",
+        "base_model:facebook/VGGT-1B",
+        "base_model:finetune:facebook/VGGT-1B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2025-12-10T22:23:19.000Z",
+      "lastModified": "2026-05-25T15:55:35.000Z"
+    },
+    {
+      "rank": 690,
+      "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "author": "Leon1000",
+      "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "flux",
+        "flux.2",
+        "flux-lora",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "image-to-image",
+        "fal-ai",
+        "en",
+        "base_model:black-forest-labs/FLUX.2-dev",
+        "base_model:adapter:black-forest-labs/FLUX.2-dev",
+        "license:creativeml-openrail-m",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T00:22:03.000Z",
+      "lastModified": "2026-05-20T00:22:04.000Z"
+    },
+    {
+      "rank": 691,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -20121,7 +20277,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 686,
+      "rank": 692,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -20145,7 +20301,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 687,
+      "rank": 693,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -20165,7 +20321,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 688,
+      "rank": 694,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -20184,7 +20340,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 689,
+      "rank": 695,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -20218,7 +20374,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 690,
+      "rank": 696,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -20250,7 +20406,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 691,
+      "rank": 697,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -20272,7 +20428,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 692,
+      "rank": 698,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -20317,7 +20473,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 693,
+      "rank": 699,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -20336,7 +20492,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 694,
+      "rank": 700,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -20370,7 +20526,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 695,
+      "rank": 701,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -20398,7 +20554,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 696,
+      "rank": 702,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -20426,7 +20582,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 697,
+      "rank": 703,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -20449,7 +20605,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 698,
+      "rank": 704,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -20476,7 +20632,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 699,
+      "rank": 705,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -20521,7 +20677,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 700,
+      "rank": 706,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -20557,7 +20713,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 701,
+      "rank": 707,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -20597,7 +20753,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 702,
+      "rank": 708,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -20626,7 +20782,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 703,
+      "rank": 709,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -20654,7 +20810,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 704,
+      "rank": 710,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -20673,7 +20829,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 705,
+      "rank": 711,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -20692,7 +20848,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 706,
+      "rank": 712,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -20724,7 +20880,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 707,
+      "rank": 713,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -20751,7 +20907,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 708,
+      "rank": 714,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -20773,7 +20929,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 709,
+      "rank": 715,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -20791,7 +20947,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 710,
+      "rank": 716,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -20820,7 +20976,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 711,
+      "rank": 717,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -20841,7 +20997,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 712,
+      "rank": 718,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -20869,7 +21025,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 713,
+      "rank": 719,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -20890,7 +21046,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 714,
+      "rank": 720,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -20926,33 +21082,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 715,
-      "id": "Qwen/Qwen-Image-Layered",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
-      "downloads": 55209,
-      "likes": 1076,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-text-to-image",
-        "en",
-        "zh",
-        "arxiv:2512.15603",
-        "base_model:Qwen/Qwen-Image",
-        "base_model:finetune:Qwen/Qwen-Image",
-        "license:apache-2.0",
-        "diffusers:QwenImageLayeredPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-12-17T06:02:34.000Z",
-      "lastModified": "2025-12-19T09:11:18.000Z"
-    },
-    {
-      "rank": 716,
+      "rank": 721,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -20975,7 +21105,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 717,
+      "rank": 722,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -21000,7 +21130,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 718,
+      "rank": 723,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -21035,7 +21165,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 719,
+      "rank": 724,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -21080,7 +21210,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 720,
+      "rank": 725,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -21107,7 +21237,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 721,
+      "rank": 726,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -21136,7 +21266,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 722,
+      "rank": 727,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -21155,7 +21285,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 723,
+      "rank": 728,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -21176,7 +21306,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 724,
+      "rank": 729,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -21202,7 +21332,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 725,
+      "rank": 730,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -21228,7 +21358,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 726,
+      "rank": 731,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -21265,7 +21395,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 727,
+      "rank": 732,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -21310,7 +21440,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 728,
+      "rank": 733,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -21335,7 +21465,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 729,
+      "rank": 734,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -21352,7 +21482,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 730,
+      "rank": 735,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -21379,7 +21509,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 731,
+      "rank": 736,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -21397,7 +21527,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 732,
+      "rank": 737,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -21422,7 +21552,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 733,
+      "rank": 738,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -21454,7 +21584,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 734,
+      "rank": 739,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -21475,7 +21605,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 735,
+      "rank": 740,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -21494,7 +21624,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 736,
+      "rank": 741,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -21525,7 +21655,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 737,
+      "rank": 742,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -21548,7 +21678,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 738,
+      "rank": 743,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -21565,7 +21695,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 739,
+      "rank": 744,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -21593,7 +21723,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 740,
+      "rank": 745,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -21610,7 +21740,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 741,
+      "rank": 746,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -21646,7 +21776,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 742,
+      "rank": 747,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -21676,7 +21806,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 743,
+      "rank": 748,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -21699,7 +21829,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 744,
+      "rank": 749,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -21732,7 +21862,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 745,
+      "rank": 750,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -21763,7 +21893,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 746,
+      "rank": 751,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -21786,7 +21916,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 747,
+      "rank": 752,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -21819,7 +21949,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 748,
+      "rank": 753,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -21842,7 +21972,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 749,
+      "rank": 754,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -21872,7 +22002,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 750,
+      "rank": 755,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -21901,7 +22031,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 751,
+      "rank": 756,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -21930,7 +22060,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 752,
+      "rank": 757,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -21966,7 +22096,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 753,
+      "rank": 758,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -21989,7 +22119,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 754,
+      "rank": 759,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -22014,7 +22144,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 755,
+      "rank": 760,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -22044,7 +22174,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 756,
+      "rank": 761,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -22080,7 +22210,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 757,
+      "rank": 762,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -22117,7 +22247,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 758,
+      "rank": 763,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -22144,7 +22274,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 759,
+      "rank": 764,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -22177,7 +22307,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 760,
+      "rank": 765,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -22214,7 +22344,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 761,
+      "rank": 766,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -22242,7 +22372,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 762,
+      "rank": 767,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -22262,11 +22392,11 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 763,
+      "rank": 768,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
-      "downloads": 14290,
+      "downloads": 14330,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22288,11 +22418,11 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 764,
+      "rank": 769,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
-      "downloads": 4362,
+      "downloads": 4549,
       "likes": 11,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22333,7 +22463,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 765,
+      "rank": 770,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -22365,11 +22495,11 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 766,
+      "rank": 771,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
-      "downloads": 206,
+      "downloads": 255,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22387,10 +22517,10 @@
         "region:us"
       ],
       "createdAt": "2026-05-19T13:45:22.000Z",
-      "lastModified": "2026-05-22T04:33:05.000Z"
+      "lastModified": "2026-05-26T08:37:41.000Z"
     },
     {
-      "rank": 767,
+      "rank": 772,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -22412,11 +22542,11 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 768,
+      "rank": 773,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
-      "downloads": 2342419,
+      "downloads": 2341629,
       "likes": 6547,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22440,7 +22570,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 769,
+      "rank": 774,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -22464,29 +22594,36 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 770,
+      "rank": 775,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
       "downloads": 0,
       "likes": 8,
       "trendingScore": 8,
-      "pipelineTag": null,
+      "pipelineTag": "text-to-image",
       "libraryName": null,
       "tags": [
+        "INT8",
+        "quantization",
+        "L2P",
+        "ComfyUI",
+        "text-to-image",
         "arxiv:2605.12013",
+        "base_model:zhen-nan/L2P",
+        "base_model:quantized:zhen-nan/L2P",
         "license:apache-2.0",
         "region:us"
       ],
       "createdAt": "2026-05-23T05:01:56.000Z",
-      "lastModified": "2026-05-23T05:40:30.000Z"
+      "lastModified": "2026-05-26T05:28:12.000Z"
     },
     {
-      "rank": 771,
+      "rank": 776,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
-      "downloads": 8450,
+      "downloads": 8567,
       "likes": 547,
       "trendingScore": 8,
       "pipelineTag": "automatic-speech-recognition",
@@ -22527,7 +22664,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 772,
+      "rank": 777,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
@@ -22557,11 +22694,11 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 773,
+      "rank": 778,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
-      "downloads": 1935,
+      "downloads": 1637,
       "likes": 33,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22573,11 +22710,11 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 774,
+      "rank": 779,
       "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
-      "downloads": 863,
+      "downloads": 1267,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -22618,11 +22755,11 @@
       "lastModified": "2026-05-24T04:55:49.000Z"
     },
     {
-      "rank": 775,
+      "rank": 780,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 36708,
+      "downloads": 37084,
       "likes": 113,
       "trendingScore": 8,
       "pipelineTag": "image-to-video",
@@ -22644,11 +22781,11 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 776,
+      "rank": 781,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
-      "downloads": 76,
+      "downloads": 87,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22664,11 +22801,11 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 777,
+      "rank": 782,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
-      "downloads": 1174048,
+      "downloads": 1179591,
       "likes": 1489,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -22688,35 +22825,11 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 778,
-      "id": "UofTCSSLab/Maia3-79M",
-      "author": "UofTCSSLab",
-      "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
-      "downloads": 0,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "chess",
-        "maia",
-        "maia3",
-        "chessformer",
-        "move-prediction",
-        "human-ai",
-        "interpretability",
-        "en",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:34:19.000Z",
-      "lastModified": "2026-05-24T16:12:28.000Z"
-    },
-    {
-      "rank": 779,
+      "rank": 783,
       "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
-      "downloads": 667,
+      "downloads": 1012,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -22757,7 +22870,7 @@
       "lastModified": "2026-05-23T00:19:59.000Z"
     },
     {
-      "rank": 780,
+      "rank": 784,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
@@ -22774,11 +22887,11 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 781,
+      "rank": 785,
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
-      "downloads": 365,
+      "downloads": 387,
       "likes": 246,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22803,11 +22916,11 @@
       "lastModified": "2025-12-17T05:12:35.000Z"
     },
     {
-      "rank": 782,
+      "rank": 786,
       "id": "tencent/Hy-MT2-1.8B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
-      "downloads": 502,
+      "downloads": 581,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -22818,19 +22931,20 @@
         "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-1.8B",
         "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "license:apache-2.0",
         "compressed-tensors",
         "region:us"
       ],
       "createdAt": "2026-05-12T10:24:46.000Z",
-      "lastModified": "2026-05-22T05:15:48.000Z"
+      "lastModified": "2026-05-26T09:06:01.000Z"
     },
     {
-      "rank": 783,
+      "rank": 787,
       "id": "openbmb/MiniCPM5-1B-SFT",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
-      "downloads": 2,
-      "likes": 9,
+      "downloads": 190,
+      "likes": 10,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -22865,64 +22979,60 @@
       "lastModified": "2026-05-25T11:18:10.000Z"
     },
     {
-      "rank": 784,
-      "id": "nvidia/vgg-ttt",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/vgg-ttt",
-      "downloads": 2,
+      "rank": 788,
+      "id": "RockTalk/Lance-3B-MLX",
+      "author": "RockTalk",
+      "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
+      "downloads": 545,
       "likes": 8,
       "trendingScore": 8,
-      "pipelineTag": "image-to-3d",
-      "libraryName": "vggttt",
+      "pipelineTag": "text-to-image",
+      "libraryName": "mlx",
       "tags": [
-        "vggttt",
+        "mlx",
         "safetensors",
-        "vggt",
-        "3d-reconstruction",
-        "pointmap",
-        "depth-estimation",
-        "camera-pose",
-        "image-to-3d",
-        "arxiv:2602.23361",
-        "arxiv:2503.11651",
-        "base_model:facebook/VGGT-1B",
-        "base_model:finetune:facebook/VGGT-1B",
-        "license:other",
+        "lance",
+        "multimodal",
+        "apple-silicon",
+        "text-to-image",
+        "image-generation",
+        "video-generation",
+        "diffusion",
+        "flow-matching",
+        "moe",
+        "qwen2_5_vl",
+        "wan",
+        "port",
+        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2025-12-10T22:23:19.000Z",
-      "lastModified": "2026-05-25T15:55:35.000Z"
+      "createdAt": "2026-05-20T03:06:34.000Z",
+      "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 785,
-      "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
-      "author": "Leon1000",
-      "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "rank": 789,
+      "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
+      "author": "circlestone-labs",
+      "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
       "downloads": 0,
       "likes": 8,
       "trendingScore": 8,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
       "tags": [
-        "flux",
-        "flux.2",
-        "flux-lora",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "image-to-image",
-        "fal-ai",
-        "en",
-        "base_model:black-forest-labs/FLUX.2-dev",
-        "base_model:adapter:black-forest-labs/FLUX.2-dev",
-        "license:creativeml-openrail-m",
+        "diffusers",
+        "safetensors",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
         "region:us"
       ],
-      "createdAt": "2026-05-20T00:22:03.000Z",
-      "lastModified": "2026-05-20T00:22:04.000Z"
+      "createdAt": "2026-05-20T22:43:49.000Z",
+      "lastModified": "2026-05-22T21:06:00.000Z"
     },
     {
-      "rank": 786,
+      "rank": 790,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -22948,7 +23058,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 787,
+      "rank": 791,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -22965,7 +23075,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 788,
+      "rank": 792,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -22993,7 +23103,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 789,
+      "rank": 793,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -23028,7 +23138,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 790,
+      "rank": 794,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -23053,7 +23163,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 791,
+      "rank": 795,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -23083,7 +23193,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 792,
+      "rank": 796,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -23112,7 +23222,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 793,
+      "rank": 797,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -23139,7 +23249,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 794,
+      "rank": 798,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -23165,7 +23275,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 795,
+      "rank": 799,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -23196,7 +23306,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 796,
+      "rank": 800,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -23214,7 +23324,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 797,
+      "rank": 801,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -23243,7 +23353,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 798,
+      "rank": 802,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -23266,7 +23376,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 799,
+      "rank": 803,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -23311,7 +23421,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 800,
+      "rank": 804,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -23337,7 +23447,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 801,
+      "rank": 805,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -23365,7 +23475,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 802,
+      "rank": 806,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -23403,7 +23513,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 803,
+      "rank": 807,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -23430,7 +23540,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 804,
+      "rank": 808,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -23456,7 +23566,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 805,
+      "rank": 809,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -23474,7 +23584,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 806,
+      "rank": 810,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -23500,7 +23610,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 807,
+      "rank": 811,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -23524,7 +23634,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 808,
+      "rank": 812,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -23565,7 +23675,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 809,
+      "rank": 813,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -23582,7 +23692,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 810,
+      "rank": 814,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -23615,7 +23725,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 811,
+      "rank": 815,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -23649,7 +23759,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 812,
+      "rank": 816,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -23688,7 +23798,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 813,
+      "rank": 817,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -23718,7 +23828,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 814,
+      "rank": 818,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -23744,7 +23854,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 815,
+      "rank": 819,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -23780,7 +23890,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 816,
+      "rank": 820,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -23810,7 +23920,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 817,
+      "rank": 821,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -23848,7 +23958,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 818,
+      "rank": 822,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -23883,7 +23993,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 819,
+      "rank": 823,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -23900,7 +24010,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 820,
+      "rank": 824,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -23942,7 +24052,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 821,
+      "rank": 825,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -23972,7 +24082,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 822,
+      "rank": 826,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -23997,7 +24107,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 823,
+      "rank": 827,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -24025,7 +24135,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 824,
+      "rank": 828,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -24042,7 +24152,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 825,
+      "rank": 829,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -24069,7 +24179,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 826,
+      "rank": 830,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -24112,7 +24222,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 827,
+      "rank": 831,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -24152,7 +24262,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 828,
+      "rank": 832,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -24176,7 +24286,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 829,
+      "rank": 833,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -24205,7 +24315,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 830,
+      "rank": 834,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -24231,7 +24341,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 831,
+      "rank": 835,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -24270,7 +24380,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 832,
+      "rank": 836,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -24294,7 +24404,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 833,
+      "rank": 837,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -24322,7 +24432,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 834,
+      "rank": 838,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -24354,7 +24464,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 835,
+      "rank": 839,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -24384,7 +24494,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 836,
+      "rank": 840,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -24413,7 +24523,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 837,
+      "rank": 841,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -24442,7 +24552,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 838,
+      "rank": 842,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -24462,7 +24572,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 839,
+      "rank": 843,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -24492,7 +24602,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 840,
+      "rank": 844,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -24522,7 +24632,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 841,
+      "rank": 845,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -24540,7 +24650,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 842,
+      "rank": 846,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -24557,7 +24667,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 843,
+      "rank": 847,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -24593,7 +24703,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 844,
+      "rank": 848,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -24624,7 +24734,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 845,
+      "rank": 849,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -24655,7 +24765,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 846,
+      "rank": 850,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -24688,7 +24798,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 847,
+      "rank": 851,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -24716,7 +24826,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 848,
+      "rank": 852,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -24741,7 +24851,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 849,
+      "rank": 853,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -24764,7 +24874,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 850,
+      "rank": 854,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -24792,7 +24902,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 851,
+      "rank": 855,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -24825,7 +24935,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 852,
+      "rank": 856,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -24855,7 +24965,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 853,
+      "rank": 857,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -24890,7 +25000,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 854,
+      "rank": 858,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -24922,7 +25032,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 855,
+      "rank": 859,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -24947,7 +25057,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 856,
+      "rank": 860,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -24970,7 +25080,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 857,
+      "rank": 861,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -24997,7 +25107,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 858,
+      "rank": 862,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -25020,7 +25130,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 859,
+      "rank": 863,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -25065,7 +25175,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 860,
+      "rank": 864,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -25097,7 +25207,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 861,
+      "rank": 865,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -25124,7 +25234,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 862,
+      "rank": 866,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -25150,7 +25260,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 863,
+      "rank": 867,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -25182,7 +25292,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 864,
+      "rank": 868,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -25211,7 +25321,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 865,
+      "rank": 869,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -25243,7 +25353,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 866,
+      "rank": 870,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -25273,7 +25383,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 867,
+      "rank": 871,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -25290,7 +25400,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 868,
+      "rank": 872,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -25310,7 +25420,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 869,
+      "rank": 873,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -25349,7 +25459,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 870,
+      "rank": 874,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -25387,7 +25497,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 871,
+      "rank": 875,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -25415,7 +25525,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 872,
+      "rank": 876,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -25460,7 +25570,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 873,
+      "rank": 877,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -25490,7 +25600,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 874,
+      "rank": 878,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -25517,7 +25627,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 875,
+      "rank": 879,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -25543,7 +25653,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 876,
+      "rank": 880,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -25572,7 +25682,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 877,
+      "rank": 881,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -25590,7 +25700,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 878,
+      "rank": 882,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -25622,7 +25732,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 879,
+      "rank": 883,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -25649,7 +25759,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 880,
+      "rank": 884,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -25667,7 +25777,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 881,
+      "rank": 885,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -25694,7 +25804,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 882,
+      "rank": 886,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -25718,7 +25828,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 883,
+      "rank": 887,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -25763,7 +25873,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 884,
+      "rank": 888,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -25794,7 +25904,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 885,
+      "rank": 889,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -25819,7 +25929,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 886,
+      "rank": 890,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -25853,12 +25963,12 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 887,
+      "rank": 891,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
-      "downloads": 85,
-      "likes": 8,
+      "downloads": 118,
+      "likes": 9,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
       "libraryName": "transformers",
@@ -25898,11 +26008,11 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 888,
+      "rank": 892,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
-      "downloads": 1029,
+      "downloads": 1043,
       "likes": 24,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
@@ -25939,7 +26049,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 889,
+      "rank": 893,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -25966,11 +26076,11 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 890,
+      "rank": 894,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
-      "downloads": 108,
+      "downloads": 146,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -25995,11 +26105,11 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 891,
+      "rank": 895,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
-      "downloads": 144051,
+      "downloads": 146104,
       "likes": 256,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26027,7 +26137,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 892,
+      "rank": 896,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -26051,7 +26161,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 893,
+      "rank": 897,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -26078,7 +26188,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 894,
+      "rank": 898,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -26117,11 +26227,11 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 895,
+      "rank": 899,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
-      "downloads": 461,
+      "downloads": 462,
       "likes": 177,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26147,11 +26257,11 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 896,
+      "rank": 900,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
-      "downloads": 7520,
+      "downloads": 7644,
       "likes": 15,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26179,11 +26289,11 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 897,
+      "rank": 901,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
-      "downloads": 347563,
+      "downloads": 361871,
       "likes": 961,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26213,7 +26323,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 898,
+      "rank": 902,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
@@ -26240,7 +26350,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 899,
+      "rank": 903,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -26268,7 +26378,7 @@
       "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 900,
+      "rank": 904,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -26296,11 +26406,11 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 901,
+      "rank": 905,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
-      "downloads": 1337,
+      "downloads": 1374,
       "likes": 45,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -26323,11 +26433,11 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 902,
+      "rank": 906,
       "id": "huytd189/Qwen3.6-27B-pure-GGUF",
       "author": "huytd189",
       "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
-      "downloads": 2078,
+      "downloads": 2444,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -26345,11 +26455,11 @@
       "lastModified": "2026-05-23T00:41:53.000Z"
     },
     {
-      "rank": 903,
+      "rank": 907,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
-      "downloads": 7380,
+      "downloads": 6352,
       "likes": 104,
       "trendingScore": 7,
       "pipelineTag": "image-to-text",
@@ -26374,7 +26484,7 @@
       "lastModified": "2026-05-13T07:13:52.000Z"
     },
     {
-      "rank": 904,
+      "rank": 908,
       "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -26419,11 +26529,11 @@
       "lastModified": "2026-05-15T06:27:56.000Z"
     },
     {
-      "rank": 905,
+      "rank": 909,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
-      "downloads": 14021,
+      "downloads": 14102,
       "likes": 26,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26445,11 +26555,11 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 906,
+      "rank": 910,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
-      "downloads": 1878,
+      "downloads": 2090,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-ranking",
@@ -26480,7 +26590,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 907,
+      "rank": 911,
       "id": "openbmb/BitCPM-CANN-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-1B",
@@ -26506,7 +26616,7 @@
       "lastModified": "2026-05-23T18:13:08.000Z"
     },
     {
-      "rank": 908,
+      "rank": 912,
       "id": "openbmb/BitCPM-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-3B",
@@ -26532,44 +26642,11 @@
       "lastModified": "2026-05-23T18:13:14.000Z"
     },
     {
-      "rank": 909,
-      "id": "RockTalk/Lance-3B-MLX",
-      "author": "RockTalk",
-      "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
-      "downloads": 480,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-image",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "lance",
-        "multimodal",
-        "apple-silicon",
-        "text-to-image",
-        "image-generation",
-        "video-generation",
-        "diffusion",
-        "flow-matching",
-        "moe",
-        "qwen2_5_vl",
-        "wan",
-        "port",
-        "base_model:Qwen/Qwen2.5-VL-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-VL-3B-Instruct",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T03:06:34.000Z",
-      "lastModified": "2026-05-20T12:36:28.000Z"
-    },
-    {
-      "rank": 910,
+      "rank": 913,
       "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
-      "downloads": 570,
+      "downloads": 591,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "image-text-to-text",
@@ -26610,7 +26687,7 @@
       "lastModified": "2026-05-20T02:34:32.000Z"
     },
     {
-      "rank": 911,
+      "rank": 914,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -26635,31 +26712,11 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 912,
-      "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
-      "author": "circlestone-labs",
-      "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T22:43:49.000Z",
-      "lastModified": "2026-05-22T21:06:00.000Z"
-    },
-    {
-      "rank": 913,
+      "rank": 915,
       "id": "Danrisi/UltraReal_FineTune_Anima_base1",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
-      "downloads": 549,
+      "downloads": 624,
       "likes": 8,
       "trendingScore": 7,
       "pipelineTag": "text-to-image",
@@ -26679,11 +26736,11 @@
       "lastModified": "2026-05-22T13:40:23.000Z"
     },
     {
-      "rank": 914,
+      "rank": 916,
       "id": "Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
       "author": "Andycurrent",
       "url": "https://huggingface.co/Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
-      "downloads": 2362452,
+      "downloads": 2373576,
       "likes": 34,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26707,11 +26764,11 @@
       "lastModified": "2026-02-18T10:06:23.000Z"
     },
     {
-      "rank": 915,
+      "rank": 917,
       "id": "tencent/Hy-MT2-7B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
-      "downloads": 526,
+      "downloads": 848,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -26722,18 +26779,19 @@
         "arxiv:2605.22064",
         "base_model:tencent/Hy-MT2-7B",
         "base_model:quantized:tencent/Hy-MT2-7B",
+        "license:apache-2.0",
         "compressed-tensors",
         "region:us"
       ],
       "createdAt": "2026-05-12T10:23:53.000Z",
-      "lastModified": "2026-05-22T05:16:09.000Z"
+      "lastModified": "2026-05-26T09:06:05.000Z"
     },
     {
-      "rank": 916,
+      "rank": 918,
       "id": "openbmb/BitCPM-CANN-0.5B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-0.5B-gguf",
-      "downloads": 404,
+      "downloads": 634,
       "likes": 10,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26753,11 +26811,11 @@
       "lastModified": "2026-05-23T18:11:41.000Z"
     },
     {
-      "rank": 917,
+      "rank": 919,
       "id": "huihui-ai/DeepSeek-V4-Flash-BF16",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/DeepSeek-V4-Flash-BF16",
-      "downloads": 94,
+      "downloads": 129,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26779,25 +26837,134 @@
       "lastModified": "2026-05-25T09:42:03.000Z"
     },
     {
-      "rank": 918,
-      "id": "Comfy-Org/PixelDiT",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
-      "downloads": 0,
+      "rank": 920,
+      "id": "google/gemma-3-1b-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-3-1b-it",
+      "downloads": 1286389,
+      "likes": 964,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma3_text",
+        "text-generation",
+        "conversational",
+        "arxiv:1905.07830",
+        "arxiv:1905.10044",
+        "arxiv:1911.11641",
+        "arxiv:1904.09728",
+        "arxiv:1705.03551",
+        "arxiv:1911.01547",
+        "arxiv:1907.10641",
+        "arxiv:1903.00161",
+        "arxiv:2009.03300",
+        "arxiv:2304.06364",
+        "arxiv:2103.03874",
+        "arxiv:2110.14168",
+        "arxiv:2311.12022",
+        "arxiv:2108.07732",
+        "arxiv:2107.03374",
+        "arxiv:2210.03057",
+        "arxiv:2106.03193",
+        "arxiv:1910.11856",
+        "arxiv:2502.12404",
+        "arxiv:2502.21228",
+        "arxiv:2404.16816",
+        "arxiv:2104.12756",
+        "arxiv:2311.16502",
+        "arxiv:2203.10244",
+        "arxiv:2404.12390"
+      ],
+      "createdAt": "2025-03-10T12:09:00.000Z",
+      "lastModified": "2025-04-04T13:12:40.000Z"
+    },
+    {
+      "rank": 921,
+      "id": "zizhaotong/SCOPE",
+      "author": "zizhaotong",
+      "url": "https://huggingface.co/zizhaotong/SCOPE",
+      "downloads": 103,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffsynth",
+      "tags": [
+        "diffsynth",
+        "safetensors",
+        "scope",
+        "world-model",
+        "video-generation",
+        "action-conditioned",
+        "game-world-model",
+        "first-person-shooter",
+        "diffusion",
+        "transformer",
+        "wan2.2",
+        "image-to-video",
+        "en",
+        "zh",
+        "arxiv:2605.23345",
+        "base_model:Wan-AI/Wan2.2-TI2V-5B",
+        "base_model:finetune:Wan-AI/Wan2.2-TI2V-5B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:26:28.000Z",
+      "lastModified": "2026-05-25T02:01:22.000Z"
+    },
+    {
+      "rank": 922,
+      "id": "internlm/CapRL-Video-4B",
+      "author": "internlm",
+      "url": "https://huggingface.co/internlm/CapRL-Video-4B",
+      "downloads": 26,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "comfyui",
-        "license:other",
+        "safetensors",
+        "qwen3_vl",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-25T14:05:48.000Z",
-      "lastModified": "2026-05-25T14:14:31.000Z"
+      "createdAt": "2026-05-22T11:23:34.000Z",
+      "lastModified": "2026-05-25T04:54:44.000Z"
     },
     {
-      "rank": 919,
+      "rank": 923,
+      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+      "downloads": 408,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gemma4",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "dataset:zerofata/Roleplay-Anime-Characters",
+        "base_model:zerofata/G4-MeroMero-26B-A4B",
+        "base_model:finetune:zerofata/G4-MeroMero-26B-A4B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T18:24:10.000Z",
+      "lastModified": "2026-05-22T19:16:35.000Z"
+    },
+    {
+      "rank": 924,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -26830,7 +26997,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 920,
+      "rank": 925,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -26859,7 +27026,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 921,
+      "rank": 926,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -26904,7 +27071,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 922,
+      "rank": 927,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -26933,7 +27100,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 923,
+      "rank": 928,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -26978,7 +27145,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 924,
+      "rank": 929,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -27022,7 +27189,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 925,
+      "rank": 930,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -27048,7 +27215,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 926,
+      "rank": 931,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -27074,7 +27241,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 927,
+      "rank": 932,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -27106,7 +27273,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 928,
+      "rank": 933,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -27129,7 +27296,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 929,
+      "rank": 934,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -27172,7 +27339,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 930,
+      "rank": 935,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -27217,7 +27384,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 931,
+      "rank": 936,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -27262,7 +27429,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 932,
+      "rank": 937,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -27289,7 +27456,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 933,
+      "rank": 938,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -27316,7 +27483,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 934,
+      "rank": 939,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -27341,7 +27508,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 935,
+      "rank": 940,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -27380,7 +27547,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 936,
+      "rank": 941,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -27405,7 +27572,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 937,
+      "rank": 942,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -27433,7 +27600,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 938,
+      "rank": 943,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -27458,7 +27625,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 939,
+      "rank": 944,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -27474,7 +27641,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 940,
+      "rank": 945,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -27501,7 +27668,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 941,
+      "rank": 946,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -27533,7 +27700,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 942,
+      "rank": 947,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -27563,7 +27730,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 943,
+      "rank": 948,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -27595,7 +27762,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 944,
+      "rank": 949,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -27623,7 +27790,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 945,
+      "rank": 950,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -27649,7 +27816,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 946,
+      "rank": 951,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -27678,7 +27845,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 947,
+      "rank": 952,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -27720,7 +27887,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 948,
+      "rank": 953,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -27747,7 +27914,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 949,
+      "rank": 954,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -27792,7 +27959,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 950,
+      "rank": 955,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -27818,7 +27985,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 951,
+      "rank": 956,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -27838,7 +28005,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 952,
+      "rank": 957,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -27865,7 +28032,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 953,
+      "rank": 958,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -27907,7 +28074,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 954,
+      "rank": 959,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -27934,7 +28101,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 955,
+      "rank": 960,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -27963,7 +28130,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 956,
+      "rank": 961,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -27990,7 +28157,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 957,
+      "rank": 962,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -28017,7 +28184,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 958,
+      "rank": 963,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -28044,7 +28211,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 959,
+      "rank": 964,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -28072,11 +28239,11 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 960,
+      "rank": 965,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
-      "downloads": 3941,
+      "downloads": 3949,
       "likes": 15,
       "trendingScore": 6,
       "pipelineTag": null,
@@ -28095,7 +28262,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 961,
+      "rank": 966,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -28126,7 +28293,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 962,
+      "rank": 967,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -28171,7 +28338,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 963,
+      "rank": 968,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -28193,7 +28360,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 964,
+      "rank": 969,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -28219,7 +28386,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 965,
+      "rank": 970,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -28250,7 +28417,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 966,
+      "rank": 971,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -28273,7 +28440,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 967,
+      "rank": 972,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -28303,7 +28470,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 968,
+      "rank": 973,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -28335,7 +28502,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 969,
+      "rank": 974,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -28364,7 +28531,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 970,
+      "rank": 975,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -28396,7 +28563,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 971,
+      "rank": 976,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -28428,7 +28595,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 972,
+      "rank": 977,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -28459,7 +28626,7 @@
       "lastModified": "2026-04-21T07:00:40.000Z"
     },
     {
-      "rank": 973,
+      "rank": 978,
       "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
       "author": "lemonyins",
       "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
@@ -28490,7 +28657,7 @@
       "lastModified": "2026-05-07T10:28:43.000Z"
     },
     {
-      "rank": 974,
+      "rank": 979,
       "id": "Danrisi/UltraReal_FineTune_Anima3",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
@@ -28513,7 +28680,7 @@
       "lastModified": "2026-05-07T13:33:58.000Z"
     },
     {
-      "rank": 975,
+      "rank": 980,
       "id": "deepseek-ai/DeepSeek-V3.2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
@@ -28540,7 +28707,7 @@
       "lastModified": "2025-12-01T11:04:59.000Z"
     },
     {
-      "rank": 976,
+      "rank": 981,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -28585,7 +28752,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 977,
+      "rank": 982,
       "id": "Civitai/Sulphur-2-distilled-fp8",
       "author": "Civitai",
       "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
@@ -28603,7 +28770,7 @@
       "lastModified": "2026-05-06T19:11:53.000Z"
     },
     {
-      "rank": 978,
+      "rank": 983,
       "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
@@ -28626,7 +28793,7 @@
       "lastModified": "2026-04-13T13:09:14.000Z"
     },
     {
-      "rank": 979,
+      "rank": 984,
       "id": "sst12345/liveditor",
       "author": "sst12345",
       "url": "https://huggingface.co/sst12345/liveditor",
@@ -28656,7 +28823,7 @@
       "lastModified": "2026-05-15T13:22:17.000Z"
     },
     {
-      "rank": 980,
+      "rank": 985,
       "id": "ibm-granite/granite-speech-4.1-2b-nar",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
@@ -28695,7 +28862,7 @@
       "lastModified": "2026-04-30T18:06:15.000Z"
     },
     {
-      "rank": 981,
+      "rank": 986,
       "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
       "author": "JANGQ-AI",
       "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
@@ -28733,7 +28900,7 @@
       "lastModified": "2026-05-08T21:46:38.000Z"
     },
     {
-      "rank": 982,
+      "rank": 987,
       "id": "openai/whisper-small",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-small",
@@ -28778,7 +28945,7 @@
       "lastModified": "2024-02-29T10:57:38.000Z"
     },
     {
-      "rank": 983,
+      "rank": 988,
       "id": "seedance2ai/Seedance-2-AI-Video-Generator",
       "author": "seedance2ai",
       "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
@@ -28803,7 +28970,7 @@
       "lastModified": "2026-03-31T13:52:44.000Z"
     },
     {
-      "rank": 984,
+      "rank": 989,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -28828,7 +28995,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 985,
+      "rank": 990,
       "id": "nvidia/Nemotron-Elastic-12B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Elastic-12B",
@@ -28861,7 +29028,7 @@
       "lastModified": "2026-05-08T19:48:42.000Z"
     },
     {
-      "rank": 986,
+      "rank": 991,
       "id": "unsloth/Qwen3.6-35B-A3B",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B",
@@ -28888,7 +29055,7 @@
       "lastModified": "2026-05-11T18:28:35.000Z"
     },
     {
-      "rank": 987,
+      "rank": 992,
       "id": "PolarSeeker/OpenSeeker-v2-30B-SFT",
       "author": "PolarSeeker",
       "url": "https://huggingface.co/PolarSeeker/OpenSeeker-v2-30B-SFT",
@@ -28918,7 +29085,7 @@
       "lastModified": "2026-05-09T06:49:21.000Z"
     },
     {
-      "rank": 988,
+      "rank": 993,
       "id": "Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF",
@@ -28950,7 +29117,7 @@
       "lastModified": "2024-11-12T09:54:27.000Z"
     },
     {
-      "rank": 989,
+      "rank": 994,
       "id": "Nanbeige/Nanbeige4.1-3B",
       "author": "Nanbeige",
       "url": "https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
@@ -28983,7 +29150,7 @@
       "lastModified": "2026-03-25T01:56:21.000Z"
     },
     {
-      "rank": 990,
+      "rank": 995,
       "id": "smthem/LTX-2.3-test-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/LTX-2.3-test-gguf",
@@ -29001,7 +29168,7 @@
       "lastModified": "2026-05-07T03:01:37.000Z"
     },
     {
-      "rank": 991,
+      "rank": 996,
       "id": "city96/FLUX.1-dev-gguf",
       "author": "city96",
       "url": "https://huggingface.co/city96/FLUX.1-dev-gguf",
@@ -29024,7 +29191,7 @@
       "lastModified": "2024-08-18T08:14:09.000Z"
     },
     {
-      "rank": 992,
+      "rank": 997,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Claude-Wasserstein-MTP-GGUF",
@@ -29056,7 +29223,7 @@
       "lastModified": "2026-05-13T09:13:49.000Z"
     },
     {
-      "rank": 993,
+      "rank": 998,
       "id": "tabularisai/multilingual-emotion-classification",
       "author": "tabularisai",
       "url": "https://huggingface.co/tabularisai/multilingual-emotion-classification",
@@ -29101,7 +29268,7 @@
       "lastModified": "2026-05-14T10:54:59.000Z"
     },
     {
-      "rank": 994,
+      "rank": 999,
       "id": "PaddlePaddle/PaddleOCR-VL",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL",
@@ -29140,7 +29307,7 @@
       "lastModified": "2026-04-30T09:43:07.000Z"
     },
     {
-      "rank": 995,
+      "rank": 1000,
       "id": "drbaph/HiDream-O1-Image-Dev-FP8",
       "author": "drbaph",
       "url": "https://huggingface.co/drbaph/HiDream-O1-Image-Dev-FP8",
@@ -29165,165 +29332,6 @@
       ],
       "createdAt": "2026-05-10T00:38:22.000Z",
       "lastModified": "2026-05-10T03:41:04.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
-      "author": "Ngixdev",
-      "url": "https://huggingface.co/Ngixdev/OmniCoder-Qwen3.5-9B-Claude-4.6-Opus-Uncensored-v2-GGUF",
-      "downloads": 21390,
-      "likes": 22,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen3_5",
-        "unsloth",
-        "qwen",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "uncensored",
-        "image-text-to-text",
-        "conversational",
-        "en",
-        "zh",
-        "ko",
-        "dataset:nohurry/Opus-4.6-Reasoning-3000x-filtered",
-        "dataset:Jackrong/Qwen3.5-reasoning-700x",
-        "dataset:Roman1111111/claude-opus-4.6-10000x",
-        "base_model:Qwen/Qwen3.5-9B",
-        "base_model:adapter:Qwen/Qwen3.5-9B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T01:13:00.000Z",
-      "lastModified": "2026-04-02T18:56:12.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "BAAI/bge-base-en-v1.5",
-      "author": "BAAI",
-      "url": "https://huggingface.co/BAAI/bge-base-en-v1.5",
-      "downloads": 8911985,
-      "likes": 422,
-      "trendingScore": 6,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "pytorch",
-        "onnx",
-        "safetensors",
-        "bert",
-        "feature-extraction",
-        "sentence-similarity",
-        "transformers",
-        "mteb",
-        "en",
-        "arxiv:2401.03462",
-        "arxiv:2312.15503",
-        "arxiv:2311.13534",
-        "arxiv:2310.07554",
-        "arxiv:2309.07597",
-        "license:mit",
-        "model-index",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2023-09-11T15:04:22.000Z",
-      "lastModified": "2024-02-21T03:00:19.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "Comfy-Org/sam3.1",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/sam3.1",
-      "downloads": 0,
-      "likes": 31,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T21:14:07.000Z",
-      "lastModified": "2026-05-06T13:59:05.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
-      "author": "Max-and-Omnis",
-      "url": "https://huggingface.co/Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-GGUF",
-      "downloads": 3067,
-      "likes": 7,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "nvidia",
-        "pytorch",
-        "nemotron-3",
-        "latent-moe",
-        "mamba2",
-        "reap",
-        "pruned",
-        "fine-tuned",
-        "math",
-        "tool-integrated reasoning",
-        "python",
-        "aime",
-        "aimo",
-        "text-generation",
-        "dataset:nguyen599/AstralMath-v1",
-        "arxiv:2512.20856",
-        "base_model:Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-BF16",
-        "base_model:quantized:Max-and-Omnis/Nemotron-3-Super-64B-A12B-Math-REAP-BF16",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-24T07:47:01.000Z",
-      "lastModified": "2026-04-24T08:34:29.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-      "author": "TinyLlama",
-      "url": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-      "downloads": 2810497,
-      "likes": 1584,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "conversational",
-        "en",
-        "dataset:cerebras/SlimPajama-627B",
-        "dataset:bigcode/starcoderdata",
-        "dataset:HuggingFaceH4/ultrachat_200k",
-        "dataset:HuggingFaceH4/ultrafeedback_binarized",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-12-30T06:27:30.000Z",
-      "lastModified": "2024-03-17T05:07:08.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26446438235

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.