### PR TITLE
chore(data): refresh lobsters signals 2026-05-26T22:53:07Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-26T21:15:22.829Z",
+  "ts": "2026-05-26T22:53:07.311Z",
   "count": 1,
-  "durationMs": 3155,
+  "durationMs": 2565,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T21:15:19.696Z",
+  "fetchedAt": "2026-05-26T22:53:04.765Z",
   "windowDays": 7,
   "scannedStories": 75,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T21:15:19.696Z",
+  "fetchedAt": "2026-05-26T22:53:04.765Z",
   "windowHours": 72,
   "scannedTotal": 75,
   "stories": [
@@ -472,11 +472,11 @@
       "url": "https://akselmo.dev/posts/stop-advertising-in-your-commits/",
       "commentsUrl": "https://lobste.rs/s/w1gpe7/stop_advertising_your_commits",
       "by": "",
-      "score": 17,
-      "commentCount": 21,
+      "score": 27,
+      "commentCount": 29,
       "createdUtc": 1779818184,
-      "ageHours": 3.3152777777777778,
-      "trendingScore": 1.3872667354811734,
+      "ageHours": 4.944444444444445,
+      "trendingScore": 1.4753922651281592,
       "tags": [
         "rant",
         "vibecoding"


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26479701770

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.