### PR TITLE
chore(data): refresh lobsters signals 2026-05-27T18:13:02Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-27T14:42:42.562Z",
+  "ts": "2026-05-27T18:13:02.560Z",
   "count": 1,
-  "durationMs": 3770,
+  "durationMs": 3111,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-27T14:42:38.815Z",
+  "fetchedAt": "2026-05-27T18:12:59.469Z",
   "windowDays": 7,
-  "scannedStories": 76,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-27T14:42:38.815Z",
+  "fetchedAt": "2026-05-27T18:12:59.469Z",
   "windowHours": 72,
-  "scannedTotal": 76,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -382,6 +382,24 @@
       "trendingScore": 1.65427236943472,
       "tags": [
         "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "yjwa9q",
+      "title": "Interview with Zig creator Andrew Kelley",
+      "url": "https://www.youtube.com/watch?v=iqddnwKF8HQ",
+      "commentsUrl": "https://lobste.rs/s/yjwa9q/interview_with_zig_creator_andrew_kelley",
+      "by": "",
+      "score": 16,
+      "commentCount": 1,
+      "createdUtc": 1779896162,
+      "ageHours": 2.6158333333333332,
+      "trendingScore": 1.6134102214594892,
+      "tags": [
+        "video",
+        "zig"
       ],
       "description": "",
       "linkedRepos": []
@@ -877,23 +895,6 @@
       "tags": [
         "practices",
         "vibecoding"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "3izfup",
-      "title": "Switching to Colemak",
-      "url": "https://pta2002.com/blog/colemak/",
-      "commentsUrl": "https://lobste.rs/s/3izfup/switching_colemak",
-      "by": "",
-      "score": 21,
-      "commentCount": 25,
-      "createdUtc": 1779708204,
-      "ageHours": 5.29,
-      "trendingScore": 1.066910531931108,
-      "tags": [
-        "a11y"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26529741194

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.