### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-27T14:34:40Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-27T00:17:48.015Z",
+  "ts": "2026-05-27T14:34:40.500Z",
   "count": 1,
-  "durationMs": 10357,
+  "durationMs": 13400,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-27T00:17:46.410Z",
+  "lastFetchedAt": "2026-05-27T14:34:35.493Z",
   "windowDays": 7,
   "launches": [
     {
@@ -2317,6 +2317,60 @@
       "aiAdjacent": true
     },
     {
+      "id": "1154630",
+      "name": "Bluedot 2.1",
+      "tagline": "Record on Apple Watch. Sync with Claude",
+      "description": "Bluedot 2.1 brings your real-world conversations into Claude. Record conversations directly from your Apple Watch, then sync them with Claude through MCP. Capture customer calls, hallway chats, interviews, coffee meetings, and in-person conversations, without a laptop or meeting bot. Bluedot turns every conversation into searchable, AI-ready context that Claude can summarize, search, and act on.",
+      "url": "https://www.producthunt.com/products/bluedot-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/FBQTRS2UMIX3RW",
+      "votesCount": 232,
+      "commentsCount": 14,
+      "createdAt": "2026-05-27T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/4eecd806-001b-456a-b591-51fe6051d442.png?auto=format",
+      "topics": [
+        "android",
+        "apple-watch",
+        "productivity"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1153508",
       "name": "ModelHub",
       "tagline": "The missing menu bar app for local LLMs on Mac.",
@@ -2436,48 +2490,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": true
-    },
-    {
-      "id": "1142238",
-      "name": "InvestorFinder",
-      "tagline": "Find investors who've backed founders just like you",
-      "description": "Finally, real data on how every VC partner actually invests - founder backgrounds, universities and prior companies. Paste your profile and find your best matches in seconds.",
-      "url": "https://www.producthunt.com/products/investorfinder?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/RYYTMN5NZ76UMA",
-      "votesCount": 218,
-      "commentsCount": 16,
-      "createdAt": "2026-05-10T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/43973f52-c69a-4d2c-b5fa-23e738090a32.jpeg?auto=format",
-      "topics": [
-        "investing",
-        "venture-capital",
-        "tech"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": false
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26517808915

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.