### PR TITLE
chore(data): refresh huggingface space signals 2026-05-26T10:37:03Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-26T04:48:29.685Z",
+  "ts": "2026-05-26T10:37:03.554Z",
   "count": 1,
-  "durationMs": 4600,
+  "durationMs": 4790,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T04:48:25.087Z",
+  "fetchedAt": "2026-05-26T10:36:58.766Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -128,6 +128,22 @@
     },
     {
       "rank": 8,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 93,
+      "trendingScore": 90,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-23T11:14:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 9,
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
@@ -144,12 +160,12 @@
       "models": []
     },
     {
-      "rank": 9,
+      "rank": 10,
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
-      "likes": 87,
-      "trendingScore": 85,
+      "likes": 88,
+      "trendingScore": 86,
       "sdk": "docker",
       "tags": [
         "docker",
@@ -157,22 +173,6 @@
       ],
       "createdAt": "2026-05-19T14:18:55.000Z",
       "lastModified": "2026-05-20T10:03:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 10,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 82,
-      "trendingScore": 79,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-23T11:14:35.000Z",
       "models": []
     },
     {
@@ -345,8 +345,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 85,
-      "trendingScore": 51,
+      "likes": 95,
+      "trendingScore": 53,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -354,7 +354,7 @@
         "region:us"
       ],
       "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-13T17:12:57.000Z",
+      "lastModified": "2026-05-26T07:30:36.000Z",
       "models": []
     },
     {
@@ -378,8 +378,8 @@
       "id": "stabilityai/stable-audio-3",
       "author": "stabilityai",
       "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 45,
-      "trendingScore": 45,
+      "likes": 48,
+      "trendingScore": 48,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -394,8 +394,8 @@
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1761,
-      "trendingScore": 44,
+      "likes": 1764,
+      "trendingScore": 46,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -458,8 +458,8 @@
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 38,
-      "trendingScore": 38,
+      "likes": 40,
+      "trendingScore": 40,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -471,11 +471,27 @@
     },
     {
       "rank": 29,
+      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
+      "author": "Saravutw",
+      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
+      "likes": 66,
+      "trendingScore": 38,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-09T19:01:39.000Z",
+      "lastModified": "2026-03-13T17:12:16.000Z",
+      "models": []
+    },
+    {
+      "rank": 30,
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
-      "likes": 3223,
-      "trendingScore": 36,
+      "likes": 3231,
+      "trendingScore": 37,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -484,22 +500,6 @@
       ],
       "createdAt": "2025-11-26T19:54:05.000Z",
       "lastModified": "2026-02-02T16:51:24.000Z",
-      "models": []
-    },
-    {
-      "rank": 30,
-      "id": "Saravutw/Omni-Video-Factory-Iframe-API",
-      "author": "Saravutw",
-      "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
-      "likes": 63,
-      "trendingScore": 36,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-09T19:01:39.000Z",
-      "lastModified": "2026-03-13T17:12:16.000Z",
       "models": []
     },
     {
@@ -620,6 +620,22 @@
     },
     {
       "rank": 38,
+      "id": "ibuildproducts/wan22-i2v-v4-demo",
+      "author": "ibuildproducts",
+      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
+      "likes": 40,
+      "trendingScore": 31,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:34:01.000Z",
+      "lastModified": "2026-05-18T00:16:12.000Z",
+      "models": []
+    },
+    {
+      "rank": 39,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -635,7 +651,7 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -651,7 +667,7 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
@@ -668,7 +684,23 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 42,
+      "id": "CohereLabs/command-a-plus-05-2026",
+      "author": "CohereLabs",
+      "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
+      "likes": 31,
+      "trendingScore": 30,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T12:07:16.000Z",
+      "lastModified": "2026-05-20T13:50:45.000Z",
+      "models": []
+    },
+    {
+      "rank": 43,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -684,23 +716,7 @@
       "models": []
     },
     {
-      "rank": 42,
-      "id": "ibuildproducts/wan22-i2v-v4-demo",
-      "author": "ibuildproducts",
-      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
-      "likes": 38,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:34:01.000Z",
-      "lastModified": "2026-05-18T00:16:12.000Z",
-      "models": []
-    },
-    {
-      "rank": 43,
+      "rank": 44,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -717,7 +733,23 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 28,
+      "trendingScore": 28,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-26T05:34:42.000Z",
+      "models": []
+    },
+    {
+      "rank": 46,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -733,23 +765,7 @@
       "models": []
     },
     {
-      "rank": 45,
-      "id": "CohereLabs/command-a-plus-05-2026",
-      "author": "CohereLabs",
-      "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
-      "likes": 27,
-      "trendingScore": 26,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T12:07:16.000Z",
-      "lastModified": "2026-05-20T13:50:45.000Z",
-      "models": []
-    },
-    {
-      "rank": 46,
+      "rank": 47,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -769,7 +785,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -786,7 +802,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -803,7 +819,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -816,26 +832,6 @@
       ],
       "createdAt": "2025-09-16T14:53:41.000Z",
       "lastModified": "2026-05-08T05:09:46.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "mrfakename/anima-v1",
-      "author": "mrfakename",
-      "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
-      "likes": 36,
-      "trendingScore": 23,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "text-to-image",
-        "anima",
-        "zerogpu",
-        "anime",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T02:42:26.000Z",
-      "lastModified": "2026-05-22T03:20:51.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26447195534

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.