### PR TITLE
chore(data): refresh lobsters signals 2026-05-27T06:00:40Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-27T01:37:08.710Z",
+  "ts": "2026-05-27T06:00:40.120Z",
   "count": 1,
-  "durationMs": 2272,
+  "durationMs": 2415,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-27T01:37:06.459Z",
+  "fetchedAt": "2026-05-27T06:00:37.725Z",
   "windowDays": 7,
-  "scannedStories": 75,
+  "scannedStories": 76,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-27T01:37:06.459Z",
+  "fetchedAt": "2026-05-27T06:00:37.725Z",
   "windowHours": 72,
-  "scannedTotal": 75,
+  "scannedTotal": 76,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26493716715

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.