### PR TITLE
chore(data): refresh huggingface signals 2026-05-27T10:22:20Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-27T04:51:14.504Z",
+  "ts": "2026-05-27T10:22:20.647Z",
   "count": 1,
-  "durationMs": 6821,
+  "durationMs": 5231,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T04:51:07.685Z",
+  "fetchedAt": "2026-05-27T10:22:15.418Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -355,8 +355,8 @@
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
       "downloads": 0,
-      "likes": 309,
-      "trendingScore": 299,
+      "likes": 321,
+      "trendingScore": 311,
       "pipelineTag": null,
       "libraryName": "diffusers",
       "tags": [
@@ -379,42 +379,12 @@
     },
     {
       "rank": 13,
-      "id": "sapientinc/HRM-Text-1B",
-      "author": "sapientinc",
-      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
-      "downloads": 103033,
-      "likes": 361,
-      "trendingScore": 292,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "hrm_text",
-        "text-generation",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "en",
-        "arxiv:2605.20613",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T15:13:02.000Z",
-      "lastModified": "2026-05-21T05:57:38.000Z"
-    },
-    {
-      "rank": 14,
       "id": "openbmb/MiniCPM5-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
       "downloads": 2409,
-      "likes": 322,
-      "trendingScore": 286,
+      "likes": 349,
+      "trendingScore": 304,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -446,6 +416,36 @@
       ],
       "createdAt": "2026-05-21T07:27:59.000Z",
       "lastModified": "2026-05-26T04:24:04.000Z"
+    },
+    {
+      "rank": 14,
+      "id": "sapientinc/HRM-Text-1B",
+      "author": "sapientinc",
+      "url": "https://huggingface.co/sapientinc/HRM-Text-1B",
+      "downloads": 103033,
+      "likes": 361,
+      "trendingScore": 292,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "hrm_text",
+        "text-generation",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "en",
+        "arxiv:2605.20613",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T15:13:02.000Z",
+      "lastModified": "2026-05-21T05:57:38.000Z"
     },
     {
       "rank": 15,
@@ -509,8 +509,8 @@
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "downloads": 1598473,
-      "likes": 921,
-      "trendingScore": 216,
+      "likes": 928,
+      "trendingScore": 221,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -607,8 +607,8 @@
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-w4a4",
       "downloads": 7769,
-      "likes": 207,
-      "trendingScore": 203,
+      "likes": 209,
+      "trendingScore": 205,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -881,41 +881,12 @@
     },
     {
       "rank": 29,
-      "id": "XiaomiMiMo/MiMo-V2.5-Pro",
-      "author": "XiaomiMiMo",
-      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
-      "downloads": 20905,
-      "likes": 467,
-      "trendingScore": 142,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "mimo_v2",
-        "text-generation",
-        "agent",
-        "long-context",
-        "code",
-        "conversational",
-        "custom_code",
-        "en",
-        "zh",
-        "license:mit",
-        "eval-results",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T12:52:53.000Z",
-      "lastModified": "2026-04-28T07:01:37.000Z"
-    },
-    {
-      "rank": 30,
       "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
       "downloads": 16379,
-      "likes": 147,
-      "trendingScore": 140,
+      "likes": 150,
+      "trendingScore": 143,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -951,6 +922,35 @@
       ],
       "createdAt": "2026-05-16T10:48:10.000Z",
       "lastModified": "2026-05-24T08:15:12.000Z"
+    },
+    {
+      "rank": 30,
+      "id": "XiaomiMiMo/MiMo-V2.5-Pro",
+      "author": "XiaomiMiMo",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
+      "downloads": 20905,
+      "likes": 467,
+      "trendingScore": 142,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "mimo_v2",
+        "text-generation",
+        "agent",
+        "long-context",
+        "code",
+        "conversational",
+        "custom_code",
+        "en",
+        "zh",
+        "license:mit",
+        "eval-results",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T12:52:53.000Z",
+      "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
       "rank": 31,
@@ -1043,6 +1043,33 @@
     },
     {
       "rank": 34,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 117,
+      "likes": 130,
+      "trendingScore": 128,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 35,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
@@ -1087,38 +1114,13 @@
       "lastModified": "2026-05-22T14:40:13.000Z"
     },
     {
-      "rank": 35,
-      "id": "Qwen/Qwen3.6-35B-A3B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
-      "downloads": 3363621,
-      "likes": 1676,
-      "trendingScore": 119,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "conversational",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-15T05:59:19.000Z",
-      "lastModified": "2026-04-24T02:53:42.000Z"
-    },
-    {
       "rank": 36,
       "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
       "downloads": 31597,
-      "likes": 122,
-      "trendingScore": 119,
+      "likes": 124,
+      "trendingScore": 121,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1158,30 +1160,28 @@
     },
     {
       "rank": 37,
-      "id": "nvidia/PiD",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/PiD",
-      "downloads": 117,
-      "likes": 120,
+      "id": "Qwen/Qwen3.6-35B-A3B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
+      "downloads": 3363621,
+      "likes": 1676,
       "trendingScore": 119,
-      "pipelineTag": "image-to-image",
-      "libraryName": "pytorch",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "pytorch",
-        "diffusers",
+        "transformers",
         "safetensors",
-        "super-resolution",
-        "diffusion",
-        "pixel-diffusion-decoder",
-        "vae-decoder",
-        "image-to-image",
-        "arxiv:2605.23902",
-        "base_model:Tongyi-MAI/Z-Image",
-        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "conversational",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2026-04-28T00:41:46.000Z",
-      "lastModified": "2026-05-26T01:17:21.000Z"
+      "createdAt": "2026-04-15T05:59:19.000Z",
+      "lastModified": "2026-04-24T02:53:42.000Z"
     },
     {
       "rank": 38,
@@ -1250,6 +1250,28 @@
     },
     {
       "rank": 40,
+      "id": "microsoft/Lens-Turbo",
+      "author": "microsoft",
+      "url": "https://huggingface.co/microsoft/Lens-Turbo",
+      "downloads": 908,
+      "likes": 111,
+      "trendingScore": 109,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "en",
+        "arxiv:2605.21573",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T06:06:39.000Z",
+      "lastModified": "2026-05-22T03:10:02.000Z"
+    },
+    {
+      "rank": 41,
       "id": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-gguf-v2",
@@ -1282,7 +1304,7 @@
       "lastModified": "2026-04-12T13:42:43.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "nvidia/Nemotron-Labs-Diffusion-14B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-14B",
@@ -1305,12 +1327,12 @@
       "lastModified": "2026-05-23T01:01:26.000Z"
     },
     {
-      "rank": 42,
-      "id": "microsoft/Lens-Turbo",
+      "rank": 43,
+      "id": "microsoft/Lens",
       "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens-Turbo",
-      "downloads": 908,
-      "likes": 109,
+      "url": "https://huggingface.co/microsoft/Lens",
+      "downloads": 673,
+      "likes": 111,
       "trendingScore": 107,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -1323,11 +1345,11 @@
         "license:mit",
         "region:us"
       ],
-      "createdAt": "2026-05-15T06:06:39.000Z",
-      "lastModified": "2026-05-22T03:10:02.000Z"
+      "createdAt": "2026-05-15T01:53:50.000Z",
+      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
@@ -1353,13 +1375,13 @@
       "lastModified": "2026-05-06T04:18:09.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "stabilityai/stable-audio-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium",
       "downloads": 0,
-      "likes": 111,
-      "trendingScore": 104,
+      "likes": 113,
+      "trendingScore": 106,
       "pipelineTag": "text-to-audio",
       "libraryName": "stable-audio-3",
       "tags": [
@@ -1381,7 +1403,7 @@
       "lastModified": "2026-05-20T14:50:07.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "sensenova/SenseNova-U1-8B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT",
@@ -1407,28 +1429,6 @@
       ],
       "createdAt": "2026-04-22T04:43:54.000Z",
       "lastModified": "2026-05-07T08:00:27.000Z"
-    },
-    {
-      "rank": 46,
-      "id": "microsoft/Lens",
-      "author": "microsoft",
-      "url": "https://huggingface.co/microsoft/Lens",
-      "downloads": 673,
-      "likes": 106,
-      "trendingScore": 102,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "arxiv:2605.21573",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T01:53:50.000Z",
-      "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
       "rank": 47,
@@ -1480,37 +1480,12 @@
     },
     {
       "rank": 49,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 100,
-      "trendingScore": 98,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
-    },
-    {
-      "rank": 50,
       "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "downloads": 10015,
-      "likes": 102,
-      "trendingScore": 98,
+      "likes": 103,
+      "trendingScore": 99,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1537,6 +1512,31 @@
       ],
       "createdAt": "2026-05-19T23:14:00.000Z",
       "lastModified": "2026-05-23T20:28:00.000Z"
+    },
+    {
+      "rank": 50,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 100,
+      "trendingScore": 98,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
       "rank": 51,
@@ -2187,6 +2187,24 @@
     },
     {
       "rank": 72,
+      "id": "zhen-nan/L2P",
+      "author": "zhen-nan",
+      "url": "https://huggingface.co/zhen-nan/L2P",
+      "downloads": 0,
+      "likes": 74,
+      "trendingScore": 74,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "arxiv:2605.12013",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-03T13:24:20.000Z",
+      "lastModified": "2026-05-22T07:53:35.000Z"
+    },
+    {
+      "rank": 73,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -2204,24 +2222,6 @@
       ],
       "createdAt": "2026-04-20T10:43:41.000Z",
       "lastModified": "2026-04-23T09:04:42.000Z"
-    },
-    {
-      "rank": 73,
-      "id": "zhen-nan/L2P",
-      "author": "zhen-nan",
-      "url": "https://huggingface.co/zhen-nan/L2P",
-      "downloads": 0,
-      "likes": 72,
-      "trendingScore": 72,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "arxiv:2605.12013",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-03T13:24:20.000Z",
-      "lastModified": "2026-05-22T07:53:35.000Z"
     },
     {
       "rank": 74,
@@ -2341,8 +2341,8 @@
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
       "downloads": 12083,
-      "likes": 67,
-      "trendingScore": 66,
+      "likes": 68,
+      "trendingScore": 67,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
@@ -2360,6 +2360,38 @@
     },
     {
       "rank": 79,
+      "id": "pyannote/speaker-diarization-3.1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
+      "downloads": 9909688,
+      "likes": 2008,
+      "trendingScore": 66,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2023-11-16T08:19:01.000Z",
+      "lastModified": "2024-05-10T19:43:23.000Z"
+    },
+    {
+      "rank": 80,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -2404,7 +2436,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 80,
+      "rank": 81,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -2431,7 +2463,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 81,
+      "rank": 82,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -2464,7 +2496,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 82,
+      "rank": 83,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -2491,38 +2523,6 @@
       ],
       "createdAt": "2026-05-11T10:02:08.000Z",
       "lastModified": "2026-05-12T11:38:27.000Z"
-    },
-    {
-      "rank": 83,
-      "id": "pyannote/speaker-diarization-3.1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 9929386,
-      "likes": 1999,
-      "trendingScore": 61,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2023-11-16T08:19:01.000Z",
-      "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
       "rank": 84,
@@ -2595,6 +2595,32 @@
     },
     {
       "rank": 86,
+      "id": "zhifeixie/Mega-ASR",
+      "author": "zhifeixie",
+      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
+      "downloads": 0,
+      "likes": 65,
+      "trendingScore": 59,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "automatic-speech-recognition",
+        "speech-recognition",
+        "audio",
+        "robust-asr",
+        "qwen3-asr",
+        "en",
+        "zh",
+        "arxiv:2605.19833",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T08:58:01.000Z",
+      "lastModified": "2026-05-27T03:03:58.000Z"
+    },
+    {
+      "rank": 87,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -2622,7 +2648,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -2649,7 +2675,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 88,
+      "rank": 89,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -2676,7 +2702,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 89,
+      "rank": 90,
       "id": "openbmb/BitCPM-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
@@ -2699,32 +2725,6 @@
       ],
       "createdAt": "2026-05-15T13:10:51.000Z",
       "lastModified": "2026-05-24T10:43:34.000Z"
