### PR TITLE
chore(data): refresh huggingface signals 2026-05-27T04:51:14Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-26T20:27:54.412Z",
+  "ts": "2026-05-27T04:51:14.504Z",
   "count": 1,
-  "durationMs": 4665,
+  "durationMs": 6821,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T20:27:49.747Z",
+  "fetchedAt": "2026-05-27T04:51:07.685Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -351,6 +351,34 @@
     },
     {
       "rank": 12,
+      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+      "downloads": 0,
+      "likes": 309,
+      "trendingScore": 299,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "onnx",
+        "safetensors",
+        "audio-text-to-video",
+        "audio-image-text-to-video",
+        "audio-driven-video-continuation",
+        "transformers",
+        "avatar",
+        "video-generation",
+        "en",
+        "zh",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:05:55.000Z",
+      "lastModified": "2026-05-26T03:21:29.000Z"
+    },
+    {
+      "rank": 13,
       "id": "sapientinc/HRM-Text-1B",
       "author": "sapientinc",
       "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
@@ -380,69 +408,13 @@
       "lastModified": "2026-05-21T05:57:38.000Z"
     },
     {
-      "rank": 13,
-      "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
-      "author": "meituan-longcat",
-      "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
-      "downloads": 0,
-      "likes": 291,
-      "trendingScore": 281,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "onnx",
-        "safetensors",
-        "audio-text-to-video",
-        "audio-image-text-to-video",
-        "audio-driven-video-continuation",
-        "transformers",
-        "avatar",
-        "video-generation",
-        "en",
-        "zh",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T09:05:55.000Z",
-      "lastModified": "2026-05-26T03:21:29.000Z"
-    },
-    {
       "rank": 14,
-      "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 268305,
-      "likes": 292,
-      "trendingScore": 271,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-11T12:57:11.000Z",
-      "lastModified": "2026-05-18T05:58:01.000Z"
-    },
-    {
-      "rank": 15,
       "id": "openbmb/MiniCPM5-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
       "downloads": 2409,
-      "likes": 295,
-      "trendingScore": 260,
+      "likes": 322,
+      "trendingScore": 286,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -476,6 +448,34 @@
       "lastModified": "2026-05-26T04:24:04.000Z"
     },
     {
+      "rank": 15,
+      "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
+      "downloads": 268305,
+      "likes": 292,
+      "trendingScore": 271,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-11T12:57:11.000Z",
+      "lastModified": "2026-05-18T05:58:01.000Z"
+    },
+    {
       "rank": 16,
       "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "unsloth",
@@ -505,78 +505,12 @@
     },
     {
       "rank": 17,
-      "id": "circlestone-labs/Anima",
-      "author": "circlestone-labs",
-      "url": "https://huggingface.co/circlestone-labs/Anima",
-      "downloads": 591834,
-      "likes": 1459,
-      "trendingScore": 211,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
-      "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-01-29T21:17:57.000Z",
-      "lastModified": "2026-05-14T17:13:39.000Z"
-    },
-    {
-      "rank": 18,
-      "id": "openai/privacy-filter",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/privacy-filter",
-      "downloads": 165240,
-      "likes": 1337,
-      "trendingScore": 206,
-      "pipelineTag": "token-classification",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "onnx",
-        "safetensors",
-        "openai_privacy_filter",
-        "token-classification",
-        "transformers.js",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T21:38:35.000Z",
-      "lastModified": "2026-04-22T16:50:17.000Z"
-    },
-    {
-      "rank": 19,
-      "id": "google/gemma-4-31B-it-assistant",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-31B-it-assistant",
-      "downloads": 66561,
-      "likes": 212,
-      "trendingScore": 205,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4_assistant",
-        "text-generation",
-        "any-to-any",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T18:55:29.000Z",
-      "lastModified": "2026-05-11T07:51:37.000Z"
-    },
-    {
-      "rank": 20,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "downloads": 1598473,
-      "likes": 903,
-      "trendingScore": 203,
+      "likes": 921,
+      "trendingScore": 216,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -602,13 +536,79 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
+      "rank": 18,
+      "id": "circlestone-labs/Anima",
+      "author": "circlestone-labs",
+      "url": "https://huggingface.co/circlestone-labs/Anima",
+      "downloads": 591834,
+      "likes": 1459,
+      "trendingScore": 211,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
+      "tags": [
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-01-29T21:17:57.000Z",
+      "lastModified": "2026-05-14T17:13:39.000Z"
+    },
+    {
+      "rank": 19,
+      "id": "openai/privacy-filter",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/privacy-filter",
+      "downloads": 165240,
+      "likes": 1337,
+      "trendingScore": 206,
+      "pipelineTag": "token-classification",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "onnx",
+        "safetensors",
+        "openai_privacy_filter",
+        "token-classification",
+        "transformers.js",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-17T21:38:35.000Z",
+      "lastModified": "2026-04-22T16:50:17.000Z"
+    },
+    {
+      "rank": 20,
+      "id": "google/gemma-4-31B-it-assistant",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-31B-it-assistant",
+      "downloads": 66561,
+      "likes": 212,
+      "trendingScore": 205,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4_assistant",
+        "text-generation",
+        "any-to-any",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T18:55:29.000Z",
+      "lastModified": "2026-05-11T07:51:37.000Z"
+    },
+    {
       "rank": 21,
       "id": "CohereLabs/command-a-plus-05-2026-w4a4",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
       "downloads": 7769,
-      "likes": 206,
-      "trendingScore": 202,
+      "likes": 207,
+      "trendingScore": 203,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -910,31 +910,12 @@
     },
     {
       "rank": 30,
-      "id": "TencentARC/Pixal3D",
-      "author": "TencentARC",
-      "url": "https://huggingface.co/TencentARC/Pixal3D",
-      "downloads": 0,
-      "likes": 146,
-      "trendingScore": 137,
-      "pipelineTag": "image-to-3d",
-      "libraryName": null,
-      "tags": [
-        "image-to-3d",
-        "arxiv:2605.10922",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T10:18:49.000Z",
-      "lastModified": "2026-05-12T23:37:47.000Z"
-    },
-    {
-      "rank": 31,
       "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
       "downloads": 16379,
-      "likes": 142,
-      "trendingScore": 135,
+      "likes": 147,
+      "trendingScore": 140,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -970,6 +951,25 @@
       ],
       "createdAt": "2026-05-16T10:48:10.000Z",
       "lastModified": "2026-05-24T08:15:12.000Z"
+    },
+    {
+      "rank": 31,
+      "id": "TencentARC/Pixal3D",
+      "author": "TencentARC",
+      "url": "https://huggingface.co/TencentARC/Pixal3D",
+      "downloads": 0,
+      "likes": 146,
+      "trendingScore": 137,
+      "pipelineTag": "image-to-3d",
+      "libraryName": null,
+      "tags": [
+        "image-to-3d",
+        "arxiv:2605.10922",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T10:18:49.000Z",
+      "lastModified": "2026-05-12T23:37:47.000Z"
     },
     {
       "rank": 32,
@@ -1113,6 +1113,78 @@
     },
     {
       "rank": 36,
+      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
+      "downloads": 31597,
+      "likes": 122,
+      "trendingScore": 119,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "coder",
+        "devops",
+        "math",
+        "science",
+        "image",
+        "text-generation",
+        "en",
+        "zh",
+        "ko",
+        "ru",
+        "ja",
+        "es",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T06:37:47.000Z",
+      "lastModified": "2026-05-23T00:38:45.000Z"
+    },
+    {
+      "rank": 37,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 117,
+      "likes": 120,
+      "trendingScore": 119,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 38,
       "id": "google/gemma-4-26B-A4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-assistant",
@@ -1135,7 +1207,7 @@
       "lastModified": "2026-05-11T07:50:08.000Z"
     },
     {
-      "rank": 37,
+      "rank": 39,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -1177,52 +1249,7 @@
       "lastModified": "2026-05-07T02:39:32.000Z"
     },
     {
-      "rank": 38,
-      "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "downloads": 31597,
-      "likes": 115,
-      "trendingScore": 113,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "coder",
-        "devops",
-        "math",
-        "science",
-        "image",
-        "text-generation",
-        "en",
-        "zh",
-        "ko",
-        "ru",
-        "ja",
-        "es",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T06:37:47.000Z",
-      "lastModified": "2026-05-23T00:38:45.000Z"
-    },
-    {
-      "rank": 39,
+      "rank": 40,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -1255,7 +1282,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "nvidia/Nemotron-Labs-Diffusion-14B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
@@ -1278,7 +1305,29 @@
       "lastModified": "2026-05-23T01:01:26.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 908,
+      "likes": 109,
+      "trendingScore": 107,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
+    },
+    {
+      "rank": 43,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -1304,34 +1353,35 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 42,
-      "id": "nvidia/PiD",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/PiD",
-      "downloads": 117,
-      "likes": 107,
-      "trendingScore": 106,
-      "pipelineTag": "image-to-image",
-      "libraryName": "pytorch",
+      "rank": 44,
+      "id": "stabilityai/stable-audio-3-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
+      "downloads": 0,
+      "likes": 111,
+      "trendingScore": 104,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
       "tags": [
-        "pytorch",
-        "diffusers",
+        "stable-audio-3",
         "safetensors",
-        "super-resolution",
+        "audio-generation",
+        "music",
+        "sound-effects",
         "diffusion",
-        "pixel-diffusion-decoder",
-        "vae-decoder",
-        "image-to-image",
-        "arxiv:2605.23902",
-        "base_model:Tongyi-MAI/Z-Image",
-        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-medium-base",
+        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-04-28T00:41:46.000Z",
-      "lastModified": "2026-05-26T01:17:21.000Z"
+      "createdAt": "2026-05-17T01:50:14.000Z",
+      "lastModified": "2026-05-20T14:50:07.000Z"
     },
     {
-      "rank": 43,
+      "rank": 45,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -1359,13 +1409,13 @@
       "lastModified": "2026-05-07T08:00:27.000Z"
     },
     {
-      "rank": 44,
-      "id": "microsoft/Lens-Turbo",
+      "rank": 46,
+      "id": "microsoft/Lens",
       "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 908,
-      "likes": 102,
-      "trendingScore": 100,
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 673,
+      "likes": 106,
+      "trendingScore": 102,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
@@ -1377,39 +1427,11 @@
         "license:mit",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
-      "rank": 45,
-      "id": "stabilityai/stable-audio-3-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
-      "downloads": 0,
-      "likes": 107,
-      "trendingScore": 100,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "sound-effects",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-medium-base",
-        "base_model:finetune:stabilityai/stable-audio-3-medium-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:50:14.000Z",
-      "lastModified": "2026-05-20T14:50:07.000Z"
-    },
-    {
-      "rank": 46,
+      "rank": 47,
       "id": "jackxinning/Leanly_AI",
       "author": "jackxinning",
       "url": "https://huggingface.co/jackxinning/Leanly_AI",
@@ -1433,7 +1455,7 @@
       "lastModified": "2026-05-04T07:50:46.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
@@ -1457,7 +1479,7 @@
       "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "Efficient-Large-Model/SANA-WM_bidirectional",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
@@ -1482,13 +1504,13 @@
       "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "downloads": 10015,
-      "likes": 100,
-      "trendingScore": 96,
+      "likes": 102,
+      "trendingScore": 98,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1515,28 +1537,6 @@
       ],
       "createdAt": "2026-05-19T23:14:00.000Z",
       "lastModified": "2026-05-23T20:28:00.000Z"
-    },
-    {
-      "rank": 50,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 673,
-      "likes": 100,
-      "trendingScore": 96,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
       "rank": 51,
@@ -2337,6 +2337,29 @@
     },
     {
       "rank": 78,
+      "id": "tencent/Hy-MT2-1.8B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
+      "downloads": 12083,
+      "likes": 67,
+      "trendingScore": 66,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:18.000Z",
+      "lastModified": "2026-05-26T09:06:16.000Z"
+    },
+    {
+      "rank": 79,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -2381,7 +2404,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 79,
+      "rank": 80,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -2408,7 +2431,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 80,
+      "rank": 81,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -2441,29 +2464,6 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 81,
-      "id": "tencent/Hy-MT2-1.8B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
-      "downloads": 12083,
-      "likes": 63,
-      "trendingScore": 62,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:18.000Z",
-      "lastModified": "2026-05-26T09:06:16.000Z"
-    },
-    {
       "rank": 82,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
@@ -2494,6 +2494,38 @@
     },
     {
       "rank": 83,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 9929386,
+      "likes": 1999,
+      "trendingScore": 61,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
+    },
+    {
+      "rank": 84,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -2518,7 +2550,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 84,
+      "rank": 85,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2562,7 +2594,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -2590,7 +2622,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -2617,7 +2649,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -2644,7 +2676,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 88,
+      "rank": 89,
       "id": "openbmb/BitCPM-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
@@ -2669,7 +2701,33 @@
       "lastModified": "2026-05-24T10:43:34.000Z"
     },
     {
-      "rank": 89,
+      "rank": 90,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 63,
+      "trendingScore": 58,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-27T03:03:58.000Z"
+    },
+    {
+      "rank": 91,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2692,7 +2750,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 90,
+      "rank": 92,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2723,34 +2781,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 91,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 62,
-      "trendingScore": 57,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
-        "en",
-        "zh",
-        "dataset:zhifeixie/Voices-in-the-Wild-2M",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-24T17:48:46.000Z"
-    },
-    {
-      "rank": 92,
+      "rank": 93,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -2778,38 +2809,6 @@
       ],
       "createdAt": "2026-04-27T13:37:38.000Z",
       "lastModified": "2026-05-07T04:23:16.000Z"
-    },
-    {
-      "rank": 93,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 9929386,
-      "likes": 1989,
-      "trendingScore": 56,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
       "rank": 94,
@@ -3020,6 +3019,38 @@
     },
     {
       "rank": 101,
+      "id": "jedisct1/MiMo-V2.5-coder-Q2",
+      "author": "jedisct1",
+      "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
+      "downloads": 1050,
+      "likes": 52,
+      "trendingScore": 51,
+      "pipelineTag": "text-generation",
+      "libraryName": "llama.cpp",
+      "tags": [
+        "llama.cpp",
+        "gguf",
+        "text-generation",
+        "code",
+        "coding",
+        "tool-calling",
+        "agent",
+        "mixture-of-experts",
+        "long-context",
+        "en",
+        "base_model:XiaomiMiMo/MiMo-V2.5",
+        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T21:13:40.000Z",
+      "lastModified": "2026-05-25T23:53:02.000Z"
+    },
+    {
+      "rank": 102,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -3047,12 +3078,12 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
       "downloads": 710720,
-      "likes": 12913,
+      "likes": 12918,
       "trendingScore": 50,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -3072,7 +3103,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -3106,7 +3137,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 104,
+      "rank": 105,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -3126,7 +3157,34 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 105,
+      "rank": 106,
+      "id": "stabilityai/stable-audio-3-small-music",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
+      "downloads": 0,
+      "likes": 49,
+      "trendingScore": 48,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "audio-generation",
+        "music",
+        "diffusion",
+        "text-to-audio",
+        "en",
+        "arxiv:2605.17991",
+        "base_model:stabilityai/stable-audio-3-small-music-base",
+        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T01:51:33.000Z",
+      "lastModified": "2026-05-19T20:02:42.000Z"
+    },
+    {
+      "rank": 107,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -3157,7 +3215,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 106,
+      "rank": 108,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -3182,7 +3240,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 107,
+      "rank": 109,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -3219,7 +3277,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 108,
+      "rank": 110,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -3256,7 +3314,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 109,
+      "rank": 111,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3273,65 +3331,6 @@
       ],
       "createdAt": "2026-03-05T15:20:18.000Z",
       "lastModified": "2026-05-20T20:31:07.000Z"
-    },
-    {
-      "rank": 110,
-      "id": "stabilityai/stable-audio-3-small-music",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
-      "downloads": 0,
-      "likes": 48,
-      "trendingScore": 47,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "audio-generation",
-        "music",
-        "diffusion",
-        "text-to-audio",
-        "en",
-        "arxiv:2605.17991",
-        "base_model:stabilityai/stable-audio-3-small-music-base",
-        "base_model:finetune:stabilityai/stable-audio-3-small-music-base",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T01:51:33.000Z",
-      "lastModified": "2026-05-19T20:02:42.000Z"
-    },
-    {
-      "rank": 111,
-      "id": "jedisct1/MiMo-V2.5-coder-Q2",
-      "author": "jedisct1",
-      "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
-      "downloads": 1050,
-      "likes": 48,
-      "trendingScore": 47,
-      "pipelineTag": "text-generation",
-      "libraryName": "llama.cpp",
-      "tags": [
-        "llama.cpp",
-        "gguf",
-        "text-generation",
-        "code",
-        "coding",
-        "tool-calling",
-        "agent",
-        "mixture-of-experts",
-        "long-context",
-        "en",
-        "base_model:XiaomiMiMo/MiMo-V2.5",
-        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T21:13:40.000Z",
-      "lastModified": "2026-05-25T23:53:02.000Z"
     },
     {
       "rank": 112,
@@ -3568,106 +3567,12 @@
     },
     {
       "rank": 121,
-      "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 753063,
-      "likes": 1404,
-      "trendingScore": 40,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.5",
-        "qwen",
-        "en",
-        "zh",
-        "multilingual",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-04T00:24:31.000Z",
-      "lastModified": "2026-04-05T19:01:05.000Z"
-    },
-    {
-      "rank": 122,
-      "id": "Zyphra/ZAYA1-74B-preview",
-      "author": "Zyphra",
-      "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
-      "downloads": 1180,
-      "likes": 39,
-      "trendingScore": 39,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "zaya",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-05T23:12:08.000Z",
-      "lastModified": "2026-05-08T23:21:12.000Z"
-    },
-    {
-      "rank": 123,
-      "id": "Tongyi-MAI/Z-Image-Turbo",
-      "author": "Tongyi-MAI",
-      "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
-      "downloads": 1219242,
-      "likes": 4672,
-      "trendingScore": 39,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2511.22699",
-        "arxiv:2511.22677",
-        "arxiv:2511.13649",
-        "license:apache-2.0",
-        "diffusers:ZImagePipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-25T15:09:48.000Z",
-      "lastModified": "2026-01-30T16:58:07.000Z"
-    },
-    {
-      "rank": 124,
-      "id": "HuggingFaceBio/Carbon-3B",
-      "author": "HuggingFaceBio",
-      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
-      "downloads": 4170,
-      "likes": 42,
-      "trendingScore": 39,
-      "pipelineTag": null,
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "dna",
-        "genomic",
-        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T11:05:49.000Z",
-      "lastModified": "2026-05-20T13:39:48.000Z"
-    },
-    {
-      "rank": 125,
       "id": "openbmb/MiniCPM5-1B-GGUF",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
       "downloads": 1655,
-      "likes": 82,
-      "trendingScore": 38.5,
+      "likes": 90,
+      "trendingScore": 42.5,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -3700,7 +3605,152 @@
       "lastModified": "2026-05-25T10:55:40.000Z"
     },
     {
+      "rank": 122,
+      "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 753063,
+      "likes": 1404,
+      "trendingScore": 40,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.5",
+        "qwen",
+        "en",
+        "zh",
+        "multilingual",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-04T00:24:31.000Z",
+      "lastModified": "2026-04-05T19:01:05.000Z"
+    },
+    {
+      "rank": 123,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2515187,
+      "likes": 2064,
+      "trendingScore": 40,
+      "pipelineTag": "mask-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
+    },
+    {
+      "rank": 124,
+      "id": "Zyphra/ZAYA1-74B-preview",
+      "author": "Zyphra",
+      "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
+      "downloads": 1180,
+      "likes": 39,
+      "trendingScore": 39,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "zaya",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-05T23:12:08.000Z",
+      "lastModified": "2026-05-08T23:21:12.000Z"
+    },
+    {
+      "rank": 125,
+      "id": "Tongyi-MAI/Z-Image-Turbo",
+      "author": "Tongyi-MAI",
+      "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
+      "downloads": 1219242,
+      "likes": 4672,
+      "trendingScore": 39,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2511.22699",
+        "arxiv:2511.22677",
+        "arxiv:2511.13649",
+        "license:apache-2.0",
+        "diffusers:ZImagePipeline",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-25T15:09:48.000Z",
+      "lastModified": "2026-01-30T16:58:07.000Z"
+    },
+    {
       "rank": 126,
+      "id": "HuggingFaceBio/Carbon-3B",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
+      "downloads": 4170,
+      "likes": 42,
+      "trendingScore": 39,
+      "pipelineTag": null,
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "dna",
+        "genomic",
+        "dataset:HuggingFaceBio/carbon-pretraining-corpus",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T11:05:49.000Z",
+      "lastModified": "2026-05-20T13:39:48.000Z"
+    },
+    {
+      "rank": 127,
+      "id": "openbmb/BitCPM-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
+      "downloads": 1282,
+      "likes": 44,
+      "trendingScore": 39,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-23T18:12:57.000Z"
+    },
+    {
+      "rank": 128,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3732,7 +3782,7 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 127,
+      "rank": 129,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3759,7 +3809,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 128,
+      "rank": 130,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3786,7 +3836,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 129,
+      "rank": 131,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -3818,34 +3868,7 @@
       "lastModified": "2026-05-21T21:34:50.000Z"
     },
     {
-      "rank": 130,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2515187,
-      "likes": 2061,
-      "trendingScore": 37,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 131,
+      "rank": 132,
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
@@ -3878,7 +3901,7 @@
       "lastModified": "2026-03-08T12:54:54.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -3902,7 +3925,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
@@ -3925,30 +3948,6 @@
       ],
       "createdAt": "2026-05-17T23:30:49.000Z",
       "lastModified": "2026-05-20T13:40:10.000Z"
-    },
-    {
-      "rank": 134,
-      "id": "openbmb/BitCPM-CANN-8B-gguf",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
-      "downloads": 1282,
-      "likes": 40,
-      "trendingScore": 36,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T06:18:55.000Z",
-      "lastModified": "2026-05-23T18:12:57.000Z"
     },
     {
       "rank": 135,
@@ -4157,6 +4156,24 @@
     },
     {
       "rank": 142,
+      "id": "Comfy-Org/Lens",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/Lens",
+      "downloads": 0,
+      "likes": 35,
+      "trendingScore": 35,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T14:51:51.000Z",
+      "lastModified": "2026-05-24T13:34:38.000Z"
+    },
+    {
+      "rank": 143,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -4180,7 +4197,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 143,
+      "rank": 144,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -4197,7 +4214,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 144,
+      "rank": 145,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -4221,7 +4238,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 145,
+      "rank": 146,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -4237,7 +4254,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 146,
+      "rank": 147,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -4264,7 +4281,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 147,
+      "rank": 148,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -4283,7 +4300,7 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 148,
+      "rank": 149,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -4328,7 +4345,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 149,
+      "rank": 150,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -4373,7 +4390,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 150,
+      "rank": 151,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -4417,7 +4434,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 151,
+      "rank": 152,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -4441,24 +4458,6 @@
       ],
       "createdAt": "2025-12-12T00:56:44.000Z",
       "lastModified": "2026-04-14T06:03:51.000Z"
-    },
-    {
-      "rank": 152,
-      "id": "Comfy-Org/Lens",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/Lens",
-      "downloads": 0,
-      "likes": 33,
-      "trendingScore": 33,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T14:51:51.000Z",
-      "lastModified": "2026-05-24T13:34:38.000Z"
     },
     {
       "rank": 153,
@@ -4853,6 +4852,38 @@
     },
     {
       "rank": 164,
+      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "author": "fal",
+      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "downloads": 50617,
+      "likes": 1350,
+      "trendingScore": 31,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "qwen",
+        "qwen-image-edit",
+        "qwen-image-edit-2511",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "camera-control",
+        "image-editing",
+        "image-to-image",
+        "gaussian-splatting",
+        "fal",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T17:01:15.000Z",
+      "lastModified": "2026-01-07T17:06:01.000Z"
+    },
+    {
+      "rank": 165,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4878,7 +4909,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 165,
+      "rank": 166,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4910,7 +4941,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 166,
+      "rank": 167,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4937,7 +4968,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 167,
+      "rank": 168,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -4971,7 +5002,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 168,
+      "rank": 169,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -4991,38 +5022,6 @@
       ],
       "createdAt": "2026-05-13T09:22:55.000Z",
       "lastModified": "2026-05-13T19:23:38.000Z"
