### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-26T14:11:17Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-26T00:15:50.605Z",
+  "ts": "2026-05-26T14:11:17.325Z",
   "count": 1,
-  "durationMs": 9264,
+  "durationMs": 12263,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-26T00:15:49.009Z",
+  "lastFetchedAt": "2026-05-26T14:11:15.847Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1185,6 +1185,54 @@
       "aiAdjacent": true
     },
     {
+      "id": "1149886",
+      "name": "Brew ",
+      "tagline": "Like Claude design for email marketing",
+      "description": "Brew is the fastest way to design and send beautiful, on-brand emails and automations that render perfectly in every inbox. Describe a campaign or a multi-step automation in plain English, and Brew builds the whole thing in seconds: copy, design, audience, and logic. Works with any AI agent: paste our docs into OpenClaw, Viktor, Claude, or Lovable. No lock-in: send from Brew or export to your ESP. Free to get started.",
+      "url": "https://www.producthunt.com/products/brew-5?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3Q7DPTEXUJAFUG",
+      "votesCount": 293,
+      "commentsCount": 53,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/a805620c-ee33-47e2-973d-5d6ea3f646a3.gif?auto=format",
+      "topics": [
+        "design-tools",
+        "email-marketing",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "942860",
       "name": "SUN-to-Spotify ",
       "tagline": "Generate audio with SUN and send it to your Spotify library",
@@ -2282,6 +2330,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1033481",
+      "name": "Bond",
+      "tagline": "Outbound campaigns powered by real buying signals",
+      "description": "Bond is your AI GTM Engineer. Tell it who you want to reach. It builds the audience, plans the campaign, writes the messaging, and executes it end to end. Every data provider and outreach tool you need, in one workflow. Build your first campaign in 15 minutes.",
+      "url": "https://www.producthunt.com/products/outbond?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H7KRMGFGCJKRRE",
+      "votesCount": 229,
+      "commentsCount": 16,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/75957930-4ba3-4608-a965-b22ec56b3c59.png?auto=format",
+      "topics": [
+        "productivity",
+        "sales",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1142238",
       "name": "InvestorFinder",
       "tagline": "Find investors who've backed founders just like you",
@@ -2358,70 +2448,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
-    },
-    {
-      "id": "1127544",
-      "name": "GitHired",
-      "tagline": "Find 100x engineers by proof of work, not resume keywords",
-      "description": "Find 100x engineers on autopilot: Describe what you're building/looking for, and instantly get a ranked list of the most cracked engineers who meet your requirements. Search from our pool of 10k+ profiles that have been evaluated based on actual code complexity, project depth, and relevant experience- including access to private repos for maximum accuracy. And if that pool falls short, use our inbuilt GitHub + LinkedIn scraper to source cracked open source devs.",
-      "url": "https://www.producthunt.com/products/githired-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/WYPKITACC4AEM6",
-      "votesCount": 210,
-      "commentsCount": 14,
-      "createdAt": "2026-05-08T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/2dc201d5-0c3f-4fbb-a8ea-9f445986c910.png?auto=format",
-      "topics": [
-        "hiring",
-        "github",
-        "yc-application"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1152815",
-      "name": "WordPress 7.0",
-      "tagline": "Introducing AI tools, new admin experience & design controls",
-      "description": "WordPress 7.0 marks the start of a new era, laying the foundation for AI across the WordPress experience. Greeting you with a modern, more intuitive dashboard, 7.0 introduces enhanced customization and development tools that inspire creativity and tap into endless potential. Whether you’re a creator, business owner or developer – WordPress 7.0 let’s you create in a way that is uniquely your own.",
-      "url": "https://www.producthunt.com/products/wordpress-7-0?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/DR7XDHFH7F2IGM",
-      "votesCount": 208,
-      "commentsCount": 5,
-      "createdAt": "2026-05-22T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/834157b6-01ba-4baa-9997-d039fee7d26b.png?auto=format",
-      "topics": [
-        "wordpress"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26453348183

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.