### PR TITLE
chore(data): refresh lobsters signals 2026-05-26T16:29:26Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-26T08:52:18.409Z",
+  "ts": "2026-05-26T16:29:26.237Z",
   "count": 1,
-  "durationMs": 2594,
+  "durationMs": 4141,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-26T08:52:15.835Z",
+  "fetchedAt": "2026-05-26T16:29:22.119Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 76,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-26T08:52:15.835Z",
+  "fetchedAt": "2026-05-26T16:29:22.119Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 76,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -300,6 +300,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "dw02ye",
+      "title": "The pressure",
+      "url": "https://daniel.haxx.se/blog/2026/05/26/the-pressure/",
+      "commentsUrl": "https://lobste.rs/s/dw02ye/pressure",
+      "by": "",
+      "score": 79,
+      "commentCount": 21,
+      "createdUtc": 1779778058,
+      "ageHours": 9.695555555555556,
+      "trendingScore": 1.9751305522686065,
+      "tags": [
+        "culture",
+        "programming"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "03djyt",
       "title": "New design for the FreeBSD website",
       "url": "https://www.freebsd.org/",
@@ -425,6 +443,25 @@
       "tags": [
         "hardware",
         "law"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "goq5ha",
+      "title": "What is a harmonic? An interactive comic about additive synthesis",
+      "url": "https://melatonin.dev/additive-synth-comic/what-is-a-harmonic/",
+      "commentsUrl": "https://lobste.rs/s/goq5ha/what_is_harmonic_interactive_comic_about",
+      "by": "",
+      "score": 22,
+      "commentCount": 3,
+      "createdUtc": 1779798819,
+      "ageHours": 3.928611111111111,
+      "trendingScore": 1.5240290152470977,
+      "tags": [
+        "art",
+        "education",
+        "visualization"
       ],
       "description": "",
       "linkedRepos": []
@@ -602,24 +639,6 @@
       "tags": [
         "mac",
         "swift"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "dw02ye",
-      "title": "The pressure",
-      "url": "https://daniel.haxx.se/blog/2026/05/26/the-pressure/",
-      "commentsUrl": "https://lobste.rs/s/dw02ye/pressure",
-      "by": "",
-      "score": 10,
-      "commentCount": 0,
-      "createdUtc": 1779778058,
-      "ageHours": 2.0769444444444445,
-      "trendingScore": 1.2147804941787144,
-      "tags": [
-        "culture",
-        "programming"
       ],
       "description": "",
       "linkedRepos": []
@@ -876,24 +895,6 @@
         "graphics",
         "historical",
         "video"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "n1gytv",
-      "title": "Why Ruby Still Feels Like Home After All These Years",
-      "url": "https://caio.ca/blog/why-ruby-still-feels-like-home",
-      "commentsUrl": "https://lobste.rs/s/n1gytv/why_ruby_still_feels_like_home_after_all",
-      "by": "",
-      "score": 16,
-      "commentCount": 6,
-      "createdUtc": 1779251135,
-      "ageHours": 4.2747222222222225,
-      "trendingScore": 1.017954169772609,
-      "tags": [
-        "programming",
-        "ruby"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26461167795

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.