### PR TITLE
chore(data): refresh huggingface space signals 2026-05-27T05:03:24Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-26T20:33:30.321Z",
+  "ts": "2026-05-27T05:03:24.928Z",
   "count": 1,
-  "durationMs": 5998,
+  "durationMs": 6022,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T20:33:24.325Z",
+  "fetchedAt": "2026-05-27T05:03:18.907Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -131,8 +131,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 101,
-      "trendingScore": 98,
+      "likes": 104,
+      "trendingScore": 101,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -311,8 +311,8 @@
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
-      "likes": 1511,
-      "trendingScore": 56,
+      "likes": 1515,
+      "trendingScore": 60,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -345,8 +345,8 @@
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 95,
-      "trendingScore": 53,
+      "likes": 101,
+      "trendingScore": 54,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -354,7 +354,7 @@
         "region:us"
       ],
       "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-26T07:30:36.000Z",
+      "lastModified": "2026-05-26T13:29:35.000Z",
       "models": []
     },
     {
@@ -439,6 +439,22 @@
     },
     {
       "rank": 27,
+      "id": "webml-community/bonsai-image-webgpu",
+      "author": "webml-community",
+      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
+      "likes": 43,
+      "trendingScore": 42,
+      "sdk": "static",
+      "tags": [
+        "static",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T17:12:36.000Z",
+      "lastModified": "2026-05-26T20:57:36.000Z",
+      "models": []
+    },
+    {
+      "rank": 28,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -454,7 +470,7 @@
       "models": []
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
@@ -470,7 +486,7 @@
       "models": []
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
@@ -487,7 +503,7 @@
       "models": []
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
@@ -503,7 +519,23 @@
       "models": []
     },
     {
-      "rank": 31,
+      "rank": 32,
+      "id": "ibuildproducts/wan22-i2v-v4-demo",
+      "author": "ibuildproducts",
+      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
+      "likes": 46,
+      "trendingScore": 35,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T23:34:01.000Z",
+      "lastModified": "2026-05-18T00:16:12.000Z",
+      "models": []
+    },
+    {
+      "rank": 33,
       "id": "multimodalart/qwen-image-multiple-angles-3d-camera",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/qwen-image-multiple-angles-3d-camera",
@@ -519,7 +551,7 @@
       "models": []
     },
     {
-      "rank": 32,
+      "rank": 34,
       "id": "suraj291/Survival_Island_Game",
       "author": "suraj291",
       "url": "https://huggingface.co/spaces/suraj291/Survival_Island_Game",
@@ -536,7 +568,7 @@
       "models": []
     },
     {
-      "rank": 33,
+      "rank": 35,
       "id": "r3gm/wan2-2-fp8da-aoti-previewG",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewG",
@@ -553,23 +585,7 @@
       "models": []
     },
     {
-      "rank": 34,
-      "id": "ibuildproducts/wan22-i2v-v4-demo",
-      "author": "ibuildproducts",
-      "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
-      "likes": 42,
-      "trendingScore": 33,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T23:34:01.000Z",
-      "lastModified": "2026-05-18T00:16:12.000Z",
-      "models": []
-    },
-    {
-      "rank": 35,
+      "rank": 36,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -585,7 +601,7 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -602,7 +618,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -619,7 +635,7 @@
       "models": []
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -635,7 +651,7 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -651,7 +667,23 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 41,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 32,
+      "trendingScore": 31,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-27T04:48:10.000Z",
+      "models": []
+    },
+    {
+      "rank": 42,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -667,7 +699,7 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 43,
       "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
@@ -684,7 +716,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 44,
       "id": "CohereLabs/command-a-plus-05-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
@@ -700,23 +732,7 @@
       "models": []
     },
     {
-      "rank": 43,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 31,
-      "trendingScore": 30,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-26T15:57:44.000Z",
-      "models": []
-    },
-    {
-      "rank": 44,
+      "rank": 45,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -732,7 +748,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -749,7 +765,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -765,7 +781,27 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
+      "id": "mrfakename/anima-v1",
+      "author": "mrfakename",
+      "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
+      "likes": 42,
+      "trendingScore": 25,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "text-to-image",
+        "anima",
+        "zerogpu",
+        "anime",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T02:42:26.000Z",
+      "lastModified": "2026-05-22T03:20:51.000Z",
+      "models": []
+    },
+    {
+      "rank": 49,
       "id": "HuggingFaceTB/smol-training-playbook",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook",
@@ -785,7 +821,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 50,
       "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
       "author": "linoyts",
       "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
@@ -799,39 +835,6 @@
       ],
       "createdAt": "2025-12-28T08:15:28.000Z",
       "lastModified": "2025-12-29T13:46:27.000Z",
-      "models": []
-    },
-    {
-      "rank": 49,
-      "id": "facebook/vggt-omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
-      "likes": 31,
-      "trendingScore": 24,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T23:39:56.000Z",
-      "lastModified": "2026-05-18T21:46:03.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "black-forest-labs/FLUX.2-klein-9B",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/spaces/black-forest-labs/FLUX.2-klein-9B",
-      "likes": 835,
-      "trendingScore": 23,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-01-15T09:50:22.000Z",
-      "lastModified": "2026-01-16T13:56:36.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26491836925

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.