### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-27T18:08:41Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-27T14:34:40.500Z",
+  "ts": "2026-05-27T18:08:41.120Z",
   "count": 1,
-  "durationMs": 13400,
+  "durationMs": 12816,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-27T14:34:35.493Z",
+  "lastFetchedAt": "2026-05-27T18:08:36.114Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1329,6 +1329,60 @@
       "tags": []
     },
     {
+      "id": "1154630",
+      "name": "Bluedot 2.1",
+      "tagline": "Record on Apple Watch. Sync with Claude",
+      "description": "Bluedot 2.1 brings your real-world conversations into Claude. Record conversations directly from your Apple Watch, then sync them with Claude through MCP. Capture customer calls, hallway chats, interviews, coffee meetings, and in-person conversations, without a laptop or meeting bot. Bluedot turns every conversation into searchable, AI-ready context that Claude can summarize, search, and act on.",
+      "url": "https://www.producthunt.com/products/bluedot-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/FBQTRS2UMIX3RW",
+      "votesCount": 291,
+      "commentsCount": 23,
+      "createdAt": "2026-05-27T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/4eecd806-001b-456a-b591-51fe6051d442.png?auto=format",
+      "topics": [
+        "android",
+        "apple-watch",
+        "productivity"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1150337",
       "name": "Composer 2.5",
       "tagline": "Cursor’s most powerful model yet",
@@ -1892,6 +1946,54 @@
       "aiAdjacent": false
     },
     {
+      "id": "1147823",
+      "name": "Powabase",
+      "tagline": "Build AI apps with Postgres, RAG, and agents",
+      "description": "Powabase is a backend-as-a-service for AI-native applications, combining Postgres, RAG, agents, memory, workflows, and automation primitives in one platform. It helps agencies and in-house IT teams build new AI apps or add AI automation to existing products without stitching together fragmented infrastructure. Designed to work seamlessly with modern coding agents, Powabase helps teams ship faster while building more robust, token-efficient systems.",
+      "url": "https://www.producthunt.com/products/powabase?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/6BBPF3XTDL5C2Y",
+      "votesCount": 259,
+      "commentsCount": 38,
+      "createdAt": "2026-05-27T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/bc1bdf28-9b59-4509-9db7-3b604380fb3b.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence",
+        "database"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1145066",
       "name": "Supaboard 3.0",
       "tagline": "AI data analysts that understand your business",
@@ -2317,60 +2419,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1154630",
-      "name": "Bluedot 2.1",
-      "tagline": "Record on Apple Watch. Sync with Claude",
-      "description": "Bluedot 2.1 brings your real-world conversations into Claude. Record conversations directly from your Apple Watch, then sync them with Claude through MCP. Capture customer calls, hallway chats, interviews, coffee meetings, and in-person conversations, without a laptop or meeting bot. Bluedot turns every conversation into searchable, AI-ready context that Claude can summarize, search, and act on.",
-      "url": "https://www.producthunt.com/products/bluedot-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/FBQTRS2UMIX3RW",
-      "votesCount": 232,
-      "commentsCount": 14,
-      "createdAt": "2026-05-27T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/4eecd806-001b-456a-b591-51fe6051d442.png?auto=format",
-      "topics": [
-        "android",
-        "apple-watch",
-        "productivity"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1153508",
       "name": "ModelHub",
       "tagline": "The missing menu bar app for local LLMs on Mac.",
@@ -2388,72 +2436,6 @@
         "menu-bar-apps"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1151167",
-      "name": "Rezonant",
-      "tagline": "Talk, spec, ship: get your product ideas into production",
-      "description": "Rezonant helps product teams turn messy ideas into code-ready specs, tickets, and engineering tasks. Collaborate with PMs, engineers, designers, and AI agents in one shared workspace. Ground decisions in your actual codebase, keep everyone aligned on the same version, and create work that humans and coding agents can confidently ship.",
-      "url": "https://www.producthunt.com/products/portia-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/P2UMFH5P4HQXTO",
-      "votesCount": 223,
-      "commentsCount": 55,
-      "createdAt": "2026-05-26T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/6de8c4b0-881b-4933-a3aa-3dfaf8beca07.png?auto=format",
-      "topics": [
-        "productivity",
-        "task-management",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26529516141

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.