### PR TITLE
chore(data): refresh lobsters signals 2026-05-26T19:04:15Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-26T16:29:26.237Z",
+  "ts": "2026-05-26T19:04:15.290Z",
   "count": 1,
-  "durationMs": 4141,
+  "durationMs": 2493,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-26T16:29:22.119Z",
+  "fetchedAt": "2026-05-26T19:04:12.818Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 75,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-26T16:29:22.119Z",
+  "fetchedAt": "2026-05-26T19:04:12.818Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 75,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -811,6 +811,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "w1gpe7",
+      "title": "Stop advertising in your commits",
+      "url": "https://akselmo.dev/posts/stop-advertising-in-your-commits/",
+      "commentsUrl": "https://lobste.rs/s/w1gpe7/stop_advertising_your_commits",
+      "by": "",
+      "score": 6,
+      "commentCount": 10,
+      "createdUtc": 1779818184,
+      "ageHours": 1.13,
+      "trendingScore": 1.0835145411071339,
+      "tags": [
+        "programming",
+        "rant"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "3izfup",
       "title": "Switching to Colemak",
       "url": "https://pta2002.com/blog/colemak/",
@@ -877,26 +895,6 @@
         "networking"
       ],
       "description": "<p>Despite the page title mentioning OpenAI, it has very little to do with the actual AI parts, only the real-time audio transport parts, which is why I've matched the URL slug instead.</p>\n",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "i6pafc",
-      "title": "How Rockstar fit an entire city into PlayStation 2 memory",
-      "url": "https://www.youtube.com/watch?v=cIbCxbrBCys",
-      "commentsUrl": "https://lobste.rs/s/i6pafc/how_rockstar_fit_entire_city_into",
-      "by": "",
-      "score": 16,
-      "commentCount": 1,
-      "createdUtc": 1778595086,
-      "ageHours": 4.211666666666667,
-      "trendingScore": 1.0334935465417077,
-      "tags": [
-        "games",
-        "graphics",
-        "historical",
-        "video"
-      ],
-      "description": "",
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26469007530

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.