### PR TITLE
chore(data): refresh ai rss signals 2026-05-26T20:30:45Z

### DIFF
--- a/data/_meta/claude-rss.json
+++ b/data/_meta/claude-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "claude-rss",
   "reason": "ok",
-  "ts": "2026-05-26T16:16:54.815Z",
+  "ts": "2026-05-26T20:30:43.646Z",
   "count": 1,
-  "durationMs": 275,
+  "durationMs": 5823,
   "extra": {}
 }

--- a/data/_meta/openai-rss.json
+++ b/data/_meta/openai-rss.json
@@ -1,8 +1,8 @@
 {
   "source": "openai-rss",
   "reason": "ok",
-  "ts": "2026-05-26T16:16:56.508Z",
+  "ts": "2026-05-26T20:30:45.231Z",
   "count": 1,
-  "durationMs": 1505,
+  "durationMs": 1398,
   "extra": {}
 }

--- a/data/claude-rss.json
+++ b/data/claude-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T16:16:54.545Z",
+  "fetchedAt": "2026-05-26T20:30:37.828Z",
   "source": "claude",
   "feedUrl": "https://www.anthropic.com/news",
   "error": null,

--- a/data/openai-rss.json
+++ b/data/openai-rss.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T16:16:55.007Z",
+  "fetchedAt": "2026-05-26T20:30:43.837Z",
   "source": "openai",
   "feedUrl": "https://openai.com/news/rss.xml",
   "error": null,


### PR DESCRIPTION
Automated data refresh from `Refresh AI RSS signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26473296313

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.