### PR TITLE
chore(data): refresh huggingface space signals 2026-05-27T10:41:16Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-27T05:03:24.928Z",
+  "ts": "2026-05-27T10:41:16.044Z",
   "count": 1,
-  "durationMs": 6022,
+  "durationMs": 5562,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T05:03:18.907Z",
+  "fetchedAt": "2026-05-27T10:41:10.483Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -108,6 +108,22 @@
     },
     {
       "rank": 7,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 112,
+      "trendingScore": 109,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-26T16:44:17.000Z",
+      "models": []
+    },
+    {
+      "rank": 8,
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/spaces/Supertone/supertonic-3",
@@ -124,22 +140,6 @@
       ],
       "createdAt": "2026-05-06T20:45:18.000Z",
       "lastModified": "2026-05-18T10:24:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 8,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 104,
-      "trendingScore": 101,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-26T16:44:17.000Z",
       "models": []
     },
     {
@@ -325,6 +325,55 @@
     },
     {
       "rank": 20,
+      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "author": "Onise",
+      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
+      "likes": 106,
+      "trendingScore": 58,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T19:11:32.000Z",
+      "lastModified": "2026-05-27T05:52:15.000Z",
+      "models": []
+    },
+    {
+      "rank": 21,
+      "id": "stabilityai/stable-audio-3",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
+      "likes": 56,
+      "trendingScore": 55,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T15:54:00.000Z",
+      "lastModified": "2026-05-22T21:24:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 22,
+      "id": "webml-community/bonsai-image-webgpu",
+      "author": "webml-community",
+      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
+      "likes": 56,
+      "trendingScore": 55,
+      "sdk": "static",
+      "tags": [
+        "static",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T17:12:36.000Z",
+      "lastModified": "2026-05-26T20:57:36.000Z",
+      "models": []
+    },
+    {
+      "rank": 23,
       "id": "zerogpu-aoti/wan2-2-fp8da-aoti-faster",
       "author": "zerogpu-aoti",
       "url": "https://huggingface.co/spaces/zerogpu-aoti/wan2-2-fp8da-aoti-faster",
@@ -341,40 +390,7 @@
       "models": []
     },
     {
-      "rank": 21,
-      "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "author": "Onise",
-      "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
-      "likes": 101,
-      "trendingScore": 54,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T19:11:32.000Z",
-      "lastModified": "2026-05-26T13:29:35.000Z",
-      "models": []
-    },
-    {
-      "rank": 22,
-      "id": "stabilityai/stable-audio-3",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
-      "likes": 53,
-      "trendingScore": 52,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T15:54:00.000Z",
-      "lastModified": "2026-05-22T21:24:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 23,
+      "rank": 24,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -390,11 +406,11 @@
       "models": []
     },
     {
-      "rank": 24,
+      "rank": 25,
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1764,
+      "likes": 1772,
       "trendingScore": 46,
       "sdk": "gradio",
       "tags": [
@@ -406,7 +422,7 @@
       "models": []
     },
     {
-      "rank": 25,
+      "rank": 26,
       "id": "FrameAI4687/Omni-Video-Factory",
       "author": "FrameAI4687",
       "url": "https://huggingface.co/spaces/FrameAI4687/Omni-Video-Factory",
@@ -422,7 +438,7 @@
       "models": []
     },
     {
-      "rank": 26,
+      "rank": 27,
       "id": "akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
       "author": "akhaliq",
       "url": "https://huggingface.co/spaces/akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
@@ -435,22 +451,6 @@
       ],
       "createdAt": "2026-05-07T16:52:45.000Z",
       "lastModified": "2026-05-07T19:19:41.000Z",
-      "models": []
-    },
-    {
-      "rank": 27,
-      "id": "webml-community/bonsai-image-webgpu",
-      "author": "webml-community",
-      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 43,
-      "trendingScore": 42,
-      "sdk": "static",
-      "tags": [
-        "static",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T17:12:36.000Z",
-      "lastModified": "2026-05-26T20:57:36.000Z",
       "models": []
     },
     {
@@ -602,6 +602,22 @@
     },
     {
       "rank": 37,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 34,
+      "trendingScore": 33,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-27T09:37:04.000Z",
+      "models": []
+    },
+    {
+      "rank": 38,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -618,7 +634,7 @@
       "models": []
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -635,7 +651,7 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -651,7 +667,7 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -664,22 +680,6 @@
       ],
       "createdAt": "2026-04-23T14:39:25.000Z",
       "lastModified": "2026-05-06T11:59:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 41,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 32,
-      "trendingScore": 31,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-27T04:48:10.000Z",
       "models": []
     },
     {
@@ -822,19 +822,18 @@
     },
     {
       "rank": 50,
-      "id": "linoyts/Qwen-Image-Edit-2511-AnyPose",
-      "author": "linoyts",
-      "url": "https://huggingface.co/spaces/linoyts/Qwen-Image-Edit-2511-AnyPose",
-      "likes": 347,
+      "id": "openbmb/VoxCPM-Demo",
+      "author": "openbmb",
+      "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
+      "likes": 498,
       "trendingScore": 24,
       "sdk": "gradio",
       "tags": [
         "gradio",
-        "mcp-server",
         "region:us"
       ],
-      "createdAt": "2025-12-28T08:15:28.000Z",
-      "lastModified": "2025-12-29T13:46:27.000Z",
+      "createdAt": "2025-09-16T14:53:41.000Z",
+      "lastModified": "2026-05-23T09:59:35.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26506207190

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.