-    },
-    {
-      "rank": 169,
-      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "author": "fal",
-      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 50617,
-      "likes": 1348,
-      "trendingScore": 30,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "qwen",
-        "qwen-image-edit",
-        "qwen-image-edit-2511",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "camera-control",
-        "image-editing",
-        "image-to-image",
-        "gaussian-splatting",
-        "fal",
-        "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-07T17:01:15.000Z",
-      "lastModified": "2026-01-07T17:06:01.000Z"
     },
     {
       "rank": 170,
@@ -5212,6 +5211,72 @@
     },
     {
       "rank": 176,
+      "id": "facebook/sam3.1",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3.1",
+      "downloads": 329120,
+      "likes": 301,
+      "trendingScore": 29,
+      "pipelineTag": "mask-generation",
+      "libraryName": "checkpoint",
+      "tags": [
+        "checkpoint",
+        "sam3.1",
+        "mask-generation",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T01:25:54.000Z",
+      "lastModified": "2026-03-27T17:40:55.000Z"
+    },
+    {
+      "rank": 177,
+      "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
+      "downloads": 0,
+      "likes": 29,
+      "trendingScore": 29,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "moss_tts_delay",
+        "text-to-speech",
+        "custom_code",
+        "zh",
+        "yue",
+        "en",
+        "ar",
+        "cs",
+        "da",
+        "de",
+        "nl",
+        "es",
+        "fr",
+        "fi",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "ja",
+        "it",
+        "ko",
+        "mk",
+        "ms",
+        "ru",
+        "fa",
+        "pl",
+        "pt",
+        "sv",
+        "ro"
+      ],
+      "createdAt": "2026-05-25T12:40:42.000Z",
+      "lastModified": "2026-05-26T08:49:43.000Z"
+    },
+    {
+      "rank": 178,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -5233,7 +5298,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 177,
+      "rank": 179,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -5270,7 +5335,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 178,
+      "rank": 180,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -5292,7 +5357,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 179,
+      "rank": 181,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -5325,7 +5390,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 180,
+      "rank": 182,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5357,7 +5422,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 181,
+      "rank": 183,
       "id": "tencent/Hy-MT2-7B-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
@@ -5380,7 +5445,60 @@
       "lastModified": "2026-05-26T09:06:21.000Z"
     },
     {
-      "rank": 182,
+      "rank": 184,
+      "id": "oron1208/OOO_Anima",
+      "author": "oron1208",
+      "url": "https://huggingface.co/oron1208/OOO_Anima",
+      "downloads": 0,
+      "likes": 28,
+      "trendingScore": 28,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "text-to-image",
+        "image-generation",
+        "anime",
+        "illustration",
+        "anima",
+        "safetensors",
+        "ja",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T09:41:37.000Z",
+      "lastModified": "2026-05-21T15:24:20.000Z"
+    },
+    {
+      "rank": 185,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 47,
+      "likes": 28,
+      "trendingScore": 28,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-26T07:40:38.000Z"
+    },
+    {
+      "rank": 186,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -5420,7 +5538,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 183,
+      "rank": 187,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -5457,7 +5575,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 184,
+      "rank": 188,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -5500,7 +5618,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 185,
+      "rank": 189,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -5520,7 +5638,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 186,
+      "rank": 190,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -5545,7 +5663,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 187,
+      "rank": 191,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5570,7 +5688,7 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 188,
+      "rank": 192,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -5593,34 +5711,7 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 189,
-      "id": "oron1208/OOO_Anima",
-      "author": "oron1208",
-      "url": "https://huggingface.co/oron1208/OOO_Anima",
-      "downloads": 0,
-      "likes": 27,
-      "trendingScore": 27,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "text-to-image",
-        "image-generation",
-        "anime",
-        "illustration",
-        "anima",
-        "safetensors",
-        "ja",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T09:41:37.000Z",
-      "lastModified": "2026-05-21T15:24:20.000Z"
-    },
-    {
-      "rank": 190,
+      "rank": 193,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5646,7 +5737,38 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 191,
+      "rank": 194,
+      "id": "pyannote/segmentation-3.0",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/segmentation-3.0",
+      "downloads": 9192817,
+      "likes": 1039,
+      "trendingScore": 27,
+      "pipelineTag": "voice-activity-detection",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pytorch",
+        "pyannote",
+        "pyannote-audio-model",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "speaker-segmentation",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "resegmentation",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2023-09-22T12:03:10.000Z",
+      "lastModified": "2024-05-10T19:35:46.000Z"
+    },
+    {
+      "rank": 195,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -5691,7 +5813,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 192,
+      "rank": 196,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -5718,7 +5840,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 193,
+      "rank": 197,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -5763,7 +5885,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 194,
+      "rank": 198,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -5789,7 +5911,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 195,
+      "rank": 199,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -5811,7 +5933,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 196,
+      "rank": 200,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -5827,7 +5949,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 197,
+      "rank": 201,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -5863,7 +5985,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 198,
+      "rank": 202,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -5881,7 +6003,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 199,
+      "rank": 203,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -5913,7 +6035,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 200,
+      "rank": 204,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
@@ -5936,28 +6058,40 @@
       "lastModified": "2026-05-26T09:06:32.000Z"
     },
     {
-      "rank": 201,
-      "id": "facebook/sam3.1",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 329120,
-      "likes": 298,
+      "rank": 205,
+      "id": "pyannote/speaker-diarization-community-1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
+      "downloads": 2844915,
+      "likes": 419,
       "trendingScore": 26,
-      "pipelineTag": "mask-generation",
-      "libraryName": "checkpoint",
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
       "tags": [
-        "checkpoint",
-        "sam3.1",
-        "mask-generation",
-        "en",
-        "license:other",
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2104.03603",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "arxiv:2110.07058",
+        "license:cc-by-4.0",
         "region:us"
       ],
-      "createdAt": "2026-03-26T01:25:54.000Z",
-      "lastModified": "2026-03-27T17:40:55.000Z"
+      "createdAt": "2025-04-15T21:31:35.000Z",
+      "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 202,
+      "rank": 206,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -5995,7 +6129,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 203,
+      "rank": 207,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -6013,7 +6147,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 204,
+      "rank": 208,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -6039,7 +6173,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 205,
+      "rank": 209,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -6059,7 +6193,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 206,
+      "rank": 210,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -6086,7 +6220,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 207,
+      "rank": 211,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -6112,7 +6246,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 208,
+      "rank": 212,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -6138,7 +6272,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 209,
+      "rank": 213,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -6175,7 +6309,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 210,
+      "rank": 214,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -6191,7 +6325,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 211,
+      "rank": 215,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -6214,7 +6348,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 212,
+      "rank": 216,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -6256,7 +6390,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 213,
+      "rank": 217,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -6295,7 +6429,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 214,
+      "rank": 218,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6340,38 +6474,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 215,
-      "id": "pyannote/segmentation-3.0",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/segmentation-3.0",
-      "downloads": 9192817,
-      "likes": 1036,
-      "trendingScore": 25,
-      "pipelineTag": "voice-activity-detection",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pytorch",
-        "pyannote",
-        "pyannote-audio-model",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "speaker-segmentation",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "resegmentation",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2023-09-22T12:03:10.000Z",
-      "lastModified": "2024-05-10T19:35:46.000Z"
-    },
-    {
-      "rank": 216,
+      "rank": 219,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -6397,7 +6500,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 217,
+      "rank": 220,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -6429,7 +6532,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 218,
+      "rank": 221,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -6453,7 +6556,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 219,
+      "rank": 222,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -6480,7 +6583,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 220,
+      "rank": 223,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -6505,7 +6608,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 221,
+      "rank": 224,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -6541,7 +6644,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 222,
+      "rank": 225,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -6557,7 +6660,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 223,
+      "rank": 226,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -6578,7 +6681,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 224,
+      "rank": 227,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -6601,7 +6704,7 @@
       "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 225,
+      "rank": 228,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -6628,33 +6731,38 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 226,
-      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "author": "Kwai-Keye",
-      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "downloads": 47,
+      "rank": 229,
+      "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "downloads": 0,
       "likes": 24,
       "trendingScore": 24,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
+        "diffusers",
         "safetensors",
-        "KeyeVL2",
-        "feature-extraction",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
+        "ternary",
+        "1.58-bit",
+        "gemlite",
+        "hqq",
+        "cuda",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-25T15:32:15.000Z",
-      "lastModified": "2026-05-26T07:40:38.000Z"
+      "createdAt": "2026-05-21T16:12:41.000Z",
+      "lastModified": "2026-05-26T16:16:59.000Z"
     },
     {
-      "rank": 227,
+      "rank": 230,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -6681,7 +6789,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 228,
+      "rank": 231,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -6710,7 +6818,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 229,
+      "rank": 232,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -6727,7 +6835,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 230,
+      "rank": 233,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -6748,7 +6856,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 231,
+      "rank": 234,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -6769,7 +6877,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 232,
+      "rank": 235,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6790,7 +6898,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 233,
+      "rank": 236,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -6822,7 +6930,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 234,
+      "rank": 237,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6853,7 +6961,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 235,
+      "rank": 238,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6884,7 +6992,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 236,
+      "rank": 239,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -6913,7 +7021,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 237,
+      "rank": 240,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -6958,7 +7066,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 238,
+      "rank": 241,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -6985,7 +7093,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 239,
+      "rank": 242,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -7009,7 +7117,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 240,
+      "rank": 243,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -7047,7 +7155,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 241,
+      "rank": 244,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -7064,7 +7172,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 242,
+      "rank": 245,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -7092,7 +7200,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 243,
+      "rank": 246,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7115,7 +7223,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 244,
+      "rank": 247,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7132,40 +7240,79 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 245,
-      "id": "pyannote/speaker-diarization-community-1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2844915,
-      "likes": 414,
+      "rank": 248,
+      "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
+      "author": "LuffyTheFox",
+      "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
+      "downloads": 29218,
+      "likes": 23,
       "trendingScore": 22,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
       "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2104.03603",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "arxiv:2110.07058",
-        "license:cc-by-4.0",
-        "region:us"
+        "gguf",
+        "uncensored",
+        "qwen3.6",
+        "moe",
+        "vision",
+        "multimodal",
+        "genesis",
+        "image-text-to-text",
+        "conversational",
+        "en",
+        "zh",
+        "multilingual",
+        "base_model:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "base_model:quantized:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix"
       ],