-    },
-    {
-      "rank": 90,
-      "id": "zhifeixie/Mega-ASR",
-      "author": "zhifeixie",
-      "url": "https://huggingface.co/zhifeixie/Mega-ASR",
-      "downloads": 0,
-      "likes": 63,
-      "trendingScore": 58,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "automatic-speech-recognition",
-        "speech-recognition",
-        "audio",
-        "robust-asr",
-        "qwen3-asr",
-        "en",
-        "zh",
-        "arxiv:2605.19833",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T08:58:01.000Z",
-      "lastModified": "2026-05-27T03:03:58.000Z"
     },
     {
       "rank": 91,
@@ -2947,6 +2947,38 @@
     },
     {
       "rank": 99,
+      "id": "jedisct1/MiMo-V2.5-coder-Q2",
+      "author": "jedisct1",
+      "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
+      "downloads": 1050,
+      "likes": 54,
+      "trendingScore": 53,
+      "pipelineTag": "text-generation",
+      "libraryName": "llama.cpp",
+      "tags": [
+        "llama.cpp",
+        "gguf",
+        "text-generation",
+        "code",
+        "coding",
+        "tool-calling",
+        "agent",
+        "mixture-of-experts",
+        "long-context",
+        "en",
+        "base_model:XiaomiMiMo/MiMo-V2.5",
+        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T21:13:40.000Z",
+      "lastModified": "2026-05-25T23:53:02.000Z"
+    },
+    {
+      "rank": 100,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2991,7 +3023,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 100,
+      "rank": 101,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -3016,38 +3048,6 @@
       ],
       "createdAt": "2026-04-29T17:33:22.000Z",
       "lastModified": "2026-05-13T18:41:56.000Z"
-    },
-    {
-      "rank": 101,
-      "id": "jedisct1/MiMo-V2.5-coder-Q2",
-      "author": "jedisct1",
-      "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
-      "downloads": 1050,
-      "likes": 52,
-      "trendingScore": 51,
-      "pipelineTag": "text-generation",
-      "libraryName": "llama.cpp",
-      "tags": [
-        "llama.cpp",
-        "gguf",
-        "text-generation",
-        "code",
-        "coding",
-        "tool-calling",
-        "agent",
-        "mixture-of-experts",
-        "long-context",
-        "en",
-        "base_model:XiaomiMiMo/MiMo-V2.5",
-        "base_model:quantized:XiaomiMiMo/MiMo-V2.5",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T21:13:40.000Z",
-      "lastModified": "2026-05-25T23:53:02.000Z"
     },
     {
       "rank": 102,
@@ -3082,8 +3082,8 @@
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
-      "downloads": 710720,
-      "likes": 12918,
+      "downloads": 715658,
+      "likes": 12923,
       "trendingScore": 50,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -3162,7 +3162,7 @@
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
       "downloads": 0,
-      "likes": 49,
+      "likes": 50,
       "trendingScore": 48,
       "pipelineTag": "text-to-audio",
       "libraryName": "stable-audio-3",
@@ -3460,119 +3460,12 @@
     },
     {
       "rank": 117,
-      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
-      "downloads": 462273,
-      "likes": 92,
-      "trendingScore": 43,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "NemotronH_Nano_Omni_Reasoning_V3",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "multimodal",
-        "any-to-any",
-        "custom_code",
-        "dataset:nvidia/Nemotron-Image-Training-v3",
-        "arxiv:2604.24954",
-        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "license:other",
-        "8-bit",
-        "modelopt",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T16:09:58.000Z",
-      "lastModified": "2026-05-05T14:35:03.000Z"
-    },
-    {
-      "rank": 118,
-      "id": "manjunathshiva/gpt-oss-20b-tq3",
-      "author": "manjunathshiva",
-      "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
-      "downloads": 2474,
-      "likes": 45,
-      "trendingScore": 43,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gpt_oss",
-        "turboquant",
-        "quantization",
-        "apple-silicon",
-        "moe",
-        "gpt-oss",
-        "text-generation",
-        "conversational",
-        "arxiv:2504.19874",
-        "base_model:openai/gpt-oss-20b",
-        "base_model:quantized:openai/gpt-oss-20b",
-        "license:apache-2.0",
-        "3-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-08T12:08:02.000Z",
-      "lastModified": "2026-05-09T11:23:07.000Z"
-    },
-    {
-      "rank": 119,
-      "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
-      "author": "Zlikwid",
-      "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
-      "downloads": 0,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T06:04:26.000Z",
-      "lastModified": "2026-05-09T01:15:32.000Z"
-    },
-    {
-      "rank": 120,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 20123,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
-    },
-    {
-      "rank": 121,
       "id": "openbmb/MiniCPM5-1B-GGUF",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
       "downloads": 1655,
-      "likes": 90,
-      "trendingScore": 42.5,
+      "likes": 94,
+      "trendingScore": 44.5,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -3605,7 +3498,165 @@
       "lastModified": "2026-05-25T10:55:40.000Z"
     },
     {
+      "rank": 118,
+      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "downloads": 462273,
+      "likes": 92,
+      "trendingScore": 43,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "NemotronH_Nano_Omni_Reasoning_V3",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "multimodal",
+        "any-to-any",
+        "custom_code",
+        "dataset:nvidia/Nemotron-Image-Training-v3",
+        "arxiv:2604.24954",
+        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "license:other",
+        "8-bit",
+        "modelopt",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-24T16:09:58.000Z",
+      "lastModified": "2026-05-05T14:35:03.000Z"
+    },
+    {
+      "rank": 119,
+      "id": "manjunathshiva/gpt-oss-20b-tq3",
+      "author": "manjunathshiva",
+      "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
+      "downloads": 2474,
+      "likes": 45,
+      "trendingScore": 43,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "gpt_oss",
+        "turboquant",
+        "quantization",
+        "apple-silicon",
+        "moe",
+        "gpt-oss",
+        "text-generation",
+        "conversational",
+        "arxiv:2504.19874",
+        "base_model:openai/gpt-oss-20b",
+        "base_model:quantized:openai/gpt-oss-20b",
+        "license:apache-2.0",
+        "3-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-08T12:08:02.000Z",
+      "lastModified": "2026-05-09T11:23:07.000Z"
+    },
+    {
+      "rank": 120,
+      "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
+      "author": "Zlikwid",
+      "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
+      "downloads": 0,
+      "likes": 43,
+      "trendingScore": 43,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-05-07T06:04:26.000Z",
+      "lastModified": "2026-05-09T01:15:32.000Z"
+    },
+    {
+      "rank": 121,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 20123,
+      "likes": 43,
+      "trendingScore": 43,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
       "rank": 122,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2344020,
+      "likes": 2067,
+      "trendingScore": 41,
+      "pipelineTag": "mask-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
+    },
+    {
+      "rank": 123,
+      "id": "openbmb/BitCPM-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
+      "downloads": 1282,
+      "likes": 46,
+      "trendingScore": 41,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-23T18:12:57.000Z"
+    },
+    {
+      "rank": 124,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3631,34 +3682,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 123,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2515187,
-      "likes": 2064,
-      "trendingScore": 40,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 124,
+      "rank": 125,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -3677,7 +3701,7 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 125,
+      "rank": 126,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -3703,7 +3727,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
       "id": "HuggingFaceBio/Carbon-3B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
@@ -3726,31 +3750,52 @@
       "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 127,
-      "id": "openbmb/BitCPM-CANN-8B-gguf",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
-      "downloads": 1282,
-      "likes": 44,
+      "rank": 128,
+      "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
+      "downloads": 0,
+      "likes": 40,
       "trendingScore": 39,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
       "tags": [
-        "transformers",
-        "gguf",
-        "text-generation",
+        "safetensors",
+        "moss_tts_delay",
+        "text-to-speech",
+        "custom_code",
         "zh",
+        "yue",
         "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "ar",
+        "cs",
+        "da",
+        "de",
+        "nl",
+        "es",
+        "fr",
+        "fi",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "ja",
+        "it",
+        "ko",
+        "mk",
+        "ms",
+        "ru",
+        "fa",
+        "pl",
+        "pt",
+        "sv",
+        "ro"
       ],
-      "createdAt": "2026-05-16T06:18:55.000Z",
-      "lastModified": "2026-05-23T18:12:57.000Z"
+      "createdAt": "2026-05-25T12:40:42.000Z",
+      "lastModified": "2026-05-26T08:49:43.000Z"
     },
     {
-      "rank": 128,
+      "rank": 129,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -3782,7 +3827,7 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3809,7 +3854,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 130,
+      "rank": 131,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3836,7 +3881,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -3868,7 +3913,7 @@
       "lastModified": "2026-05-21T21:34:50.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
@@ -3901,7 +3946,7 @@
       "lastModified": "2026-03-08T12:54:54.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -3925,7 +3970,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 134,
+      "rank": 135,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
@@ -3950,7 +3995,7 @@
       "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 135,
+      "rank": 136,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -3982,7 +4027,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 136,
+      "rank": 137,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -4005,7 +4050,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 137,
+      "rank": 138,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -4034,7 +4079,7 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 138,
+      "rank": 139,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -4063,7 +4108,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 139,
+      "rank": 140,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -4103,12 +4148,12 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 140,
+      "rank": 141,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "downloads": 0,
-      "likes": 2054,
+      "likes": 2060,
       "trendingScore": 35,
       "pipelineTag": "text-to-image",
       "libraryName": "comfyUI",
@@ -4128,7 +4173,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 141,
+      "rank": 142,
       "id": "stabilityai/stable-audio-3-small-sfx",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
@@ -4155,7 +4200,7 @@
       "lastModified": "2026-05-19T20:02:45.000Z"
     },
     {
-      "rank": 142,
+      "rank": 143,
       "id": "Comfy-Org/Lens",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Lens",
@@ -4173,7 +4218,7 @@
       "lastModified": "2026-05-24T13:34:38.000Z"
     },
     {
-      "rank": 143,
+      "rank": 144,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -4197,7 +4242,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 144,
+      "rank": 145,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -4214,7 +4259,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 145,
+      "rank": 146,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -4238,7 +4283,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 146,
+      "rank": 147,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -4254,7 +4299,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 147,
+      "rank": 148,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -4281,7 +4326,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 148,
+      "rank": 149,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -4300,7 +4345,7 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 149,
+      "rank": 150,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -4345,7 +4390,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 150,
+      "rank": 151,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -4390,7 +4435,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 151,
+      "rank": 152,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -4434,7 +4479,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 152,
+      "rank": 153,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -4460,7 +4505,110 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 153,
+      "rank": 154,
+      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "author": "fal",
+      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
+      "downloads": 51837,
+      "likes": 1353,
+      "trendingScore": 33,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "qwen",
+        "qwen-image-edit",
+        "qwen-image-edit-2511",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "camera-control",
+        "image-editing",
+        "image-to-image",
+        "gaussian-splatting",
+        "fal",
+        "en",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-07T17:01:15.000Z",
+      "lastModified": "2026-01-07T17:06:01.000Z"
+    },
+    {
+      "rank": 155,
+      "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "downloads": 0,
+      "likes": 33,
+      "trendingScore": 33,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "gemlite",
+        "hqq",
+        "cuda",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:12:41.000Z",
+      "lastModified": "2026-05-26T16:16:59.000Z"
+    },
+    {
+      "rank": 156,
+      "id": "nvidia/LocateAnything-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/LocateAnything-3B",
+      "downloads": 14,
+      "likes": 33,
+      "trendingScore": 33,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "locateanything",
+        "feature-extraction",
+        "nvidia",
+        "eagle",
+        "vision",
+        "object-detection",
+        "grounding",
+        "arxiv:2605.27365",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "arxiv:2504.07491",
+        "arxiv:2109.10852",
+        "arxiv:2510.12798",
+        "arxiv:2303.05499",
+        "arxiv:1405.0312",
+        "arxiv:1908.03195",
+        "arxiv:2504.07981",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T20:05:49.000Z",
+      "lastModified": "2026-05-27T08:30:54.000Z"
+    },
+    {
+      "rank": 157,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -4504,7 +4652,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 154,
+      "rank": 158,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -4549,7 +4697,7 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 155,
+      "rank": 159,
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
@@ -4577,7 +4725,7 @@
       "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 156,
+      "rank": 160,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -4610,7 +4758,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 157,
+      "rank": 161,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -4634,7 +4782,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 158,
+      "rank": 162,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -4661,7 +4809,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 159,
+      "rank": 163,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -4703,7 +4851,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 160,
+      "rank": 164,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -4731,7 +4879,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 161,
+      "rank": 165,
       "id": "ByteDance-Seed/Cola-DLM",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
@@ -4761,7 +4909,7 @@
       "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
-      "rank": 162,
+      "rank": 166,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
@@ -4806,7 +4954,7 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 163,
+      "rank": 167,
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
@@ -4851,39 +4999,33 @@
       "lastModified": "2026-05-22T14:40:30.000Z"
     },
     {
-      "rank": 164,
-      "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "author": "fal",
-      "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
-      "downloads": 50617,
-      "likes": 1350,
+      "rank": 168,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 47,
+      "likes": 31,
       "trendingScore": 31,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "diffusers",
-        "qwen",
-        "qwen-image-edit",
-        "qwen-image-edit-2511",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "camera-control",
-        "image-editing",
-        "image-to-image",
-        "gaussian-splatting",
-        "fal",
+        "transformers",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
         "en",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:adapter:Qwen/Qwen-Image-Edit-2511",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-01-07T17:01:15.000Z",
-      "lastModified": "2026-01-07T17:06:01.000Z"
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-27T06:28:10.000Z"
     },
     {
-      "rank": 165,
+      "rank": 169,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -4909,7 +5051,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 166,
+      "rank": 170,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -4941,7 +5083,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 167,
+      "rank": 171,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -4968,7 +5110,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 168,
+      "rank": 172,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -5002,7 +5144,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 169,
+      "rank": 173,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -5024,7 +5166,30 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 170,
+      "rank": 174,
+      "id": "tencent/Hy-MT2-7B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
+      "downloads": 14891,
+      "likes": 31,
+      "trendingScore": 30,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:31.000Z",
+      "lastModified": "2026-05-26T09:06:21.000Z"
+    },
+    {
+      "rank": 175,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -5055,7 +5220,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 171,
+      "rank": 176,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -5078,7 +5243,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 172,
+      "rank": 177,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -5105,7 +5270,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 173,
+      "rank": 178,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -5136,7 +5301,7 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 174,
+      "rank": 179,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -5165,12 +5330,12 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 175,
+      "rank": 180,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
-      "downloads": 262278076,
-      "likes": 4833,
+      "downloads": 262809768,
+      "likes": 4839,
       "trendingScore": 29,
       "pipelineTag": "sentence-similarity",
       "libraryName": "sentence-transformers",
@@ -5210,12 +5375,12 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 176,
+      "rank": 181,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
-      "downloads": 329120,
-      "likes": 301,
+      "downloads": 329236,
+      "likes": 302,
       "trendingScore": 29,
       "pipelineTag": "mask-generation",
       "libraryName": "checkpoint",
@@ -5231,52 +5396,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 177,
-      "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
-      "downloads": 0,
-      "likes": 29,
-      "trendingScore": 29,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "moss_tts_delay",
-        "text-to-speech",
-        "custom_code",
-        "zh",
-        "yue",
-        "en",
-        "ar",
-        "cs",
-        "da",
-        "de",
-        "nl",
-        "es",
-        "fr",
-        "fi",
-        "el",
-        "he",
-        "hi",
-        "hu",
-        "ja",
-        "it",
-        "ko",
-        "mk",
-        "ms",
-        "ru",
-        "fa",
-        "pl",
-        "pt",
-        "sv",
-        "ro"
-      ],
-      "createdAt": "2026-05-25T12:40:42.000Z",
-      "lastModified": "2026-05-26T08:49:43.000Z"
-    },
-    {
-      "rank": 178,
+      "rank": 182,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -5298,7 +5418,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 179,
+      "rank": 183,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -5335,7 +5455,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 180,
+      "rank": 184,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -5357,7 +5477,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 181,
+      "rank": 185,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -5390,7 +5510,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 182,
+      "rank": 186,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5422,30 +5542,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 183,
-      "id": "tencent/Hy-MT2-7B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 14891,
-      "likes": 29,
-      "trendingScore": 28,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-26T09:06:21.000Z"
-    },
-    {
-      "rank": 184,
+      "rank": 187,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -5472,33 +5569,7 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 185,
-      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "author": "Kwai-Keye",
-      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "downloads": 47,
-      "likes": 28,
-      "trendingScore": 28,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "KeyeVL2",
-        "feature-extraction",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:32:15.000Z",
-      "lastModified": "2026-05-26T07:40:38.000Z"
-    },
-    {
-      "rank": 186,
+      "rank": 188,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -5538,7 +5609,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 187,
+      "rank": 189,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -5575,7 +5646,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 188,
+      "rank": 190,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -5618,7 +5689,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 189,
+      "rank": 191,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -5638,7 +5709,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 190,
+      "rank": 192,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -5663,7 +5734,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 191,
+      "rank": 193,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5688,7 +5759,7 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 192,
+      "rank": 194,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -5711,7 +5782,7 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 193,
+      "rank": 195,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5737,12 +5808,12 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 194,
+      "rank": 196,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
-      "downloads": 9192817,
-      "likes": 1039,
+      "downloads": 9117096,
+      "likes": 1041,
       "trendingScore": 27,
       "pipelineTag": "voice-activity-detection",
       "libraryName": "pyannote-audio",
@@ -5768,7 +5839,40 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 195,
+      "rank": 197,
+      "id": "pyannote/speaker-diarization-community-1",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
+      "downloads": 2831417,
+      "likes": 421,
+      "trendingScore": 27,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pyannote",
+        "pyannote-audio-pipeline",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "automatic-speech-recognition",
+        "arxiv:2104.03603",
+        "arxiv:2111.14448",
+        "arxiv:2012.01477",
+        "arxiv:2110.07058",
+        "license:cc-by-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-04-15T21:31:35.000Z",
+      "lastModified": "2025-09-29T08:43:24.000Z"
+    },
+    {
+      "rank": 198,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -5813,7 +5917,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 196,
+      "rank": 199,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -5840,7 +5944,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 197,
+      "rank": 200,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -5885,7 +5989,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 198,
+      "rank": 201,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -5911,7 +6015,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 199,
+      "rank": 202,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -5933,7 +6037,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 200,
+      "rank": 203,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -5949,7 +6053,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 201,
+      "rank": 204,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -5985,7 +6089,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 202,
+      "rank": 205,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -6003,7 +6107,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 203,
+      "rank": 206,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -6035,7 +6139,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 204,
+      "rank": 207,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
@@ -6058,40 +6162,7 @@
       "lastModified": "2026-05-26T09:06:32.000Z"
     },
     {
-      "rank": 205,
-      "id": "pyannote/speaker-diarization-community-1",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
-      "downloads": 2844915,
-      "likes": 419,
-      "trendingScore": 26,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pyannote",
-        "pyannote-audio-pipeline",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "automatic-speech-recognition",
-        "arxiv:2104.03603",
-        "arxiv:2111.14448",
-        "arxiv:2012.01477",
-        "arxiv:2110.07058",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-04-15T21:31:35.000Z",
-      "lastModified": "2025-09-29T08:43:24.000Z"
-    },
-    {
-      "rank": 206,
+      "rank": 208,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -6129,7 +6200,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 207,
+      "rank": 209,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -6147,7 +6218,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 208,
+      "rank": 210,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -6173,7 +6244,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 209,
+      "rank": 211,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -6193,7 +6264,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 210,
+      "rank": 212,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -6220,7 +6291,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 211,
+      "rank": 213,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -6246,7 +6317,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 212,
+      "rank": 214,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -6272,7 +6343,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 213,
+      "rank": 215,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -6309,7 +6380,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 214,
+      "rank": 216,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -6325,7 +6396,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 215,
+      "rank": 217,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -6348,7 +6419,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 216,
+      "rank": 218,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -6390,7 +6461,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 217,
+      "rank": 219,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -6429,7 +6500,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 218,
+      "rank": 220,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6474,7 +6545,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 219,
+      "rank": 221,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -6500,7 +6571,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 220,
+      "rank": 222,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -6532,7 +6603,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 221,
+      "rank": 223,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -6556,7 +6627,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 222,
+      "rank": 224,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -6583,7 +6654,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 223,
+      "rank": 225,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -6608,7 +6679,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 224,
+      "rank": 226,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -6644,7 +6715,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 225,
+      "rank": 227,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -6660,7 +6731,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 226,
+      "rank": 228,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -6681,7 +6752,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 227,
+      "rank": 229,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -6704,7 +6775,7 @@
       "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 228,
+      "rank": 230,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -6731,38 +6802,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 229,
-      "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
-      "downloads": 0,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "ternary",
-        "1.58-bit",
-        "gemlite",
-        "hqq",
-        "cuda",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:12:41.000Z",
-      "lastModified": "2026-05-26T16:16:59.000Z"
-    },
-    {
-      "rank": 230,
+      "rank": 231,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -6789,7 +6829,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 231,
+      "rank": 232,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -6818,7 +6858,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 232,
+      "rank": 233,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -6835,7 +6875,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 233,
+      "rank": 234,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -6856,7 +6896,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 234,
+      "rank": 235,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -6877,7 +6917,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 235,
+      "rank": 236,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -6898,7 +6938,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 236,
+      "rank": 237,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -6930,7 +6970,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 237,
+      "rank": 238,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -6961,7 +7001,38 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 238,
+      "rank": 239,
+      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "downloads": 0,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "text-to-image",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:15:18.000Z",
+      "lastModified": "2026-05-26T16:16:59.000Z"
+    },
+    {
+      "rank": 240,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -6992,7 +7063,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 239,
+      "rank": 241,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -7021,7 +7092,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 240,
+      "rank": 242,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -7066,7 +7137,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 241,
+      "rank": 243,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -7093,7 +7164,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 242,
+      "rank": 244,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -7117,7 +7188,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 243,
+      "rank": 245,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -7155,7 +7226,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 244,
+      "rank": 246,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -7172,7 +7243,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 245,
+      "rank": 247,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -7200,7 +7271,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 246,
+      "rank": 248,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7223,7 +7294,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 247,
+      "rank": 249,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7240,7 +7311,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 248,
+      "rank": 250,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
@@ -7273,46 +7344,46 @@
       "lastModified": "2026-05-24T17:32:37.000Z"
     },
     {
-      "rank": 249,
-      "id": "nvidia/LocateAnything-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/LocateAnything-3B",
-      "downloads": 0,
+      "rank": 251,
+      "id": "SupraLabs/Supra-50M-Instruct",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
+      "downloads": 1318,
       "likes": 22,
       "trendingScore": 22,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "locateanything",
-        "feature-extraction",
-        "nvidia",
-        "eagle",
-        "vision",
-        "object-detection",
-        "grounding",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
+        "gguf",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
         "en",
-        "arxiv:2504.07491",
-        "arxiv:2109.10852",
-        "arxiv:2510.12798",
-        "arxiv:2303.05499",
-        "arxiv:1405.0312",
-        "arxiv:1908.03195",
-        "arxiv:2504.07981",
-        "base_model:Qwen/Qwen2.5-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
-        "license:other",
-        "region:us"
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "dataset:yahma/alpaca-cleaned",
+        "base_model:SupraLabs/Supra-50M-Base",
+        "base_model:quantized:SupraLabs/Supra-50M-Base",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
       ],
