### PR TITLE
chore(data): refresh lobsters signals 2026-05-26T21:15:22Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-26T19:04:15.290Z",
+  "ts": "2026-05-26T21:15:22.829Z",
   "count": 1,
-  "durationMs": 2493,
+  "durationMs": 3155,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T19:04:12.818Z",
+  "fetchedAt": "2026-05-26T21:15:19.696Z",
   "windowDays": 7,
   "scannedStories": 75,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T19:04:12.818Z",
+  "fetchedAt": "2026-05-26T21:15:19.696Z",
   "windowHours": 72,
   "scannedTotal": 75,
   "stories": [
@@ -467,6 +467,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "w1gpe7",
+      "title": "Stop advertising in your commits",
+      "url": "https://akselmo.dev/posts/stop-advertising-in-your-commits/",
+      "commentsUrl": "https://lobste.rs/s/w1gpe7/stop_advertising_your_commits",
+      "by": "",
+      "score": 17,
+      "commentCount": 21,
+      "createdUtc": 1779818184,
+      "ageHours": 3.3152777777777778,
+      "trendingScore": 1.3872667354811734,
+      "tags": [
+        "rant",
+        "vibecoding"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "xb2edj",
       "title": "Replacing a 3 GB SQLite database with a 10 MB FST (finite state transducer) binary",
       "url": "https://til.andrew-quinn.me/posts/replacing-a-3-gb-sqlite-database-with-a-7-mb-fst-finite-state-trandsucer-binary/",
@@ -806,24 +824,6 @@
       "tags": [
         "practices",
         "vibecoding"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "w1gpe7",
-      "title": "Stop advertising in your commits",
-      "url": "https://akselmo.dev/posts/stop-advertising-in-your-commits/",
-      "commentsUrl": "https://lobste.rs/s/w1gpe7/stop_advertising_your_commits",
-      "by": "",
-      "score": 6,
-      "commentCount": 10,
-      "createdUtc": 1779818184,
-      "ageHours": 1.13,
-      "trendingScore": 1.0835145411071339,
-      "tags": [
-        "programming",
-        "rant"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26475510817

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.