### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-27T00:17:48Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-26T21:00:17.691Z",
+  "ts": "2026-05-27T00:17:48.015Z",
   "count": 1,
-  "durationMs": 12148,
+  "durationMs": 10357,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,36 +1,24 @@
 {
-  "lastFetchedAt": "2026-05-26T21:00:15.799Z",
+  "lastFetchedAt": "2026-05-27T00:17:46.410Z",
   "windowDays": 7,
   "launches": [
     {
-      "id": "1144771",
-      "name": "StoreClaw",
-      "tagline": "Grow your store profits with agents that know how to sell",
-      "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
-      "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
-      "votesCount": 496,
-      "commentsCount": 206,
-      "createdAt": "2026-05-20T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
+      "id": "1149886",
+      "name": "Brew ",
+      "tagline": "Like Claude design for email marketing",
+      "description": "Brew is the fastest way to design and send beautiful, on-brand emails and automations that render perfectly in every inbox. Describe a campaign or a multi-step automation in plain English, and Brew builds the whole thing in seconds: copy, design, audience, and logic. Works with any AI agent: paste our docs into OpenClaw, Viktor, Claude, or Lovable. No lock-in: send from Brew or export to your ESP. Free to get started.",
+      "url": "https://www.producthunt.com/products/brew-5?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/3Q7DPTEXUJAFUG",
+      "votesCount": 545,
+      "commentsCount": 101,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/a805620c-ee33-47e2-973d-5d6ea3f646a3.gif?auto=format",
       "topics": [
-        "artificial-intelligence",
-        "e-commerce",
-        "marketing-automation"
+        "design-tools",
+        "email-marketing",
+        "artificial-intelligence"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -63,22 +51,34 @@
       "aiAdjacent": true
     },
     {
-      "id": "1149886",
-      "name": "Brew ",
-      "tagline": "Like Claude design for email marketing",
-      "description": "Brew is the fastest way to design and send beautiful, on-brand emails and automations that render perfectly in every inbox. Describe a campaign or a multi-step automation in plain English, and Brew builds the whole thing in seconds: copy, design, audience, and logic. Works with any AI agent: paste our docs into OpenClaw, Viktor, Claude, or Lovable. No lock-in: send from Brew or export to your ESP. Free to get started.",
-      "url": "https://www.producthunt.com/products/brew-5?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/3Q7DPTEXUJAFUG",
-      "votesCount": 487,
-      "commentsCount": 93,
-      "createdAt": "2026-05-26T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/a805620c-ee33-47e2-973d-5d6ea3f646a3.gif?auto=format",
+      "id": "1144771",
+      "name": "StoreClaw",
+      "tagline": "Grow your store profits with agents that know how to sell",
+      "description": "StoreClaw is the first AI commerce platform with agents that know how to sell, so you can make more money with less effort and less stress. Connect StoreClaw to your existing store and it will study your numbers, current sales figures, and growth trajectory, and then offer proactive suggestions that it can execute on your behalf — once you give it your approval. Ask StoreClaw how your business is doing any time, anywhere. Sell more with less stress: StoreClaw.",
+      "url": "https://www.producthunt.com/products/storeclaw?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/PVXOOJINEBKKUA",
+      "votesCount": 496,
+      "commentsCount": 206,
+      "createdAt": "2026-05-20T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/407049a2-0be3-4b8d-a7c0-4fc5b9754db2.png?auto=format",
       "topics": [
-        "design-tools",
-        "email-marketing",
-        "artificial-intelligence"
+        "artificial-intelligence",
+        "e-commerce",
+        "marketing-automation"
       ],
       "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -866,6 +866,48 @@
       "aiAdjacent": false
     },
     {
+      "id": "1033481",
+      "name": "Bond",
+      "tagline": "Outbound campaigns powered by real buying signals",
+      "description": "Bond is your AI GTM Engineer. Tell it who you want to reach. It builds the audience, plans the campaign, writes the messaging, and executes it end to end. Every data provider and outreach tool you need, in one workflow. Build your first campaign in 15 minutes.",
+      "url": "https://www.producthunt.com/products/outbond?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/H7KRMGFGCJKRRE",
+      "votesCount": 330,
+      "commentsCount": 23,
+      "createdAt": "2026-05-26T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/75957930-4ba3-4608-a965-b22ec56b3c59.png?auto=format",
+      "topics": [
+        "productivity",
+        "sales",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1147569",
       "name": "LobeHub",
       "tagline": "Your Chief Agent Operator for multi-agent work",
@@ -1031,48 +1073,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1033481",
-      "name": "Bond",
-      "tagline": "Outbound campaigns powered by real buying signals",
-      "description": "Bond is your AI GTM Engineer. Tell it who you want to reach. It builds the audience, plans the campaign, writes the messaging, and executes it end to end. Every data provider and outreach tool you need, in one workflow. Build your first campaign in 15 minutes.",
-      "url": "https://www.producthunt.com/products/outbond?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/H7KRMGFGCJKRRE",
-      "votesCount": 315,
-      "commentsCount": 23,
-      "createdAt": "2026-05-26T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/75957930-4ba3-4608-a965-b22ec56b3c59.png?auto=format",
-      "topics": [
-        "productivity",
-        "sales",
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -2372,55 +2372,13 @@
       "aiAdjacent": true
     },
     {
-      "id": "1142238",
-      "name": "InvestorFinder",
-      "tagline": "Find investors who've backed founders just like you",
-      "description": "Finally, real data on how every VC partner actually invests - founder backgrounds, universities and prior companies. Paste your profile and find your best matches in seconds.",
-      "url": "https://www.producthunt.com/products/investorfinder?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RYYTMN5NZ76UMA",
-      "votesCount": 218,
-      "commentsCount": 16,
-      "createdAt": "2026-05-10T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/43973f52-c69a-4d2c-b5fa-23e738090a32.jpeg?auto=format",
-      "topics": [
-        "investing",
-        "venture-capital",
-        "tech"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
-    },
-    {
       "id": "1151167",
       "name": "Rezonant",
       "tagline": "Talk, spec, ship: get your product ideas into production",
       "description": "Rezonant helps product teams turn messy ideas into code-ready specs, tickets, and engineering tasks. Collaborate with PMs, engineers, designers, and AI agents in one shared workspace. Ground decisions in your actual codebase, keep everyone aligned on the same version, and create work that humans and coding agents can confidently ship.",
       "url": "https://www.producthunt.com/products/portia-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
       "website": "https://www.producthunt.com/r/P2UMFH5P4HQXTO",
-      "votesCount": 214,
+      "votesCount": 223,
       "commentsCount": 55,
       "createdAt": "2026-05-26T07:01:00Z",
       "thumbnail": "https://ph-files.imgix.net/6de8c4b0-881b-4933-a3aa-3dfaf8beca07.png?auto=format",
@@ -2478,6 +2436,48 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
+    },
+    {
+      "id": "1142238",
+      "name": "InvestorFinder",
+      "tagline": "Find investors who've backed founders just like you",
+      "description": "Finally, real data on how every VC partner actually invests - founder backgrounds, universities and prior companies. Paste your profile and find your best matches in seconds.",
+      "url": "https://www.producthunt.com/products/investorfinder?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RYYTMN5NZ76UMA",
+      "votesCount": 218,
+      "commentsCount": 16,
+      "createdAt": "2026-05-10T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/43973f52-c69a-4d2c-b5fa-23e738090a32.jpeg?auto=format",
+      "topics": [
+        "investing",
+        "venture-capital",
+        "tech"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26482755095

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.