### PR TITLE
chore(data): refresh huggingface space signals 2026-05-26T16:30:14Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-26T10:37:03.554Z",
+  "ts": "2026-05-26T16:30:14.227Z",
   "count": 1,
-  "durationMs": 4790,
+  "durationMs": 6257,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T10:36:58.766Z",
+  "fetchedAt": "2026-05-26T16:30:07.971Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -131,8 +131,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 93,
-      "trendingScore": 90,
+      "likes": 98,
+      "trendingScore": 95,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -311,8 +311,8 @@
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
-      "likes": 1444,
-      "trendingScore": 55,
+      "likes": 1510,
+      "trendingScore": 56,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -320,7 +320,7 @@
         "region:us"
       ],
       "createdAt": "2025-12-19T05:20:19.000Z",
-      "lastModified": "2026-05-17T02:27:17.000Z",
+      "lastModified": "2026-05-19T14:05:12.000Z",
       "models": []
     },
     {
@@ -359,6 +359,22 @@
     },
     {
       "rank": 22,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 51,
+      "trendingScore": 50,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-22T21:24:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 23,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -371,22 +387,6 @@
       ],
       "createdAt": "2026-01-27T14:05:13.000Z",
       "lastModified": "2026-05-08T10:48:11.000Z",
-      "models": []
-    },
-    {
-      "rank": 23,
-      "id": "stabilityai/stable-audio-3",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 48,
-      "trendingScore": 48,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T15:54:00.000Z",
-      "lastModified": "2026-05-22T21:24:33.000Z",
       "models": []
     },
     {
@@ -471,6 +471,23 @@
     },
     {
       "rank": 29,
+      "id": "mrfakename/Z-Image-Turbo",
+      "author": "mrfakename",
+      "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
+      "likes": 3234,
+      "trendingScore": 38,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2025-11-26T19:54:05.000Z",
+      "lastModified": "2026-02-02T16:51:24.000Z",
+      "models": []
+    },
+    {
+      "rank": 30,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
@@ -483,23 +500,6 @@
       ],
       "createdAt": "2025-12-09T19:01:39.000Z",
       "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 30,
-      "id": "mrfakename/Z-Image-Turbo",
-      "author": "mrfakename",
-      "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
-      "likes": 3231,
-      "trendingScore": 37,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2025-11-26T19:54:05.000Z",
-      "lastModified": "2026-02-02T16:51:24.000Z",
       "models": []
     },
     {
@@ -701,6 +701,22 @@
     },
     {
       "rank": 43,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 30,
+      "trendingScore": 30,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-26T15:57:44.000Z",
+      "models": []
+    },
+    {
+      "rank": 44,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -716,7 +732,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -730,22 +746,6 @@
       ],
       "createdAt": "2026-03-28T19:57:45.000Z",
       "lastModified": "2026-05-15T03:44:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 45,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 28,
-      "trendingScore": 28,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-26T05:34:42.000Z",
       "models": []
     },
     {
@@ -803,6 +803,22 @@
     },
     {
       "rank": 49,
+      "id": "facebook/vggt-omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
+      "likes": 31,
+      "trendingScore": 24,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T23:39:56.000Z",
+      "lastModified": "2026-05-18T21:46:03.000Z",
+      "models": []
+    },
+    {
+      "rank": 50,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
@@ -816,22 +832,6 @@
       ],
       "createdAt": "2026-01-15T09:50:22.000Z",
       "lastModified": "2026-01-16T13:56:36.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "openbmb/VoxCPM-Demo",
-      "author": "openbmb",
-      "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
-      "likes": 449,
-      "trendingScore": 23,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-09-16T14:53:41.000Z",
-      "lastModified": "2026-05-08T05:09:46.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26461205480

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.