-      "createdAt": "2025-04-15T21:31:35.000Z",
-      "lastModified": "2025-09-29T08:43:24.000Z"
+      "createdAt": "2026-05-21T12:23:23.000Z",
+      "lastModified": "2026-05-24T17:32:37.000Z"
     },
     {
-      "rank": 246,
+      "rank": 249,
+      "id": "nvidia/LocateAnything-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/LocateAnything-3B",
+      "downloads": 0,
+      "likes": 22,
+      "trendingScore": 22,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "locateanything",
+        "feature-extraction",
+        "nvidia",
+        "eagle",
+        "vision",
+        "object-detection",
+        "grounding",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "arxiv:2504.07491",
+        "arxiv:2109.10852",
+        "arxiv:2510.12798",
+        "arxiv:2303.05499",
+        "arxiv:1405.0312",
+        "arxiv:1908.03195",
+        "arxiv:2504.07981",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T20:05:49.000Z",
+      "lastModified": "2026-05-25T13:55:19.000Z"
+    },
+    {
+      "rank": 250,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -7210,7 +7357,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 247,
+      "rank": 251,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -7238,7 +7385,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 248,
+      "rank": 252,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -7274,7 +7421,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 249,
+      "rank": 253,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -7301,7 +7448,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 250,
+      "rank": 254,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -7326,7 +7473,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 251,
+      "rank": 255,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -7353,7 +7500,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 252,
+      "rank": 256,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -7379,40 +7526,112 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 253,
-      "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "author": "LuffyTheFox",
-      "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "downloads": 29218,
-      "likes": 22,
+      "rank": 257,
+      "id": "SupraLabs/Supra-50M-Instruct",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
+      "downloads": 1318,
+      "likes": 21,
+      "trendingScore": 21,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "dataset:yahma/alpaca-cleaned",
+        "base_model:SupraLabs/Supra-50M-Base",
+        "base_model:quantized:SupraLabs/Supra-50M-Base",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-21T12:06:17.000Z",
+      "lastModified": "2026-05-23T08:10:17.000Z"
+    },
+    {
+      "rank": 258,
+      "id": "MiniMaxAI/MiniMax-M2.7",
+      "author": "MiniMaxAI",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
+      "downloads": 996823,
+      "likes": 1154,
+      "trendingScore": 21,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "text-generation",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-09T03:37:12.000Z",
+      "lastModified": "2026-04-20T04:28:14.000Z"
+    },
+    {
+      "rank": 259,
+      "id": "Jackrong/Qwopus3.6-27B-v2",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
+      "downloads": 4313,
+      "likes": 21,
       "trendingScore": 21,
       "pipelineTag": "image-text-to-text",
-      "libraryName": null,
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.6",
-        "moe",
-        "vision",
-        "multimodal",
-        "genesis",
+        "transformers",
+        "safetensors",
+        "qwen3_5",
         "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
         "conversational",
         "en",
         "zh",
-        "multilingual",
-        "base_model:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-        "base_model:quantized:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us",
-        "imatrix"
+        "region:us"
       ],
