### PR TITLE
chore(data): refresh huggingface space signals 2026-05-26T20:33:30Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-26T16:30:14.227Z",
+  "ts": "2026-05-26T20:33:30.321Z",
   "count": 1,
-  "durationMs": 6257,
+  "durationMs": 5998,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T16:30:07.971Z",
+  "fetchedAt": "2026-05-26T20:33:24.325Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -131,15 +131,15 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 98,
-      "trendingScore": 95,
+      "likes": 101,
+      "trendingScore": 98,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
       "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-23T11:14:35.000Z",
+      "lastModified": "2026-05-26T16:44:17.000Z",
       "models": []
     },
     {
@@ -311,7 +311,7 @@
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
-      "likes": 1510,
+      "likes": 1511,
       "trendingScore": 56,
       "sdk": "gradio",
       "tags": [
@@ -362,8 +362,8 @@
       "id": "stabilityai/stable-audio-3",
       "author": "stabilityai",
       "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 51,
-      "trendingScore": 50,
+      "likes": 53,
+      "trendingScore": 52,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -554,6 +554,22 @@
     },
     {
       "rank": 34,
+      "id": "ibuildproducts/wan22-i2v-v4-demo",
+      "author": "ibuildproducts",
+      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
+      "likes": 42,
+      "trendingScore": 33,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:34:01.000Z",
+      "lastModified": "2026-05-18T00:16:12.000Z",
+      "models": []
+    },
+    {
+      "rank": 35,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -569,7 +585,7 @@
       "models": []
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -586,7 +602,7 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -603,7 +619,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -616,22 +632,6 @@
       ],
       "createdAt": "2026-04-28T09:41:42.000Z",
       "lastModified": "2026-04-29T17:05:14.000Z",
-      "models": []
-    },
-    {
-      "rank": 38,
-      "id": "ibuildproducts/wan22-i2v-v4-demo",
-      "author": "ibuildproducts",
-      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
-      "likes": 40,
-      "trendingScore": 31,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:34:01.000Z",
-      "lastModified": "2026-05-18T00:16:12.000Z",
       "models": []
     },
     {
@@ -704,7 +704,7 @@
       "id": "bytedance-research/Lance",
       "author": "bytedance-research",
       "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 30,
+      "likes": 31,
       "trendingScore": 30,
       "sdk": "gradio",
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26473442078

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.