### PR TITLE
chore(data): refresh lobsters signals 2026-05-27T14:42:42Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-27T10:41:16.701Z",
+  "ts": "2026-05-27T14:42:42.562Z",
   "count": 1,
-  "durationMs": 2540,
+  "durationMs": 3770,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T10:41:14.181Z",
+  "fetchedAt": "2026-05-27T14:42:38.815Z",
   "windowDays": 7,
   "scannedStories": 76,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T10:41:14.181Z",
+  "fetchedAt": "2026-05-27T14:42:38.815Z",
   "windowHours": 72,
   "scannedTotal": 76,
   "stories": [
@@ -485,6 +485,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "rzdtx8",
+      "title": "May I recommend thinking of Emacs as your Fortress of Solitude",
+      "url": "https://martinsos.com/posts/may-recommend-emacs-home-base",
+      "commentsUrl": "https://lobste.rs/s/rzdtx8/may_i_recommend_thinking_emacs_as_your",
+      "by": "",
+      "score": 24,
+      "commentCount": 5,
+      "createdUtc": 1779876078,
+      "ageHours": 4.688888888888889,
+      "trendingScore": 1.3873315694466386,
+      "tags": [
+        "emacs"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "xb2edj",
       "title": "Replacing a 3 GB SQLite database with a 10 MB FST (finite state transducer) binary",
       "url": "https://til.andrew-quinn.me/posts/replacing-a-3-gb-sqlite-database-with-a-7-mb-fst-finite-state-trandsucer-binary/",
@@ -644,6 +661,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "iuv7kw",
+      "title": "Raft Consensus with a Minority of Nodes",
+      "url": "https://padhye.org/raft-minority/",
+      "commentsUrl": "https://lobste.rs/s/iuv7kw/raft_consensus_with_minority_nodes",
+      "by": "",
+      "score": 7,
+      "commentCount": 0,
+      "createdUtc": 1779888710,
+      "ageHours": 1.18,
+      "trendingScore": 1.2344041127812295,
+      "tags": [
+        "distributed",
+        "math"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "neclbs",
       "title": "Native all the way, until you need text",
       "url": "https://justsitandgrin.im/posts/native-all-the-way-until-you-need-text/",
@@ -738,6 +773,24 @@
           "confidence": 1
         }
       ]
+    },
+    {
+      "shortId": "2jdvxa",
+      "title": "What are some of your favourite developer tools?",
+      "url": "",
+      "commentsUrl": "https://lobste.rs/s/2jdvxa/what_are_some_your_favourite_developer",
+      "by": "",
+      "score": 43,
+      "commentCount": 58,
+      "createdUtc": 1779860447,
+      "ageHours": 9.030833333333334,
+      "trendingScore": 1.173696937425279,
+      "tags": [
+        "ask",
+        "programming"
+      ],
+      "description": "<p>Developers are so opinionated that it's difficult to pin down one favourite tool !</p>\n",
+      "linkedRepos": []
     },
     {
       "shortId": "msrczi",
@@ -843,58 +896,6 @@
         "a11y"
       ],
       "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "r87zln",
-      "title": "Internships for early university / no former employment",
-      "url": "",
-      "commentsUrl": "https://lobste.rs/s/r87zln/internships_for_early_university_no",
-      "by": "",
-      "score": 9,
-      "commentCount": 4,
-      "createdUtc": 1779376172,
-      "ageHours": 2.1441666666666666,
-      "trendingScore": 1.0668090460783293,
-      "tags": [
-        "ask",
-        "job"
-      ],
-      "description": "<p>As a rising freshman beginning an undergraduate computer science degree this fall, I wonder what internship opportunities (FOSS preferred) are there, for applicants in early university or who otherwise have no former employment experience (despite, perhaps, contributions to FOSS).</p>\n<p>Possible template, adapted from previous <code>t/job</code> posts:</p>\n<pre><code>**Company:** XYZ\r\n\r\n**Company website:** WWW\r\n\r\n**Position(s):** ABC\r\n\r\n**Target applicant pool:** XXX (for example, \"graduati",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "lwihzw",
-      "title": "The React2Shell Story and What Happened Next.js",
-      "url": "https://sylvie.fyi/posts/react2shell/",
-      "commentsUrl": "https://lobste.rs/s/lwihzw/react2shell_story_what_happened_next_js",
-      "by": "",
-      "score": 6,
-      "commentCount": 1,
-      "createdUtc": 1778336386,
-      "ageHours": 1.2008333333333334,
-      "trendingScore": 1.0477475614174054,
-      "tags": [
-        "security"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "39xkt3",
-      "title": "WebRTC is the Problem",
-      "url": "https://moq.dev/blog/webrtc-is-the-problem/",
-      "commentsUrl": "https://lobste.rs/s/39xkt3/webrtc_is_problem",
-      "by": "",
-      "score": 13,
-      "commentCount": 5,
-      "createdUtc": 1778339434,
-      "ageHours": 3.3880555555555554,
-      "trendingScore": 1.0394300179501819,
-      "tags": [
-        "networking"
-      ],
-      "description": "<p>Despite the page title mentioning OpenAI, it has very little to do with the actual AI parts, only the real-time audio transport parts, which is why I've matched the URL slug instead.</p>\n",
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26518274586

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.