### PR TITLE
chore(data): refresh awesome-skills index 2026-05-27T08:15:24Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-26T08:04:46.930Z",
+  "ts": "2026-05-27T08:15:24.855Z",
   "count": 1,
-  "durationMs": 3100,
+  "durationMs": 2486,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T08:04:43.831Z",
+  "fetchedAt": "2026-05-27T08:15:22.370Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",
@@ -55,7 +55,8 @@
       "sickn33/antigravity-awesome-skills"
     ],
     "buywhere/buywhere-mcp": [
-      "sickn33/antigravity-awesome-skills"
+      "sickn33/antigravity-awesome-skills",
+      "punkpeye/awesome-mcp-servers"
     ],
     "expo/skills": [
       "sickn33/antigravity-awesome-skills"
@@ -80,7 +81,8 @@
       "sickn33/antigravity-awesome-skills"
     ],
     "ejentum/ejentum-mcp": [
-      "sickn33/antigravity-awesome-skills"
+      "sickn33/antigravity-awesome-skills",
+      "punkpeye/awesome-mcp-servers"
     ],
     "luoyuctl/agenttrace": [
       "sickn33/antigravity-awesome-skills"
@@ -397,6 +399,9 @@
     "punkpeye/awesome-mcp-clients": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "zafronix/wc-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "1mcp-app/agent": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -421,6 +426,9 @@
     "agenthotspot/agenthotspot-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "garasegae/aiskillstore": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "alexanderclapp/clirank-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -440,6 +448,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "blockrunai/blockrun-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "cinderwright-ai/cinderwright-api": [
       "punkpeye/awesome-mcp-servers"
     ],
     "data-everything/mcp-server-templates": [
@@ -526,6 +537,9 @@
     "mindsdb/mindsdb": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "octodamus/octodamus-core": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "opentabs-dev/opentabs": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -552,6 +566,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "rupinder2/mcp-orchestrator": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "sf1nx/x402station-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "supertrained/rhumb": [
@@ -601,6 +618,9 @@
     "whiteknightonhorse/apibase": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "wolido/openaaas": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "rplryan/x402-discovery-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -611,6 +631,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "yangliangwei/personalizationmcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "swarmwage/swarmwage": [
       "punkpeye/awesome-mcp-servers"
     ],
     "gregario/astronomy-oracle": [
@@ -626,6 +649,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "acedatacloud/seedreammcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "aidatanordic/alexandria-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "8ensmith/mcp-open-library": [
@@ -668,6 +694,9 @@
     "cfpramod/open-museum-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "clawdbotworker/imagegen-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "cifero74/mcp-apple-music": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -678,6 +707,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "cswkim/discogs-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "delmas41/gradusnotation": [
       "punkpeye/awesome-mcp-servers"
     ],
     "diivi/aseprite-mcp": [
@@ -729,6 +761,9 @@
     "peek-travel/mcp-intro": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "pzfreo/build123d-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "doctorm333/promptpilot-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -766,6 +801,9 @@
     "bv-venky/excalidraw-architect-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "ejwhite7/brandkit-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "erajasekar/ai-diagram-maker-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -773,6 +811,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "gittyburstein/mermaid-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "karyaboyraz/mockit-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "narasimhaponnada/mermaid-mcp": [
@@ -809,6 +850,9 @@
     "mymedi-ai/mymedi-ai-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "salwks/mcp-techtrend": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "nyxtoolsdev/dicom-hl7-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -830,10 +874,16 @@
     "ohnlp/omop_mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "pantelisgeorgiadis/dicomweb-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "tatsuju/opdstar-nhi-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "pkotecha-eng/aria-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "sidneybissoli/medical-terminologies-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "the-momentum/apple-health-mcp-server": [
@@ -914,10 +964,16 @@
     "freema/firefox-devtools-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "sh6drack/zen-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "getrupt/ashra-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "hanzili/comet-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "hshintelligence/agent-scrape": [
       "punkpeye/awesome-mcp-servers"
     ],
     "larrywalkerdev/mcp-immostage": [
@@ -982,6 +1038,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "pskill9/web-search": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "protostatis/unbrowser": [
       "punkpeye/awesome-mcp-servers"
     ],
     "kuvopllc/purroxy2": [
@@ -1050,6 +1109,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "alexpota/cloudscope-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "alikarami/mikromcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "aliyun/alibaba-cloud-ops-mcp-server": [
@@ -1185,6 +1247,9 @@
     "sevalla-hosting/mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "shdomi8599/vibie-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "shipstatic/mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -1264,6 +1329,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "hileamlakb/prims": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "ksterx/srunx": [
       "punkpeye/awesome-mcp-servers"
     ],
     "mavdol/capsule": [
@@ -1400,6 +1468,9 @@
     "preflight-dev/preflight": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "pschina/deepseek-as-subagent": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "religa/multi_mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -1419,6 +1490,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "stippi/code-assistant": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "pthrower/strata": [
       "punkpeye/awesome-mcp-servers"
     ],
     "sunflowerslwtech/mcp_creator_growth": [
@@ -1451,6 +1525,12 @@
     "x51xxx/copilot-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "eliottreich/taskbounty-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "capsulerun/bash": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "danmartuszewski/hop": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -1469,13 +1549,22 @@
     "lukelamb/claude-terminal-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "hasanjahidul/terminal-history-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "abdelstark/nostr-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "adhikasp/mcp-twikit": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "agenticmail/agenticmail": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "agentmail-to/agentmail-toolkit": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "automatelab-tech/content-distribution-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "bababoi-bibilabu/agent-mq": [
@@ -1525,6 +1614,9 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "ethanqc/feishu-user-plugin": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "expertvagabond/solmail-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -1544,6 +1636,9 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "googlarz/signal-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "gotoolkits/mcp-wecombot-server": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
@@ -1554,6 +1649,9 @@
     "i-am-bee/acp-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "iletimerkezi/iletimerkezi-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "imdinu/apple-mail-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -1561,6 +1659,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "infobip/mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "iprashantraj/mcp-discord-bridge": [
       "punkpeye/awesome-mcp-servers"
     ],
     "shahabazdev/inxmail-mcp": [
@@ -1626,6 +1727,9 @@
     "marlinjai/email-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "marras0914/agent-toolbelt": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "multimail-dev/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -1644,6 +1748,9 @@
     "phononx/cv-mcp-server": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "pingfyr/mcp": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "platfone-com/mcp": [
       "punkpeye/awesome-mcp-servers"
@@ -1664,6 +1771,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "sawa-zen/vrchat-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "sealjay/mcp-hey": [
       "punkpeye/awesome-mcp-servers"
     ],
     "sirgreed808/zoho-mail-mcp": [
@@ -1718,7 +1828,16 @@
     "zacccck/claude-mcp-read-email-attachments": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "kiro0x/five-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "perspective-ai/mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "denismaggior8/enigma-python-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "denismaggior8/enigma-python": [
       "punkpeye/awesome-mcp-servers"
     ],
     "antvis/mcp-server-chart": [
@@ -1776,6 +1895,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "arcadedata/arcadedb": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "astandrik/local-ydb-toolkit": [
       "punkpeye/awesome-mcp-servers"
     ],
     "benborla/mcp-server-mysql": [
@@ -1938,6 +2060,9 @@
     "kiliczsh/mcp-mongo-server": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "kosminus/querywise-mcp": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "ktanaka101/mcp-server-duckdb": [
       "punkpeye/awesome-mcp-servers"
@@ -2108,7 +2233,13 @@
     "1luvc0d3/metabase-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "alanpcf/brasil-data-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "carrierone/verilexdata-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "aegis-dq/aegis-dq": [
       "punkpeye/awesome-mcp-servers"
     ],
     "alkemi-ai/alkemi-mcp": [
@@ -2135,6 +2266,9 @@
     "dbt-labs/dbt-mcp": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "evan-crx/permisapi-mcp": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "flowcore-io/mcp-flowcore-platform": [
       "punkpeye/awesome-mcp-servers"
@@ -2177,6 +2311,9 @@
     "saikiyusuke/registep-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "soil-dev/capsulemcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "vikramgorla/mcp-swiss": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -2184,6 +2321,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "leekangbum/networklytics-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "adrianczuczka/mason": [
       "punkpeye/awesome-mcp-servers"
     ],
     "masondelan/selvedge": [
@@ -2198,10 +2338,16 @@
     "drhalto/agentmako": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "magna-nz/aspnetcore-debugger-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "marin1321/mcp-devtools": [
       "punkpeye/awesome-mcp-servers"
     ],
     "etiennechollet/ontomics": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "ozgurcd/gograph": [
       "punkpeye/awesome-mcp-servers"
     ],
     "lwtlong/ai-dev-analytics": [
@@ -2248,6 +2394,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "geiserx/atlassian-browser-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "rust-works/omni-dev": [
       "punkpeye/awesome-mcp-servers"
     ],
     "abrinsmead/mindpilot-mcp": [
@@ -2323,6 +2472,9 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "astandrik/codex-pets": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "arvindand/maven-tools-mcp": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
@@ -2337,6 +2489,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "axliupore/mcp-code-runner": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "ayhammouda/python-docs-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
     "azer/react-analyzer-mcp": [
@@ -2368,6 +2523,9 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "carloshpdoc/memorydetective": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "cerebrixos-org/tuning-engines-cli": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -2389,6 +2547,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "saikiyusuke/claudecodenavi-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "cocaxcode/api-testing-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "patricksys/codebase-context": [
@@ -2430,6 +2591,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "dannote/figma-use": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "musepy/genable": [
       "punkpeye/awesome-mcp-servers"
     ],
     "davidan90/time-node-mcp": [
@@ -2654,9 +2818,15 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "jungle-grid/mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "kadykov/mcp-openapi-schema-explorer": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "kao273183/mk-qa-master": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "kapeli/dash-mcp-server": [
       "punkpeye/awesome-mcp-servers"
@@ -2802,6 +2972,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "nikolai-vysotskyi/trace-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "nishant-chaudhary5338/mcp-toolkit": [
       "punkpeye/awesome-mcp-servers"
     ],
     "nk3750/jitapi": [
@@ -2968,6 +3141,9 @@
     "selvage-lab/selvage": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "notasandy/mcp-code-sanitizer": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "shellsage-ai/mcp-server-boilerplate": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3021,6 +3197,9 @@
     "stass/lldb-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "stfade/moth": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "storybookjs/addon-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3028,6 +3207,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "tamarengel/jira-github-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "tao-izm/devpulse-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "tcsoftinc/testcollab-mcp-server": [
@@ -3053,6 +3235,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "tipdotmd/tip-md-x402-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "mibayy/token-savior": [
       "punkpeye/awesome-mcp-servers"
     ],
     "tommertom/awesome-ionic-mcp": [
@@ -3086,6 +3271,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "vercel/next-devtools-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "vighriday/veris": [
       "punkpeye/awesome-mcp-servers"
     ],
     "vezlo/src-to-kb": [
@@ -3204,7 +3392,16 @@
     "hikmahtech/drwhome": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "nazarkalytiuk/tarn": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "tooluse-labs/perfetto-mcp-rs": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "mshegolev/jaeger-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "parasxos/cpp26-adapter": [
       "punkpeye/awesome-mcp-servers"
     ],
     "jordandalton/doordash-mcp-server": [
@@ -3275,6 +3472,9 @@
     "leap-laboratories/discovery-engine": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "lihtness/gnomon-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "mckinsey/vizro": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3282,6 +3482,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "whatsonyourmind/oraclaw": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "playidea-lab/pcq": [
       "punkpeye/awesome-mcp-servers"
     ],
     "phisanti/mcpr": [
@@ -3354,10 +3557,19 @@
     "catallo/misterclaw": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "admin978/canvas-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "connectry-io/connectrylab-architect-cert-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "juhongpark/mcp-server-pronunciation": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "rohanmuppa/brightspace-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "agentcentral-to/agent-central-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "agentlux/agentlux-mcp": [
@@ -3390,10 +3602,19 @@
     "pcdck/ozon-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "vitrine3d/mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "pepabo/colormeshop-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "nicktcode/swissgroceries-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "aliafsahnoudeh/wildfire-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "atmospore/atmospore-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "nalediym/touch-grass": [
@@ -3411,6 +3632,9 @@
     "cyberchitta/llm-context.py": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "drolosoft/go-docs-mcp": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "ebbfijsf/agent-reader": [
       "punkpeye/awesome-mcp-servers"
@@ -3461,6 +3685,9 @@
     "facundolucci/plsreadme": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "colapsis/transfa": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "usejunior/safe-docx": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3471,6 +3698,12 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "xxczaki/local-history": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "logitale/toreador-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "infaton/mcp35": [
       "punkpeye/awesome-mcp-servers"
     ],
     "mrslbt/xendit-mcp": [
@@ -3491,7 +3724,13 @@
     "iiatlas/hledger-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "fabio662/yieldagentx402-sdks": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "openpulsechain/public": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "0xdegenmo/lighter-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "aaronjmars/web3-research-mcp": [
@@ -3501,6 +3740,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "ahnlabio/bicscan-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "aletaindex/aletaindex-fin-narratives": [
       "punkpeye/awesome-mcp-servers"
     ],
     "alexanderlawson17/revettr-python": [
@@ -3546,13 +3788,22 @@
     "autonsol/sol-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "vatnode/vatnode-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "vdalhambra/axiom-calculator-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "azeth-protocol/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "claynsn/agent-discovery-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "bakyang2/kr-crypto-intelligence": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "whdrnr2583-cmd/koreanpulse": [
       "punkpeye/awesome-mcp-servers"
     ],
     "cuthongthai-vn/vimo-mcp-server": [
@@ -3648,6 +3899,9 @@
     "declan142/calcnook-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "deficlow/zipp-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "demwick/polymarket-agent-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3660,10 +3914,16 @@
     "doggybee/mcp-server-ccxt": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "dolphinquant/echolon": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "douglasborthwick-crypto/mcp-server-insumer": [
       "punkpeye/awesome-mcp-servers"
     ],
     "edge-claw/mood-booster-agent": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "emblemcompany/agent-skills": [
       "punkpeye/awesome-mcp-servers"
     ],
     "equivault/equivault-mcp": [
@@ -3681,6 +3941,9 @@
     "haiku-trading/haiku-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "hashlock-tech/hashlock-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "hifriendbot/agentwallet-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3690,10 +3953,16 @@
     "evan-moon/firma": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "falsifylab/falsifylab-alpha-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "brunopessoa22/chiliz-marketing-intel": [
       "punkpeye/awesome-mcp-servers"
     ],
     "fernsugi/x402-api-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "felippeyann/agentfi": [
       "punkpeye/awesome-mcp-servers"
     ],
     "ferdousbhai/investor-agent": [
@@ -3717,7 +3986,13 @@
     "finmap-org/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "flox-foundation/flox": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "fund-z/fundzwatch-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "gblinproject/gblin-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "getalby/mcp": [
@@ -3758,6 +4033,9 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "hypeprinter007-stack/signalfuse-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "hypurrquant/perp-cli": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -3774,6 +4052,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "huggingagi/mcp-baostock-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "hypeprinter007-stack/anchor-x402-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "ignaciohermosillacornejo/copilot-money-mcp": [
@@ -3816,6 +4097,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "jacobsd32-cpu/djd-agent-score-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "krystiangw/agenticpay": [
       "punkpeye/awesome-mcp-servers"
     ],
     "kukapay/binance-alpha-mcp": [
@@ -3888,6 +4172,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "kukapay/cryptopanic-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "lambopoewert/mcp-server-madeonsol": [
       "punkpeye/awesome-mcp-servers"
     ],
     "make-software/cspr-trade-mcp": [
@@ -4010,7 +4297,13 @@
     "unixlamadev-spec/lpxpoly-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "untitledfinancial/dpx-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "lnbits/lnbits-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "longbridge/longbridge-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "longportapp/openapi": [
@@ -4129,6 +4422,9 @@
     "pythia-the-oracle/pythia-oracle-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "piquesignal/piquesignal-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "qbt-labs/openmm-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4173,10 +4469,16 @@
     "sapph1re/findata-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "sailorpepe/undesirables-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "shareseer/shareseer-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
     "shipitandpray/mcp-market-data": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "shinydapps/l402-kit": [
       "punkpeye/awesome-mcp-servers"
     ],
     "lmwharton/sieve-mcp": [
@@ -4300,6 +4602,9 @@
     "pickelfintech/the13f-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "tradallo/reputation": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "3akhp/prts-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4387,6 +4692,9 @@
     "n24q02m/better-godot-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "najemwehbe/unreal-ai-connection": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "opgginc/opgg-mcp": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
@@ -4427,6 +4735,9 @@
     "hadicherkaoui/crafty-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "handsomejustin/mijia-control": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "apiarya/wemo-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4434,6 +4745,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "kambriso/fritzbox-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "a2cr/a2cr": [
       "punkpeye/awesome-mcp-servers"
     ],
     "aidesignblueprint/integrations": [
@@ -4512,6 +4826,9 @@
     "cameronrye/openzim-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "cachly-dev/cachly-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "cdeust/cortex": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4524,6 +4841,9 @@
     "canopyhq/phloem": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "cavinooo/claude-find": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "chatmcp/mcp-server-chatsum": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4534,6 +4854,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "cipherfoxie/sovereign-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "codeabra/iai-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "xjtlumedia/context-first-mcp": [
@@ -4554,10 +4877,19 @@
     "decisionnode/decisionnode": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "giuliohome-org/doc-manager": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "destrayon/connapse": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "dengls24/annota": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "deusxmachina-dev/memorylane": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "dnotitia/akb": [
       "punkpeye/awesome-mcp-servers"
     ],
     "dodopayments/context-mcp": [
@@ -4569,7 +4901,13 @@
     "doobidoo/mcp-memory-service": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "dot-realitytest/obsidian-codex-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "dollhousemcp/mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "domdemetz/claude-soul": [
       "punkpeye/awesome-mcp-servers"
     ],
     "edobusy/agenthold": [
@@ -4591,6 +4929,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "erebusenigma/context-memory": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "makeamouse/fish-bridge-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "for-sunny/hebbian-mind-enterprise": [
@@ -4675,6 +5016,9 @@
     "keepgoing-dev/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "kunwar-shah/claudex": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "kvantra-dev/nouz-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4685,6 +5029,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "linxule/lotus-wisdom-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "lithtrix/lithtrix-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "louis030195/easy-obsidian-mcp": [
@@ -4702,7 +5049,13 @@
     "mattjoyce/mcp-persona-sessions": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "maxkuminov/obsidian-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "mem0ai/mem0-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "udjin-labs/mnemostack": [
       "punkpeye/awesome-mcp-servers"
     ],
     "tverney/mcp-agent-memory": [
@@ -4741,6 +5094,9 @@
     "nfemmanuel/iranti": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "nicolasprimeau/artel": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "nicholasglazer/gnosis-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4763,6 +5119,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "paladini/mcp-me": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "patdolitse/piia-engram": [
       "punkpeye/awesome-mcp-servers"
     ],
     "papersflow-ai/papersflow-mcp": [
@@ -4798,6 +5157,9 @@
     "redleaves/context-keeper": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "skitchy/rekindle": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "roampal-ai/roampal-core": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4808,6 +5170,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "s60yucca/mnemos": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "sachitrafa/yourmemory": [
       "punkpeye/awesome-mcp-servers"
     ],
     "securityronin/alaya": [
@@ -4831,6 +5196,9 @@
     "l33tdawg/sage": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "laradji/deadzone": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "smart-ai-memory/empathy-framework": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4844,6 +5212,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "yusufkaraaslan/skill_seekers": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "stevepridemore/graph-memory": [
       "punkpeye/awesome-mcp-servers"
     ],
     "subdownload/subdownload-mcp": [
@@ -4871,6 +5242,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "tt-wang/cortex-plugin": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "tykolt/kremis": [
       "punkpeye/awesome-mcp-servers"
     ],
     "unibaseio/membase-mcp": [
@@ -4912,6 +5286,9 @@
     "wynelson94/longhand": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "stifler7/memex": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "ark-forge/mcp-eu-ai-act": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4933,6 +5310,9 @@
     "philrox/ris-mcp-ts": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "apogeoapi/apogeoapi-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "bamwor-dev/bamwor-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -4943,6 +5323,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "cqtrinv/trinvmcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "cturkieh/france-data-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "devilcoder01/weather-mcp-server": [
@@ -5087,6 +5470,9 @@
     "live-direct-marketing/ldm-inbox-check-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "localseodata/mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "mailboxvalidator/mcp-mailboxvalidator": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5124,6 +5510,9 @@
     "qr-maker-io/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "krissanders/ai-visibility-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "sharozdawa/ai-visibility": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5145,10 +5534,16 @@
     "tomba-io/tomba-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "whdrnr2583-cmd/token-meter": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "zleventer/salesforce-marketing-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "andrealufino/aapl-ads-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "appvisionos/apple-search-ads-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "alilxxey/openobserve-community-mcp": [
@@ -5198,6 +5593,9 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "hugoles/langfuse-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "hyperb1iss/lucidity-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5215,6 +5613,9 @@
       "wong2/awesome-mcp-servers"
     ],
     "inventer-dev/mcp-internet-speed-test": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "jwrede/llmprobe": [
       "punkpeye/awesome-mcp-servers"
     ],
     "last9/last9-mcp-server": [
@@ -5249,6 +5650,9 @@
     "mindscapehq/mcp-server-raygun": [
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
+    ],
+    "andreisirbu91-lab/mcpspend": [
+      "punkpeye/awesome-mcp-servers"
     ],
     "mpeirone/zabbix-mcp-server": [
       "punkpeye/awesome-mcp-servers"
@@ -5287,6 +5691,9 @@
     "thinkneoai/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "tickstem/mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "tumf/grafana-loki-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5309,6 +5716,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "acedatacloud/sunomcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "afshinator/mcp-server-pexels": [
       "punkpeye/awesome-mcp-servers"
     ],
     "agenticdecks/deckrun-mcp": [
@@ -5359,6 +5769,9 @@
     "pastorsimon1798/mcp-video": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "stabgan/openrouter-mcp-multimodal": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "stass/exif-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5396,6 +5809,9 @@
     "dimpagk92/cellar": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "harusame64/desktop-touch-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "daiji-sshr/redmine-mcp-stateless": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5411,7 +5827,13 @@
     "spranab/saga-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "agrath/trello-desktop-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "ashev87/propstack-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "forgemeshlabs/disruption-intelligence-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "agnuxo1/benchclaw-integrations": [
@@ -5430,6 +5852,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "kimimgo/viznoir": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "mlava/scholar-sidekick-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "mnemox-ai/idea-reality-mcp": [
@@ -5453,13 +5878,22 @@
     "thinkchainai/agentinterviews_mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "vassiliylakhonin/agenda-intelligence-md": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "xmpuspus/ph-civic-data-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "yusong652/pfc-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "sparkit-science/sparkit-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "yusong652/yade-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "selfpy/science-ai-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
     "gogabrielordonez/mcp-ragchat": [
@@ -5469,6 +5903,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "vectara/vectara-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "aiweather-anurag/ottasia-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
     "mrslbt/rippr": [
@@ -5506,6 +5943,9 @@
     "andybrandt/mcp-simple-pubmed": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "andyliszewski/webcrawl-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "angheljf/nyt": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5513,6 +5953,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "atlasprzetargow/mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "automatelab-tech/citation-intelligence": [
       "punkpeye/awesome-mcp-servers"
     ],
     "khamel83/argus": [
@@ -5540,6 +5983,9 @@
     "cameronrye/gopher-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "einiba/canyougrab-api": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "cevatkerim/unsplash-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5548,6 +5994,9 @@
       "wong2/awesome-mcp-servers"
     ],
     "chasesaurabh/mcp-page-capture": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "ckbrennan/overtone-news-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "conechoai/openai-websearch-mcp": [
@@ -5635,6 +6084,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "hellokaton/unsplash-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "hughescuit/heventure-search-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "himalayas-app/himalayas-mcp": [
@@ -5881,6 +6333,9 @@
     "vitorpavinato/ncbi-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "gaoshan0971/digeguigui": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "robbyczgw-cla/web-search-plus-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5891,22 +6346,34 @@
       "punkpeye/awesome-mcp-servers",
       "wong2/awesome-mcp-servers"
     ],
+    "ashlrai/webfetch": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "webpeel/webpeel": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "whw23/searxng_http_mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "yamanoku/baseline-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "yubinkim444/ai-first-scraper-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "zhsama/duckduckgo-mpc-server": [
       "punkpeye/awesome-mcp-servers"
     ],
-    "zoharbabin/google-researcher-mcp": [
+    "zoharbabin/web-researcher-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "zlatkoc/youtube-summarize": [
       "punkpeye/awesome-mcp-servers"
     ],
     "zoomeye-ai/mcp_zoomeye": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "srinivasan-sundaresan95/orihime": [
       "punkpeye/awesome-mcp-servers"
     ],
     "alexfleetcommander/agent-trust-stack-mcp": [
@@ -5945,6 +6412,9 @@
     "agntor/mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "gaoharimran29-glitch/cybersecurity-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "vinaybhosle/agentstamp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5958,6 +6428,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "alberthild/shieldapi-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "rudraneel93/mcp-guardian": [
       "punkpeye/awesome-mcp-servers"
     ],
     "jagmarques/asqav-mcp": [
@@ -5978,6 +6451,9 @@
     "behrensd/mcp-firewall": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "bichev/agentradar-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "burtthecoder/mcp-dnstwist": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -5990,6 +6466,9 @@
     "burtthecoder/mcp-virustotal": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "declade/lucairn-sdks": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "chrbailey/promptspeak-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6000,6 +6479,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "co-browser/attestable-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "coreyhines/opnsense-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "creatorrmode-lead/avp-sdk": [
@@ -6143,10 +6625,22 @@
     "operantlabs/operant-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "orygnscode/opa-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "styrainc/regal": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "pentagonal-ai/pentagonal": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "p4st4s/mcp-audit": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "panther-labs/mcp-panther": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "piiiico/proof-of-commitment": [
       "punkpeye/awesome-mcp-servers"
     ],
     "pullkitsan/mobsf-mcp-server": [
@@ -6163,6 +6657,9 @@
       "wong2/awesome-mcp-servers"
     ],
     "radareorg/radare2-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "rev2ret/secureaudit-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "roadwy/cve-search_mcp": [
@@ -6206,6 +6703,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "sidclawhq/platform": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "chronolapse411/sicarius-guard": [
       "punkpeye/awesome-mcp-servers"
     ],
     "sint-ai/sint-protocol": [
@@ -6291,7 +6791,13 @@
     "layervai/qurl-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "wrg-11/wrg-sigma-rules": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "06ketan/substack-ops": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "abhineet34/linkedin-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
     "anwerj/youtube-uploader-mcp": [
@@ -6357,6 +6863,9 @@
     "sinanefeozler/reddit-summarizer-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "socialintel/socialintel-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "bulatko/vk-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6406,6 +6915,9 @@
     "partymola/fitbit-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "proplineapi/propline-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "r-huijts/firstcycling-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6436,6 +6948,9 @@
     "incentivai/quickchat-ai-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "michaelrice/zendesk-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "nguyenvanduocit/jira-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6455,6 +6970,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "translated/lara-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "eviscerations/whisper-windows-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "daisys-ai/daisys-mcp": [
@@ -6477,6 +6995,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "alcylu/nightlife-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "autonomad1/autonomad-travel": [
       "punkpeye/awesome-mcp-servers"
     ],
     "campertunity/mcp-server": [
@@ -6507,6 +7028,9 @@
     "marceausolutions/rideshare-comparison-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "mattjeff/orizn-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "openbnb-org/mcp-server-airbnb": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6520,6 +7044,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "r-huijts/ns-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "roamzy-io/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
     "skedgo/tripgo-mcp-server": [
@@ -6601,6 +7128,9 @@
     "agentled/mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "arifur9993/attendance-engine-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "6figr-com/jobgpt-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6617,6 +7147,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "bug-breeder/quip-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "ayo-nci/bulkrender-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "can4hou6joeng4/boss-agent-cli": [
@@ -6650,6 +7183,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "ellmos-ai/n8n-manager-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "ernestocorona/kanboard-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "foxintheloop/uptier": [
@@ -6706,7 +7242,13 @@
     "moro3k/mcp-altegio": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "opsconduit/jobber-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "prompeteer/prompeteer-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "proompteng/bilig": [
       "punkpeye/awesome-mcp-servers"
     ],
     "saikiyusuke/sparksheets-mcp": [
@@ -6730,6 +7272,9 @@
     "tubasasakunn/context-apps-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "tuanle96/mcp-odoo": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "twtrubiks/odoo19-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6751,6 +7296,9 @@
     "vasylenko/claude-desktop-extension-bear-notes": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "workopia/workopia-mcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "wyattjoh/calendar-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -6761,6 +7309,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "yuvalsuede/claudia": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "bit2beat/bitrix24-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "2niuhe/plantuml_web": [
@@ -7040,6 +7591,9 @@
     "magarcia/mcp-server-giphy": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "mag-cie/mcp-microsoft-todo": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "marcelmarais/spotify-mcp-server": [
       "punkpeye/awesome-mcp-servers"
     ],
@@ -7288,7 +7842,16 @@
     "epistates/turbomcp": [
       "punkpeye/awesome-mcp-servers"
     ],
+    "heymrun/heym": [
+      "punkpeye/awesome-mcp-servers"
+    ],
     "zhangpanda/gomcp": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "kioie/tiny-go-mcp-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "modelcontextprotocol/go-sdk": [
       "punkpeye/awesome-mcp-servers"
     ],
     "jlowin/fastmcp": [
@@ -7310,6 +7873,9 @@
       "punkpeye/awesome-mcp-servers"
     ],
     "rocketride-org/rocketride-server": [
+      "punkpeye/awesome-mcp-servers"
+    ],
+    "vivek081166/japan-utils-mcp": [
       "punkpeye/awesome-mcp-servers"
     ],
     "adfin-engineering/mcp-server-adfin": [
@@ -8135,6 +8701,6 @@
   "counts": {
     "lists": 4,
     "listsAttempted": 5,
-    "uniqueSkills": 2633
+    "uniqueSkills": 2821
   }
 }


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26499334886

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.