-      "createdAt": "2026-03-02T20:05:49.000Z",
-      "lastModified": "2026-05-25T13:55:19.000Z"
+      "createdAt": "2026-05-21T12:06:17.000Z",
+      "lastModified": "2026-05-27T07:47:37.000Z"
     },
     {
-      "rank": 250,
+      "rank": 252,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -7357,7 +7428,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 251,
+      "rank": 253,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -7385,7 +7456,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 252,
+      "rank": 254,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -7421,7 +7492,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 253,
+      "rank": 255,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -7448,7 +7519,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 254,
+      "rank": 256,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -7473,7 +7544,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 255,
+      "rank": 257,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -7500,7 +7571,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 256,
+      "rank": 258,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -7526,50 +7597,11 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 257,
-      "id": "SupraLabs/Supra-50M-Instruct",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
-      "downloads": 1318,
-      "likes": 21,
-      "trendingScore": 21,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "llama",
-        "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "dataset:yahma/alpaca-cleaned",
-        "base_model:SupraLabs/Supra-50M-Base",
-        "base_model:quantized:SupraLabs/Supra-50M-Base",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-21T12:06:17.000Z",
-      "lastModified": "2026-05-23T08:10:17.000Z"
-    },
-    {
-      "rank": 258,
+      "rank": 259,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
-      "downloads": 996823,
+      "downloads": 1124064,
       "likes": 1154,
       "trendingScore": 21,
       "pipelineTag": "text-generation",
@@ -7587,7 +7619,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "Jackrong/Qwopus3.6-27B-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
@@ -7631,7 +7663,7 @@
       "lastModified": "2026-05-23T00:38:29.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -7659,7 +7691,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -7692,7 +7724,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -7717,7 +7749,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -7754,7 +7786,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -7797,7 +7829,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -7821,7 +7853,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 266,
+      "rank": 267,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -7845,7 +7877,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -7874,7 +7906,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -7892,7 +7924,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 269,
+      "rank": 270,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7937,7 +7969,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 270,
+      "rank": 271,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -7982,7 +8014,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 271,
+      "rank": 272,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -8011,7 +8043,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 272,
+      "rank": 273,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -8035,7 +8067,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 273,
+      "rank": 274,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -8064,7 +8096,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 274,
+      "rank": 275,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8088,7 +8120,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 275,
+      "rank": 276,
       "id": "netease-youdao/Confucius4",
       "author": "netease-youdao",
       "url": "https://huggingface.co/netease-youdao/Confucius4",
@@ -8106,7 +8138,7 @@
       "lastModified": "2026-05-20T08:42:10.000Z"
     },
     {
-      "rank": 276,
+      "rank": 277,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -8124,7 +8156,52 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 277,
+      "rank": 278,
+      "id": "syvai/cohere-transcribe-diarize",
+      "author": "syvai",
+      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
+      "downloads": 205,
+      "likes": 20,
+      "trendingScore": 20,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "cohere_asr",
+        "automatic-speech-recognition",
+        "audio",
+        "speech-recognition",
+        "transcription",
+        "diarization",
+        "speaker-diarization",
+        "timestamps",
+        "custom_code",
+        "en",
+        "ar",
+        "de",
+        "el",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt",
+        "vi",
+        "zh",
+        "base_model:CohereLabs/cohere-transcribe-03-2026",
+        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T03:51:05.000Z",
+      "lastModified": "2026-05-22T20:56:30.000Z"
+    },
+    {
+      "rank": 279,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -8169,7 +8246,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 278,
+      "rank": 280,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -8202,7 +8279,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 279,
+      "rank": 281,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -8224,7 +8301,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 280,
+      "rank": 282,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -8251,7 +8328,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 281,
+      "rank": 283,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -8267,7 +8344,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 282,
+      "rank": 284,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -8290,7 +8367,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 283,
+      "rank": 285,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -8315,7 +8392,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 284,
+      "rank": 286,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -8351,7 +8428,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 285,
+      "rank": 287,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -8380,7 +8457,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 286,
+      "rank": 288,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -8410,7 +8487,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 287,
+      "rank": 289,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -8455,7 +8532,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 288,
+      "rank": 290,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -8482,7 +8559,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 289,
+      "rank": 291,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -8508,7 +8585,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 290,
+      "rank": 292,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -8536,7 +8613,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 291,
+      "rank": 293,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -8565,7 +8642,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 292,
+      "rank": 294,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -8589,7 +8666,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 293,
+      "rank": 295,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -8611,7 +8688,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 294,
+      "rank": 296,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -8645,7 +8722,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 295,
+      "rank": 297,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -8669,7 +8746,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 296,
+      "rank": 298,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -8691,7 +8768,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 297,
+      "rank": 299,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -8720,7 +8797,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 298,
+      "rank": 300,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8752,7 +8829,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 299,
+      "rank": 301,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8770,7 +8847,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 300,
+      "rank": 302,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8799,7 +8876,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 301,
+      "rank": 303,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8817,7 +8894,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 302,
+      "rank": 304,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -8843,7 +8920,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 303,
+      "rank": 305,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -8871,7 +8948,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -8903,7 +8980,36 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
+      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "downloads": 0,
+      "likes": 18,
+      "trendingScore": 18,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-audio",
+        "diffusion",
+        "flow-matching",
+        "sound-effects",
+        "audio-generation",
+        "en",
+        "zh",
+        "base_model:Qwen/Qwen3-1.7B",
+        "base_model:finetune:Qwen/Qwen3-1.7B",
+        "license:apache-2.0",
+        "diffusers:MossSoundEffectPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T14:19:58.000Z",
+      "lastModified": "2026-05-26T09:41:39.000Z"
+    },
+    {
+      "rank": 308,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -8948,7 +9054,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 306,
+      "rank": 309,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -8977,7 +9083,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 307,
+      "rank": 310,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -9006,7 +9112,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 308,
+      "rank": 311,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -9038,7 +9144,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 309,
+      "rank": 312,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -9068,7 +9174,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 310,
+      "rank": 313,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -9089,7 +9195,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 311,
+      "rank": 314,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -9134,7 +9240,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 312,
+      "rank": 315,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -9163,7 +9269,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 313,
+      "rank": 316,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -9191,7 +9297,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 314,
+      "rank": 317,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -9216,7 +9322,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 315,
+      "rank": 318,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -9239,7 +9345,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 316,
+      "rank": 319,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -9266,7 +9372,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 317,
+      "rank": 320,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -9292,7 +9398,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 318,
+      "rank": 321,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -9321,7 +9427,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 319,
+      "rank": 322,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9340,7 +9446,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 320,
+      "rank": 323,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9368,7 +9474,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 321,
+      "rank": 324,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -9413,56 +9519,11 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 322,
-      "id": "syvai/cohere-transcribe-diarize",
-      "author": "syvai",
-      "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
-      "downloads": 205,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "cohere_asr",
-        "automatic-speech-recognition",
-        "audio",
-        "speech-recognition",
-        "transcription",
-        "diarization",
-        "speaker-diarization",
-        "timestamps",
-        "custom_code",
-        "en",
-        "ar",
-        "de",
-        "el",
-        "es",
-        "fr",
-        "it",
-        "ja",
-        "ko",
-        "nl",
-        "pl",
-        "pt",
-        "vi",
-        "zh",
-        "base_model:CohereLabs/cohere-transcribe-03-2026",
-        "base_model:finetune:CohereLabs/cohere-transcribe-03-2026",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T03:51:05.000Z",
-      "lastModified": "2026-05-22T20:56:30.000Z"
-    },
-    {
-      "rank": 323,
+      "rank": 325,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
-      "downloads": 1249187,
+      "downloads": 1246756,
       "likes": 216,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
@@ -9485,38 +9546,66 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 324,
-      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "downloads": 0,
-      "likes": 17,
+      "rank": 326,
+      "id": "datalab-to/chandra-ocr-2",
+      "author": "datalab-to",
+      "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
+      "downloads": 1621522,
+      "likes": 357,
       "trendingScore": 17,
-      "pipelineTag": "text-to-image",
-      "libraryName": "mlx",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "mlx",
-        "diffusers",
+        "transformers",
         "safetensors",
-        "ternary",
-        "1.58-bit",
-        "apple-silicon",
-        "on-device",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "license:apache-2.0",
+        "qwen3_5",
+        "image-text-to-text",
+        "ocr",
+        "pdf",
+        "markdown",
+        "layout",
+        "conversational",
+        "license:openrail",
+        "eval-results",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-21T16:15:18.000Z",
-      "lastModified": "2026-05-26T16:16:59.000Z"
+      "createdAt": "2026-03-16T20:47:07.000Z",
+      "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 325,
+      "rank": 327,
+      "id": "numind/NuMarkdown-8B-Thinking",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
+      "downloads": 48368,
+      "likes": 469,
+      "trendingScore": 17,
+      "pipelineTag": "image-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "OCR",
+        "vision-language",
+        "VLM",
+        "Reasoning",
+        "document-to-markdown",
+        "qwen2.5",
+        "markdown",
+        "extraction",
+        "RAG",
+        "image-to-text",
+        "license:mit",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-07-29T18:39:08.000Z",
+      "lastModified": "2026-05-19T19:01:34.000Z"
+    },
+    {
+      "rank": 328,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -9541,7 +9630,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 326,
+      "rank": 329,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -9576,7 +9665,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 327,
+      "rank": 330,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -9621,7 +9710,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 328,
+      "rank": 331,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -9648,7 +9737,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -9677,7 +9766,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -9700,7 +9789,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -9744,7 +9833,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -9789,7 +9878,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -9807,7 +9896,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -9852,7 +9941,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -9890,7 +9979,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -9910,7 +9999,7 @@
       "lastModified": "2026-04-15T15:30:05.000Z"
     },
     {
-      "rank": 337,
+      "rank": 340,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -9943,7 +10032,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 338,
+      "rank": 341,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -9973,7 +10062,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 339,
+      "rank": 342,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -10005,7 +10094,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -10030,7 +10119,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -10053,7 +10142,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -10083,7 +10172,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 343,
+      "rank": 346,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -10107,11 +10196,11 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 344,
+      "rank": 347,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
-      "downloads": 728009,
+      "downloads": 713369,
       "likes": 301,
       "trendingScore": 16,
       "pipelineTag": "image-feature-extraction",
@@ -10135,7 +10224,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 345,
+      "rank": 348,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -10163,12 +10252,12 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 346,
+      "rank": 349,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
       "downloads": 0,
-      "likes": 525,
+      "likes": 527,
       "trendingScore": 16,
       "pipelineTag": null,
       "libraryName": null,
@@ -10208,7 +10297,68 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 347,
+      "rank": 350,
+      "id": "Qwen/Qwen3-ASR-1.7B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
+      "downloads": 1962256,
+      "likes": 828,
+      "trendingScore": 16,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_asr",
+        "automatic-speech-recognition",
+        "arxiv:2601.21337",
+        "license:apache-2.0",
+        "eval-results",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-01-28T03:22:40.000Z",
+      "lastModified": "2026-01-30T03:00:12.000Z"
+    },
+    {
+      "rank": 351,
+      "id": "meta-llama/Llama-3.2-1B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
+      "downloads": 8270484,
+      "likes": 1439,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:12:47.000Z",
+      "lastModified": "2024-10-24T15:07:51.000Z"
+    },
+    {
+      "rank": 352,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -10235,7 +10385,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 348,
+      "rank": 353,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -10280,7 +10430,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 349,
+      "rank": 354,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -10310,7 +10460,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 350,
+      "rank": 355,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -10340,7 +10490,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 351,
+      "rank": 356,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -10385,7 +10535,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 352,
+      "rank": 357,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -10420,7 +10570,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 353,
+      "rank": 358,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -10449,7 +10599,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 354,
+      "rank": 359,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -10474,7 +10624,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 355,
+      "rank": 360,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -10502,7 +10652,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 356,
+      "rank": 361,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -10530,7 +10680,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 357,
+      "rank": 362,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -10561,7 +10711,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 358,
+      "rank": 363,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -10606,7 +10756,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 359,
+      "rank": 364,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -10638,7 +10788,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 360,
+      "rank": 365,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -10665,7 +10815,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 361,
+      "rank": 366,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -10688,7 +10838,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 362,
+      "rank": 367,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -10715,30 +10865,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 363,
-      "id": "Qwen/Qwen3-ASR-1.7B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
-      "downloads": 1956782,
-      "likes": 825,
-      "trendingScore": 15,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_asr",
-        "automatic-speech-recognition",
-        "arxiv:2601.21337",
-        "license:apache-2.0",
-        "eval-results",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-01-28T03:22:40.000Z",
-      "lastModified": "2026-01-30T03:00:12.000Z"
-    },
-    {
-      "rank": 364,
+      "rank": 368,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -10764,7 +10891,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 365,
+      "rank": 369,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -10794,7 +10921,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 366,
+      "rank": 370,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -10821,7 +10948,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 367,
+      "rank": 371,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -10852,35 +10979,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 368,
-      "id": "datalab-to/chandra-ocr-2",
-      "author": "datalab-to",
-      "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
-      "downloads": 1573212,
-      "likes": 355,
-      "trendingScore": 15,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "ocr",
-        "pdf",
-        "markdown",
-        "layout",
-        "conversational",
-        "license:openrail",
-        "eval-results",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-16T20:47:07.000Z",
-      "lastModified": "2026-03-18T18:21:07.000Z"
-    },
-    {
-      "rank": 369,
+      "rank": 372,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -10912,7 +11011,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 370,
+      "rank": 373,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -10957,7 +11056,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 371,
+      "rank": 374,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -10990,7 +11089,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 372,
+      "rank": 375,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -11030,7 +11129,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 373,
+      "rank": 376,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -11071,7 +11170,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -11094,45 +11193,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 375,
-      "id": "meta-llama/Llama-3.2-1B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 8253739,
-      "likes": 1437,
-      "trendingScore": 15,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:12:47.000Z",
-      "lastModified": "2024-10-24T15:07:51.000Z"
-    },
-    {
-      "rank": 376,
+      "rank": 378,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11155,7 +11216,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 377,
+      "rank": 379,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -11186,7 +11247,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 378,
+      "rank": 380,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11217,7 +11278,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 379,
+      "rank": 381,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -11246,7 +11307,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 380,
+      "rank": 382,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -11279,7 +11340,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 381,
+      "rank": 383,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -11305,7 +11366,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 382,
+      "rank": 384,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -11349,42 +11410,11 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 383,
-      "id": "numind/NuMarkdown-8B-Thinking",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
-      "downloads": 51292,
-      "likes": 467,
-      "trendingScore": 15,
-      "pipelineTag": "image-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "OCR",
-        "vision-language",
-        "VLM",
-        "Reasoning",
-        "document-to-markdown",
-        "qwen2.5",
-        "markdown",
-        "extraction",
-        "RAG",
-        "image-to-text",
-        "license:mit",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-07-29T18:39:08.000Z",
-      "lastModified": "2026-05-19T19:01:34.000Z"
-    },
-    {
-      "rank": 384,
+      "rank": 385,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
-      "downloads": 2168446,
+      "downloads": 2224408,
       "likes": 2407,
       "trendingScore": 15,
       "pipelineTag": "text-generation",
@@ -11417,7 +11447,7 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 385,
+      "rank": 386,
       "id": "openbmb/MiniCPM5-1B-SFT",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
@@ -11457,7 +11487,56 @@
       "lastModified": "2026-05-25T11:18:10.000Z"
     },
     {
-      "rank": 386,
+      "rank": 387,
+      "id": "stabilityai/SAME-L",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/SAME-L",
+      "downloads": 0,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": null,
+      "libraryName": "stable-audio-3",
+      "tags": [
+        "stable-audio-3",
+        "safetensors",
+        "music",
+        "sound-effects",
+        "audio",
+        "autoencoder",
+        "en",
+        "arxiv:2605.18613",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T02:18:14.000Z",
+      "lastModified": "2026-05-19T20:11:14.000Z"
+    },
+    {
+      "rank": 388,
+      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+      "downloads": 0,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:07:19.000Z",
+      "lastModified": "2026-05-26T16:17:00.000Z"
+    },
+    {
+      "rank": 389,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -11481,7 +11560,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 387,
+      "rank": 390,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -11508,7 +11587,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 388,
+      "rank": 391,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -11536,7 +11615,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 389,
+      "rank": 392,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -11555,7 +11634,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 390,
+      "rank": 393,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -11587,7 +11666,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 391,
+      "rank": 394,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -11616,7 +11695,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 392,
+      "rank": 395,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -11642,7 +11721,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 393,
+      "rank": 396,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -11670,7 +11749,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 394,
+      "rank": 397,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -11704,7 +11783,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 395,
+      "rank": 398,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -11730,7 +11809,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 396,
+      "rank": 399,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -11772,7 +11851,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 397,
+      "rank": 400,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -11810,7 +11889,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 398,
+      "rank": 401,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -11829,7 +11908,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 399,
+      "rank": 402,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -11849,12 +11928,12 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 400,
+      "rank": 403,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
-      "downloads": 504708,
-      "likes": 138,
+      "downloads": 584459,
+      "likes": 146,
       "trendingScore": 14,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -11876,7 +11955,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 401,
+      "rank": 404,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -11902,7 +11981,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 402,
+      "rank": 405,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -11927,7 +12006,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 403,
+      "rank": 406,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -11956,7 +12035,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 404,
+      "rank": 407,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -12001,7 +12080,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 405,
+      "rank": 408,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -12028,7 +12107,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 406,
+      "rank": 409,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -12057,7 +12136,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 407,
+      "rank": 410,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -12083,7 +12162,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 408,
+      "rank": 411,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
@@ -12113,32 +12192,7 @@
       "lastModified": "2026-05-25T00:33:13.000Z"
     },
     {
-      "rank": 409,
-      "id": "stabilityai/SAME-L",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/SAME-L",
-      "downloads": 0,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": null,
-      "libraryName": "stable-audio-3",
-      "tags": [
-        "stable-audio-3",
-        "safetensors",
-        "music",
-        "sound-effects",
-        "audio",
-        "autoencoder",
-        "en",
-        "arxiv:2605.18613",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T02:18:14.000Z",
-      "lastModified": "2026-05-19T20:11:14.000Z"
-    },
-    {
-      "rank": 410,
+      "rank": 412,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -12163,7 +12217,7 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 411,
+      "rank": 413,
       "id": "Comfy-Org/PixelDiT",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/PixelDiT",
@@ -12181,11 +12235,11 @@
       "lastModified": "2026-05-26T12:10:42.000Z"
     },
     {
-      "rank": 412,
+      "rank": 414,
       "id": "nvidia/vgg-ttt",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/vgg-ttt",
-      "downloads": 42,
+      "downloads": 317,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": "image-to-3d",
@@ -12210,7 +12264,217 @@
       "lastModified": "2026-05-25T15:55:35.000Z"
     },
     {
-      "rank": 413,
+      "rank": 415,
+      "id": "google/medgemma-1.5-4b-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
+      "downloads": 230500,
+      "likes": 633,
+      "trendingScore": 14,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma3",
+        "image-text-to-text",
+        "medical",
+        "radiology",
+        "clinical-reasoning",
+        "dermatology",
+        "pathology",
+        "ophthalmology",
+        "chest-x-ray",
+        "conversational",
+        "arxiv:2303.15343",
+        "arxiv:2604.05081",
+        "arxiv:2406.19578",
+        "arxiv:2405.03162",
+        "arxiv:2106.14463",
+        "arxiv:2009.13081",
+        "arxiv:2203.14371",
+        "arxiv:1909.06146",
+        "arxiv:2102.09542",
+        "arxiv:2411.15640",
+        "arxiv:2404.05590",
+        "arxiv:2501.18362",
+        "arxiv:1605.01397",
+        "arxiv:1901.07031",
+        "arxiv:2403.17834",
+        "arxiv:2402.16040",
+        "license:other",
+        "text-generation-inference"
+      ],
+      "createdAt": "2026-01-07T23:07:01.000Z",
+      "lastModified": "2026-04-13T23:20:55.000Z"
+    },
+    {
+      "rank": 416,
+      "id": "numind/NuExtract3-GGUF",
+      "author": "numind",
+      "url": "https://huggingface.co/numind/NuExtract3-GGUF",
+      "downloads": 3489,
+      "likes": 15,
+      "trendingScore": 14,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "image-text-to-text",
+        "safetensors",
+        "qwen3_5",
+        "vision-language",
+        "vlm",
+        "document-understanding",
+        "structured-extraction",
+        "information-extraction",
+        "ocr",
+        "document-to-markdown",
+        "markdown",
+        "rag",
+        "reasoning",
+        "multilingual",
+        "conversational",
+        "base_model:numind/NuExtract3",
+        "base_model:quantized:numind/NuExtract3",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T16:24:32.000Z",
+      "lastModified": "2026-05-20T10:49:42.000Z"
+    },
+    {
+      "rank": 417,
+      "id": "meta-llama/Llama-3.1-8B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
+      "downloads": 1252658,
+      "likes": 2213,
+      "trendingScore": 14,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "license:llama3.1",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-07-14T22:20:15.000Z",
+      "lastModified": "2024-10-16T22:00:37.000Z"
+    },
+    {
+      "rank": 418,
+      "id": "meta-llama/Llama-3.2-3B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
+      "downloads": 2079726,
+      "likes": 2155,
+      "trendingScore": 14,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:19:20.000Z",
+      "lastModified": "2024-10-24T15:07:29.000Z"
+    },
+    {
+      "rank": 419,
+      "id": "spiritbuun/buun-Qwen3.6-chat_template",
+      "author": "spiritbuun",
+      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
+      "downloads": 0,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "chat-template",
+        "qwen3",
+        "qwen3.5",
+        "qwen3.6",
+        "jinja",
+        "llama-cpp",
+        "tool-use",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T16:33:22.000Z",
+      "lastModified": "2026-05-26T16:38:59.000Z"
+    },
+    {
+      "rank": 420,
+      "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
+      "downloads": 0,
+      "likes": 14,
+      "trendingScore": 14,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "1-bit",
+        "gemlite",
+        "hqq",
+        "cuda",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:40:12.000Z",
+      "lastModified": "2026-05-26T16:16:58.000Z"
+    },
+    {
+      "rank": 421,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -12239,7 +12503,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 414,
+      "rank": 422,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -12284,7 +12548,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 415,
+      "rank": 423,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -12313,7 +12577,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 416,
+      "rank": 424,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -12340,7 +12604,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 417,
+      "rank": 425,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -12367,7 +12631,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 418,
+      "rank": 426,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -12398,7 +12662,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 419,
+      "rank": 427,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -12422,52 +12686,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 420,
-      "id": "google/medgemma-1.5-4b-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
-      "downloads": 127327,
-      "likes": 610,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma3",
-        "image-text-to-text",
-        "medical",
-        "radiology",
-        "clinical-reasoning",
-        "dermatology",
-        "pathology",
-        "ophthalmology",
-        "chest-x-ray",
-        "conversational",
-        "arxiv:2303.15343",
-        "arxiv:2604.05081",
-        "arxiv:2406.19578",
-        "arxiv:2405.03162",
-        "arxiv:2106.14463",
-        "arxiv:2009.13081",
-        "arxiv:2203.14371",
-        "arxiv:1909.06146",
-        "arxiv:2102.09542",
-        "arxiv:2411.15640",
-        "arxiv:2404.05590",
-        "arxiv:2501.18362",
-        "arxiv:1605.01397",
-        "arxiv:1901.07031",
-        "arxiv:2403.17834",
-        "arxiv:2402.16040",
-        "license:other",
-        "text-generation-inference"
-      ],
-      "createdAt": "2026-01-07T23:07:01.000Z",
-      "lastModified": "2026-04-13T23:20:55.000Z"
-    },
-    {
-      "rank": 421,
+      "rank": 428,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -12494,7 +12713,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 422,
+      "rank": 429,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -12530,7 +12749,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 423,
+      "rank": 430,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -12561,7 +12780,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 424,
+      "rank": 431,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -12592,7 +12811,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 425,
+      "rank": 432,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -12625,7 +12844,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 426,
+      "rank": 433,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -12654,7 +12873,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 427,
+      "rank": 434,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -12680,7 +12899,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 428,
+      "rank": 435,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -12710,7 +12929,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 429,
+      "rank": 436,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -12728,7 +12947,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 430,
+      "rank": 437,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -12759,7 +12978,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 431,
+      "rank": 438,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -12780,7 +12999,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 432,
+      "rank": 439,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -12800,7 +13019,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 433,
+      "rank": 440,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -12827,7 +13046,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 434,
+      "rank": 441,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -12857,7 +13076,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 435,
+      "rank": 442,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -12874,7 +13093,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 436,
+      "rank": 443,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -12901,7 +13120,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 437,
+      "rank": 444,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -12926,7 +13145,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 438,
+      "rank": 445,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -12969,7 +13188,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 439,
+      "rank": 446,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -12998,7 +13217,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 440,
+      "rank": 447,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -13021,7 +13240,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 441,
+      "rank": 448,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -13048,7 +13267,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 442,
+      "rank": 449,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13078,7 +13297,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 443,
+      "rank": 450,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -13106,7 +13325,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 444,
+      "rank": 451,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
@@ -13137,7 +13356,7 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 445,
+      "rank": 452,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -13159,48 +13378,11 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 446,
-      "id": "numind/NuExtract3-GGUF",
-      "author": "numind",
-      "url": "https://huggingface.co/numind/NuExtract3-GGUF",
-      "downloads": 3489,
-      "likes": 14,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "image-text-to-text",
-        "safetensors",
-        "qwen3_5",
-        "vision-language",
-        "vlm",
-        "document-understanding",
-        "structured-extraction",
-        "information-extraction",
-        "ocr",
-        "document-to-markdown",
-        "markdown",
-        "rag",
-        "reasoning",
-        "multilingual",
-        "conversational",
-        "base_model:numind/NuExtract3",
-        "base_model:quantized:numind/NuExtract3",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T16:24:32.000Z",
-      "lastModified": "2026-05-20T10:49:42.000Z"
-    },
-    {
-      "rank": 447,
+      "rank": 453,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
-      "downloads": 55705,
+      "downloads": 55706,
       "likes": 192,
       "trendingScore": 13,
       "pipelineTag": "text-to-image",
@@ -13224,81 +13406,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 448,
-      "id": "meta-llama/Llama-3.1-8B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
-      "downloads": 1249949,
-      "likes": 2211,
-      "trendingScore": 13,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "license:llama3.1",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-07-14T22:20:15.000Z",
-      "lastModified": "2024-10-16T22:00:37.000Z"
-    },
-    {
-      "rank": 449,
-      "id": "meta-llama/Llama-3.2-3B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 2097928,
-      "likes": 2154,
-      "trendingScore": 13,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:19:20.000Z",
-      "lastModified": "2024-10-24T15:07:29.000Z"
-    },
-    {
-      "rank": 450,
+      "rank": 454,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -13328,60 +13436,57 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 451,
-      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "downloads": 0,
-      "likes": 13,
-      "trendingScore": 13,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-audio",
-        "diffusion",
-        "flow-matching",
-        "sound-effects",
-        "audio-generation",
-        "en",
-        "zh",
-        "base_model:Qwen/Qwen3-1.7B",
-        "base_model:finetune:Qwen/Qwen3-1.7B",
-        "license:apache-2.0",
-        "diffusers:MossSoundEffectPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T14:19:58.000Z",
-      "lastModified": "2026-05-26T09:41:39.000Z"
-    },
-    {
-      "rank": 452,
-      "id": "spiritbuun/buun-Qwen3.6-chat_template",
-      "author": "spiritbuun",
-      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
-      "downloads": 0,
+      "rank": 455,
+      "id": "tencent/Hy-MT2-30B-A3B-FP8",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
+      "downloads": 1500,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "chat-template",
-        "qwen3",
-        "qwen3.5",
-        "qwen3.6",
-        "jinja",
-        "llama-cpp",
-        "tool-use",
+        "safetensors",
+        "hy_v3",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-30B-A3B",
+        "base_model:quantized:tencent/Hy-MT2-30B-A3B",
+        "license:apache-2.0",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T06:09:22.000Z",
+      "lastModified": "2026-05-26T09:06:09.000Z"
+    },
+    {
+      "rank": 456,
+      "id": "Abiray/Lance_3B_Video-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
+      "downloads": 2059,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "multimodal",
+        "video-generation",
+        "video-editing",
+        "video-understanding",
+        "quantized",
+        "bytedance",
+        "arxiv:2605.18678",
+        "base_model:bytedance-research/Lance",
+        "base_model:quantized:bytedance-research/Lance",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-26T16:33:22.000Z",
-      "lastModified": "2026-05-26T16:38:59.000Z"
+      "createdAt": "2026-05-21T09:34:34.000Z",
+      "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 453,
+      "rank": 457,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -13408,7 +13513,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 454,
+      "rank": 458,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -13436,7 +13541,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 455,
+      "rank": 459,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -13469,7 +13574,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 456,
+      "rank": 460,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -13485,7 +13590,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 457,
+      "rank": 461,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -13508,7 +13613,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 458,
+      "rank": 462,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -13542,7 +13647,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 459,
+      "rank": 463,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -13562,7 +13667,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 460,
+      "rank": 464,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -13597,7 +13702,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 461,
+      "rank": 465,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -13627,7 +13732,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 462,
+      "rank": 466,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -13648,7 +13753,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 463,
+      "rank": 467,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -13677,7 +13782,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 464,
+      "rank": 468,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -13707,7 +13812,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 465,
+      "rank": 469,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -13735,7 +13840,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 466,
+      "rank": 470,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -13764,7 +13869,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 467,
+      "rank": 471,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -13796,7 +13901,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 468,
+      "rank": 472,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -13831,7 +13936,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 469,
+      "rank": 473,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -13869,7 +13974,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 470,
+      "rank": 474,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -13908,7 +14013,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 471,
+      "rank": 475,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -13945,7 +14050,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 472,
+      "rank": 476,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -13969,7 +14074,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 473,
+      "rank": 477,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -13987,7 +14092,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 474,
+      "rank": 478,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -14006,7 +14111,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 475,
+      "rank": 479,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -14034,19 +14139,18 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 476,
+      "rank": 480,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
-      "downloads": 35224,
-      "likes": 635,
+      "downloads": 33832,
+      "likes": 640,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
       "libraryName": "PaddleOCR",
       "tags": [
         "PaddleOCR",
         "safetensors",
-        "paddleocr_vl",
         "ERNIE4.5",
         "PaddlePaddle",
         "image-to-text",
@@ -14059,8 +14163,6 @@
         "seal",
         "spotting",
         "image-text-to-text",
-        "conversational",
-        "custom_code",
         "en",
         "zh",
         "multilingual",
@@ -14075,7 +14177,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 477,
+      "rank": 481,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -14097,7 +14199,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 478,
+      "rank": 482,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -14134,7 +14236,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 479,
+      "rank": 483,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -14164,7 +14266,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 480,
+      "rank": 484,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -14193,7 +14295,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 481,
+      "rank": 485,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -14221,7 +14323,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 482,
+      "rank": 486,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -14247,7 +14349,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 483,
+      "rank": 487,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -14274,7 +14376,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 484,
+      "rank": 488,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -14299,7 +14401,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 485,
+      "rank": 489,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -14328,7 +14430,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 486,
+      "rank": 490,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -14353,7 +14455,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 487,
+      "rank": 491,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -14379,7 +14481,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 488,
+      "rank": 492,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -14418,7 +14520,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 489,
+      "rank": 493,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
@@ -14446,7 +14548,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 490,
+      "rank": 494,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -14472,7 +14574,7 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 491,
+      "rank": 495,
       "id": "SupraLabs/Supra-50M-Base",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
@@ -14506,30 +14608,7 @@
       "lastModified": "2026-05-23T07:46:11.000Z"
     },
     {
-      "rank": 492,
-      "id": "tencent/Hy-MT2-30B-A3B-FP8",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
-      "downloads": 1500,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "hy_v3",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-30B-A3B",
-        "base_model:quantized:tencent/Hy-MT2-30B-A3B",
-        "license:apache-2.0",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T06:09:22.000Z",
-      "lastModified": "2026-05-26T09:06:09.000Z"
-    },
-    {
-      "rank": 493,
+      "rank": 496,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -14549,7 +14628,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
@@ -14569,11 +14648,11 @@
       "lastModified": "2026-05-23T14:54:50.000Z"
     },
     {
-      "rank": 495,
+      "rank": 498,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
-      "downloads": 833994,
+      "downloads": 843734,
       "likes": 555,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -14594,11 +14673,11 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 496,
+      "rank": 499,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
-      "downloads": 431,
+      "downloads": 493,
       "likes": 18,
       "trendingScore": 12,
       "pipelineTag": "other",
@@ -14627,11 +14706,11 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 497,
+      "rank": 500,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 145954,
+      "downloads": 146703,
       "likes": 356,
       "trendingScore": 12,
       "pipelineTag": null,
@@ -14653,34 +14732,105 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 498,
-      "id": "Abiray/Lance_3B_Video-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
-      "downloads": 2059,
+      "rank": 501,
+      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "author": "opendatalab",
+      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "downloads": 535,
       "likes": 12,
       "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
       "tags": [
-        "gguf",
-        "multimodal",
-        "video-generation",
-        "video-editing",
-        "video-understanding",
-        "quantized",
-        "bytedance",
-        "arxiv:2605.18678",
-        "base_model:bytedance-research/Lance",
-        "base_model:quantized:bytedance-research/Lance",
+        "transformers",
+        "safetensors",
+        "qwen2_vl",
+        "image-text-to-text",
+        "conversational",
+        "zh",
+        "en",
+        "arxiv:2604.04771",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T11:00:43.000Z",
+      "lastModified": "2026-05-25T10:58:41.000Z"
+    },
+    {
+      "rank": 502,
+      "id": "joyfox/LTX-2.3-Transition-LORA",
+      "author": "joyfox",
+      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
+      "downloads": 36829,
+      "likes": 117,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ValiantCat",
+        "Lightricks",
+        "LTX-2.3",
+        "image-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-21T09:34:34.000Z",
-      "lastModified": "2026-05-21T09:49:53.000Z"
+      "createdAt": "2026-03-20T10:25:10.000Z",
+      "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 499,
+      "rank": 503,
+      "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
+      "downloads": 1012,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "transformers",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "text-generation",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "base_model:Jackrong/Qwopus3.6-27B-v2",
+        "base_model:adapter:Jackrong/Qwopus3.6-27B-v2",
+        "license:apache-2.0"
+      ],
+      "createdAt": "2026-05-23T00:16:01.000Z",
+      "lastModified": "2026-05-23T00:19:59.000Z"
+    },
+    {
+      "rank": 504,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -14725,7 +14875,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 500,
+      "rank": 505,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -14767,7 +14917,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 501,
+      "rank": 506,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -14793,7 +14943,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 502,
+      "rank": 507,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -14818,7 +14968,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 503,
+      "rank": 508,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -14835,7 +14985,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 504,
+      "rank": 509,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -14863,7 +15013,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 505,
+      "rank": 510,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -14889,7 +15039,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 506,
+      "rank": 511,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -14916,7 +15066,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 507,
+      "rank": 512,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -14944,7 +15094,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 508,
+      "rank": 513,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -14977,7 +15127,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 509,
+      "rank": 514,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -15011,7 +15161,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 510,
+      "rank": 515,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -15040,7 +15190,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 511,
+      "rank": 516,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -15069,7 +15219,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 512,
+      "rank": 517,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -15102,7 +15252,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 513,
+      "rank": 518,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -15129,7 +15279,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 514,
+      "rank": 519,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -15159,7 +15309,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 515,
+      "rank": 520,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -15185,7 +15335,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 516,
+      "rank": 521,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -15209,7 +15359,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 517,
+      "rank": 522,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -15236,7 +15386,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 518,
+      "rank": 523,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -15270,7 +15420,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 519,
+      "rank": 524,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -15286,7 +15436,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 520,
+      "rank": 525,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -15317,7 +15467,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 521,
+      "rank": 526,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -15339,7 +15489,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 522,
+      "rank": 527,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -15359,7 +15509,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 523,
+      "rank": 528,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -15381,7 +15531,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 524,
+      "rank": 529,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -15410,7 +15560,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 525,
+      "rank": 530,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -15435,7 +15585,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 526,
+      "rank": 531,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -15460,7 +15610,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 527,
+      "rank": 532,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -15495,7 +15645,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 528,
+      "rank": 533,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -15519,7 +15669,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 529,
+      "rank": 534,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -15550,7 +15700,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 530,
+      "rank": 535,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -15580,7 +15730,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 531,
+      "rank": 536,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -15606,7 +15756,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 532,
+      "rank": 537,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -15651,7 +15801,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 533,
+      "rank": 538,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -15678,7 +15828,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 534,
+      "rank": 539,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -15705,7 +15855,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 535,
+      "rank": 540,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -15750,7 +15900,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 536,
+      "rank": 541,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -15776,7 +15926,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 537,
+      "rank": 542,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -15805,7 +15955,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 538,
+      "rank": 543,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -15850,7 +16000,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 539,
+      "rank": 544,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -15882,7 +16032,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 540,
+      "rank": 545,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -15917,7 +16067,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 541,
+      "rank": 546,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
@@ -15948,7 +16098,7 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 542,
+      "rank": 547,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -15993,7 +16143,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 543,
+      "rank": 548,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -16034,7 +16184,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 544,
+      "rank": 549,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -16059,7 +16209,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 545,
+      "rank": 550,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -16098,34 +16248,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 546,
-      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "author": "opendatalab",
-      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "downloads": 535,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_vl",
-        "image-text-to-text",
-        "conversational",
-        "zh",
-        "en",
-        "arxiv:2604.04771",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T11:00:43.000Z",
-      "lastModified": "2026-05-25T10:58:41.000Z"
-    },
-    {
-      "rank": 547,
+      "rank": 551,
       "id": "Abiray/L2P-model-1k-merge-INT8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
@@ -16150,7 +16273,7 @@
       "lastModified": "2026-05-23T17:24:01.000Z"
     },
     {
-      "rank": 548,
+      "rank": 552,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
@@ -16172,11 +16295,11 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 549,
+      "rank": 553,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
-      "downloads": 130412,
+      "downloads": 123075,
       "likes": 82,
       "trendingScore": 11,
       "pipelineTag": "text-ranking",
@@ -16202,7 +16325,7 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 550,
+      "rank": 554,
       "id": "mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
@@ -16232,7 +16355,7 @@
       "lastModified": "2026-05-10T04:13:55.000Z"
     },
     {
-      "rank": 551,
+      "rank": 555,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
@@ -16249,7 +16372,7 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 552,
+      "rank": 556,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -16272,7 +16395,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 553,
+      "rank": 557,
       "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
       "author": "Leon1000",
       "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
@@ -16300,33 +16423,7 @@
       "lastModified": "2026-05-20T00:22:04.000Z"
     },
     {
-      "rank": 554,
-      "id": "joyfox/LTX-2.3-Transition-LORA",
-      "author": "joyfox",
-      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 37084,
-      "likes": 116,
-      "trendingScore": 11,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ValiantCat",
-        "Lightricks",
-        "LTX-2.3",
-        "image-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-20T10:25:10.000Z",
-      "lastModified": "2026-03-30T03:28:58.000Z"
-    },
-    {
-      "rank": 555,
+      "rank": 558,
       "id": "UofTCSSLab/Maia3-79M",
       "author": "UofTCSSLab",
       "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
@@ -16350,55 +16447,10 @@
       "lastModified": "2026-05-24T16:12:28.000Z"
     },
     {
-      "rank": 556,
-      "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
-      "downloads": 1012,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "transformers",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "text-generation",
-        "conversational",
-        "en",
-        "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "base_model:Jackrong/Qwopus3.6-27B-v2",
-        "base_model:adapter:Jackrong/Qwopus3.6-27B-v2",
-        "license:apache-2.0"
-      ],
-      "createdAt": "2026-05-23T00:16:01.000Z",
-      "lastModified": "2026-05-23T00:19:59.000Z"
-    },
-    {
-      "rank": 557,
-      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
+      "rank": 559,
+      "id": "prism-ml/bonsai-image-binary-4B-unpacked",
       "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
       "downloads": 0,
       "likes": 11,
       "trendingScore": 11,
@@ -16415,11 +16467,11 @@
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-21T16:07:19.000Z",
-      "lastModified": "2026-05-26T16:17:00.000Z"
+      "createdAt": "2026-05-18T15:40:11.000Z",
+      "lastModified": "2026-05-26T16:16:58.000Z"
     },
     {
-      "rank": 558,
+      "rank": 560,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -16448,7 +16500,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 559,
+      "rank": 561,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -16482,7 +16534,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 560,
+      "rank": 562,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -16527,7 +16579,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 561,
+      "rank": 563,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -16556,7 +16608,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 562,
+      "rank": 564,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -16581,7 +16633,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 563,
+      "rank": 565,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -16616,7 +16668,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 564,
+      "rank": 566,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -16643,7 +16695,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 565,
+      "rank": 567,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -16688,7 +16740,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 566,
+      "rank": 568,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -16710,7 +16762,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 567,
+      "rank": 569,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -16742,7 +16794,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 568,
+      "rank": 570,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -16767,7 +16819,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 569,
+      "rank": 571,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -16791,7 +16843,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 570,
+      "rank": 572,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -16834,7 +16886,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 571,
+      "rank": 573,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -16858,7 +16910,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 572,
+      "rank": 574,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -16887,7 +16939,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 573,
+      "rank": 575,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -16919,7 +16971,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 574,
+      "rank": 576,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -16943,7 +16995,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 575,
+      "rank": 577,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -16965,7 +17017,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 576,
+      "rank": 578,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -16990,7 +17042,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 577,
+      "rank": 579,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -17018,7 +17070,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 578,
+      "rank": 580,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -17042,11 +17094,11 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 579,
+      "rank": 581,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
-      "downloads": 6392,
+      "downloads": 6337,
       "likes": 165,
       "trendingScore": 10,
       "pipelineTag": "text-to-audio",
@@ -17069,7 +17121,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 580,
+      "rank": 582,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -17086,7 +17138,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 581,
+      "rank": 583,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -17110,7 +17162,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 582,
+      "rank": 584,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -17134,7 +17186,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 583,
+      "rank": 585,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -17167,7 +17219,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 584,
+      "rank": 586,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -17201,7 +17253,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 585,
+      "rank": 587,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -17223,7 +17275,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 586,
+      "rank": 588,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -17246,7 +17298,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 587,
+      "rank": 589,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -17266,7 +17318,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 588,
+      "rank": 590,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -17298,7 +17350,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 589,
+      "rank": 591,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -17337,7 +17389,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 590,
+      "rank": 592,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -17371,7 +17423,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 591,
+      "rank": 593,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -17391,7 +17443,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 592,
+      "rank": 594,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -17420,7 +17472,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 593,
+      "rank": 595,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -17442,7 +17494,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 594,
+      "rank": 596,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -17474,7 +17526,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 595,
+      "rank": 597,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -17501,7 +17553,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 596,
+      "rank": 598,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -17545,7 +17597,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 597,
+      "rank": 599,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -17563,7 +17615,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 598,
+      "rank": 600,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -17602,7 +17654,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 599,
+      "rank": 601,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -17641,7 +17693,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 600,
+      "rank": 602,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -17675,7 +17727,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 601,
+      "rank": 603,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -17703,7 +17755,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 602,
+      "rank": 604,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -17725,7 +17777,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 603,
+      "rank": 605,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -17753,7 +17805,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 604,
+      "rank": 606,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -17771,7 +17823,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 605,
+      "rank": 607,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -17799,7 +17851,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 606,
+      "rank": 608,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -17830,7 +17882,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 607,
+      "rank": 609,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -17846,7 +17898,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 608,
+      "rank": 610,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -17873,7 +17925,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 609,
+      "rank": 611,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -17902,7 +17954,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 610,
+      "rank": 612,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -17930,7 +17982,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 611,
+      "rank": 613,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -17959,7 +18011,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 612,
+      "rank": 614,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -17980,7 +18032,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 613,
+      "rank": 615,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -18001,7 +18053,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 614,
+      "rank": 616,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -18031,7 +18083,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 615,
+      "rank": 617,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -18055,11 +18107,11 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 616,
+      "rank": 618,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
-      "downloads": 1118670,
+      "downloads": 1184338,
       "likes": 418,
       "trendingScore": 10,
       "pipelineTag": "sentence-similarity",
@@ -18085,7 +18137,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 617,
+      "rank": 619,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -18116,12 +18168,12 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 618,
+      "rank": 620,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
-      "downloads": 1666,
-      "likes": 482,
+      "downloads": 1837,
+      "likes": 483,
       "trendingScore": 10,
       "pipelineTag": "text-to-video",
       "libraryName": "diffusers",
@@ -18142,7 +18194,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 619,
+      "rank": 621,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -18168,7 +18220,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 620,
+      "rank": 622,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -18186,7 +18238,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 621,
+      "rank": 623,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -18219,7 +18271,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 622,
+      "rank": 624,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -18244,7 +18296,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 623,
+      "rank": 625,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -18269,7 +18321,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 624,
+      "rank": 626,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -18303,7 +18355,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 625,
+      "rank": 627,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
@@ -18343,7 +18395,7 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 626,
+      "rank": 628,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
@@ -18378,11 +18430,11 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 627,
+      "rank": 629,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
-      "downloads": 57322,
+      "downloads": 57415,
       "likes": 1086,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-image",
@@ -18404,7 +18456,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 628,
+      "rank": 630,
       "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
@@ -18449,7 +18501,7 @@
       "lastModified": "2026-05-24T04:55:49.000Z"
     },
     {
-      "rank": 629,
+      "rank": 631,
       "id": "FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
@@ -18479,10 +18531,99 @@
         "region:us"
       ],
       "createdAt": "2026-05-26T18:07:50.000Z",