-      "createdAt": "2026-05-21T12:23:23.000Z",
-      "lastModified": "2026-05-24T17:32:37.000Z"
+      "createdAt": "2026-05-14T08:20:50.000Z",
+      "lastModified": "2026-05-23T00:38:29.000Z"
     },
     {
-      "rank": 254,
+      "rank": 260,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -7440,7 +7659,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 255,
+      "rank": 261,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -7473,7 +7692,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 256,
+      "rank": 262,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -7498,7 +7717,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 257,
+      "rank": 263,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -7535,7 +7754,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 258,
+      "rank": 264,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -7578,7 +7797,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 259,
+      "rank": 265,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -7602,7 +7821,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 260,
+      "rank": 266,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -7626,7 +7845,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 261,
+      "rank": 267,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -7655,7 +7874,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 262,
+      "rank": 268,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -7673,7 +7892,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 263,
+      "rank": 269,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7718,7 +7937,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 264,
+      "rank": 270,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7763,7 +7982,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 265,
+      "rank": 271,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -7792,7 +8011,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 266,
+      "rank": 272,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -7816,7 +8035,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 267,
+      "rank": 273,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -7845,7 +8064,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 268,
+      "rank": 274,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -7869,12 +8088,12 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 269,
+      "rank": 275,
       "id": "netease-youdao/Confucius4",
       "author": "netease-youdao",
       "url": "https://huggingface.co/netease-youdao/Confucius4",
       "downloads": 493,
-      "likes": 20,
+      "likes": 21,
       "trendingScore": 20,
       "pipelineTag": null,
       "libraryName": null,
@@ -7887,68 +8106,25 @@
       "lastModified": "2026-05-20T08:42:10.000Z"
     },
     {
-      "rank": 270,
-      "id": "SupraLabs/Supra-50M-Instruct",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
-      "downloads": 1318,
-      "likes": 20,
+      "rank": 276,
+      "id": "Comfy-Org/stable-audio-3",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
+      "downloads": 0,
+      "likes": 21,
       "trendingScore": 20,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "llama",
-        "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "dataset:yahma/alpaca-cleaned",
-        "base_model:SupraLabs/Supra-50M-Base",
-        "base_model:quantized:SupraLabs/Supra-50M-Base",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-21T12:06:17.000Z",
-      "lastModified": "2026-05-23T08:10:17.000Z"
-    },
-    {
-      "rank": 271,
-      "id": "MiniMaxAI/MiniMax-M2.7",
-      "author": "MiniMaxAI",
-      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
-      "downloads": 996823,
-      "likes": 1152,
-      "trendingScore": 20,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "text-generation",
+        "comfyui",
         "license:other",
-        "eval-results",
-        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-04-09T03:37:12.000Z",
-      "lastModified": "2026-04-20T04:28:14.000Z"
+      "createdAt": "2026-05-12T23:23:44.000Z",
+      "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 272,
+      "rank": 277,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -7993,7 +8169,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 273,
+      "rank": 278,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -8026,7 +8202,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 274,
+      "rank": 279,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -8048,7 +8224,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 275,
+      "rank": 280,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -8075,7 +8251,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 276,
+      "rank": 281,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -8091,7 +8267,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 277,
+      "rank": 282,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -8114,7 +8290,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 278,
+      "rank": 283,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -8139,7 +8315,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 279,
+      "rank": 284,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -8175,7 +8351,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 280,
+      "rank": 285,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -8204,7 +8380,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 281,
+      "rank": 286,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -8234,7 +8410,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 282,
+      "rank": 287,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -8279,7 +8455,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 283,
+      "rank": 288,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -8306,7 +8482,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 284,
+      "rank": 289,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -8332,7 +8508,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 285,
+      "rank": 290,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -8360,7 +8536,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 286,
+      "rank": 291,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -8389,7 +8565,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 287,
+      "rank": 292,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -8413,114 +8589,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 288,
-      "id": "Comfy-Org/stable-audio-3",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
-      "downloads": 0,
-      "likes": 20,
-      "trendingScore": 19,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T23:23:44.000Z",
-      "lastModified": "2026-05-20T15:19:38.000Z"
-    },
-    {
-      "rank": 289,
-      "id": "Jackrong/Qwopus3.6-27B-v2",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
-      "downloads": 4313,
-      "likes": 19,
-      "trendingScore": 19,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "image",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T08:20:50.000Z",
-      "lastModified": "2026-05-23T00:38:29.000Z"
-    },
-    {
-      "rank": 290,
-      "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
-      "downloads": 0,
-      "likes": 19,
-      "trendingScore": 19,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "moss_tts_delay",
-        "text-to-speech",
-        "custom_code",
-        "zh",
-        "yue",
-        "en",
-        "ar",
-        "cs",
-        "da",
-        "de",
-        "nl",
-        "es",
-        "fr",
-        "fi",
-        "el",
-        "he",
-        "hi",
-        "hu",
-        "ja",
-        "it",
-        "ko",
-        "mk",
-        "ms",
-        "ru",
-        "fa",
-        "pl",
-        "pt",
-        "sv",
-        "ro"
-      ],
-      "createdAt": "2026-05-25T12:40:42.000Z",
-      "lastModified": "2026-05-26T08:49:43.000Z"
-    },
-    {
-      "rank": 291,
+      "rank": 293,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -8542,7 +8611,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 292,
+      "rank": 294,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -8576,7 +8645,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 293,
+      "rank": 295,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -8600,7 +8669,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 294,
+      "rank": 296,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -8622,7 +8691,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 295,
+      "rank": 297,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -8651,7 +8720,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 296,
+      "rank": 298,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8683,7 +8752,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 297,
+      "rank": 299,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8701,7 +8770,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 298,
+      "rank": 300,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8730,7 +8799,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 299,
+      "rank": 301,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8748,7 +8817,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 300,
+      "rank": 302,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -8774,7 +8843,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 301,
+      "rank": 303,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -8802,7 +8871,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 302,
+      "rank": 304,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -8834,7 +8903,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 303,
+      "rank": 305,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -8879,7 +8948,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -8908,7 +8977,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -8937,7 +9006,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 306,
+      "rank": 308,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -8969,7 +9038,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 307,
+      "rank": 309,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -8999,7 +9068,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 308,
+      "rank": 310,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -9020,7 +9089,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 309,
+      "rank": 311,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -9065,7 +9134,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 310,
+      "rank": 312,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -9094,7 +9163,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 311,
+      "rank": 313,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -9122,7 +9191,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 312,
+      "rank": 314,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -9147,7 +9216,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 313,
+      "rank": 315,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -9170,7 +9239,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 314,
+      "rank": 316,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -9197,7 +9266,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 315,
+      "rank": 317,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -9223,7 +9292,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 316,
+      "rank": 318,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -9252,7 +9321,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 317,
+      "rank": 319,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9271,7 +9340,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9299,7 +9368,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 319,
+      "rank": 321,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -9344,7 +9413,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 320,
+      "rank": 322,
       "id": "syvai/cohere-transcribe-diarize",
       "author": "syvai",
       "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
@@ -9389,7 +9458,7 @@
       "lastModified": "2026-05-22T20:56:30.000Z"
     },
     {
-      "rank": 321,
+      "rank": 323,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -9416,7 +9485,38 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 322,
+      "rank": 324,
+      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "downloads": 0,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "text-to-image",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:15:18.000Z",
+      "lastModified": "2026-05-26T16:16:59.000Z"
+    },
+    {
+      "rank": 325,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -9441,7 +9541,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 323,
+      "rank": 326,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -9476,7 +9576,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 324,
+      "rank": 327,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -9521,7 +9621,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 325,
+      "rank": 328,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -9548,7 +9648,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 326,
+      "rank": 329,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -9577,7 +9677,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 327,
+      "rank": 330,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -9600,7 +9700,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 328,
+      "rank": 331,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -9644,7 +9744,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -9689,7 +9789,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -9707,7 +9807,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -9752,7 +9852,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -9790,7 +9890,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -9810,7 +9910,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -9843,7 +9943,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -9873,7 +9973,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -9905,7 +10005,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 337,
+      "rank": 340,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -9930,7 +10030,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 338,
+      "rank": 341,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -9953,7 +10053,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 339,
+      "rank": 342,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -9983,7 +10083,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -10007,12 +10107,12 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
       "downloads": 728009,
-      "likes": 299,
+      "likes": 301,
       "trendingScore": 16,
       "pipelineTag": "image-feature-extraction",
       "libraryName": "transformers",
@@ -10035,7 +10135,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -10063,7 +10163,7 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 343,
+      "rank": 346,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -10108,7 +10208,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 344,
+      "rank": 347,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -10135,7 +10235,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 345,
+      "rank": 348,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -10180,7 +10280,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 346,
+      "rank": 349,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -10210,7 +10310,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 347,
+      "rank": 350,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -10240,7 +10340,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 348,
+      "rank": 351,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -10285,7 +10385,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 349,
+      "rank": 352,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -10320,7 +10420,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 350,
+      "rank": 353,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -10349,7 +10449,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 351,
+      "rank": 354,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -10374,7 +10474,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 352,
+      "rank": 355,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -10402,7 +10502,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 353,
+      "rank": 356,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -10430,7 +10530,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 354,
+      "rank": 357,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -10461,7 +10561,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 355,
+      "rank": 358,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -10506,7 +10606,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 356,
+      "rank": 359,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -10538,7 +10638,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 357,
+      "rank": 360,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -10565,7 +10665,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 358,
+      "rank": 361,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -10588,7 +10688,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 359,
+      "rank": 362,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -10615,7 +10715,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 360,
+      "rank": 363,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -10638,7 +10738,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 361,
+      "rank": 364,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -10664,7 +10764,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 362,
+      "rank": 365,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -10694,7 +10794,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 363,
+      "rank": 366,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -10721,7 +10821,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 364,
+      "rank": 367,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -10752,12 +10852,12 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 365,
+      "rank": 368,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
       "downloads": 1573212,
-      "likes": 353,
+      "likes": 355,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -10780,7 +10880,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 366,
+      "rank": 369,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10812,7 +10912,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 367,
+      "rank": 370,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10857,12 +10957,12 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 368,
+      "rank": 371,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
-      "downloads": 505,
-      "likes": 17,
+      "downloads": 641,
+      "likes": 19,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -10890,7 +10990,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 369,
+      "rank": 372,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -10930,7 +11030,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 370,
+      "rank": 373,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -10971,7 +11071,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 371,
+      "rank": 374,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -10994,12 +11094,12 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 372,
+      "rank": 375,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 8056945,
-      "likes": 1429,
+      "downloads": 8253739,
+      "likes": 1437,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -11032,7 +11132,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 373,
+      "rank": 376,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11055,7 +11155,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -11086,7 +11186,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 375,
+      "rank": 378,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11117,7 +11217,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 376,
+      "rank": 379,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -11146,7 +11246,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 377,
+      "rank": 380,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -11179,7 +11279,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 378,
+      "rank": 381,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -11205,7 +11305,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 379,
+      "rank": 382,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -11249,7 +11349,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 380,
+      "rank": 383,
       "id": "numind/NuMarkdown-8B-Thinking",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
@@ -11280,7 +11380,84 @@
       "lastModified": "2026-05-19T19:01:34.000Z"
     },
     {
-      "rank": 381,
+      "rank": 384,
+      "id": "meta-llama/Llama-3.2-1B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
+      "downloads": 2168446,
+      "likes": 2407,
+      "trendingScore": 15,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:03:14.000Z",
+      "lastModified": "2024-10-24T15:08:03.000Z"
+    },
+    {
+      "rank": 385,
+      "id": "openbmb/MiniCPM5-1B-SFT",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
+      "downloads": 190,
+      "likes": 17,
+      "trendingScore": 15,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "minicpm",
+        "minicpm5",
+        "long-context",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "conversational",
+        "en",
+        "zh",
+        "dataset:openbmb/Ultra-FineWeb",
+        "dataset:openbmb/Ultra-FineWeb-L3",
+        "dataset:openbmb/UltraData-Math",
+        "dataset:openbmb/UltraData-SFT-2605",
+        "arxiv:2506.07900",
+        "arxiv:2602.09003",
+        "arxiv:2512.16649",
+        "arxiv:2604.13016",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T07:27:50.000Z",
+      "lastModified": "2026-05-25T11:18:10.000Z"
+    },
+    {
+      "rank": 386,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -11304,7 +11481,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 382,
+      "rank": 387,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -11331,7 +11508,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 383,
+      "rank": 388,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -11359,7 +11536,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 384,
+      "rank": 389,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -11378,7 +11555,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 385,
+      "rank": 390,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -11410,7 +11587,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 386,
+      "rank": 391,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -11439,7 +11616,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 387,
+      "rank": 392,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -11465,7 +11642,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 388,
+      "rank": 393,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -11493,7 +11670,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 389,
+      "rank": 394,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -11527,7 +11704,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 390,
+      "rank": 395,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -11553,7 +11730,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 391,
+      "rank": 396,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -11595,7 +11772,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 392,
+      "rank": 397,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -11633,7 +11810,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 393,
+      "rank": 398,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -11652,7 +11829,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 394,
+      "rank": 399,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -11672,7 +11849,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 395,
+      "rank": 400,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -11699,7 +11876,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 396,
+      "rank": 401,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -11725,7 +11902,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 397,
+      "rank": 402,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -11750,7 +11927,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 398,
+      "rank": 403,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -11779,7 +11956,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 399,
+      "rank": 404,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -11824,7 +12001,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 400,
+      "rank": 405,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -11851,7 +12028,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 401,
+      "rank": 406,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -11880,44 +12057,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 402,
-      "id": "meta-llama/Llama-3.2-1B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
-      "downloads": 2033091,
-      "likes": 2401,
-      "trendingScore": 14,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:03:14.000Z",
-      "lastModified": "2024-10-24T15:08:03.000Z"
-    },
-    {
-      "rank": 403,
+      "rank": 407,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -11943,7 +12083,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 404,
+      "rank": 408,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
@@ -11973,7 +12113,7 @@
       "lastModified": "2026-05-25T00:33:13.000Z"
     },
     {
-      "rank": 405,
+      "rank": 409,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -11998,7 +12138,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 406,
+      "rank": 410,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -12023,7 +12163,54 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 407,
+      "rank": 411,
+      "id": "Comfy-Org/PixelDiT",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+      "downloads": 0,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T14:05:48.000Z",
+      "lastModified": "2026-05-26T12:10:42.000Z"
+    },
+    {
+      "rank": 412,
+      "id": "nvidia/vgg-ttt",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/vgg-ttt",
+      "downloads": 42,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "image-to-3d",
+      "libraryName": "vggttt",
+      "tags": [
+        "vggttt",
+        "safetensors",
+        "vggt",
+        "3d-reconstruction",
+        "pointmap",
+        "depth-estimation",
+        "camera-pose",
+        "image-to-3d",
+        "arxiv:2602.23361",
+        "arxiv:2503.11651",
+        "base_model:facebook/VGGT-1B",
+        "base_model:finetune:facebook/VGGT-1B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2025-12-10T22:23:19.000Z",
+      "lastModified": "2026-05-25T15:55:35.000Z"
+    },
+    {
+      "rank": 413,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -12052,7 +12239,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 408,
+      "rank": 414,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -12097,7 +12284,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 409,
+      "rank": 415,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -12126,7 +12313,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 410,
+      "rank": 416,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -12153,7 +12340,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 411,
+      "rank": 417,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -12180,7 +12367,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 412,
+      "rank": 418,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -12211,7 +12398,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 413,
+      "rank": 419,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -12235,7 +12422,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 414,
+      "rank": 420,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -12280,7 +12467,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 415,
+      "rank": 421,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -12307,7 +12494,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 416,
+      "rank": 422,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -12343,7 +12530,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 417,
+      "rank": 423,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -12374,7 +12561,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 418,
+      "rank": 424,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -12405,7 +12592,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 419,
+      "rank": 425,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -12438,7 +12625,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 420,
+      "rank": 426,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -12467,7 +12654,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 421,
+      "rank": 427,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -12493,7 +12680,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 422,
+      "rank": 428,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -12523,7 +12710,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 423,
+      "rank": 429,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -12541,7 +12728,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 424,
+      "rank": 430,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -12572,7 +12759,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 425,
+      "rank": 431,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -12593,7 +12780,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 426,
+      "rank": 432,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -12613,7 +12800,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 427,
+      "rank": 433,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -12640,7 +12827,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 428,
+      "rank": 434,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -12670,7 +12857,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 429,
+      "rank": 435,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -12687,7 +12874,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 430,
+      "rank": 436,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -12714,7 +12901,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 431,
+      "rank": 437,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12739,7 +12926,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 432,
+      "rank": 438,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -12782,7 +12969,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 433,
+      "rank": 439,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -12811,7 +12998,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 434,
+      "rank": 440,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -12834,7 +13021,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 435,
+      "rank": 441,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -12861,7 +13048,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 436,
+      "rank": 442,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -12891,7 +13078,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 437,
+      "rank": 443,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -12919,7 +13106,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 438,
+      "rank": 444,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
@@ -12950,7 +13137,7 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 439,
+      "rank": 445,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -12972,7 +13159,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 440,
+      "rank": 446,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
@@ -13009,7 +13196,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 441,
+      "rank": 447,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13037,7 +13224,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 442,
+      "rank": 448,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -13073,64 +13260,128 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 443,
-      "id": "Comfy-Org/PixelDiT",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+      "rank": 449,
+      "id": "meta-llama/Llama-3.2-3B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
+      "downloads": 2097928,
+      "likes": 2154,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:19:20.000Z",
+      "lastModified": "2024-10-24T15:07:29.000Z"
+    },
+    {
+      "rank": 450,
+      "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
+      "author": "KevinJK51",
+      "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
+      "downloads": 20497,
+      "likes": 18,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen",
+        "uncensored",
+        "thinking",
+        "qwen3.5",
+        "heretic",
+        "text-generation",
+        "en",
+        "zh",
+        "base_model:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+        "base_model:quantized:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-17T14:55:59.000Z",
+      "lastModified": "2026-05-22T09:41:49.000Z"
+    },
+    {
+      "rank": 451,
+      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "downloads": 0,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-audio",
+        "diffusion",
+        "flow-matching",
+        "sound-effects",
+        "audio-generation",
+        "en",
+        "zh",
+        "base_model:Qwen/Qwen3-1.7B",
+        "base_model:finetune:Qwen/Qwen3-1.7B",
+        "license:apache-2.0",
+        "diffusers:MossSoundEffectPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T14:19:58.000Z",
+      "lastModified": "2026-05-26T09:41:39.000Z"
+    },
+    {
+      "rank": 452,
+      "id": "spiritbuun/buun-Qwen3.6-chat_template",
+      "author": "spiritbuun",
+      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
       "downloads": 0,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "comfyui",
-        "license:other",
+        "chat-template",
+        "qwen3",
+        "qwen3.5",
+        "qwen3.6",
+        "jinja",
+        "llama-cpp",
+        "tool-use",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-25T14:05:48.000Z",
-      "lastModified": "2026-05-26T12:10:42.000Z"
+      "createdAt": "2026-05-26T16:33:22.000Z",
+      "lastModified": "2026-05-26T16:38:59.000Z"
     },
     {
-      "rank": 444,
-      "id": "nvidia/LocateAnything-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/LocateAnything-3B",
-      "downloads": 0,
-      "likes": 13,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "locateanything",
-        "feature-extraction",
-        "nvidia",
-        "eagle",
-        "vision",
-        "object-detection",
-        "grounding",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "arxiv:2504.07491",
-        "arxiv:2109.10852",
-        "arxiv:2510.12798",
-        "arxiv:2303.05499",
-        "arxiv:1405.0312",
-        "arxiv:1908.03195",
-        "arxiv:2504.07981",
-        "base_model:Qwen/Qwen2.5-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T20:05:49.000Z",
-      "lastModified": "2026-05-25T13:55:19.000Z"
-    },
-    {
-      "rank": 445,
+      "rank": 453,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -13157,7 +13408,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 446,
+      "rank": 454,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -13185,7 +13436,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 447,
+      "rank": 455,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -13218,7 +13469,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 448,
+      "rank": 456,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -13234,7 +13485,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 449,
+      "rank": 457,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -13257,7 +13508,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 450,
+      "rank": 458,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -13291,7 +13542,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 451,
+      "rank": 459,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -13311,7 +13562,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 452,
+      "rank": 460,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -13346,7 +13597,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 453,
+      "rank": 461,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -13376,7 +13627,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 454,
+      "rank": 462,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -13397,7 +13648,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 455,
+      "rank": 463,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -13426,7 +13677,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 456,
+      "rank": 464,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -13456,7 +13707,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 457,
+      "rank": 465,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -13484,7 +13735,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 458,
+      "rank": 466,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -13513,7 +13764,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 459,
+      "rank": 467,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -13545,7 +13796,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 460,
+      "rank": 468,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -13580,7 +13831,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 461,
+      "rank": 469,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -13618,7 +13869,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 462,
+      "rank": 470,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -13657,7 +13908,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 463,
+      "rank": 471,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -13694,7 +13945,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 464,
+      "rank": 472,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -13718,7 +13969,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 465,
+      "rank": 473,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -13736,7 +13987,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 466,
+      "rank": 474,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -13755,7 +14006,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 467,
+      "rank": 475,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -13783,7 +14034,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 468,
+      "rank": 476,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -13824,7 +14075,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 469,
+      "rank": 477,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -13846,7 +14097,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 470,
+      "rank": 478,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -13883,7 +14134,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 471,
+      "rank": 479,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -13913,7 +14164,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 472,
+      "rank": 480,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -13942,7 +14193,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 473,
+      "rank": 481,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -13970,7 +14221,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 474,
+      "rank": 482,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -13996,7 +14247,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 475,
+      "rank": 483,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -14023,7 +14274,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 476,
+      "rank": 484,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -14048,7 +14299,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 477,
+      "rank": 485,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -14077,7 +14328,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 478,
+      "rank": 486,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -14102,7 +14353,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 479,
+      "rank": 487,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -14128,7 +14379,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 480,
+      "rank": 488,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -14167,7 +14418,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 481,
+      "rank": 489,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
@@ -14195,7 +14446,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 482,
+      "rank": 490,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -14221,7 +14472,7 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 483,
+      "rank": 491,
       "id": "SupraLabs/Supra-50M-Base",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
@@ -14255,7 +14506,7 @@
       "lastModified": "2026-05-23T07:46:11.000Z"
     },
     {
-      "rank": 484,
+      "rank": 492,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -14278,45 +14529,7 @@
       "lastModified": "2026-05-26T09:06:09.000Z"
     },
     {
-      "rank": 485,
-      "id": "meta-llama/Llama-3.2-3B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 2097928,
-      "likes": 2151,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:19:20.000Z",
-      "lastModified": "2024-10-24T15:07:29.000Z"
-    },
-    {
-      "rank": 486,
+      "rank": 493,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -14336,7 +14549,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 487,
+      "rank": 494,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
@@ -14356,7 +14569,7 @@
       "lastModified": "2026-05-23T14:54:50.000Z"
     },
     {
-      "rank": 488,
+      "rank": 495,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -14381,37 +14594,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 489,
-      "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "author": "KevinJK51",
-      "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "downloads": 20497,
-      "likes": 17,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen",
-        "uncensored",
-        "thinking",
-        "qwen3.5",
-        "heretic",
-        "text-generation",
-        "en",
-        "zh",
-        "base_model:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-        "base_model:quantized:DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-17T14:55:59.000Z",
-      "lastModified": "2026-05-22T09:41:49.000Z"
-    },
-    {
-      "rank": 490,
+      "rank": 496,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -14444,36 +14627,60 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 491,
-      "id": "nvidia/vgg-ttt",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/vgg-ttt",
-      "downloads": 42,
-      "likes": 12,
+      "rank": 497,
+      "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 145954,
+      "likes": 356,
       "trendingScore": 12,
-      "pipelineTag": "image-to-3d",
-      "libraryName": "vggttt",
+      "pipelineTag": null,
+      "libraryName": null,
       "tags": [
-        "vggttt",
-        "safetensors",
-        "vggt",
-        "3d-reconstruction",
-        "pointmap",
-        "depth-estimation",
-        "camera-pose",
-        "image-to-3d",
-        "arxiv:2602.23361",
-        "arxiv:2503.11651",
-        "base_model:facebook/VGGT-1B",
-        "base_model:finetune:facebook/VGGT-1B",
-        "license:other",
-        "region:us"
+        "gguf",
+        "uncensored",
+        "qwen3.5",
+        "qwen",
+        "en",
+        "zh",
+        "multilingual",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2025-12-10T22:23:19.000Z",
-      "lastModified": "2026-05-25T15:55:35.000Z"
+      "createdAt": "2026-03-03T12:16:35.000Z",
+      "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 492,
+      "rank": 498,
+      "id": "Abiray/Lance_3B_Video-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
+      "downloads": 2059,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "multimodal",
+        "video-generation",
+        "video-editing",
+        "video-understanding",
+        "quantized",
+        "bytedance",
+        "arxiv:2605.18678",
+        "base_model:bytedance-research/Lance",
+        "base_model:quantized:bytedance-research/Lance",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T09:34:34.000Z",
+      "lastModified": "2026-05-21T09:49:53.000Z"
+    },
+    {
+      "rank": 499,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -14518,7 +14725,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 493,
+      "rank": 500,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -14560,7 +14767,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 494,
+      "rank": 501,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -14586,7 +14793,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 495,
+      "rank": 502,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -14611,7 +14818,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 496,
+      "rank": 503,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -14628,7 +14835,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 497,
+      "rank": 504,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -14656,7 +14863,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 498,
+      "rank": 505,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -14682,7 +14889,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 499,
+      "rank": 506,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -14709,7 +14916,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 500,
+      "rank": 507,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -14737,7 +14944,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 501,
+      "rank": 508,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -14770,7 +14977,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 502,
+      "rank": 509,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -14804,7 +15011,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 503,
+      "rank": 510,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -14833,7 +15040,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 504,
+      "rank": 511,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -14862,7 +15069,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 505,
+      "rank": 512,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -14895,7 +15102,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 506,
+      "rank": 513,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -14922,7 +15129,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 507,
+      "rank": 514,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -14952,7 +15159,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 508,
+      "rank": 515,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -14978,7 +15185,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 509,
+      "rank": 516,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -15002,7 +15209,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 510,
+      "rank": 517,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -15029,7 +15236,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 511,
+      "rank": 518,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -15063,7 +15270,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 512,
+      "rank": 519,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -15079,7 +15286,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 513,
+      "rank": 520,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -15110,7 +15317,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 514,
+      "rank": 521,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -15132,7 +15339,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 515,
+      "rank": 522,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -15152,7 +15359,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 516,
+      "rank": 523,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -15174,7 +15381,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 517,
+      "rank": 524,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -15203,7 +15410,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 518,
+      "rank": 525,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -15228,7 +15435,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 519,
+      "rank": 526,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -15253,7 +15460,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 520,
+      "rank": 527,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -15288,7 +15495,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 521,
+      "rank": 528,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -15312,7 +15519,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 522,
+      "rank": 529,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -15343,33 +15550,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 523,
-      "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 145954,
-      "likes": 355,
-      "trendingScore": 11,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.5",
-        "qwen",
-        "en",
-        "zh",
-        "multilingual",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-03T12:16:35.000Z",
-      "lastModified": "2026-04-05T19:01:02.000Z"
-    },
-    {
-      "rank": 524,
+      "rank": 530,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -15399,7 +15580,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 525,
+      "rank": 531,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -15425,7 +15606,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 526,
+      "rank": 532,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -15470,7 +15651,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 527,
+      "rank": 533,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -15497,7 +15678,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 528,
+      "rank": 534,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -15524,7 +15705,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 529,
+      "rank": 535,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -15569,7 +15750,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 530,
+      "rank": 536,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -15595,7 +15776,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 531,
+      "rank": 537,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -15624,7 +15805,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 532,
+      "rank": 538,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -15669,7 +15850,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 533,
+      "rank": 539,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15701,7 +15882,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 534,
+      "rank": 540,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -15736,7 +15917,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 535,
+      "rank": 541,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
@@ -15767,7 +15948,7 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 536,
+      "rank": 542,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -15812,7 +15993,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 537,
+      "rank": 543,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -15853,7 +16034,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 538,
+      "rank": 544,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -15878,7 +16059,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 539,
+      "rank": 545,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -15917,7 +16098,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 540,
+      "rank": 546,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -15944,7 +16125,7 @@
       "lastModified": "2026-05-25T10:58:41.000Z"
     },
     {
-      "rank": 541,
+      "rank": 547,
       "id": "Abiray/L2P-model-1k-merge-INT8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
@@ -15969,7 +16150,7 @@
       "lastModified": "2026-05-23T17:24:01.000Z"
     },
     {
-      "rank": 542,
+      "rank": 548,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
@@ -15991,7 +16172,7 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 543,
+      "rank": 549,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
@@ -16021,7 +16202,7 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 544,
+      "rank": 550,
       "id": "mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
@@ -16051,7 +16232,7 @@
       "lastModified": "2026-05-10T04:13:55.000Z"
     },
     {
-      "rank": 545,
+      "rank": 551,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
@@ -16068,47 +16249,177 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 546,
-      "id": "openbmb/MiniCPM5-1B-SFT",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
-      "downloads": 190,
-      "likes": 13,
+      "rank": 552,
+      "id": "stabilityai/stable-diffusion-3.5-large",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+      "downloads": 34428,
+      "likes": 3495,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "stable-diffusion",
+        "en",
+        "arxiv:2403.03206",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2024-10-22T07:29:57.000Z",
+      "lastModified": "2024-10-22T14:36:33.000Z"
+    },
+    {
+      "rank": 553,
+      "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "author": "Leon1000",
+      "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "flux",
+        "flux.2",
+        "flux-lora",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "image-to-image",
+        "fal-ai",
+        "en",
+        "base_model:black-forest-labs/FLUX.2-dev",
+        "base_model:adapter:black-forest-labs/FLUX.2-dev",
+        "license:creativeml-openrail-m",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T00:22:03.000Z",
+      "lastModified": "2026-05-20T00:22:04.000Z"
+    },
+    {
+      "rank": 554,
+      "id": "joyfox/LTX-2.3-Transition-LORA",
+      "author": "joyfox",
+      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
+      "downloads": 37084,
+      "likes": 116,
+      "trendingScore": 11,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ValiantCat",
+        "Lightricks",
+        "LTX-2.3",
+        "image-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-20T10:25:10.000Z",
+      "lastModified": "2026-03-30T03:28:58.000Z"
+    },
+    {
+      "rank": 555,
+      "id": "UofTCSSLab/Maia3-79M",
+      "author": "UofTCSSLab",
+      "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "chess",
+        "maia",
+        "maia3",
+        "chessformer",
+        "move-prediction",
+        "human-ai",
+        "interpretability",
+        "en",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:34:19.000Z",
+      "lastModified": "2026-05-24T16:12:28.000Z"
+    },
+    {
+      "rank": 556,
+      "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
+      "downloads": 1012,
+      "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "libraryName": "mlx",
       "tags": [
-        "transformers",
+        "mlx",
         "safetensors",
-        "llama",
-        "text-generation",
-        "minicpm",
-        "minicpm5",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "transformers",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
         "long-context",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
+        "agent",
+        "text-generation",
         "conversational",
         "en",
         "zh",
-        "dataset:openbmb/Ultra-FineWeb",
-        "dataset:openbmb/Ultra-FineWeb-L3",
-        "dataset:openbmb/UltraData-Math",
-        "dataset:openbmb/UltraData-SFT-2605",
-        "arxiv:2506.07900",
-        "arxiv:2602.09003",
-        "arxiv:2512.16649",
-        "arxiv:2604.13016",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "base_model:Jackrong/Qwopus3.6-27B-v2",
+        "base_model:adapter:Jackrong/Qwopus3.6-27B-v2",
+        "license:apache-2.0"
       ],
-      "createdAt": "2026-05-21T07:27:50.000Z",
-      "lastModified": "2026-05-25T11:18:10.000Z"
+      "createdAt": "2026-05-23T00:16:01.000Z",
+      "lastModified": "2026-05-23T00:19:59.000Z"
     },
     {
-      "rank": 547,
+      "rank": 557,
+      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+      "downloads": 0,
+      "likes": 11,
+      "trendingScore": 11,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:07:19.000Z",
+      "lastModified": "2026-05-26T16:17:00.000Z"
+    },
+    {
+      "rank": 558,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -16137,7 +16448,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 548,
+      "rank": 559,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -16171,7 +16482,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 549,
+      "rank": 560,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -16216,7 +16527,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 550,
+      "rank": 561,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -16245,7 +16556,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 551,
+      "rank": 562,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -16270,7 +16581,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 552,
+      "rank": 563,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -16305,7 +16616,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 553,
+      "rank": 564,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -16332,7 +16643,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 554,
+      "rank": 565,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -16377,7 +16688,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 555,
+      "rank": 566,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -16399,7 +16710,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 556,
+      "rank": 567,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -16431,7 +16742,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 557,
+      "rank": 568,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -16456,7 +16767,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 558,
+      "rank": 569,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -16480,7 +16791,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 559,
+      "rank": 570,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -16523,7 +16834,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 560,
+      "rank": 571,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -16547,7 +16858,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 561,
+      "rank": 572,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -16576,7 +16887,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 562,
+      "rank": 573,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -16608,7 +16919,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 563,
+      "rank": 574,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -16632,7 +16943,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 564,
+      "rank": 575,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -16654,7 +16965,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 565,
+      "rank": 576,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -16679,7 +16990,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 566,
+      "rank": 577,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -16707,7 +17018,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 567,
+      "rank": 578,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -16731,12 +17042,12 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 568,
+      "rank": 579,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
-      "downloads": 6514,
-      "likes": 162,
+      "downloads": 6392,
+      "likes": 165,
       "trendingScore": 10,
       "pipelineTag": "text-to-audio",
       "libraryName": "transformers",
@@ -16758,7 +17069,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 569,
+      "rank": 580,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -16775,7 +17086,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 570,
+      "rank": 581,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -16799,7 +17110,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 571,
+      "rank": 582,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -16823,7 +17134,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 572,
+      "rank": 583,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -16856,7 +17167,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 573,
+      "rank": 584,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -16890,7 +17201,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 574,
+      "rank": 585,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -16912,7 +17223,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 575,
+      "rank": 586,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -16935,7 +17246,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 576,
+      "rank": 587,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -16955,7 +17266,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 577,
+      "rank": 588,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -16987,7 +17298,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 578,
+      "rank": 589,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -17026,7 +17337,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 579,
+      "rank": 590,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -17060,30 +17371,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 580,
-      "id": "stabilityai/stable-diffusion-3.5-large",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
-      "downloads": 34428,
-      "likes": 3493,
-      "trendingScore": 10,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "stable-diffusion",
-        "en",
-        "arxiv:2403.03206",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2024-10-22T07:29:57.000Z",
-      "lastModified": "2024-10-22T14:36:33.000Z"
-    },
-    {
-      "rank": 581,
+      "rank": 591,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -17103,7 +17391,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 582,
+      "rank": 592,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -17132,7 +17420,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 583,
+      "rank": 593,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -17154,7 +17442,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 584,
+      "rank": 594,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -17186,7 +17474,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 585,
+      "rank": 595,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -17213,7 +17501,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 586,
+      "rank": 596,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -17257,7 +17545,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 587,
+      "rank": 597,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -17275,7 +17563,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 588,
+      "rank": 598,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -17314,7 +17602,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 589,
+      "rank": 599,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -17353,7 +17641,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 590,
+      "rank": 600,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -17387,7 +17675,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 591,
+      "rank": 601,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -17415,7 +17703,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 592,
+      "rank": 602,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -17437,7 +17725,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 593,
+      "rank": 603,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -17465,7 +17753,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 594,
+      "rank": 604,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -17483,7 +17771,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 595,
+      "rank": 605,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -17511,7 +17799,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 596,
+      "rank": 606,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -17542,7 +17830,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 597,
+      "rank": 607,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -17558,7 +17846,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 598,
+      "rank": 608,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -17585,7 +17873,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 599,
+      "rank": 609,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -17614,7 +17902,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 600,
+      "rank": 610,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -17642,7 +17930,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 601,
+      "rank": 611,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -17671,7 +17959,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 602,
+      "rank": 612,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -17692,7 +17980,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 603,
+      "rank": 613,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -17713,7 +18001,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 604,
+      "rank": 614,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -17743,7 +18031,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 605,
+      "rank": 615,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -17767,12 +18055,12 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 606,
+      "rank": 616,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
       "downloads": 1118670,
-      "likes": 417,
+      "likes": 418,
       "trendingScore": 10,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -17797,7 +18085,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 607,
+      "rank": 617,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -17828,7 +18116,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 608,
+      "rank": 618,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -17854,7 +18142,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 609,
+      "rank": 619,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -17880,7 +18168,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 610,
+      "rank": 620,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -17898,7 +18186,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 611,
+      "rank": 621,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -17931,34 +18219,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 612,
-      "id": "Abiray/Lance_3B_Video-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
-      "downloads": 2059,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "multimodal",
-        "video-generation",
-        "video-editing",
-        "video-understanding",
-        "quantized",
-        "bytedance",
-        "arxiv:2605.18678",
-        "base_model:bytedance-research/Lance",
-        "base_model:quantized:bytedance-research/Lance",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T09:34:34.000Z",
-      "lastModified": "2026-05-21T09:49:53.000Z"
-    },
-    {
-      "rank": 613,
+      "rank": 622,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -17983,7 +18244,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 614,
+      "rank": 623,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -18008,7 +18269,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 615,
+      "rank": 624,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -18042,7 +18303,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 616,
+      "rank": 625,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
@@ -18082,7 +18343,7 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 617,
+      "rank": 626,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
@@ -18117,61 +18378,7 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 618,
-      "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
-      "author": "Leon1000",
-      "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
-      "downloads": 0,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "flux",
-        "flux.2",
-        "flux-lora",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "image-to-image",
-        "fal-ai",
-        "en",
-        "base_model:black-forest-labs/FLUX.2-dev",
-        "base_model:adapter:black-forest-labs/FLUX.2-dev",
-        "license:creativeml-openrail-m",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T00:22:03.000Z",
-      "lastModified": "2026-05-20T00:22:04.000Z"
-    },
-    {
-      "rank": 619,
-      "id": "joyfox/LTX-2.3-Transition-LORA",
-      "author": "joyfox",
-      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 37084,
-      "likes": 115,
-      "trendingScore": 10,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ValiantCat",
-        "Lightricks",
-        "LTX-2.3",
-        "image-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-20T10:25:10.000Z",
-      "lastModified": "2026-03-30T03:28:58.000Z"
-    },
-    {
-      "rank": 620,
+      "rank": 627,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -18197,38 +18404,85 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 621,
-      "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "rank": 628,
+      "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
+      "downloads": 1267,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T10:55:08.000Z",
+      "lastModified": "2026-05-24T04:55:49.000Z"
+    },
+    {
+      "rank": 629,
+      "id": "FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
+      "author": "FrontiersMind",
+      "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
       "downloads": 0,
       "likes": 10,
       "trendingScore": 10,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
+        "transformers",
         "safetensors",
-        "ternary",
-        "1.58-bit",
-        "gemlite",
-        "hqq",
-        "cuda",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "nandi",
+        "text-generation",
+        "custom_code",
+        "en",
+        "hi",
+        "mr",
+        "ta",
+        "te",
+        "kn",
+        "ml",
+        "bn",
+        "pa",
+        "gu",
+        "or",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-21T16:12:41.000Z",
-      "lastModified": "2026-05-26T16:16:59.000Z"
+      "createdAt": "2026-05-26T18:07:50.000Z",
+      "lastModified": "2026-05-26T20:42:23.000Z"
     },
     {
-      "rank": 622,
+      "rank": 630,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -18255,7 +18509,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 623,
+      "rank": 631,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -18281,7 +18535,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 624,
+      "rank": 632,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -18309,7 +18563,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 625,
+      "rank": 633,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -18335,7 +18589,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 626,
+      "rank": 634,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -18375,7 +18629,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 627,
+      "rank": 635,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -18411,7 +18665,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 628,
+      "rank": 636,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -18455,7 +18709,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 629,
+      "rank": 637,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -18480,7 +18734,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 630,
+      "rank": 638,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -18525,7 +18779,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 631,
+      "rank": 639,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -18544,7 +18798,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 632,
+      "rank": 640,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -18569,7 +18823,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 633,
+      "rank": 641,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -18608,7 +18862,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 634,
+      "rank": 642,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -18625,7 +18879,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 635,
+      "rank": 643,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -18653,7 +18907,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 636,
+      "rank": 644,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -18682,7 +18936,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 637,
+      "rank": 645,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -18707,7 +18961,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 638,
+      "rank": 646,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -18742,7 +18996,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 639,
+      "rank": 647,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -18772,7 +19026,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 640,
+      "rank": 648,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -18808,7 +19062,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 641,
+      "rank": 649,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -18831,7 +19085,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 642,
+      "rank": 650,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -18848,7 +19102,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 643,
+      "rank": 651,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -18868,7 +19122,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 644,
+      "rank": 652,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -18895,7 +19149,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 645,
+      "rank": 653,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -18919,7 +19173,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 646,
+      "rank": 654,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -18941,7 +19195,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 647,
+      "rank": 655,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -18973,7 +19227,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 648,
+      "rank": 656,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -19001,7 +19255,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 649,
+      "rank": 657,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -19019,7 +19273,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 650,
+      "rank": 658,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -19044,7 +19298,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 651,
+      "rank": 659,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -19067,7 +19321,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 652,
+      "rank": 660,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -19085,7 +19339,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 653,
+      "rank": 661,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -19120,7 +19374,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 654,
+      "rank": 662,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -19148,7 +19402,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 655,
+      "rank": 663,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -19170,7 +19424,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 656,
+      "rank": 664,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -19197,7 +19451,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 657,
+      "rank": 665,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -19222,7 +19476,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 658,
+      "rank": 666,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -19256,7 +19510,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 659,
+      "rank": 667,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -19283,7 +19537,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 660,
+      "rank": 668,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -19310,7 +19564,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 661,
+      "rank": 669,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -19351,7 +19605,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 662,
+      "rank": 670,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -19381,7 +19635,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 663,
+      "rank": 671,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -19418,7 +19672,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 664,
+      "rank": 672,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -19450,7 +19704,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 665,
+      "rank": 673,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -19492,7 +19746,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 666,
+      "rank": 674,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -19522,7 +19776,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 667,
+      "rank": 675,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -19567,7 +19821,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 668,
+      "rank": 676,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -19594,7 +19848,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 669,
+      "rank": 677,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -19626,7 +19880,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 670,
+      "rank": 678,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -19660,7 +19914,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 671,
+      "rank": 679,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -19690,7 +19944,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 672,
+      "rank": 680,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -19715,7 +19969,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 673,
+      "rank": 681,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -19742,7 +19996,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 674,
+      "rank": 682,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -19774,7 +20028,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 675,
+      "rank": 683,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -19819,7 +20073,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 676,
+      "rank": 684,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -19847,7 +20101,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 677,
+      "rank": 685,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -19873,7 +20127,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 678,
+      "rank": 686,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -19902,7 +20156,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 679,
+      "rank": 687,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -19944,7 +20198,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 680,
+      "rank": 688,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -19972,7 +20226,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 681,
+      "rank": 689,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -20001,7 +20255,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 682,
+      "rank": 690,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -20031,7 +20285,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 683,
+      "rank": 691,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -20058,7 +20312,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 684,
+      "rank": 692,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -20087,7 +20341,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 685,
+      "rank": 693,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -20114,7 +20368,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 686,
+      "rank": 694,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -20143,7 +20397,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 687,
+      "rank": 695,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -20183,7 +20437,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 688,
+      "rank": 696,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -20201,7 +20455,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 689,
+      "rank": 697,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -20226,7 +20480,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 690,
+      "rank": 698,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -20242,7 +20496,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 691,
+      "rank": 699,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -20287,7 +20541,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 692,
+      "rank": 700,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -20310,7 +20564,7 @@
       "lastModified": "2026-05-26T09:06:26.000Z"
     },
     {
-      "rank": 693,
+      "rank": 701,
       "id": "Anbeeld/Qwen3.6-27B-DFlash-GGUF",
       "author": "Anbeeld",
       "url": "https://huggingface.co/Anbeeld/Qwen3.6-27B-DFlash-GGUF",
@@ -20331,7 +20585,7 @@
       "lastModified": "2026-05-22T17:31:30.000Z"
     },
     {
-      "rank": 694,
+      "rank": 702,
       "id": "nvidia/GLM-5.1-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
@@ -20360,7 +20614,7 @@
       "lastModified": "2026-05-20T21:18:02.000Z"
     },
     {
-      "rank": 695,
+      "rank": 703,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -20393,7 +20647,7 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 696,
+      "rank": 704,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
@@ -20422,126 +20676,12 @@
       "lastModified": "2026-05-22T20:32:34.000Z"
     },
     {
-      "rank": 697,
-      "id": "UofTCSSLab/Maia3-79M",
-      "author": "UofTCSSLab",
-      "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
-      "downloads": 0,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "chess",
-        "maia",
-        "maia3",
-        "chessformer",
-        "move-prediction",
-        "human-ai",
-        "interpretability",
-        "en",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:34:19.000Z",
-      "lastModified": "2026-05-24T16:12:28.000Z"
-    },
-    {
-      "rank": 698,
-      "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
-      "downloads": 1267,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "image",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T10:55:08.000Z",
-      "lastModified": "2026-05-24T04:55:49.000Z"
-    },
-    {
-      "rank": 699,
-      "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
-      "downloads": 1012,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "transformers",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "text-generation",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "base_model:Jackrong/Qwopus3.6-27B-v2",
-        "base_model:adapter:Jackrong/Qwopus3.6-27B-v2",
-        "license:apache-2.0"
-      ],
-      "createdAt": "2026-05-23T00:16:01.000Z",
-      "lastModified": "2026-05-23T00:19:59.000Z"
-    },
-    {
-      "rank": 700,
+      "rank": 705,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
       "downloads": 1286389,
-      "likes": 965,
+      "likes": 966,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -20581,7 +20721,97 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 701,
+      "rank": 706,
+      "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
+      "author": "Fortytwo-Network",
+      "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
+      "downloads": 462,
+      "likes": 179,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "dataset:Fortytwo-Network/Strandset-Rust-v1",
+        "arxiv:2510.24801",
+        "arxiv:2409.08386",
+        "base_model:Qwen/Qwen2.5-Coder-14B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-Coder-14B-Instruct",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-09-29T06:09:17.000Z",
+      "lastModified": "2026-01-05T17:19:35.000Z"
+    },
+    {
+      "rank": 707,
+      "id": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
+      "downloads": 577,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "mpoa",
+        "mtp",
+        "image-text-to-text",
+        "base_model:llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "base_model:quantized:llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-25T03:13:44.000Z",
+      "lastModified": "2026-05-25T03:44:12.000Z"
+    },
+    {
+      "rank": 708,
+      "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
+      "downloads": 0,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "1-bit",
+        "gemlite",
+        "hqq",
+        "cuda",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:40:12.000Z",
+      "lastModified": "2026-05-26T16:16:58.000Z"
+    },
+    {
+      "rank": 709,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -20608,7 +20838,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 702,
+      "rank": 710,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -20632,7 +20862,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 703,
+      "rank": 711,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -20652,7 +20882,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 704,
+      "rank": 712,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -20671,7 +20901,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 705,
+      "rank": 713,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -20705,7 +20935,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 706,
+      "rank": 714,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -20737,7 +20967,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 707,
+      "rank": 715,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -20759,7 +20989,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 708,
+      "rank": 716,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -20804,7 +21034,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 709,
+      "rank": 717,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -20823,7 +21053,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 710,
+      "rank": 718,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -20857,7 +21087,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 711,
+      "rank": 719,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -20885,7 +21115,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 712,
+      "rank": 720,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -20913,7 +21143,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 713,
+      "rank": 721,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -20936,7 +21166,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 714,
+      "rank": 722,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -20963,7 +21193,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 715,
+      "rank": 723,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -21008,7 +21238,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 716,
+      "rank": 724,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -21044,7 +21274,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 717,
+      "rank": 725,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -21084,7 +21314,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 718,
+      "rank": 726,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -21113,7 +21343,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 719,
+      "rank": 727,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -21141,7 +21371,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 720,
+      "rank": 728,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -21160,7 +21390,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 721,
+      "rank": 729,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -21179,7 +21409,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 722,
+      "rank": 730,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -21211,7 +21441,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 723,
+      "rank": 731,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -21238,7 +21468,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 724,
+      "rank": 732,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -21260,7 +21490,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 725,
+      "rank": 733,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -21278,7 +21508,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 726,
+      "rank": 734,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -21307,7 +21537,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 727,
+      "rank": 735,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -21328,7 +21558,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 728,
+      "rank": 736,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -21356,7 +21586,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 729,
+      "rank": 737,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -21377,7 +21607,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 730,
+      "rank": 738,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -21413,7 +21643,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 731,
+      "rank": 739,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -21436,7 +21666,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 732,
+      "rank": 740,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -21461,12 +21691,12 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 733,
+      "rank": 741,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
-      "downloads": 7128,
-      "likes": 621,
+      "downloads": 8109,
+      "likes": 635,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -21496,7 +21726,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 734,
+      "rank": 742,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -21541,7 +21771,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 735,
+      "rank": 743,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -21568,7 +21798,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 736,
+      "rank": 744,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -21597,7 +21827,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 737,
+      "rank": 745,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -21616,7 +21846,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 738,
+      "rank": 746,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -21637,7 +21867,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 739,
+      "rank": 747,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -21663,7 +21893,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 740,
+      "rank": 748,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -21689,7 +21919,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 741,
+      "rank": 749,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -21726,7 +21956,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 742,
+      "rank": 750,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -21771,7 +22001,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 743,
+      "rank": 751,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -21796,7 +22026,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 744,
+      "rank": 752,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -21813,7 +22043,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 745,
+      "rank": 753,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -21840,7 +22070,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 746,
+      "rank": 754,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -21858,7 +22088,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 747,
+      "rank": 755,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -21883,7 +22113,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 748,
+      "rank": 756,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -21915,7 +22145,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 749,
+      "rank": 757,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -21936,7 +22166,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 750,
+      "rank": 758,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -21955,7 +22185,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 751,
+      "rank": 759,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -21986,7 +22216,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 752,
+      "rank": 760,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -22009,7 +22239,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 753,
+      "rank": 761,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -22026,7 +22256,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 754,
+      "rank": 762,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -22054,7 +22284,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 755,
+      "rank": 763,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -22071,7 +22301,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 756,
+      "rank": 764,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -22107,7 +22337,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 757,
+      "rank": 765,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -22137,7 +22367,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 758,
+      "rank": 766,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -22160,7 +22390,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 759,
+      "rank": 767,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -22193,7 +22423,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 760,
+      "rank": 768,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -22224,7 +22454,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 761,
+      "rank": 769,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -22247,7 +22477,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 762,
+      "rank": 770,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -22280,7 +22510,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 763,
+      "rank": 771,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -22303,7 +22533,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 764,
+      "rank": 772,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -22333,7 +22563,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 765,
+      "rank": 773,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -22362,7 +22592,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 766,
+      "rank": 774,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -22391,7 +22621,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 767,
+      "rank": 775,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -22427,7 +22657,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 768,
+      "rank": 776,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -22450,7 +22680,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 769,
+      "rank": 777,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -22475,7 +22705,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 770,
+      "rank": 778,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -22505,7 +22735,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 771,
+      "rank": 779,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -22541,20 +22771,18 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 772,
+      "rank": 780,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
-      "downloads": 146255,
-      "likes": 127,
+      "downloads": 156440,
+      "likes": 132,
       "trendingScore": 8,
-      "pipelineTag": "text-classification",
+      "pipelineTag": null,
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "deberta-v2",
-        "text-classification",
         "facebook",
         "meta",
         "pytorch",
@@ -22570,7 +22798,6 @@
         "es",
         "th",
         "license:other",
-        "text-embeddings-inference",
         "endpoints_compatible",
         "region:us"
       ],
@@ -22578,7 +22805,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 773,
+      "rank": 781,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -22605,7 +22832,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 774,
+      "rank": 782,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -22638,12 +22865,12 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 775,
+      "rank": 783,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
-      "downloads": 1183471,
-      "likes": 785,
+      "downloads": 1130092,
+      "likes": 790,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -22675,7 +22902,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 776,
+      "rank": 784,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -22703,7 +22930,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 777,
+      "rank": 785,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -22723,7 +22950,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 778,
+      "rank": 786,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -22746,7 +22973,7 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 779,
+      "rank": 787,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -22791,7 +23018,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 780,
+      "rank": 788,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -22823,7 +23050,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 781,
+      "rank": 789,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -22848,7 +23075,7 @@
       "lastModified": "2026-05-26T08:37:41.000Z"
     },
     {
-      "rank": 782,
+      "rank": 790,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -22870,7 +23097,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 783,
+      "rank": 791,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -22898,7 +23125,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 784,
+      "rank": 792,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -22922,7 +23149,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 785,
+      "rank": 793,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
@@ -22947,7 +23174,7 @@
       "lastModified": "2026-05-26T05:28:12.000Z"
     },
     {
-      "rank": 786,
+      "rank": 794,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -22992,7 +23219,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 787,
+      "rank": 795,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
@@ -23022,7 +23249,7 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 788,
+      "rank": 796,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -23038,7 +23265,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 789,
+      "rank": 797,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -23058,7 +23285,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 790,
+      "rank": 798,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -23082,7 +23309,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 791,
+      "rank": 799,
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
@@ -23111,7 +23338,7 @@
       "lastModified": "2025-12-17T05:12:35.000Z"
     },
     {
-      "rank": 792,
+      "rank": 800,
       "id": "tencent/Hy-MT2-1.8B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
@@ -23134,7 +23361,7 @@
       "lastModified": "2026-05-26T09:06:01.000Z"
     },
     {
-      "rank": 793,
+      "rank": 801,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -23167,7 +23394,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 794,
+      "rank": 802,
       "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
@@ -23187,37 +23414,7 @@
       "lastModified": "2026-05-22T21:06:00.000Z"
     },
     {
-      "rank": 795,
-      "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
-      "author": "Fortytwo-Network",
-      "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
-      "downloads": 462,
-      "likes": 178,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "dataset:Fortytwo-Network/Strandset-Rust-v1",
-        "arxiv:2510.24801",
-        "arxiv:2409.08386",
-        "base_model:Qwen/Qwen2.5-Coder-14B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-Coder-14B-Instruct",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-09-29T06:09:17.000Z",
-      "lastModified": "2026-01-05T17:19:35.000Z"
-    },
-    {
-      "rank": 796,
+      "rank": 803,
       "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
@@ -23262,7 +23459,7 @@
       "lastModified": "2026-05-20T02:34:32.000Z"
     },
     {
-      "rank": 797,
+      "rank": 804,
       "id": "openbmb/BitCPM-CANN-0.5B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-0.5B-gguf",
@@ -23286,7 +23483,7 @@
       "lastModified": "2026-05-23T18:11:41.000Z"
     },
     {
-      "rank": 798,
+      "rank": 805,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -23310,7 +23507,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 799,
+      "rank": 806,
       "id": "huihui-ai/DeepSeek-V4-Flash-BF16",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/DeepSeek-V4-Flash-BF16",
@@ -23336,7 +23533,163 @@
       "lastModified": "2026-05-25T09:42:03.000Z"
     },
     {
-      "rank": 800,
+      "rank": 807,
+      "id": "Overworld/Waypoint-1.5-1B",
+      "author": "Overworld",
+      "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
+      "downloads": 1374,
+      "likes": 46,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": "world_engine",
+      "tags": [
+        "world_engine",
+        "diffusers",
+        "safetensors",
+        "world-model",
+        "interactive-video",
+        "generative-worlds",
+        "real-time",
+        "consumer-gpu",
+        "diffusion",
+        "transformer",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-08T04:47:43.000Z",
+      "lastModified": "2026-04-17T18:41:37.000Z"
+    },
+    {
+      "rank": 808,
+      "id": "Danrisi/UltraReal_FineTune_Anima_base1",
+      "author": "Danrisi",
+      "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
+      "downloads": 624,
+      "likes": 9,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "realistic",
+        "anima",
+        "text-to-image",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T20:11:14.000Z",
+      "lastModified": "2026-05-22T13:40:23.000Z"
+    },
+    {
+      "rank": 809,
+      "id": "google/gemma-3-4b-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-3-4b-it",
+      "downloads": 1944194,
+      "likes": 1339,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "image-text-to-text",
+        "arxiv:1905.07830",
+        "arxiv:1905.10044",
+        "arxiv:1911.11641",
+        "arxiv:1904.09728",
+        "arxiv:1705.03551",
+        "arxiv:1911.01547",
+        "arxiv:1907.10641",
+        "arxiv:1903.00161",
+        "arxiv:2009.03300",
+        "arxiv:2304.06364",
+        "arxiv:2103.03874",
+        "arxiv:2110.14168",
+        "arxiv:2311.12022",
+        "arxiv:2108.07732",
+        "arxiv:2107.03374",
+        "arxiv:2210.03057",
+        "arxiv:2106.03193",
+        "arxiv:1910.11856",
+        "arxiv:2502.12404",
+        "arxiv:2502.21228",
+        "arxiv:2404.16816",
+        "arxiv:2104.12756",
+        "arxiv:2311.16502",
+        "arxiv:2203.10244",
+        "arxiv:2404.12390",
+        "arxiv:1810.12440",
+        "arxiv:1908.02660"
+      ],
+      "createdAt": "2025-02-20T21:20:07.000Z",
+      "lastModified": "2025-03-21T20:20:53.000Z"
+    },
+    {
+      "rank": 810,
+      "id": "zeroentropy/zembed-1-embedding",
+      "author": "zeroentropy",
+      "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
+      "downloads": 349242,
+      "likes": 108,
+      "trendingScore": 8,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3",
+        "finance",
+        "legal",
+        "healthcare",
+        "code",
+        "stem",
+        "medical",
+        "multilingual",
+        "feature-extraction",
+        "en",
+        "arxiv:2509.12541",
+        "base_model:Qwen/Qwen3-4B",
+        "base_model:finetune:Qwen/Qwen3-4B",
+        "license:cc-by-nc-4.0",
+        "text-embeddings-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T07:11:05.000Z",
+      "lastModified": "2026-03-12T21:10:43.000Z"
+    },
+    {
+      "rank": 811,
+      "id": "avaturn-live/avtr-1",
+      "author": "avaturn-live",
+      "url": "https://huggingface.co/avaturn-live/avtr-1",
+      "downloads": 2,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-video",
+      "libraryName": "tensorrt",
+      "tags": [
+        "tensorrt",
+        "onnx",
+        "talking-head",
+        "lip-sync",
+        "avatar",
+        "real-time",
+        "audio-driven",
+        "non-commercial",
+        "image-to-video",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:26:51.000Z",
+      "lastModified": "2026-05-25T21:18:34.000Z"
+    },
+    {
+      "rank": 812,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -23362,7 +23715,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 801,
+      "rank": 813,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -23379,7 +23732,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 802,
+      "rank": 814,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -23407,7 +23760,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 803,
+      "rank": 815,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -23442,7 +23795,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 804,
+      "rank": 816,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -23467,7 +23820,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 805,
+      "rank": 817,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -23497,7 +23850,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 806,
+      "rank": 818,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -23526,7 +23879,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 807,
+      "rank": 819,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -23553,7 +23906,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 808,
+      "rank": 820,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -23579,7 +23932,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 809,
+      "rank": 821,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -23610,7 +23963,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 810,
+      "rank": 822,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -23628,7 +23981,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 811,
+      "rank": 823,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -23657,7 +24010,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 812,
+      "rank": 824,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -23680,7 +24033,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 813,
+      "rank": 825,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -23725,7 +24078,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 814,
+      "rank": 826,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -23751,7 +24104,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 815,
+      "rank": 827,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -23779,7 +24132,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 816,
+      "rank": 828,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -23817,7 +24170,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 817,
+      "rank": 829,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -23844,7 +24197,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 818,
+      "rank": 830,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -23870,7 +24223,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 819,
+      "rank": 831,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -23888,7 +24241,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 820,
+      "rank": 832,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -23914,12 +24267,12 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 821,
+      "rank": 833,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
-      "downloads": 34146,
-      "likes": 249,
+      "downloads": 34300,
+      "likes": 251,
       "trendingScore": 7,
       "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
@@ -23938,7 +24291,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 822,
+      "rank": 834,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -23979,7 +24332,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 823,
+      "rank": 835,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -23996,7 +24349,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 824,
+      "rank": 836,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -24029,7 +24382,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 825,
+      "rank": 837,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -24063,7 +24416,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 826,
+      "rank": 838,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -24102,7 +24455,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 827,
+      "rank": 839,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -24132,7 +24485,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 828,
+      "rank": 840,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -24158,7 +24511,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 829,
+      "rank": 841,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -24194,7 +24547,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 830,
+      "rank": 842,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -24224,7 +24577,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 831,
+      "rank": 843,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -24262,7 +24615,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 832,
+      "rank": 844,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -24297,7 +24650,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 833,
+      "rank": 845,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -24314,7 +24667,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 834,
+      "rank": 846,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -24356,7 +24709,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 835,
+      "rank": 847,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -24386,7 +24739,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 836,
+      "rank": 848,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -24411,7 +24764,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 837,
+      "rank": 849,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -24439,7 +24792,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 838,
+      "rank": 850,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -24456,7 +24809,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 839,
+      "rank": 851,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -24483,7 +24836,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 840,
+      "rank": 852,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -24526,7 +24879,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 841,
+      "rank": 853,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -24566,7 +24919,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 842,
+      "rank": 854,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -24590,7 +24943,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 843,
+      "rank": 855,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -24619,7 +24972,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 844,
+      "rank": 856,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -24645,7 +24998,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 845,
+      "rank": 857,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -24684,7 +25037,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 846,
+      "rank": 858,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -24708,7 +25061,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 847,
+      "rank": 859,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -24736,7 +25089,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 848,
+      "rank": 860,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -24768,7 +25121,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 849,
+      "rank": 861,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -24798,7 +25151,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 850,
+      "rank": 862,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -24827,7 +25180,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 851,
+      "rank": 863,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -24856,7 +25209,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 852,
+      "rank": 864,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -24876,7 +25229,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 853,
+      "rank": 865,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -24906,7 +25259,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 854,
+      "rank": 866,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -24936,7 +25289,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 855,
+      "rank": 867,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -24954,7 +25307,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 856,
+      "rank": 868,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -24971,7 +25324,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 857,
+      "rank": 869,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -25007,7 +25360,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 858,
+      "rank": 870,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -25038,7 +25391,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 859,
+      "rank": 871,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -25069,7 +25422,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 860,
+      "rank": 872,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -25102,7 +25455,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 861,
+      "rank": 873,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -25130,7 +25483,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 862,
+      "rank": 874,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -25155,7 +25508,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 863,
+      "rank": 875,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -25178,7 +25531,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 864,
+      "rank": 876,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -25206,7 +25559,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 865,
+      "rank": 877,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -25239,7 +25592,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 866,
+      "rank": 878,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -25269,7 +25622,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 867,
+      "rank": 879,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -25304,7 +25657,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 868,
+      "rank": 880,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -25336,7 +25689,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 869,
+      "rank": 881,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -25361,7 +25714,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 870,
+      "rank": 882,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -25384,7 +25737,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 871,
+      "rank": 883,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -25411,7 +25764,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 872,
+      "rank": 884,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -25434,7 +25787,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 873,
+      "rank": 885,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -25479,7 +25832,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 874,
+      "rank": 886,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -25511,7 +25864,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 875,
+      "rank": 887,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -25538,7 +25891,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 876,
+      "rank": 888,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -25564,7 +25917,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 877,
+      "rank": 889,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -25596,7 +25949,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 878,
+      "rank": 890,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -25625,7 +25978,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 879,
+      "rank": 891,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -25657,7 +26010,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 880,
+      "rank": 892,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -25687,7 +26040,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 881,
+      "rank": 893,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -25704,7 +26057,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 882,
+      "rank": 894,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -25724,7 +26077,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 883,
+      "rank": 895,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -25763,7 +26116,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 884,
+      "rank": 896,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -25801,7 +26154,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 885,
+      "rank": 897,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -25829,7 +26182,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 886,
+      "rank": 898,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -25874,7 +26227,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 887,
+      "rank": 899,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -25904,7 +26257,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 888,
+      "rank": 900,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -25931,7 +26284,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 889,
+      "rank": 901,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -25957,7 +26310,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 890,
+      "rank": 902,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -25986,7 +26339,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 891,
+      "rank": 903,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -26004,7 +26357,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 892,
+      "rank": 904,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -26036,7 +26389,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 893,
+      "rank": 905,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -26063,7 +26416,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 894,
+      "rank": 906,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -26081,7 +26434,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 895,
+      "rank": 907,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -26108,7 +26461,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 896,
+      "rank": 908,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -26132,7 +26485,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 897,
+      "rank": 909,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -26177,7 +26530,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 898,
+      "rank": 910,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -26208,7 +26561,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 899,
+      "rank": 911,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -26233,7 +26586,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 900,
+      "rank": 912,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -26267,12 +26620,12 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 901,
+      "rank": 913,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
       "downloads": 118,
-      "likes": 9,
+      "likes": 10,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
       "libraryName": "transformers",
@@ -26312,7 +26665,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 902,
+      "rank": 914,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -26353,7 +26706,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 903,
+      "rank": 915,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -26380,7 +26733,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 904,
+      "rank": 916,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -26409,7 +26762,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 905,
+      "rank": 917,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -26441,7 +26794,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 906,
+      "rank": 918,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -26465,7 +26818,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 907,
+      "rank": 919,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -26492,7 +26845,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 908,
+      "rank": 920,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -26531,7 +26884,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 909,
+      "rank": 921,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
@@ -26563,7 +26916,7 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 910,
+      "rank": 922,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -26597,7 +26950,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 911,
+      "rank": 923,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
@@ -26624,7 +26977,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 912,
+      "rank": 924,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -26652,7 +27005,7 @@
       "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 913,
+      "rank": 925,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -26680,34 +27033,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 914,
-      "id": "Overworld/Waypoint-1.5-1B",
-      "author": "Overworld",
-      "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
-      "downloads": 1374,
-      "likes": 45,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": "world_engine",
-      "tags": [
-        "world_engine",
-        "diffusers",
-        "safetensors",
-        "world-model",
-        "interactive-video",
-        "generative-worlds",
-        "real-time",
-        "consumer-gpu",
-        "diffusion",
-        "transformer",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-08T04:47:43.000Z",
-      "lastModified": "2026-04-17T18:41:37.000Z"
-    },
-    {
-      "rank": 915,
+      "rank": 926,
       "id": "huytd189/Qwen3.6-27B-pure-GGUF",
       "author": "huytd189",
       "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
@@ -26729,7 +27055,7 @@
       "lastModified": "2026-05-23T00:41:53.000Z"
     },
     {
-      "rank": 916,
+      "rank": 927,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
@@ -26758,7 +27084,7 @@
       "lastModified": "2026-05-13T07:13:52.000Z"
     },
     {
-      "rank": 917,
+      "rank": 928,
       "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -26803,7 +27129,7 @@
       "lastModified": "2026-05-15T06:27:56.000Z"
     },
     {
-      "rank": 918,
+      "rank": 929,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
@@ -26829,7 +27155,7 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 919,
+      "rank": 930,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
@@ -26864,7 +27190,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 920,
+      "rank": 931,
       "id": "openbmb/BitCPM-CANN-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-1B",
@@ -26890,7 +27216,7 @@
       "lastModified": "2026-05-23T18:13:08.000Z"
     },
     {
-      "rank": 921,
+      "rank": 932,
       "id": "openbmb/BitCPM-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-3B",
@@ -26916,7 +27242,7 @@
       "lastModified": "2026-05-23T18:13:14.000Z"
     },
     {
-      "rank": 922,
+      "rank": 933,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -26941,36 +27267,12 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 923,
-      "id": "Danrisi/UltraReal_FineTune_Anima_base1",
-      "author": "Danrisi",
-      "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
-      "downloads": 624,
-      "likes": 8,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "realistic",
-        "anima",
-        "text-to-image",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T20:11:14.000Z",
-      "lastModified": "2026-05-22T13:40:23.000Z"
-    },
-    {
-      "rank": 924,
+      "rank": 934,
       "id": "Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
       "author": "Andycurrent",
       "url": "https://huggingface.co/Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
       "downloads": 2373576,
-      "likes": 34,
+      "likes": 36,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -26993,7 +27295,7 @@
       "lastModified": "2026-02-18T10:06:23.000Z"
     },
     {
-      "rank": 925,
+      "rank": 935,
       "id": "tencent/Hy-MT2-7B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
@@ -27016,7 +27318,7 @@
       "lastModified": "2026-05-26T09:06:05.000Z"
     },
     {
-      "rank": 926,
+      "rank": 936,
       "id": "zizhaotong/SCOPE",
       "author": "zizhaotong",
       "url": "https://huggingface.co/zizhaotong/SCOPE",
@@ -27050,7 +27352,7 @@
       "lastModified": "2026-05-25T02:01:22.000Z"
     },
     {
-      "rank": 927,
+      "rank": 937,
       "id": "internlm/CapRL-Video-4B",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/CapRL-Video-4B",
@@ -27070,7 +27372,7 @@
       "lastModified": "2026-05-26T12:13:45.000Z"
     },
     {
-      "rank": 928,
+      "rank": 938,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
@@ -27098,57 +27400,12 @@
       "lastModified": "2026-05-22T19:16:35.000Z"
     },
     {
-      "rank": 929,
-      "id": "google/gemma-3-4b-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-3-4b-it",
-      "downloads": 1944194,
-      "likes": 1338,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "image-text-to-text",
-        "arxiv:1905.07830",
-        "arxiv:1905.10044",
-        "arxiv:1911.11641",
-        "arxiv:1904.09728",
-        "arxiv:1705.03551",
-        "arxiv:1911.01547",
-        "arxiv:1907.10641",
-        "arxiv:1903.00161",
-        "arxiv:2009.03300",
-        "arxiv:2304.06364",
-        "arxiv:2103.03874",
-        "arxiv:2110.14168",
-        "arxiv:2311.12022",
-        "arxiv:2108.07732",
-        "arxiv:2107.03374",
-        "arxiv:2210.03057",
-        "arxiv:2106.03193",
-        "arxiv:1910.11856",
-        "arxiv:2502.12404",
-        "arxiv:2502.21228",
-        "arxiv:2404.16816",
-        "arxiv:2104.12756",
-        "arxiv:2311.16502",
-        "arxiv:2203.10244",
-        "arxiv:2404.12390",
-        "arxiv:1810.12440",
-        "arxiv:1908.02660"
-      ],
-      "createdAt": "2025-02-20T21:20:07.000Z",
-      "lastModified": "2025-03-21T20:20:53.000Z"
-    },
-    {
-      "rank": 930,
+      "rank": 939,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "downloads": 51381,
-      "likes": 550,
+      "likes": 551,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -27188,41 +27445,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 931,
-      "id": "zeroentropy/zembed-1-embedding",
-      "author": "zeroentropy",
-      "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
-      "downloads": 349242,
-      "likes": 107,
-      "trendingScore": 7,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3",
-        "finance",
-        "legal",
-        "healthcare",
-        "code",
-        "stem",
-        "medical",
-        "multilingual",
-        "feature-extraction",
-        "en",
-        "arxiv:2509.12541",
-        "base_model:Qwen/Qwen3-4B",
-        "base_model:finetune:Qwen/Qwen3-4B",
-        "license:cc-by-nc-4.0",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T07:11:05.000Z",
-      "lastModified": "2026-03-12T21:10:43.000Z"
-    },
-    {
-      "rank": 932,
+      "rank": 940,
       "id": "microsoft/SchGen",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/SchGen",
@@ -27250,36 +27473,7 @@
       "lastModified": "2026-05-14T16:50:37.000Z"
     },
     {
-      "rank": 933,
-      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-audio",
-        "diffusion",
-        "flow-matching",
-        "sound-effects",
-        "audio-generation",
-        "en",
-        "zh",
-        "base_model:Qwen/Qwen3-1.7B",
-        "base_model:finetune:Qwen/Qwen3-1.7B",
-        "license:apache-2.0",
-        "diffusers:MossSoundEffectPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T14:19:58.000Z",
-      "lastModified": "2026-05-26T09:41:39.000Z"
-    },
-    {
-      "rank": 934,
+      "rank": 941,
       "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
@@ -27306,10 +27500,39 @@
       "lastModified": "2026-05-20T20:34:29.000Z"
     },
     {
-      "rank": 935,
-      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
+      "rank": 942,
+      "id": "MassivDash/Gemma-4-Rust-Coder",
+      "author": "MassivDash",
+      "url": "https://huggingface.co/MassivDash/Gemma-4-Rust-Coder",
+      "downloads": 7160,
+      "likes": 14,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "gemma4",
+        "llama.cpp",
+        "unsloth",
+        "vision-language-model",
+        "rust",
+        "coding",
+        "dataset:Fortytwo-Network/Strandset-Rust-v1",
+        "base_model:google/gemma-4-E4B-it",
+        "base_model:quantized:google/gemma-4-E4B-it",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T07:27:18.000Z",
+      "lastModified": "2026-04-24T09:46:25.000Z"
+    },
+    {
+      "rank": 943,
+      "id": "prism-ml/bonsai-image-binary-4B-unpacked",
       "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
       "downloads": 0,
       "likes": 7,
       "trendingScore": 7,
@@ -27326,41 +27549,100 @@
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-21T16:07:19.000Z",
-      "lastModified": "2026-05-26T16:17:00.000Z"
+      "createdAt": "2026-05-18T15:40:11.000Z",
+      "lastModified": "2026-05-26T16:16:58.000Z"
     },
     {
-      "rank": 936,
-      "id": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "downloads": 577,
+      "rank": 944,
+      "id": "HuggingFaceBio/Carbon-8B-GGUF",
+      "author": "HuggingFaceBio",
+      "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B-GGUF",
+      "downloads": 662,
       "likes": 7,
       "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": null,
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "dna",
+        "genomic",
+        "llama.cpp",
+        "hybriddna",
+        "base_model:HuggingFaceBio/Carbon-8B",
+        "base_model:quantized:HuggingFaceBio/Carbon-8B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T12:59:53.000Z",
+      "lastModified": "2026-05-21T21:32:52.000Z"
+    },
+    {
+      "rank": 945,
+      "id": "Convence/Aroow-Rust-Coder-9B",
+      "author": "Convence",
+      "url": "https://huggingface.co/Convence/Aroow-Rust-Coder-9B",
+      "downloads": 64,
+      "likes": 8,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "mpoa",
-        "mtp",
+        "safetensors",
+        "qwen3_5",
         "image-text-to-text",
-        "base_model:llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved",
-        "base_model:quantized:llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "rust",
+        "code",
+        "code-generation",
+        "code-completion",
+        "fill-in-the-middle",
+        "text-generation",
+        "conversational",
+        "en",
+        "base_model:Qwen/Qwen3.5-9B",
+        "base_model:finetune:Qwen/Qwen3.5-9B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T19:05:37.000Z",
+      "lastModified": "2026-05-23T19:16:54.000Z"
+    },
+    {
+      "rank": 946,
+      "id": "Abiray/MiniCPM5-1B-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "llama.cpp",
+        "en",
+        "zh",
+        "base_model:openbmb/MiniCPM5-1B",
+        "base_model:quantized:openbmb/MiniCPM5-1B",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-25T03:13:44.000Z",
-      "lastModified": "2026-05-25T03:44:12.000Z"
+      "createdAt": "2026-05-26T04:47:48.000Z",
+      "lastModified": "2026-05-26T04:52:17.000Z"
     },
     {
-      "rank": 937,
+      "rank": 947,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -27393,7 +27675,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 938,
+      "rank": 948,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -27422,7 +27704,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 939,
+      "rank": 949,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -27467,7 +27749,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 940,
+      "rank": 950,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -27496,7 +27778,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 941,
+      "rank": 951,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -27541,7 +27823,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 942,
+      "rank": 952,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -27585,7 +27867,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 943,
+      "rank": 953,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -27611,7 +27893,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 944,
+      "rank": 954,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -27637,7 +27919,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 945,
+      "rank": 955,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -27669,7 +27951,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 946,
+      "rank": 956,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -27692,7 +27974,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 947,
+      "rank": 957,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -27735,7 +28017,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 948,
+      "rank": 958,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -27780,7 +28062,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 949,
+      "rank": 959,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -27825,7 +28107,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 950,
+      "rank": 960,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -27852,7 +28134,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 951,
+      "rank": 961,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -27879,7 +28161,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 952,
+      "rank": 962,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -27904,7 +28186,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 953,
+      "rank": 963,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -27943,7 +28225,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 954,
+      "rank": 964,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -27968,7 +28250,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 955,
+      "rank": 965,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -27996,7 +28278,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 956,
+      "rank": 966,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -28021,7 +28303,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 957,
+      "rank": 967,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -28037,7 +28319,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 958,
+      "rank": 968,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -28064,7 +28346,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 959,
+      "rank": 969,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -28096,7 +28378,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 960,
+      "rank": 970,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -28126,7 +28408,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 961,
+      "rank": 971,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -28158,7 +28440,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 962,
+      "rank": 972,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -28186,7 +28468,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 963,
+      "rank": 973,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -28212,7 +28494,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 964,
+      "rank": 974,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -28241,7 +28523,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 965,
+      "rank": 975,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -28283,7 +28565,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 966,
+      "rank": 976,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -28310,7 +28592,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 967,
+      "rank": 977,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -28355,7 +28637,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 968,
+      "rank": 978,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -28381,7 +28663,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 969,
+      "rank": 979,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -28401,7 +28683,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 970,
+      "rank": 980,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -28428,7 +28710,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 971,
+      "rank": 981,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -28470,7 +28752,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 972,
+      "rank": 982,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -28497,7 +28779,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 973,
+      "rank": 983,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -28526,7 +28808,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 974,
+      "rank": 984,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -28553,7 +28835,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 975,
+      "rank": 985,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -28580,7 +28862,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 976,
+      "rank": 986,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -28607,7 +28889,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 977,
+      "rank": 987,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -28635,7 +28917,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 978,
+      "rank": 988,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -28658,7 +28940,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 979,
+      "rank": 989,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -28689,7 +28971,7 @@
       "lastModified": "2026-01-28T12:11:14.000Z"
     },
     {
-      "rank": 980,
+      "rank": 990,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
@@ -28734,7 +29016,7 @@
       "lastModified": "2026-05-01T06:44:11.000Z"
     },
     {
-      "rank": 981,
+      "rank": 991,
       "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
@@ -28756,7 +29038,7 @@
       "lastModified": "2026-05-06T15:54:14.000Z"
     },
     {
-      "rank": 982,
+      "rank": 992,
       "id": "black-forest-labs/FLUX.2-klein-9b-kv",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
@@ -28782,7 +29064,7 @@
       "lastModified": "2026-03-12T16:13:40.000Z"
     },
     {
-      "rank": 983,
+      "rank": 993,
       "id": "RedHatAI/gemma-4-31B-it-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
@@ -28813,7 +29095,7 @@
       "lastModified": "2026-05-04T21:08:38.000Z"
     },
     {
-      "rank": 984,
+      "rank": 994,
       "id": "unsloth/ERNIE-Image-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
@@ -28836,7 +29118,7 @@
       "lastModified": "2026-04-14T23:57:35.000Z"
     },
     {
-      "rank": 985,
+      "rank": 995,
       "id": "barozp/ZAYA1-8B-BNB",
       "author": "barozp",
       "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
@@ -28866,7 +29148,7 @@
       "lastModified": "2026-05-07T15:30:53.000Z"
     },
     {
-      "rank": 986,
+      "rank": 996,
       "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
@@ -28898,7 +29180,7 @@
       "lastModified": "2026-05-12T15:09:39.000Z"
     },
     {
-      "rank": 987,
+      "rank": 997,
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -28927,7 +29209,7 @@
       "lastModified": "2025-09-17T06:57:40.000Z"
     },
     {
-      "rank": 988,
+      "rank": 998,
       "id": "mixedbread-ai/mxbai-embed-large-v1",
       "author": "mixedbread-ai",
       "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
@@ -28959,7 +29241,7 @@
       "lastModified": "2026-01-23T11:59:58.000Z"
     },
     {
-      "rank": 989,
+      "rank": 999,
       "id": "distilbert/distilbert-base-uncased",
       "author": "distilbert",
       "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
@@ -28991,7 +29273,7 @@
       "lastModified": "2024-05-06T13:44:53.000Z"
     },
     {
-      "rank": 990,
+      "rank": 1000,
       "id": "MediaTek-Research/Breeze-ASR-26",
       "author": "MediaTek-Research",
       "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
@@ -29020,305 +29302,6 @@
       ],
       "createdAt": "2025-11-28T04:01:35.000Z",
       "lastModified": "2026-04-21T07:00:40.000Z"
-    },
-    {
-      "rank": 991,
-      "id": "lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
-      "author": "lemonyins",
-      "url": "https://huggingface.co/lemonyins/Qwen3.6-27B-abliterated-i1-IQ4_XS-GGUF-Smaller",
-      "downloads": 6274,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen3_5",
-        "Qwen3.6-27B",
-        "abliterated",
-        "Uncensored",
-        "Smaller",
-        "TurboQuant",
-        "IQ4_XS",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix"
-      ],
-      "createdAt": "2026-05-07T01:56:08.000Z",
-      "lastModified": "2026-05-07T10:28:43.000Z"
-    },
-    {
-      "rank": 992,
-      "id": "Danrisi/UltraReal_FineTune_Anima3",
-      "author": "Danrisi",
-      "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima3",
-      "downloads": 413,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "realistic",
-        "text-to-image",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T01:09:37.000Z",
-      "lastModified": "2026-05-07T13:33:58.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "deepseek-ai/DeepSeek-V3.2",
-      "author": "deepseek-ai",
-      "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2",
-      "downloads": 4211873,
-      "likes": 1434,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "deepseek_v32",
-        "text-generation",
-        "conversational",
-        "base_model:deepseek-ai/DeepSeek-V3.2-Exp-Base",
-        "base_model:finetune:deepseek-ai/DeepSeek-V3.2-Exp-Base",
-        "license:mit",
-        "eval-results",
-        "endpoints_compatible",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2025-12-01T02:34:49.000Z",
-      "lastModified": "2025-12-01T11:04:59.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "Civitai/Sulphur-2-distilled-fp8",
-      "author": "Civitai",
-      "url": "https://huggingface.co/Civitai/Sulphur-2-distilled-fp8",
-      "downloads": 6844,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "text-to-video",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T19:03:36.000Z",
-      "lastModified": "2026-05-06T19:11:53.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "mlx-community/gemma-4-26b-a4b-it-4bit",
-      "author": "mlx-community",
-      "url": "https://huggingface.co/mlx-community/gemma-4-26b-a4b-it-4bit",
-      "downloads": 53771,
-      "likes": 54,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "conversational",
-        "license:apache-2.0",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-02T17:15:47.000Z",
-      "lastModified": "2026-04-13T13:09:14.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "sst12345/liveditor",
-      "author": "sst12345",
-      "url": "https://huggingface.co/sst12345/liveditor",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 6,
-      "pipelineTag": "image-to-video",
-      "libraryName": "pytorch",
-      "tags": [
-        "pytorch",
-        "video-editing",
-        "text-to-video",
-        "diffusion-transformer",
-        "sparse-attention",
-        "wan",
-        "tilelang",
-        "triton",
-        "image-to-video",
-        "en",
-        "arxiv:2605.04569",
-        "base_model:Wan-AI/Wan2.2-T2V-A14B",
-        "base_model:finetune:Wan-AI/Wan2.2-T2V-A14B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T17:45:27.000Z",
-      "lastModified": "2026-05-15T13:22:17.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "ibm-granite/granite-speech-4.1-2b-nar",
-      "author": "ibm-granite",
-      "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar",
-      "downloads": 2685,
-      "likes": 42,
-      "trendingScore": 6,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nle",
-        "feature-extraction",
-        "speech",
-        "asr",
-        "non-autoregressive",
-        "ctc",
-        "custom_code",
-        "en",
-        "fr",
-        "de",
-        "es",
-        "pt",
-        "arxiv:2603.08397",
-        "arxiv:2505.08699",
-        "arxiv:2603.11243",
-        "arxiv:2604.12398",
-        "arxiv:2604.22817",
-        "arxiv:2604.11269",
-        "base_model:ibm-granite/granite-4.0-1b-base",
-        "base_model:finetune:ibm-granite/granite-4.0-1b-base",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-10T12:21:20.000Z",
-      "lastModified": "2026-04-30T18:06:15.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
-      "author": "JANGQ-AI",
-      "url": "https://huggingface.co/JANGQ-AI/MiniMax-M2.7-JANGTQ_K",
-      "downloads": 1144,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "minimax_m2",
-        "jang",
-        "jangtq",
-        "jangtq-prestack",
-        "jangtq-k",
-        "mixed-precision",
-        "minimax",
-        "minimax-m2",
-        "moe",
-        "apple-silicon",
-        "text-generation",
-        "conversational",
-        "reasoning",
-        "chain-of-thought",
-        "quantization",
-        "230b",
-        "custom_code",
-        "base_model:MiniMaxAI/MiniMax-M2.7",
-        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-05T17:47:40.000Z",
-      "lastModified": "2026-05-08T21:46:38.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "openai/whisper-small",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/whisper-small",
-      "downloads": 2279453,
-      "likes": 558,
-      "trendingScore": 6,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "tf",
-        "jax",
-        "safetensors",
-        "whisper",
-        "automatic-speech-recognition",
-        "audio",
-        "hf-asr-leaderboard",
-        "en",
-        "zh",
-        "de",
-        "es",
-        "ru",
-        "ko",
-        "fr",
-        "ja",
-        "pt",
-        "tr",
-        "pl",
-        "ca",
-        "nl",
-        "ar",
-        "sv",
-        "it",
-        "id",
-        "hi",
-        "fi",
-        "vi",
-        "he"
-      ],
-      "createdAt": "2022-09-26T06:51:27.000Z",
-      "lastModified": "2024-02-29T10:57:38.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "seedance2ai/Seedance-2-AI-Video-Generator",
-      "author": "seedance2ai",
-      "url": "https://huggingface.co/seedance2ai/Seedance-2-AI-Video-Generator",
-      "downloads": 0,
-      "likes": 9,
-      "trendingScore": 6,
-      "pipelineTag": "image-to-video",
-      "libraryName": null,
-      "tags": [
-        "text-to-video",
-        "image-to-video",
-        "multimodal",
-        "diffusion",
-        "dit",
-        "lip-sync",
-        "physics-simulation",
-        "en",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-31T13:44:12.000Z",
-      "lastModified": "2026-03-31T13:52:44.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26491445019

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.