### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-26T21:00:17Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-26T18:07:14.848Z",
+  "ts": "2026-05-26T21:00:17.691Z",
   "count": 1,
-  "durationMs": 10202,
+  "durationMs": 12148,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-26T18:07:13.320Z",
+  "lastFetchedAt": "2026-05-26T21:00:15.799Z",
   "windowDays": 7,
   "launches": [
     {
@@ -31,6 +31,54 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1149886",
+      "name": "Brew ",
+      "tagline": "Like Claude design for email marketing",
+      "description": "Brew is the fastest way to design and send beautiful, on-brand emails and automations that render perfectly in every inbox. Describe a campaign or a multi-step automation in plain English, and Brew builds the whole thing in seconds: copy, design, audience, and logic. Works with any AI agent: paste our docs into OpenClaw, Viktor, Claude, or Lovable. No lock-in: send from Brew or export to your ESP. Free to get started.",
+      "url": "https://www.producthunt.com/products/brew-5?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3Q7DPTEXUJAFUG",
+      "votesCount": 487,
+      "commentsCount": 93,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/a805620c-ee33-47e2-973d-5d6ea3f646a3.gif?auto=format",
+      "topics": [
+        "design-tools",
+        "email-marketing",
+        "artificial-intelligence"
+      ],
+      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -324,54 +372,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1149886",
-      "name": "Brew ",
-      "tagline": "Like Claude design for email marketing",
-      "description": "Brew is the fastest way to design and send beautiful, on-brand emails and automations that render perfectly in every inbox. Describe a campaign or a multi-step automation in plain English, and Brew builds the whole thing in seconds: copy, design, audience, and logic. Works with any AI agent: paste our docs into OpenClaw, Viktor, Claude, or Lovable. No lock-in: send from Brew or export to your ESP. Free to get started.",
-      "url": "https://www.producthunt.com/products/brew-5?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/3Q7DPTEXUJAFUG",
-      "votesCount": 422,
-      "commentsCount": 80,
-      "createdAt": "2026-05-26T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/a805620c-ee33-47e2-973d-5d6ea3f646a3.gif?auto=format",
-      "topics": [
-        "design-tools",
-        "email-marketing",
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1057,6 +1057,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1033481",
+      "name": "Bond",
+      "tagline": "Outbound campaigns powered by real buying signals",
+      "description": "Bond is your AI GTM Engineer. Tell it who you want to reach. It builds the audience, plans the campaign, writes the messaging, and executes it end to end. Every data provider and outreach tool you need, in one workflow. Build your first campaign in 15 minutes.",
+      "url": "https://www.producthunt.com/products/outbond?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H7KRMGFGCJKRRE",
+      "votesCount": 315,
+      "commentsCount": 23,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/75957930-4ba3-4608-a965-b22ec56b3c59.png?auto=format",
+      "topics": [
+        "productivity",
+        "sales",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1136169",
       "name": "Fere AI",
       "tagline": "AI agents that turn signals into crypto + Polymarket trades",
@@ -1427,48 +1469,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1033481",
-      "name": "Bond",
-      "tagline": "Outbound campaigns powered by real buying signals",
-      "description": "Bond is your AI GTM Engineer. Tell it who you want to reach. It builds the audience, plans the campaign, writes the messaging, and executes it end to end. Every data provider and outreach tool you need, in one workflow. Build your first campaign in 15 minutes.",
-      "url": "https://www.producthunt.com/products/outbond?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H7KRMGFGCJKRRE",
-      "votesCount": 283,
-      "commentsCount": 22,
-      "createdAt": "2026-05-26T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/75957930-4ba3-4608-a965-b22ec56b3c59.png?auto=format",
-      "topics": [
-        "productivity",
-        "sales",
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2414,22 +2414,52 @@
       "aiAdjacent": false
     },
     {
-      "id": "1137047",
-      "name": "Theneo",
-      "tagline": "The API management platform for humans and agents",
-      "description": "The all-in-one platform to design, document, manage, and observe your APIs. Built for the developers shipping them, the customers integrating them, and the agents now calling them at scale.",
-      "url": "https://www.producthunt.com/products/theneo?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/Y542HLTRAGPMSR",
-      "votesCount": 211,
-      "commentsCount": 18,
-      "createdAt": "2026-05-14T07:00:00Z",
-      "thumbnail": "https://ph-files.imgix.net/f8b82f28-04da-47f5-b97a-fb4a4479b4bf.png?auto=format",
+      "id": "1151167",
+      "name": "Rezonant",
+      "tagline": "Talk, spec, ship: get your product ideas into production",
+      "description": "Rezonant helps product teams turn messy ideas into code-ready specs, tickets, and engineering tasks. Collaborate with PMs, engineers, designers, and AI agents in one shared workspace. Ground decisions in your actual codebase, keep everyone aligned on the same version, and create work that humans and coding agents can confidently ship.",
+      "url": "https://www.producthunt.com/products/portia-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/P2UMFH5P4HQXTO",
+      "votesCount": 214,
+      "commentsCount": 55,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/6de8c4b0-881b-4933-a3aa-3dfaf8beca07.png?auto=format",
       "topics": [
-        "api-1",
-        "developer-tools",
-        "pitch-dubai"
+        "productivity",
+        "task-management",
+        "artificial-intelligence"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26474780284

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.