-      "lastModified": "2026-05-26T20:42:23.000Z"
+      "lastModified": "2026-05-27T07:55:25.000Z"
     },
     {
-      "rank": 630,
+      "rank": 632,
+      "id": "nvidia/GLM-5.1-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
+      "downloads": 5318,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "nvidia",
+        "ModelOpt",
+        "quantized",
+        "4-bit precision",
+        "FP4",
+        "fp4",
+        "text-generation",
+        "base_model:zai-org/GLM-5.1",
+        "base_model:finetune:zai-org/GLM-5.1",
+        "license:mit",
+        "8-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-09T20:32:52.000Z",
+      "lastModified": "2026-05-20T21:18:02.000Z"
+    },
+    {
+      "rank": 633,
+      "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
+      "author": "cHunter789",
+      "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
+      "downloads": 1679,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "text-generation",
+        "qwen",
+        "ik_llama.cpp",
+        "nvidia",
+        "imatrix",
+        "4-bit",
+        "iq4_ks",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-21T16:00:17.000Z",
+      "lastModified": "2026-05-22T20:32:34.000Z"
+    },
+    {
+      "rank": 634,
+      "id": "kepeng/PRSIMVL-LoRA-V1",
+      "author": "kepeng",
+      "url": "https://huggingface.co/kepeng/PRSIMVL-LoRA-V1",
+      "downloads": 0,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": "visual-question-answering",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "vision-language",
+        "multimodal",
+        "visual-question-answering",
+        "measurement-grounding",
+        "raw-image",
+        "camera-raw",
+        "meas-xyz",
+        "low-light",
+        "hdr",
+        "benchmark",
+        "prsimvl",
+        "en",
+        "arxiv:2605.11727",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T06:27:04.000Z",
+      "lastModified": "2026-05-27T06:35:24.000Z"
+    },
+    {
+      "rank": 635,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -18509,7 +18650,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 631,
+      "rank": 636,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -18535,7 +18676,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 632,
+      "rank": 637,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -18563,7 +18704,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 633,
+      "rank": 638,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -18589,7 +18730,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 634,
+      "rank": 639,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -18629,7 +18770,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 635,
+      "rank": 640,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -18665,7 +18806,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 636,
+      "rank": 641,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -18709,7 +18850,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 637,
+      "rank": 642,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -18734,7 +18875,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 638,
+      "rank": 643,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -18779,7 +18920,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 639,
+      "rank": 644,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -18798,7 +18939,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 640,
+      "rank": 645,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -18823,7 +18964,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 641,
+      "rank": 646,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -18862,7 +19003,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 642,
+      "rank": 647,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -18879,7 +19020,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 643,
+      "rank": 648,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -18907,7 +19048,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 644,
+      "rank": 649,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -18936,7 +19077,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 645,
+      "rank": 650,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -18961,7 +19102,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 646,
+      "rank": 651,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -18996,7 +19137,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 647,
+      "rank": 652,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -19026,7 +19167,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 648,
+      "rank": 653,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -19062,7 +19203,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 649,
+      "rank": 654,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -19085,7 +19226,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 650,
+      "rank": 655,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -19102,7 +19243,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 651,
+      "rank": 656,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -19122,7 +19263,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 652,
+      "rank": 657,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -19149,7 +19290,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 653,
+      "rank": 658,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -19173,7 +19314,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 654,
+      "rank": 659,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -19195,7 +19336,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 655,
+      "rank": 660,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -19227,7 +19368,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 656,
+      "rank": 661,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -19255,7 +19396,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 657,
+      "rank": 662,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -19273,7 +19414,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 658,
+      "rank": 663,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -19298,7 +19439,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 659,
+      "rank": 664,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -19321,7 +19462,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 660,
+      "rank": 665,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -19339,7 +19480,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 661,
+      "rank": 666,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -19374,7 +19515,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 662,
+      "rank": 667,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -19402,7 +19543,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 663,
+      "rank": 668,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -19424,7 +19565,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 664,
+      "rank": 669,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -19451,7 +19592,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 665,
+      "rank": 670,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -19476,7 +19617,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 666,
+      "rank": 671,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -19510,7 +19651,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 667,
+      "rank": 672,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -19537,7 +19678,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 668,
+      "rank": 673,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -19564,7 +19705,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 669,
+      "rank": 674,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -19605,7 +19746,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 670,
+      "rank": 675,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -19635,7 +19776,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 671,
+      "rank": 676,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -19672,7 +19813,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 672,
+      "rank": 677,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -19704,7 +19845,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 673,
+      "rank": 678,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -19746,7 +19887,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 674,
+      "rank": 679,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -19776,7 +19917,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 675,
+      "rank": 680,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -19821,7 +19962,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 676,
+      "rank": 681,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -19848,7 +19989,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 677,
+      "rank": 682,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -19880,7 +20021,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 678,
+      "rank": 683,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -19914,7 +20055,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 679,
+      "rank": 684,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -19944,7 +20085,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 680,
+      "rank": 685,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -19969,7 +20110,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 681,
+      "rank": 686,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -19996,7 +20137,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 682,
+      "rank": 687,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -20028,7 +20169,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 683,
+      "rank": 688,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -20073,7 +20214,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 684,
+      "rank": 689,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -20101,7 +20242,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 685,
+      "rank": 690,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -20127,7 +20268,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 686,
+      "rank": 691,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -20156,7 +20297,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 687,
+      "rank": 692,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -20198,7 +20339,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 688,
+      "rank": 693,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -20226,7 +20367,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 689,
+      "rank": 694,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -20255,7 +20396,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 690,
+      "rank": 695,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -20285,7 +20426,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 691,
+      "rank": 696,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -20312,7 +20453,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 692,
+      "rank": 697,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -20341,7 +20482,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 693,
+      "rank": 698,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -20368,7 +20509,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 694,
+      "rank": 699,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -20397,7 +20538,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 695,
+      "rank": 700,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -20437,7 +20578,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 696,
+      "rank": 701,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -20455,7 +20596,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 697,
+      "rank": 702,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -20480,7 +20621,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 698,
+      "rank": 703,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -20496,7 +20637,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 699,
+      "rank": 704,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -20541,7 +20682,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 700,
+      "rank": 705,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -20564,7 +20705,7 @@
       "lastModified": "2026-05-26T09:06:26.000Z"
     },
     {
-      "rank": 701,
+      "rank": 706,
       "id": "Anbeeld/Qwen3.6-27B-DFlash-GGUF",
       "author": "Anbeeld",
       "url": "https://huggingface.co/Anbeeld/Qwen3.6-27B-DFlash-GGUF",
@@ -20585,36 +20726,7 @@
       "lastModified": "2026-05-22T17:31:30.000Z"
     },
     {
-      "rank": 702,
-      "id": "nvidia/GLM-5.1-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
-      "downloads": 5318,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "nvidia",
-        "ModelOpt",
-        "quantized",
-        "4-bit precision",
-        "FP4",
-        "fp4",
-        "text-generation",
-        "base_model:zai-org/GLM-5.1",
-        "base_model:finetune:zai-org/GLM-5.1",
-        "license:mit",
-        "8-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T20:32:52.000Z",
-      "lastModified": "2026-05-20T21:18:02.000Z"
-    },
-    {
-      "rank": 703,
+      "rank": 707,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -20647,41 +20759,12 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 704,
-      "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
-      "author": "cHunter789",
-      "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
-      "downloads": 1679,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "text-generation",
-        "qwen",
-        "ik_llama.cpp",
-        "nvidia",
-        "imatrix",
-        "4-bit",
-        "iq4_ks",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-21T16:00:17.000Z",
-      "lastModified": "2026-05-22T20:32:34.000Z"
-    },
-    {
-      "rank": 705,
+      "rank": 708,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
-      "downloads": 1286389,
-      "likes": 966,
+      "downloads": 1316727,
+      "likes": 967,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -20721,11 +20804,11 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 706,
+      "rank": 709,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
-      "downloads": 462,
+      "downloads": 476,
       "likes": 179,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -20751,7 +20834,7 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 707,
+      "rank": 710,
       "id": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -20781,37 +20864,147 @@
       "lastModified": "2026-05-25T03:44:12.000Z"
     },
     {
-      "rank": 708,
-      "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
-      "downloads": 0,
+      "rank": 711,
+      "id": "tencent/Hy-MT2-1.8B-FP8",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
+      "downloads": 581,
       "likes": 9,
       "trendingScore": 9,
-      "pipelineTag": "text-to-image",
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "hunyuan_v1_dense",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-1.8B",
+        "base_model:quantized:tencent/Hy-MT2-1.8B",
+        "license:apache-2.0",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:24:46.000Z",
+      "lastModified": "2026-05-26T09:06:01.000Z"
+    },
+    {
+      "rank": 712,
+      "id": "zeroentropy/zembed-1-embedding",
+      "author": "zeroentropy",
+      "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
+      "downloads": 341636,
+      "likes": 109,
+      "trendingScore": 9,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "sentence-transformers",
+      "tags": [
+        "sentence-transformers",
+        "safetensors",
+        "qwen3",
+        "finance",
+        "legal",
+        "healthcare",
+        "code",
+        "stem",
+        "medical",
+        "multilingual",
+        "feature-extraction",
+        "en",
+        "arxiv:2509.12541",
+        "base_model:Qwen/Qwen3-4B",
+        "base_model:finetune:Qwen/Qwen3-4B",
+        "license:cc-by-nc-4.0",
+        "text-embeddings-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T07:11:05.000Z",
+      "lastModified": "2026-03-12T21:10:43.000Z"
+    },
+    {
+      "rank": 713,
+      "id": "avaturn-live/avtr-1",
+      "author": "avaturn-live",
+      "url": "https://huggingface.co/avaturn-live/avtr-1",
+      "downloads": 2,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-video",
+      "libraryName": "tensorrt",
+      "tags": [
+        "tensorrt",
+        "onnx",
+        "talking-head",
+        "lip-sync",
+        "avatar",
+        "real-time",
+        "audio-driven",
+        "non-commercial",
+        "image-to-video",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:26:51.000Z",
+      "lastModified": "2026-05-25T21:18:34.000Z"
+    },
+    {
+      "rank": 714,
+      "id": "FireRedTeam/FireRed-Image-Edit-1.1",
+      "author": "FireRedTeam",
+      "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
+      "downloads": 35020,
+      "likes": 253,
+      "trendingScore": 9,
+      "pipelineTag": "image-to-image",
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
         "safetensors",
-        "1-bit",
-        "gemlite",
-        "hqq",
-        "cuda",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2602.13344",
         "license:apache-2.0",
+        "diffusers:QwenImageEditPlusPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-18T15:40:12.000Z",
-      "lastModified": "2026-05-26T16:16:58.000Z"
+      "createdAt": "2026-03-02T13:47:43.000Z",
+      "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 709,
+      "rank": 715,
+      "id": "FunAudioLLM/SenseVoiceSmall",
+      "author": "FunAudioLLM",
+      "url": "https://huggingface.co/FunAudioLLM/SenseVoiceSmall",
+      "downloads": 3817,
+      "likes": 404,
+      "trendingScore": 9,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "funasr",
+      "tags": [
+        "funasr",
+        "speech-recognition",
+        "asr",
+        "emotion-recognition",
+        "audio-event-detection",
+        "multilingual",
+        "non-autoregressive",
+        "whisper-alternative",
+        "real-time",
+        "voice-ai",
+        "automatic-speech-recognition",
+        "zh",
+        "en",
+        "ja",
+        "ko",
+        "yue",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2024-07-03T03:56:49.000Z",
+      "lastModified": "2026-05-25T17:28:01.000Z"
+    },
+    {
+      "rank": 716,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -20838,7 +21031,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 710,
+      "rank": 717,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -20862,7 +21055,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 711,
+      "rank": 718,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -20882,7 +21075,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 712,
+      "rank": 719,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -20901,7 +21094,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 713,
+      "rank": 720,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -20935,7 +21128,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 714,
+      "rank": 721,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -20967,7 +21160,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 715,
+      "rank": 722,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -20989,7 +21182,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 716,
+      "rank": 723,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -21034,7 +21227,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 717,
+      "rank": 724,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -21053,7 +21246,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 718,
+      "rank": 725,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -21087,7 +21280,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 719,
+      "rank": 726,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -21115,7 +21308,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 720,
+      "rank": 727,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -21143,7 +21336,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 721,
+      "rank": 728,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -21166,7 +21359,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 722,
+      "rank": 729,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -21193,7 +21386,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 723,
+      "rank": 730,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -21238,7 +21431,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 724,
+      "rank": 731,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -21274,7 +21467,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 725,
+      "rank": 732,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -21314,7 +21507,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 726,
+      "rank": 733,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -21343,7 +21536,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 727,
+      "rank": 734,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -21371,7 +21564,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 728,
+      "rank": 735,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -21390,7 +21583,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 729,
+      "rank": 736,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -21409,7 +21602,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 730,
+      "rank": 737,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -21441,7 +21634,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 731,
+      "rank": 738,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -21468,7 +21661,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 732,
+      "rank": 739,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -21490,7 +21683,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 733,
+      "rank": 740,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -21508,7 +21701,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 734,
+      "rank": 741,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -21537,7 +21730,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 735,
+      "rank": 742,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -21558,7 +21751,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 736,
+      "rank": 743,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -21586,7 +21779,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 737,
+      "rank": 744,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -21607,7 +21800,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 738,
+      "rank": 745,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -21643,7 +21836,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 739,
+      "rank": 746,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -21666,7 +21859,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 740,
+      "rank": 747,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -21691,11 +21884,11 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 741,
+      "rank": 748,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
-      "downloads": 8109,
+      "downloads": 8098,
       "likes": 635,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -21726,7 +21919,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 742,
+      "rank": 749,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -21771,7 +21964,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 743,
+      "rank": 750,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -21798,7 +21991,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 744,
+      "rank": 751,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -21827,7 +22020,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 745,
+      "rank": 752,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -21846,7 +22039,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 746,
+      "rank": 753,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -21867,7 +22060,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 747,
+      "rank": 754,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -21893,7 +22086,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 748,
+      "rank": 755,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -21919,7 +22112,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 749,
+      "rank": 756,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -21956,7 +22149,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 750,
+      "rank": 757,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -22001,7 +22194,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 751,
+      "rank": 758,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -22026,7 +22219,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 752,
+      "rank": 759,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -22043,7 +22236,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 753,
+      "rank": 760,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -22070,7 +22263,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 754,
+      "rank": 761,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -22088,7 +22281,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 755,
+      "rank": 762,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -22113,7 +22306,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 756,
+      "rank": 763,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -22145,7 +22338,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 757,
+      "rank": 764,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -22166,7 +22359,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 758,
+      "rank": 765,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -22185,7 +22378,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 759,
+      "rank": 766,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -22216,7 +22409,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 760,
+      "rank": 767,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -22239,7 +22432,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 761,
+      "rank": 768,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -22256,7 +22449,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 762,
+      "rank": 769,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -22284,7 +22477,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 763,
+      "rank": 770,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -22301,7 +22494,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 764,
+      "rank": 771,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -22337,7 +22530,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 765,
+      "rank": 772,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -22367,7 +22560,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 766,
+      "rank": 773,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -22390,7 +22583,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 767,
+      "rank": 774,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -22423,7 +22616,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 768,
+      "rank": 775,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -22454,7 +22647,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 769,
+      "rank": 776,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -22477,7 +22670,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 770,
+      "rank": 777,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -22510,7 +22703,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 771,
+      "rank": 778,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -22533,7 +22726,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 772,
+      "rank": 779,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -22563,7 +22756,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 773,
+      "rank": 780,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -22592,7 +22785,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 774,
+      "rank": 781,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -22621,7 +22814,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 775,
+      "rank": 782,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -22657,7 +22850,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 776,
+      "rank": 783,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -22680,7 +22873,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 777,
+      "rank": 784,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -22705,7 +22898,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 778,
+      "rank": 785,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -22735,7 +22928,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 779,
+      "rank": 786,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -22771,7 +22964,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 780,
+      "rank": 787,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -22805,7 +22998,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 781,
+      "rank": 788,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -22832,7 +23025,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 782,
+      "rank": 789,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -22865,12 +23058,12 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 783,
+      "rank": 790,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
-      "downloads": 1130092,
-      "likes": 790,
+      "downloads": 1107796,
+      "likes": 791,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -22902,7 +23095,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 784,
+      "rank": 791,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -22930,7 +23123,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 785,
+      "rank": 792,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -22950,7 +23143,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 786,
+      "rank": 793,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -22973,7 +23166,7 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 787,
+      "rank": 794,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -23018,7 +23211,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 788,
+      "rank": 795,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -23050,7 +23243,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 789,
+      "rank": 796,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -23075,7 +23268,7 @@
       "lastModified": "2026-05-26T08:37:41.000Z"
     },
     {
-      "rank": 790,
+      "rank": 797,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -23097,7 +23290,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 791,
+      "rank": 798,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -23125,7 +23318,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 792,
+      "rank": 799,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -23149,7 +23342,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 793,
+      "rank": 800,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
@@ -23174,7 +23367,7 @@
       "lastModified": "2026-05-26T05:28:12.000Z"
     },
     {
-      "rank": 794,
+      "rank": 801,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -23219,7 +23412,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 795,
+      "rank": 802,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
@@ -23249,7 +23442,7 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 796,
+      "rank": 803,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -23265,7 +23458,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 797,
+      "rank": 804,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -23285,7 +23478,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 798,
+      "rank": 805,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -23309,7 +23502,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 799,
+      "rank": 806,
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
@@ -23338,30 +23531,7 @@
       "lastModified": "2025-12-17T05:12:35.000Z"
     },
     {
-      "rank": 800,
-      "id": "tencent/Hy-MT2-1.8B-FP8",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
-      "downloads": 581,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "hunyuan_v1_dense",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-1.8B",
-        "base_model:quantized:tencent/Hy-MT2-1.8B",
-        "license:apache-2.0",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:24:46.000Z",
-      "lastModified": "2026-05-26T09:06:01.000Z"
-    },
-    {
-      "rank": 801,
+      "rank": 807,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -23394,7 +23564,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 802,
+      "rank": 808,
       "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
@@ -23414,7 +23584,7 @@
       "lastModified": "2026-05-22T21:06:00.000Z"
     },
     {
-      "rank": 803,
+      "rank": 809,
       "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
@@ -23459,7 +23629,7 @@
       "lastModified": "2026-05-20T02:34:32.000Z"
     },
     {
-      "rank": 804,
+      "rank": 810,
       "id": "openbmb/BitCPM-CANN-0.5B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-0.5B-gguf",
@@ -23483,7 +23653,7 @@
       "lastModified": "2026-05-23T18:11:41.000Z"
     },
     {
-      "rank": 805,
+      "rank": 811,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -23507,7 +23677,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 806,
+      "rank": 812,
       "id": "huihui-ai/DeepSeek-V4-Flash-BF16",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/DeepSeek-V4-Flash-BF16",
@@ -23533,11 +23703,11 @@
       "lastModified": "2026-05-25T09:42:03.000Z"
     },
     {
-      "rank": 807,
+      "rank": 813,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
-      "downloads": 1374,
+      "downloads": 1361,
       "likes": 46,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -23560,7 +23730,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 808,
+      "rank": 814,
       "id": "Danrisi/UltraReal_FineTune_Anima_base1",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
@@ -23584,7 +23754,7 @@
       "lastModified": "2026-05-22T13:40:23.000Z"
     },
     {
-      "rank": 809,
+      "rank": 815,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -23629,67 +23799,233 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 810,
-      "id": "zeroentropy/zembed-1-embedding",
-      "author": "zeroentropy",
-      "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
-      "downloads": 349242,
-      "likes": 108,
+      "rank": 816,
+      "id": "thelamapi/neuvoice",
+      "author": "thelamapi",
+      "url": "https://huggingface.co/thelamapi/neuvoice",
+      "downloads": 118,
+      "likes": 11,
       "trendingScore": 8,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "sentence-transformers",
+      "pipelineTag": "text-to-speech",
+      "libraryName": "transformers",
       "tags": [
-        "sentence-transformers",
-        "safetensors",
-        "qwen3",
-        "finance",
-        "legal",
-        "healthcare",
-        "code",
-        "stem",
-        "medical",
-        "multilingual",
-        "feature-extraction",
+        "transformers",
+        "onnx",
+        "text",
+        "speech",
+        "tts",
+        "neuvoice",
+        "turkish",
+        "turkey",
+        "ai voice",
+        "text to speech",
+        "turkish tts",
+        "open source ai",
+        "huggingface model",
+        "voice cloning",
+        "realistic ai voice",
+        "speech synthesis",
+        "turkish ai",
+        "local ai",
+        "offline tts",
+        "low latency tts",
+        "multilingual tts",
+        "pytorch",
+        "audio generation",
+        "speech model",
+        "real time tts",
+        "hf model",
+        "synthetic voice",
+        "text-to-speech",
+        "tr",
+        "bg"
+      ],
+      "createdAt": "2026-05-15T18:15:55.000Z",
+      "lastModified": "2026-05-20T13:29:46.000Z"
+    },
+    {
+      "rank": 817,
+      "id": "huytd189/Qwen3.6-27B-pure-GGUF",
+      "author": "huytd189",
+      "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
+      "downloads": 2444,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-22T01:15:54.000Z",
+      "lastModified": "2026-05-27T05:35:38.000Z"
+    },
+    {
+      "rank": 818,
+      "id": "Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
+      "author": "Andycurrent",
+      "url": "https://huggingface.co/Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
+      "downloads": 2382231,
+      "likes": 37,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "text-generation",
+        "reasoning",
+        "instruction-tuned",
+        "lightweight",
         "en",
-        "arxiv:2509.12541",
-        "base_model:Qwen/Qwen3-4B",
-        "base_model:finetune:Qwen/Qwen3-4B",
-        "license:cc-by-nc-4.0",
-        "text-embeddings-inference",
+        "base_model:google/gemma-3-1b-it",
+        "base_model:quantized:google/gemma-3-1b-it",
+        "license:gemma",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-02-18T09:56:14.000Z",
+      "lastModified": "2026-02-18T10:06:23.000Z"
+    },
+    {
+      "rank": 819,
+      "id": "tencent/Hy-MT2-7B-FP8",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
+      "downloads": 848,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "hunyuan_v1_dense",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
+        "license:apache-2.0",
+        "compressed-tensors",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T10:23:53.000Z",
+      "lastModified": "2026-05-26T09:06:05.000Z"
+    },
+    {
+      "rank": 820,
+      "id": "Convence/Aroow-Rust-Coder-9B",
+      "author": "Convence",
+      "url": "https://huggingface.co/Convence/Aroow-Rust-Coder-9B",
+      "downloads": 64,
+      "likes": 9,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "rust",
+        "code",
+        "code-generation",
+        "code-completion",
+        "fill-in-the-middle",
+        "text-generation",
+        "conversational",
+        "en",
+        "base_model:Qwen/Qwen3.5-9B",
+        "base_model:finetune:Qwen/Qwen3.5-9B",
+        "license:apache-2.0",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-03-02T07:11:05.000Z",
-      "lastModified": "2026-03-12T21:10:43.000Z"
+      "createdAt": "2026-05-23T19:05:37.000Z",
+      "lastModified": "2026-05-23T19:16:54.000Z"
     },
     {
-      "rank": 811,
-      "id": "avaturn-live/avtr-1",
-      "author": "avaturn-live",
-      "url": "https://huggingface.co/avaturn-live/avtr-1",
-      "downloads": 2,
+      "rank": 821,
+      "id": "google/gemma-3-12b-it-qat-q4_0-unquantized",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized",
+      "downloads": 68262,
+      "likes": 116,
+      "trendingScore": 8,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma3",
+        "image-text-to-text",
+        "gemma",
+        "google",
+        "conversational",
+        "arxiv:1905.07830",
+        "arxiv:1905.10044",
+        "arxiv:1911.11641",
+        "arxiv:1904.09728",
+        "arxiv:1705.03551",
+        "arxiv:1911.01547",
+        "arxiv:1907.10641",
+        "arxiv:1903.00161",
+        "arxiv:2009.03300",
+        "arxiv:2304.06364",
+        "arxiv:2103.03874",
+        "arxiv:2110.14168",
+        "arxiv:2311.12022",
+        "arxiv:2108.07732",
+        "arxiv:2107.03374",
+        "arxiv:2210.03057",
+        "arxiv:2106.03193",
+        "arxiv:1910.11856",
+        "arxiv:2502.12404",
+        "arxiv:2502.21228",
+        "arxiv:2404.16816",
+        "arxiv:2104.12756",
+        "arxiv:2311.16502"
+      ],
+      "createdAt": "2025-04-08T13:29:53.000Z",
+      "lastModified": "2025-04-15T21:07:07.000Z"
+    },
+    {
+      "rank": 822,
+      "id": "prism-ml/bonsai-image-binary-4B-mlx-1bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit",
+      "downloads": 0,
       "likes": 8,
       "trendingScore": 8,
-      "pipelineTag": "image-to-video",
-      "libraryName": "tensorrt",
+      "pipelineTag": "text-to-image",
+      "libraryName": "mlx",
       "tags": [
-        "tensorrt",
-        "onnx",
-        "talking-head",
-        "lip-sync",
-        "avatar",
-        "real-time",
-        "audio-driven",
-        "non-commercial",
-        "image-to-video",
-        "license:other",
+        "mlx",
+        "diffusers",
+        "safetensors",
+        "1-bit",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-25T15:26:51.000Z",
-      "lastModified": "2026-05-25T21:18:34.000Z"
+      "createdAt": "2026-05-18T15:40:10.000Z",
+      "lastModified": "2026-05-26T16:16:57.000Z"
     },
     {
-      "rank": 812,
+      "rank": 823,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -23715,7 +24051,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 813,
+      "rank": 824,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -23732,7 +24068,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 814,
+      "rank": 825,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -23760,7 +24096,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 815,
+      "rank": 826,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -23795,7 +24131,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 816,
+      "rank": 827,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -23820,7 +24156,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 817,
+      "rank": 828,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -23850,7 +24186,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 818,
+      "rank": 829,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -23879,7 +24215,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 819,
+      "rank": 830,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -23906,7 +24242,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 820,
+      "rank": 831,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -23932,7 +24268,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 821,
+      "rank": 832,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -23963,7 +24299,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 822,
+      "rank": 833,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -23981,7 +24317,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 823,
+      "rank": 834,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -24010,7 +24346,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 824,
+      "rank": 835,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -24033,7 +24369,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 825,
+      "rank": 836,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -24078,7 +24414,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 826,
+      "rank": 837,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -24104,7 +24440,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 827,
+      "rank": 838,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -24132,7 +24468,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 828,
+      "rank": 839,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -24170,7 +24506,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 829,
+      "rank": 840,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -24197,7 +24533,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 830,
+      "rank": 841,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -24223,7 +24559,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 831,
+      "rank": 842,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -24241,7 +24577,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 832,
+      "rank": 843,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -24267,31 +24603,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 833,
-      "id": "FireRedTeam/FireRed-Image-Edit-1.1",
-      "author": "FireRedTeam",
-      "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
-      "downloads": 34300,
-      "likes": 251,
-      "trendingScore": 7,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2602.13344",
-        "license:apache-2.0",
-        "diffusers:QwenImageEditPlusPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T13:47:43.000Z",
-      "lastModified": "2026-03-09T09:24:51.000Z"
-    },
-    {
-      "rank": 834,
+      "rank": 844,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -24332,7 +24644,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 835,
+      "rank": 845,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -24349,7 +24661,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 836,
+      "rank": 846,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -24382,7 +24694,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 837,
+      "rank": 847,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -24416,7 +24728,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 838,
+      "rank": 848,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -24455,7 +24767,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 839,
+      "rank": 849,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -24485,7 +24797,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 840,
+      "rank": 850,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -24511,7 +24823,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 841,
+      "rank": 851,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -24547,7 +24859,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 842,
+      "rank": 852,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -24577,11 +24889,11 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 843,
+      "rank": 853,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
-      "downloads": 32657,
+      "downloads": 32456,
       "likes": 353,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -24615,7 +24927,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 844,
+      "rank": 854,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -24650,7 +24962,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 845,
+      "rank": 855,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -24667,7 +24979,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 846,
+      "rank": 856,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -24709,7 +25021,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 847,
+      "rank": 857,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -24739,7 +25051,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 848,
+      "rank": 858,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -24764,7 +25076,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 849,
+      "rank": 859,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -24792,7 +25104,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 850,
+      "rank": 860,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -24809,7 +25121,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 851,
+      "rank": 861,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -24836,7 +25148,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 852,
+      "rank": 862,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -24879,7 +25191,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 853,
+      "rank": 863,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -24919,7 +25231,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 854,
+      "rank": 864,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -24943,7 +25255,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 855,
+      "rank": 865,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -24972,7 +25284,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 856,
+      "rank": 866,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -24998,7 +25310,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 857,
+      "rank": 867,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -25037,7 +25349,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 858,
+      "rank": 868,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -25061,7 +25373,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 859,
+      "rank": 869,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -25089,7 +25401,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 860,
+      "rank": 870,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -25121,7 +25433,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 861,
+      "rank": 871,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -25151,7 +25463,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 862,
+      "rank": 872,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -25180,7 +25492,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 863,
+      "rank": 873,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -25209,7 +25521,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 864,
+      "rank": 874,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -25229,7 +25541,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 865,
+      "rank": 875,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -25259,7 +25571,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 866,
+      "rank": 876,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -25289,7 +25601,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 867,
+      "rank": 877,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -25307,7 +25619,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 868,
+      "rank": 878,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -25324,7 +25636,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 869,
+      "rank": 879,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -25360,7 +25672,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 870,
+      "rank": 880,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -25391,7 +25703,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 871,
+      "rank": 881,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -25422,7 +25734,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 872,
+      "rank": 882,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -25455,7 +25767,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 873,
+      "rank": 883,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -25483,7 +25795,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 874,
+      "rank": 884,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -25508,7 +25820,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 875,
+      "rank": 885,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -25531,7 +25843,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 876,
+      "rank": 886,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -25559,7 +25871,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 877,
+      "rank": 887,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -25592,7 +25904,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 878,
+      "rank": 888,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -25622,7 +25934,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 879,
+      "rank": 889,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -25657,7 +25969,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 880,
+      "rank": 890,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -25689,7 +26001,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 881,
+      "rank": 891,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -25714,7 +26026,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 882,
+      "rank": 892,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -25737,7 +26049,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 883,
+      "rank": 893,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -25764,7 +26076,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 884,
+      "rank": 894,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -25787,7 +26099,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 885,
+      "rank": 895,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -25832,7 +26144,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 886,
+      "rank": 896,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -25864,7 +26176,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 887,
+      "rank": 897,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -25891,7 +26203,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 888,
+      "rank": 898,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -25917,7 +26229,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 889,
+      "rank": 899,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -25949,7 +26261,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 890,
+      "rank": 900,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -25978,7 +26290,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 891,
+      "rank": 901,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -26010,7 +26322,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 892,
+      "rank": 902,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -26040,7 +26352,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 893,
+      "rank": 903,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -26057,7 +26369,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 894,
+      "rank": 904,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -26077,7 +26389,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 895,
+      "rank": 905,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -26116,7 +26428,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 896,
+      "rank": 906,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -26154,7 +26466,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 897,
+      "rank": 907,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -26182,7 +26494,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 898,
+      "rank": 908,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -26227,7 +26539,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 899,
+      "rank": 909,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -26257,7 +26569,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 900,
+      "rank": 910,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -26284,7 +26596,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 901,
+      "rank": 911,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -26310,7 +26622,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 902,
+      "rank": 912,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -26339,7 +26651,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 903,
+      "rank": 913,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -26357,7 +26669,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 904,
+      "rank": 914,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -26389,7 +26701,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 905,
+      "rank": 915,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -26416,7 +26728,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 906,
+      "rank": 916,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -26434,7 +26746,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 907,
+      "rank": 917,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -26461,7 +26773,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 908,
+      "rank": 918,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -26485,7 +26797,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 909,
+      "rank": 919,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -26530,7 +26842,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 910,
+      "rank": 920,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -26561,7 +26873,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 911,
+      "rank": 921,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -26586,7 +26898,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 912,
+      "rank": 922,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -26620,52 +26932,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 913,
-      "id": "thelamapi/neuvoice",
-      "author": "thelamapi",
-      "url": "https://huggingface.co/thelamapi/neuvoice",
-      "downloads": 118,
-      "likes": 10,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "onnx",
-        "text",
-        "speech",
-        "tts",
-        "neuvoice",
-        "turkish",
-        "turkey",
-        "ai voice",
-        "text to speech",
-        "turkish tts",
-        "open source ai",
-        "huggingface model",
-        "voice cloning",
-        "realistic ai voice",
-        "speech synthesis",
-        "turkish ai",
-        "local ai",
-        "offline tts",
-        "low latency tts",
-        "multilingual tts",
-        "pytorch",
-        "audio generation",
-        "speech model",
-        "real time tts",
-        "hf model",
-        "synthetic voice",
-        "text-to-speech",
-        "tr",
-        "bg"
-      ],
-      "createdAt": "2026-05-15T18:15:55.000Z",
-      "lastModified": "2026-05-20T13:29:46.000Z"
-    },
-    {
-      "rank": 914,
+      "rank": 923,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -26706,7 +26973,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 915,
+      "rank": 924,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -26733,7 +27000,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 916,
+      "rank": 925,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -26762,7 +27029,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 917,
+      "rank": 926,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -26794,7 +27061,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 918,
+      "rank": 927,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -26818,7 +27085,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 919,
+      "rank": 928,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -26845,7 +27112,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 920,
+      "rank": 929,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -26884,7 +27151,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 921,
+      "rank": 930,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
@@ -26916,11 +27183,11 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 922,
+      "rank": 931,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
-      "downloads": 361871,
+      "downloads": 376761,
       "likes": 961,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
@@ -26950,7 +27217,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 923,
+      "rank": 932,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
@@ -26977,7 +27244,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 924,
+      "rank": 933,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -27005,7 +27272,7 @@
       "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 925,
+      "rank": 934,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -27033,33 +27300,11 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 926,
-      "id": "huytd189/Qwen3.6-27B-pure-GGUF",
-      "author": "huytd189",
-      "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
-      "downloads": 2444,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-22T01:15:54.000Z",
-      "lastModified": "2026-05-23T00:41:53.000Z"
-    },
-    {
-      "rank": 927,
+      "rank": 935,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
-      "downloads": 6352,
+      "downloads": 5312,
       "likes": 104,
       "trendingScore": 7,
       "pipelineTag": "image-to-text",
@@ -27084,7 +27329,7 @@
       "lastModified": "2026-05-13T07:13:52.000Z"
     },
     {
-      "rank": 928,
+      "rank": 936,
       "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -27129,12 +27374,12 @@
       "lastModified": "2026-05-15T06:27:56.000Z"
     },
     {
-      "rank": 929,
+      "rank": 937,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
       "downloads": 14102,
-      "likes": 26,
+      "likes": 27,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -27155,7 +27400,7 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 930,
+      "rank": 938,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
@@ -27190,7 +27435,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 931,
+      "rank": 939,
       "id": "openbmb/BitCPM-CANN-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-1B",
@@ -27216,7 +27461,7 @@
       "lastModified": "2026-05-23T18:13:08.000Z"
     },
     {
-      "rank": 932,
+      "rank": 940,
       "id": "openbmb/BitCPM-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-3B",
@@ -27242,7 +27487,7 @@
       "lastModified": "2026-05-23T18:13:14.000Z"
     },
     {
-      "rank": 933,
+      "rank": 941,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -27267,58 +27512,7 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 934,
-      "id": "Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
-      "author": "Andycurrent",
-      "url": "https://huggingface.co/Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
-      "downloads": 2373576,
-      "likes": 36,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "text-generation",
-        "reasoning",
-        "instruction-tuned",
-        "lightweight",
-        "en",
-        "base_model:google/gemma-3-1b-it",
-        "base_model:quantized:google/gemma-3-1b-it",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-02-18T09:56:14.000Z",
-      "lastModified": "2026-02-18T10:06:23.000Z"
-    },
-    {
-      "rank": 935,
-      "id": "tencent/Hy-MT2-7B-FP8",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
-      "downloads": 848,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "hunyuan_v1_dense",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
-        "license:apache-2.0",
-        "compressed-tensors",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T10:23:53.000Z",
-      "lastModified": "2026-05-26T09:06:05.000Z"
-    },
-    {
-      "rank": 936,
+      "rank": 942,
       "id": "zizhaotong/SCOPE",
       "author": "zizhaotong",
       "url": "https://huggingface.co/zizhaotong/SCOPE",
@@ -27352,7 +27546,7 @@
       "lastModified": "2026-05-25T02:01:22.000Z"
     },
     {
-      "rank": 937,
+      "rank": 943,
       "id": "internlm/CapRL-Video-4B",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/CapRL-Video-4B",
@@ -27372,7 +27566,7 @@
       "lastModified": "2026-05-26T12:13:45.000Z"
     },
     {
-      "rank": 938,
+      "rank": 944,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
@@ -27400,12 +27594,12 @@
       "lastModified": "2026-05-22T19:16:35.000Z"
     },
     {
-      "rank": 939,
+      "rank": 945,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
-      "downloads": 51381,
-      "likes": 551,
+      "downloads": 51279,
+      "likes": 552,
       "trendingScore": 7,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -27445,7 +27639,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 940,
+      "rank": 946,
       "id": "microsoft/SchGen",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/SchGen",
@@ -27473,7 +27667,7 @@
       "lastModified": "2026-05-14T16:50:37.000Z"
     },
     {
-      "rank": 941,
+      "rank": 947,
       "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
@@ -27500,7 +27694,7 @@
       "lastModified": "2026-05-20T20:34:29.000Z"
     },
     {
-      "rank": 942,
+      "rank": 948,
       "id": "MassivDash/Gemma-4-Rust-Coder",
       "author": "MassivDash",
       "url": "https://huggingface.co/MassivDash/Gemma-4-Rust-Coder",
@@ -27529,31 +27723,7 @@
       "lastModified": "2026-04-24T09:46:25.000Z"
     },
     {
-      "rank": 943,
-      "id": "prism-ml/bonsai-image-binary-4B-unpacked",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
-      "downloads": 0,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:40:11.000Z",
-      "lastModified": "2026-05-26T16:16:58.000Z"
-    },
-    {
-      "rank": 944,
+      "rank": 949,
       "id": "HuggingFaceBio/Carbon-8B-GGUF",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B-GGUF",
@@ -27578,39 +27748,7 @@
       "lastModified": "2026-05-21T21:32:52.000Z"
     },
     {
-      "rank": 945,
-      "id": "Convence/Aroow-Rust-Coder-9B",
-      "author": "Convence",
-      "url": "https://huggingface.co/Convence/Aroow-Rust-Coder-9B",
-      "downloads": 64,
-      "likes": 8,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "rust",
-        "code",
-        "code-generation",
-        "code-completion",
-        "fill-in-the-middle",
-        "text-generation",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3.5-9B",
-        "base_model:finetune:Qwen/Qwen3.5-9B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T19:05:37.000Z",
-      "lastModified": "2026-05-23T19:16:54.000Z"
-    },
-    {
-      "rank": 946,
+      "rank": 950,
       "id": "Abiray/MiniCPM5-1B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
@@ -27642,7 +27780,205 @@
       "lastModified": "2026-05-26T04:52:17.000Z"
     },
     {
-      "rank": 947,
+      "rank": 951,
+      "id": "google/electra-base-discriminator",
+      "author": "google",
+      "url": "https://huggingface.co/google/electra-base-discriminator",
+      "downloads": 56606743,
+      "likes": 114,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "tf",
+        "jax",
+        "rust",
+        "electra",
+        "pretraining",
+        "en",
+        "arxiv:1406.2661",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2022-03-02T23:29:05.000Z",
+      "lastModified": "2024-02-29T10:20:20.000Z"
+    },
+    {
+      "rank": 952,
+      "id": "stabilityai/stable-video-diffusion-img2vid-xt-1-1",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1",
+      "downloads": 9800,
+      "likes": 1015,
+      "trendingScore": 7,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-to-video",
+        "license:other",
+        "diffusers:StableVideoDiffusionPipeline",
+        "region:us"
+      ],
+      "createdAt": "2024-02-02T15:40:53.000Z",
+      "lastModified": "2024-07-10T11:52:10.000Z"
+    },
+    {
+      "rank": 953,
+      "id": "LiquidAI/LFM2-8B-A1B-GGUF",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF",
+      "downloads": 3210,
+      "likes": 106,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "liquid",
+        "lfm2",
+        "edge",
+        "moe",
+        "llama.cpp",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "base_model:LiquidAI/LFM2-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2025-10-06T16:09:29.000Z",
+      "lastModified": "2026-03-30T13:41:14.000Z"
+    },
+    {
+      "rank": 954,
+      "id": "EssentialAI/rnj-1.5-instruct",
+      "author": "EssentialAI",
+      "url": "https://huggingface.co/EssentialAI/rnj-1.5-instruct",
+      "downloads": 1515,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma3_text",
+        "text-generation",
+        "conversational",
+        "code",
+        "arxiv:2602.15763",
+        "arxiv:2409.12186",
+        "arxiv:2510.19817",
+        "arxiv:2004.05150",
+        "arxiv:2512.13961",
+        "arxiv:2407.21783",
+        "arxiv:2501.15383",
+        "base_model:EssentialAI/rnj-1",
+        "base_model:finetune:EssentialAI/rnj-1",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T19:39:50.000Z",
+      "lastModified": "2026-05-26T06:18:03.000Z"
+    },
+    {
+      "rank": 955,
+      "id": "chili-lab/Ouro-hybrid-1.4B",
+      "author": "chili-lab",
+      "url": "https://huggingface.co/chili-lab/Ouro-hybrid-1.4B",
+      "downloads": 45,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "student",
+        "text-generation",
+        "causal-lm",
+        "language-model",
+        "distilled",
+        "knowledge-distillation",
+        "research",
+        "ouro",
+        "long-context",
+        "chili-lab",
+        "conversational",
+        "dataset:open-thoughts/OpenThoughts3-1.2M",
+        "base_model:ByteDance/Ouro-1.4B",
+        "base_model:finetune:ByteDance/Ouro-1.4B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T20:51:02.000Z",
+      "lastModified": "2026-05-19T20:51:28.000Z"
+    },
+    {
+      "rank": 956,
+      "id": "meituan-longcat/WBench-weights",
+      "author": "meituan-longcat",
+      "url": "https://huggingface.co/meituan-longcat/WBench-weights",
+      "downloads": 0,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "other",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "video-evaluation",
+        "world-model",
+        "benchmark",
+        "other",
+        "arxiv:2605.25874",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T08:12:09.000Z",
+      "lastModified": "2026-05-27T03:01:06.000Z"
+    },
+    {
+      "rank": 957,
+      "id": "Jackrong/Qwopus3.5-4B-v3-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-4B-v3-MTP-GGUF",
+      "downloads": 2271,
+      "likes": 8,
+      "trendingScore": 7,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "base_model:Jackrong/Qwopus3.5-4B-v3",
+        "base_model:quantized:Jackrong/Qwopus3.5-4B-v3",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-22T10:27:06.000Z",
+      "lastModified": "2026-05-22T11:38:18.000Z"
+    },
+    {
+      "rank": 958,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -27675,7 +28011,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 948,
+      "rank": 959,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -27704,7 +28040,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 949,
+      "rank": 960,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -27749,7 +28085,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 950,
+      "rank": 961,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -27778,7 +28114,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 951,
+      "rank": 962,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -27823,7 +28159,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 952,
+      "rank": 963,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -27867,7 +28203,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 953,
+      "rank": 964,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -27893,7 +28229,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 954,
+      "rank": 965,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -27919,7 +28255,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 955,
+      "rank": 966,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -27951,7 +28287,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 956,
+      "rank": 967,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -27974,7 +28310,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 957,
+      "rank": 968,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -28017,7 +28353,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 958,
+      "rank": 969,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -28062,7 +28398,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 959,
+      "rank": 970,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -28107,7 +28443,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 960,
+      "rank": 971,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -28134,7 +28470,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 961,
+      "rank": 972,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -28161,7 +28497,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 962,
+      "rank": 973,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -28186,7 +28522,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 963,
+      "rank": 974,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -28225,7 +28561,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 964,
+      "rank": 975,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -28250,7 +28586,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 965,
+      "rank": 976,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -28278,7 +28614,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 966,
+      "rank": 977,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -28303,7 +28639,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 967,
+      "rank": 978,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -28319,7 +28655,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 968,
+      "rank": 979,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -28346,7 +28682,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 969,
+      "rank": 980,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -28378,7 +28714,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 970,
+      "rank": 981,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -28408,7 +28744,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 971,
+      "rank": 982,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -28440,7 +28776,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 972,
+      "rank": 983,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -28468,7 +28804,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 973,
+      "rank": 984,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -28494,7 +28830,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 974,
+      "rank": 985,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -28523,7 +28859,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 975,
+      "rank": 986,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -28565,7 +28901,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 976,
+      "rank": 987,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -28592,7 +28928,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 977,
+      "rank": 988,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -28637,7 +28973,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 978,
+      "rank": 989,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -28663,7 +28999,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 979,
+      "rank": 990,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -28683,7 +29019,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 980,
+      "rank": 991,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -28710,7 +29046,7 @@
       "lastModified": "2026-02-12T05:05:50.000Z"
     },
     {
-      "rank": 981,
+      "rank": 992,
       "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
       "author": "saricles",
       "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
@@ -28752,7 +29088,7 @@
       "lastModified": "2026-04-19T14:34:59.000Z"
     },
     {
-      "rank": 982,
+      "rank": 993,
       "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
@@ -28779,7 +29115,7 @@
       "lastModified": "2026-04-22T14:12:35.000Z"
     },
     {
-      "rank": 983,
+      "rank": 994,
       "id": "unsloth/GLM-5.1-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
@@ -28808,7 +29144,7 @@
       "lastModified": "2026-04-07T20:09:36.000Z"
     },
     {
-      "rank": 984,
+      "rank": 995,
       "id": "briaai/VRMBG-3.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/VRMBG-3.0",
@@ -28835,7 +29171,7 @@
       "lastModified": "2026-05-07T14:07:25.000Z"
     },
     {
-      "rank": 985,
+      "rank": 996,
       "id": "mlx-community/gemma-4-E4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-E4B-it-assistant-bf16",
@@ -28862,7 +29198,7 @@
       "lastModified": "2026-05-05T17:10:52.000Z"
     },
     {
-      "rank": 986,
+      "rank": 997,
       "id": "dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/Gemma-4-26B-A4B-JANG_4M-CRACK",
@@ -28889,7 +29225,7 @@
       "lastModified": "2026-04-25T21:33:04.000Z"
     },
     {
-      "rank": 987,
+      "rank": 998,
       "id": "unsloth/FLUX.2-klein-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF",
@@ -28917,7 +29253,7 @@
       "lastModified": "2026-01-16T15:46:37.000Z"
     },
     {
-      "rank": 988,
+      "rank": 999,
       "id": "Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
       "author": "Ununnilium",
       "url": "https://huggingface.co/Ununnilium/Qwen3.6-27B-IQ4_XS-pure-GGUF",
@@ -28940,7 +29276,7 @@
       "lastModified": "2026-04-25T20:19:54.000Z"
     },
     {
-      "rank": 989,
+      "rank": 1000,
       "id": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
@@ -28969,339 +29305,6 @@
       ],
       "createdAt": "2026-01-23T06:50:31.000Z",
       "lastModified": "2026-01-28T12:11:14.000Z"
-    },
-    {
-      "rank": 990,
-      "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
-      "author": "AEON-7",
-      "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP",
-      "downloads": 11345,
-      "likes": 11,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "abliterated",
-        "uncensored",
-        "qwen3",
-        "qwen3.6",
-        "nvfp4",
-        "modelopt",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "hybrid-attention",
-        "mamba",
-        "gated-deltanet",
-        "multimodal",
-        "aeon",
-        "rtx-pro-6000",
-        "b100",
-        "b200",
-        "dedicated-vram-blackwell",
-        "sm_120",
-        "sm_100",
-        "text-generation",
-        "conversational",
-        "en",
-        "zh",
-        "multilingual",
-        "base_model:AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16"
-      ],
-      "createdAt": "2026-04-28T05:55:36.000Z",
-      "lastModified": "2026-05-01T06:44:11.000Z"
-    },
-    {
-      "rank": 991,
-      "id": "Jundot/Qwen3.6-27B-oQ8-mtp",
-      "author": "Jundot",
-      "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ8-mtp",
-      "downloads": 1703,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": null,
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "oq",
-        "quantized",
-        "8-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T15:53:35.000Z",
-      "lastModified": "2026-05-06T15:54:14.000Z"
-    },
-    {
-      "rank": 992,
-      "id": "black-forest-labs/FLUX.2-klein-9b-kv",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
-      "downloads": 16787,
-      "likes": 169,
-      "trendingScore": 6,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-generation",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "license:other",
-        "diffusers:Flux2KleinPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-03-09T17:39:05.000Z",
-      "lastModified": "2026-03-12T16:13:40.000Z"
-    },
-    {
-      "rank": 993,
-      "id": "RedHatAI/gemma-4-31B-it-NVFP4",
-      "author": "RedHatAI",
-      "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4",
-      "downloads": 187530,
-      "likes": 40,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "fp4",
-        "vllm",
-        "llm-compressor",
-        "compressed-tensors",
-        "conversational",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:quantized:google/gemma-4-31B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "8-bit",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-03T16:59:13.000Z",
-      "lastModified": "2026-05-04T21:08:38.000Z"
-    },
-    {
-      "rank": 994,
-      "id": "unsloth/ERNIE-Image-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/ERNIE-Image-GGUF",
-      "downloads": 40204,
-      "likes": 63,
-      "trendingScore": 6,
-      "pipelineTag": "text-to-image",
-      "libraryName": "ggml",
-      "tags": [
-        "ggml",
-        "gguf",
-        "text-to-image",
-        "unsloth",
-        "base_model:baidu/ERNIE-Image",
-        "base_model:quantized:baidu/ERNIE-Image",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T18:22:55.000Z",
-      "lastModified": "2026-04-14T23:57:35.000Z"
-    },
-    {
-      "rank": 995,
-      "id": "barozp/ZAYA1-8B-BNB",
-      "author": "barozp",
-      "url": "https://huggingface.co/barozp/ZAYA1-8B-BNB",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "bitsandbytes",
-        "quantized",
-        "4-bit",
-        "8-bit",
-        "nf4",
-        "zaya",
-        "mixture-of-experts",
-        "reasoning",
-        "text-generation",
-        "en",
-        "base_model:Zyphra/ZAYA1-8B",
-        "base_model:quantized:Zyphra/ZAYA1-8B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T15:20:54.000Z",
-      "lastModified": "2026-05-07T15:30:53.000Z"
-    },
-    {
-      "rank": 996,
-      "id": "GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
-      "author": "GestaltLabs",
-      "url": "https://huggingface.co/GestaltLabs/Qwen3.5-9B-NSC-ACE-SABER",
-      "downloads": 273,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "conversational",
-        "nsc-ace",
-        "saber",
-        "agentic",
-        "tool-calling",
-        "refusal-calibration",
-        "harmbench",
-        "base_model:GestaltLabs/Qwen3.5-9B-NSC-ACE",
-        "base_model:finetune:GestaltLabs/Qwen3.5-9B-NSC-ACE",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T14:37:42.000Z",
-      "lastModified": "2026-05-12T15:09:39.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct",
-      "downloads": 292484,
-      "likes": 1019,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_next",
-        "text-generation",
-        "conversational",
-        "arxiv:2309.00071",
-        "arxiv:2404.06654",
-        "arxiv:2505.09388",
-        "arxiv:2501.15383",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-09-09T15:40:56.000Z",
-      "lastModified": "2025-09-17T06:57:40.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "mixedbread-ai/mxbai-embed-large-v1",
-      "author": "mixedbread-ai",
-      "url": "https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1",
-      "downloads": 4425778,
-      "likes": 795,
-      "trendingScore": 6,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "sentence-transformers",
-      "tags": [
-        "sentence-transformers",
-        "onnx",
-        "safetensors",
-        "openvino",
-        "gguf",
-        "bert",
-        "feature-extraction",
-        "mteb",
-        "transformers.js",
-        "transformers",
-        "en",
-        "arxiv:2309.12871",
-        "license:apache-2.0",
-        "model-index",
-        "text-embeddings-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-03-07T15:45:34.000Z",
-      "lastModified": "2026-01-23T11:59:58.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "distilbert/distilbert-base-uncased",
-      "author": "distilbert",
-      "url": "https://huggingface.co/distilbert/distilbert-base-uncased",
-      "downloads": 16437627,
-      "likes": 878,
-      "trendingScore": 6,
-      "pipelineTag": "fill-mask",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "tf",
-        "jax",
-        "rust",
-        "safetensors",
-        "distilbert",
-        "fill-mask",
-        "exbert",
-        "en",
-        "dataset:bookcorpus",
-        "dataset:wikipedia",
-        "arxiv:1910.01108",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2022-03-02T23:29:04.000Z",
-      "lastModified": "2024-05-06T13:44:53.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "MediaTek-Research/Breeze-ASR-26",
-      "author": "MediaTek-Research",
-      "url": "https://huggingface.co/MediaTek-Research/Breeze-ASR-26",
-      "downloads": 5795,
-      "likes": 48,
-      "trendingScore": 6,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "whisper",
-        "automatic-speech-recognition",
-        "taiwanese-hokkien",
-        "taigi",
-        "low-resource-language",
-        "fine-tuned",
-        "nan",
-        "zh",
-        "arxiv:2603.19259",
-        "base_model:openai/whisper-large-v2",
-        "base_model:finetune:openai/whisper-large-v2",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-11-28T04:01:35.000Z",
-      "lastModified": "2026-04-21T07:00:40.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26505346966

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.