### PR TITLE
chore(data): refresh huggingface signals 2026-05-27T20:31:11Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-27T16:14:02.405Z",
+  "ts": "2026-05-27T20:31:11.585Z",
   "count": 1,
-  "durationMs": 7946,
+  "durationMs": 7549,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T16:13:54.461Z",
+  "fetchedAt": "2026-05-27T20:31:04.036Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -282,6 +282,46 @@
     },
     {
       "rank": 10,
+      "id": "openbmb/MiniCPM5-1B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
+      "downloads": 2409,
+      "likes": 392,
+      "trendingScore": 340,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "minicpm",
+        "minicpm5",
+        "long-context",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "conversational",
+        "en",
+        "zh",
+        "dataset:openbmb/Ultra-FineWeb",
+        "dataset:openbmb/Ultra-FineWeb-L3",
+        "dataset:openbmb/UltraData-Math",
+        "dataset:openbmb/UltraData-SFT-2605",
+        "arxiv:2506.07900",
+        "arxiv:2602.09003",
+        "arxiv:2512.16649",
+        "arxiv:2604.13016",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T07:27:59.000Z",
+      "lastModified": "2026-05-26T04:24:04.000Z"
+    },
+    {
+      "rank": 11,
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/Supertone/supertonic-3",
@@ -326,7 +366,7 @@
       "lastModified": "2026-05-18T08:59:01.000Z"
     },
     {
-      "rank": 11,
+      "rank": 12,
       "id": "HiDream-ai/HiDream-O1-Image",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
@@ -350,13 +390,13 @@
       "lastModified": "2026-05-15T10:40:00.000Z"
     },
     {
-      "rank": 12,
+      "rank": 13,
       "id": "meituan-longcat/LongCat-Video-Avatar-1.5",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
       "downloads": 0,
-      "likes": 333,
-      "trendingScore": 323,
+      "likes": 340,
+      "trendingScore": 330,
       "pipelineTag": null,
       "libraryName": "diffusers",
       "tags": [
@@ -376,46 +416,6 @@
       ],
       "createdAt": "2026-05-21T09:05:55.000Z",
       "lastModified": "2026-05-26T03:21:29.000Z"
-    },
-    {
-      "rank": 13,
-      "id": "openbmb/MiniCPM5-1B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
-      "downloads": 2409,
-      "likes": 372,
-      "trendingScore": 320,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "minicpm",
-        "minicpm5",
-        "long-context",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "conversational",
-        "en",
-        "zh",
-        "dataset:openbmb/Ultra-FineWeb",
-        "dataset:openbmb/Ultra-FineWeb-L3",
-        "dataset:openbmb/UltraData-Math",
-        "dataset:openbmb/UltraData-SFT-2605",
-        "arxiv:2506.07900",
-        "arxiv:2602.09003",
-        "arxiv:2512.16649",
-        "arxiv:2604.13016",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T07:27:59.000Z",
-      "lastModified": "2026-05-26T04:24:04.000Z"
     },
     {
       "rank": 14,
@@ -509,8 +509,8 @@
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "downloads": 1598473,
-      "likes": 937,
-      "trendingScore": 225,
+      "likes": 943,
+      "trendingScore": 227,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -848,8 +848,8 @@
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
       "downloads": 16379,
-      "likes": 154,
-      "trendingScore": 147,
+      "likes": 157,
+      "trendingScore": 150,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -973,6 +973,33 @@
     },
     {
       "rank": 32,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 117,
+      "likes": 137,
+      "trendingScore": 135,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 33,
       "id": "Qwen/Qwen3.6-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
@@ -995,33 +1022,6 @@
       ],
       "createdAt": "2026-04-21T07:50:43.000Z",
       "lastModified": "2026-04-24T02:39:16.000Z"
-    },
-    {
-      "rank": 33,
-      "id": "nvidia/PiD",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/PiD",
-      "downloads": 117,
-      "likes": 135,
-      "trendingScore": 133,
-      "pipelineTag": "image-to-image",
-      "libraryName": "pytorch",
-      "tags": [
-        "pytorch",
-        "diffusers",
-        "safetensors",
-        "super-resolution",
-        "diffusion",
-        "pixel-diffusion-decoder",
-        "vae-decoder",
-        "image-to-image",
-        "arxiv:2605.23902",
-        "base_model:Tongyi-MAI/Z-Image",
-        "base_model:finetune:Tongyi-MAI/Z-Image",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T00:41:46.000Z",
-      "lastModified": "2026-05-26T01:17:21.000Z"
     },
     {
       "rank": 34,
@@ -1074,8 +1074,8 @@
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
       "downloads": 31597,
-      "likes": 129,
-      "trendingScore": 126,
+      "likes": 130,
+      "trendingScore": 127,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1276,8 +1276,8 @@
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens",
       "downloads": 673,
-      "likes": 114,
-      "trendingScore": 110,
+      "likes": 116,
+      "trendingScore": 112,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
@@ -1432,60 +1432,12 @@
     },
     {
       "rank": 47,
-      "id": "jackxinning/Leanly_AI",
-      "author": "jackxinning",
-      "url": "https://huggingface.co/jackxinning/Leanly_AI",
-      "downloads": 10822,
-      "likes": 111,
-      "trendingScore": 99,
-      "pipelineTag": "question-answering",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "medical",
-        "question-answering",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-16T10:43:03.000Z",
-      "lastModified": "2026-05-04T07:50:46.000Z"
-    },
-    {
-      "rank": 48,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
-      "downloads": 3819,
-      "likes": 99,
-      "trendingScore": 99,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:09:29.000Z",
-      "lastModified": "2026-05-15T10:40:24.000Z"
-    },
-    {
-      "rank": 49,
       "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "downloads": 10015,
-      "likes": 103,
-      "trendingScore": 99,
+      "likes": 105,
+      "trendingScore": 101,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -1512,6 +1464,54 @@
       ],
       "createdAt": "2026-05-19T23:14:00.000Z",
       "lastModified": "2026-05-23T20:28:00.000Z"
+    },
+    {
+      "rank": 48,
+      "id": "jackxinning/Leanly_AI",
+      "author": "jackxinning",
+      "url": "https://huggingface.co/jackxinning/Leanly_AI",
+      "downloads": 10822,
+      "likes": 111,
+      "trendingScore": 99,
+      "pipelineTag": "question-answering",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "medical",
+        "question-answering",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T10:43:03.000Z",
+      "lastModified": "2026-05-04T07:50:46.000Z"
+    },
+    {
+      "rank": 49,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+      "downloads": 3819,
+      "likes": 99,
+      "trendingScore": 99,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T13:09:29.000Z",
+      "lastModified": "2026-05-15T10:40:24.000Z"
     },
     {
       "rank": 50,
@@ -2225,35 +2225,12 @@
     },
     {
       "rank": 74,
-      "id": "google/gemma-4-E4B-it-assistant",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
-      "downloads": 51766,
-      "likes": 70,
-      "trendingScore": 69,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4_assistant",
-        "text-generation",
-        "any-to-any",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-23T18:44:33.000Z",
-      "lastModified": "2026-05-11T07:50:40.000Z"
-    },
-    {
-      "rank": 75,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
       "downloads": 9909688,
-      "likes": 2012,
-      "trendingScore": 69,
+      "likes": 2017,
+      "trendingScore": 71,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "pyannote-audio",
       "tags": [
@@ -2277,6 +2254,29 @@
       ],
       "createdAt": "2023-11-16T08:19:01.000Z",
       "lastModified": "2024-05-10T19:43:23.000Z"
+    },
+    {
+      "rank": 75,
+      "id": "google/gemma-4-E4B-it-assistant",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
+      "downloads": 51766,
+      "likes": 70,
+      "trendingScore": 69,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4_assistant",
+        "text-generation",
+        "any-to-any",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-23T18:44:33.000Z",
+      "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
       "rank": 76,
@@ -2530,7 +2530,7 @@
       "author": "zhifeixie",
       "url": "https://huggingface.co/zhifeixie/Mega-ASR",
       "downloads": 0,
-      "likes": 66,
+      "likes": 67,
       "trendingScore": 60,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": null,
@@ -2979,6 +2979,46 @@
     },
     {
       "rank": 100,
+      "id": "nvidia/LocateAnything-3B",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/LocateAnything-3B",
+      "downloads": 14,
+      "likes": 53,
+      "trendingScore": 53,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "locateanything",
+        "feature-extraction",
+        "nvidia",
+        "eagle",
+        "vision",
+        "object-detection",
+        "grounding",
+        "arxiv:2605.27365",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "arxiv:2504.07491",
+        "arxiv:2109.10852",
+        "arxiv:2510.12798",
+        "arxiv:2303.05499",
+        "arxiv:1405.0312",
+        "arxiv:1908.03195",
+        "arxiv:2504.07981",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-02T20:05:49.000Z",
+      "lastModified": "2026-05-27T08:30:54.000Z"
+    },
+    {
+      "rank": 101,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -3023,7 +3063,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 101,
+      "rank": 102,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -3050,12 +3090,12 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
       "downloads": 715658,
-      "likes": 12928,
+      "likes": 12929,
       "trendingScore": 51,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -3075,7 +3115,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -3103,7 +3143,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 104,
+      "rank": 105,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -3137,7 +3177,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 105,
+      "rank": 106,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -3157,7 +3197,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 106,
+      "rank": 107,
       "id": "stabilityai/stable-audio-3-small-music",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
@@ -3184,7 +3224,7 @@
       "lastModified": "2026-05-19T20:02:42.000Z"
     },
     {
-      "rank": 107,
+      "rank": 108,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -3215,7 +3255,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 108,
+      "rank": 109,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -3240,7 +3280,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 109,
+      "rank": 110,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -3277,7 +3317,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 110,
+      "rank": 111,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -3314,7 +3354,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 111,
+      "rank": 112,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3333,89 +3373,13 @@
       "lastModified": "2026-05-20T20:31:07.000Z"
     },
     {
-      "rank": 112,
-      "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
-      "downloads": 3359784,
-      "likes": 718,
-      "trendingScore": 46,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "gemma4",
-        "unsloth",
-        "gemma",
-        "google",
-        "image-text-to-text",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-01T14:42:29.000Z",
-      "lastModified": "2026-05-04T09:45:46.000Z"
-    },
-    {
       "rank": 113,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
-      "downloads": 681,
-      "likes": 46,
-      "trendingScore": 46,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T15:12:13.000Z",
-      "lastModified": "2026-05-15T10:41:43.000Z"
-    },
-    {
-      "rank": 114,
-      "id": "LatitudeGames/Equinox-31B",
-      "author": "LatitudeGames",
-      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
-      "downloads": 653,
-      "likes": 46,
-      "trendingScore": 46,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "gemma4",
-        "text adventure",
-        "roleplay",
-        "en",
-        "base_model:google/gemma-4-31B-it",
-        "base_model:finetune:google/gemma-4-31B-it",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:45:53.000Z",
-      "lastModified": "2026-05-22T04:55:49.000Z"
-    },
-    {
-      "rank": 115,
       "id": "openbmb/MiniCPM5-1B-GGUF",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
       "downloads": 1655,
-      "likes": 96,
-      "trendingScore": 45.5,
+      "likes": 98,
+      "trendingScore": 46.5,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -3448,7 +3412,83 @@
       "lastModified": "2026-05-25T10:55:40.000Z"
     },
     {
+      "rank": 114,
+      "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
+      "downloads": 3359784,
+      "likes": 718,
+      "trendingScore": 46,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "gemma4",
+        "unsloth",
+        "gemma",
+        "google",
+        "image-text-to-text",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-01T14:42:29.000Z",
+      "lastModified": "2026-05-04T09:45:46.000Z"
+    },
+    {
+      "rank": 115,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+      "downloads": 681,
+      "likes": 46,
+      "trendingScore": 46,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T15:12:13.000Z",
+      "lastModified": "2026-05-15T10:41:43.000Z"
+    },
+    {
       "rank": 116,
+      "id": "LatitudeGames/Equinox-31B",
+      "author": "LatitudeGames",
+      "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
+      "downloads": 653,
+      "likes": 46,
+      "trendingScore": 46,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "gemma4",
+        "text adventure",
+        "roleplay",
+        "en",
+        "base_model:google/gemma-4-31B-it",
+        "base_model:finetune:google/gemma-4-31B-it",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:45:53.000Z",
+      "lastModified": "2026-05-22T04:55:49.000Z"
+    },
+    {
+      "rank": 117,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -3471,7 +3511,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -3498,120 +3538,13 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 118,
-      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
-      "downloads": 462273,
-      "likes": 92,
-      "trendingScore": 43,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "NemotronH_Nano_Omni_Reasoning_V3",
-        "feature-extraction",
-        "nvidia",
-        "pytorch",
-        "multimodal",
-        "any-to-any",
-        "custom_code",
-        "dataset:nvidia/Nemotron-Image-Training-v3",
-        "arxiv:2604.24954",
-        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
-        "license:other",
-        "8-bit",
-        "modelopt",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T16:09:58.000Z",
-      "lastModified": "2026-05-05T14:35:03.000Z"
-    },
-    {
       "rank": 119,
-      "id": "manjunathshiva/gpt-oss-20b-tq3",
-      "author": "manjunathshiva",
-      "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
-      "downloads": 2474,
-      "likes": 45,
-      "trendingScore": 43,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gpt_oss",
-        "turboquant",
-        "quantization",
-        "apple-silicon",
-        "moe",
-        "gpt-oss",
-        "text-generation",
-        "conversational",
-        "arxiv:2504.19874",
-        "base_model:openai/gpt-oss-20b",
-        "base_model:quantized:openai/gpt-oss-20b",
-        "license:apache-2.0",
-        "3-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-08T12:08:02.000Z",
-      "lastModified": "2026-05-09T11:23:07.000Z"
-    },
-    {
-      "rank": 120,
-      "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
-      "author": "Zlikwid",
-      "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
-      "downloads": 0,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T06:04:26.000Z",
-      "lastModified": "2026-05-09T01:15:32.000Z"
-    },
-    {
-      "rank": 121,
-      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "byteshape",
-      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 20123,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "qwen3.6",
-        "byteshape",
-        "mtp",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T21:48:29.000Z",
-      "lastModified": "2026-05-20T01:46:59.000Z"
-    },
-    {
-      "rank": 122,
       "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
       "downloads": 0,
-      "likes": 44,
-      "trendingScore": 43,
+      "likes": 45,
+      "trendingScore": 44,
       "pipelineTag": "text-to-speech",
       "libraryName": null,
       "tags": [
@@ -3650,104 +3583,13 @@
       "lastModified": "2026-05-26T08:49:43.000Z"
     },
     {
-      "rank": 123,
-      "id": "nvidia/LocateAnything-3B",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/LocateAnything-3B",
-      "downloads": 14,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "locateanything",
-        "feature-extraction",
-        "nvidia",
-        "eagle",
-        "vision",
-        "object-detection",
-        "grounding",
-        "arxiv:2605.27365",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "arxiv:2504.07491",
-        "arxiv:2109.10852",
-        "arxiv:2510.12798",
-        "arxiv:2303.05499",
-        "arxiv:1405.0312",
-        "arxiv:1908.03195",
-        "arxiv:2504.07981",
-        "base_model:Qwen/Qwen2.5-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-03-02T20:05:49.000Z",
-      "lastModified": "2026-05-27T08:30:54.000Z"
-    },
-    {
-      "rank": 124,
-      "id": "facebook/sam3",
-      "author": "facebook",
-      "url": "https://huggingface.co/facebook/sam3",
-      "downloads": 2344020,
-      "likes": 2067,
-      "trendingScore": 41,
-      "pipelineTag": "mask-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "sam3_video",
-        "feature-extraction",
-        "sam3",
-        "mask-generation",
-        "en",
-        "license:other",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-11-07T05:17:48.000Z",
-      "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 125,
-      "id": "openbmb/BitCPM-CANN-8B-gguf",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
-      "downloads": 1282,
-      "likes": 45,
-      "trendingScore": 41,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-16T06:18:55.000Z",
-      "lastModified": "2026-05-23T18:12:57.000Z"
-    },
-    {
-      "rank": 126,
+      "rank": 120,
       "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
       "downloads": 0,
-      "likes": 41,
-      "trendingScore": 41,
+      "likes": 44,
+      "trendingScore": 44,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
@@ -3770,6 +3612,164 @@
       ],
       "createdAt": "2026-05-21T16:12:41.000Z",
       "lastModified": "2026-05-26T16:16:59.000Z"
+    },
+    {
+      "rank": 121,
+      "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+      "downloads": 462273,
+      "likes": 92,
+      "trendingScore": 43,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "NemotronH_Nano_Omni_Reasoning_V3",
+        "feature-extraction",
+        "nvidia",
+        "pytorch",
+        "multimodal",
+        "any-to-any",
+        "custom_code",
+        "dataset:nvidia/Nemotron-Image-Training-v3",
+        "arxiv:2604.24954",
+        "base_model:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "base_model:quantized:nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
+        "license:other",
+        "8-bit",
+        "modelopt",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-24T16:09:58.000Z",
+      "lastModified": "2026-05-05T14:35:03.000Z"
+    },
+    {
+      "rank": 122,
+      "id": "manjunathshiva/gpt-oss-20b-tq3",
+      "author": "manjunathshiva",
+      "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
+      "downloads": 2474,
+      "likes": 45,
+      "trendingScore": 43,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "gpt_oss",
+        "turboquant",
+        "quantization",
+        "apple-silicon",
+        "moe",
+        "gpt-oss",
+        "text-generation",
+        "conversational",
+        "arxiv:2504.19874",
+        "base_model:openai/gpt-oss-20b",
+        "base_model:quantized:openai/gpt-oss-20b",
+        "license:apache-2.0",
+        "3-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-08T12:08:02.000Z",
+      "lastModified": "2026-05-09T11:23:07.000Z"
+    },
+    {
+      "rank": 123,
+      "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
+      "author": "Zlikwid",
+      "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
+      "downloads": 0,
+      "likes": 43,
+      "trendingScore": 43,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-05-07T06:04:26.000Z",
+      "lastModified": "2026-05-09T01:15:32.000Z"
+    },
+    {
+      "rank": 124,
+      "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "byteshape",
+      "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 20123,
+      "likes": 43,
+      "trendingScore": 43,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "qwen3.6",
+        "byteshape",
+        "mtp",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T21:48:29.000Z",
+      "lastModified": "2026-05-20T01:46:59.000Z"
+    },
+    {
+      "rank": 125,
+      "id": "facebook/sam3",
+      "author": "facebook",
+      "url": "https://huggingface.co/facebook/sam3",
+      "downloads": 2344020,
+      "likes": 2070,
+      "trendingScore": 42,
+      "pipelineTag": "mask-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "sam3_video",
+        "feature-extraction",
+        "sam3",
+        "mask-generation",
+        "en",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-11-07T05:17:48.000Z",
+      "lastModified": "2025-11-20T22:05:08.000Z"
+    },
+    {
+      "rank": 126,
+      "id": "openbmb/BitCPM-CANN-8B-gguf",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
+      "downloads": 1282,
+      "likes": 45,
+      "trendingScore": 41,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-16T06:18:55.000Z",
+      "lastModified": "2026-05-23T18:12:57.000Z"
     },
     {
       "rank": 127,
@@ -3899,6 +3899,32 @@
     },
     {
       "rank": 132,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 47,
+      "likes": 38,
+      "trendingScore": 38,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-27T06:28:10.000Z"
+    },
+    {
+      "rank": 133,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -3925,7 +3951,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -3952,7 +3978,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 134,
+      "rank": 135,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -3982,32 +4008,6 @@
       ],
       "createdAt": "2026-05-16T19:11:26.000Z",
       "lastModified": "2026-05-21T21:34:50.000Z"
-    },
-    {
-      "rank": 135,
-      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "author": "Kwai-Keye",
-      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "downloads": 47,
-      "likes": 37,
-      "trendingScore": 37,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "KeyeVL2",
-        "feature-extraction",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:32:15.000Z",
-      "lastModified": "2026-05-27T06:28:10.000Z"
     },
     {
       "rank": 136,
@@ -5026,6 +5026,60 @@
     },
     {
       "rank": 169,
+      "id": "tencent/Hy-MT2-7B-GGUF",
+      "author": "tencent",
+      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
+      "downloads": 14891,
+      "likes": 32,
+      "trendingScore": 31,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "arxiv:2605.22064",
+        "base_model:tencent/Hy-MT2-7B",
+        "base_model:quantized:tencent/Hy-MT2-7B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T06:21:31.000Z",
+      "lastModified": "2026-05-26T09:06:21.000Z"
+    },
+    {
+      "rank": 170,
+      "id": "pyannote/segmentation-3.0",
+      "author": "pyannote",
+      "url": "https://huggingface.co/pyannote/segmentation-3.0",
+      "downloads": 9117096,
+      "likes": 1046,
+      "trendingScore": 31,
+      "pipelineTag": "voice-activity-detection",
+      "libraryName": "pyannote-audio",
+      "tags": [
+        "pyannote-audio",
+        "pytorch",
+        "pyannote",
+        "pyannote-audio-model",
+        "audio",
+        "voice",
+        "speech",
+        "speaker",
+        "speaker-diarization",
+        "speaker-change-detection",
+        "speaker-segmentation",
+        "voice-activity-detection",
+        "overlapped-speech-detection",
+        "resegmentation",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2023-09-22T12:03:10.000Z",
+      "lastModified": "2024-05-10T19:35:46.000Z"
+    },
+    {
+      "rank": 171,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -5051,7 +5105,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 170,
+      "rank": 172,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -5083,7 +5137,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 171,
+      "rank": 173,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -5110,7 +5164,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 172,
+      "rank": 174,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -5144,7 +5198,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 173,
+      "rank": 175,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -5166,30 +5220,7 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 174,
-      "id": "tencent/Hy-MT2-7B-GGUF",
-      "author": "tencent",
-      "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
-      "downloads": 14891,
-      "likes": 31,
-      "trendingScore": 30,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "arxiv:2605.22064",
-        "base_model:tencent/Hy-MT2-7B",
-        "base_model:quantized:tencent/Hy-MT2-7B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T06:21:31.000Z",
-      "lastModified": "2026-05-26T09:06:21.000Z"
-    },
-    {
-      "rank": 175,
+      "rank": 176,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
@@ -5234,7 +5265,38 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 176,
+      "rank": 177,
+      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "downloads": 0,
+      "likes": 30,
+      "trendingScore": 30,
+      "pipelineTag": "text-to-image",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:15:18.000Z",
+      "lastModified": "2026-05-26T16:16:59.000Z"
+    },
+    {
+      "rank": 178,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -5265,7 +5327,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 177,
+      "rank": 179,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -5288,7 +5350,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 178,
+      "rank": 180,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -5315,7 +5377,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 179,
+      "rank": 181,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -5346,7 +5408,7 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 180,
+      "rank": 182,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -5375,7 +5437,7 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 181,
+      "rank": 183,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -5396,38 +5458,7 @@
       "lastModified": "2026-03-27T17:40:55.000Z"
     },
     {
-      "rank": 182,
-      "id": "pyannote/segmentation-3.0",
-      "author": "pyannote",
-      "url": "https://huggingface.co/pyannote/segmentation-3.0",
-      "downloads": 9117096,
-      "likes": 1043,
-      "trendingScore": 29,
-      "pipelineTag": "voice-activity-detection",
-      "libraryName": "pyannote-audio",
-      "tags": [
-        "pyannote-audio",
-        "pytorch",
-        "pyannote",
-        "pyannote-audio-model",
-        "audio",
-        "voice",
-        "speech",
-        "speaker",
-        "speaker-diarization",
-        "speaker-change-detection",
-        "speaker-segmentation",
-        "voice-activity-detection",
-        "overlapped-speech-detection",
-        "resegmentation",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2023-09-22T12:03:10.000Z",
-      "lastModified": "2024-05-10T19:35:46.000Z"
-    },
-    {
-      "rank": 183,
+      "rank": 184,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -5449,7 +5480,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 184,
+      "rank": 185,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -5486,7 +5517,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 185,
+      "rank": 186,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -5508,7 +5539,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 186,
+      "rank": 187,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -5541,7 +5572,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 187,
+      "rank": 188,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5573,7 +5604,7 @@
       "lastModified": "2026-05-09T01:18:02.000Z"
     },
     {
-      "rank": 188,
+      "rank": 189,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -5600,12 +5631,12 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 189,
+      "rank": 190,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
       "downloads": 2831417,
-      "likes": 423,
+      "likes": 426,
       "trendingScore": 28,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "pyannote-audio",
@@ -5633,7 +5664,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 190,
+      "rank": 191,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -5673,7 +5704,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 191,
+      "rank": 192,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -5710,7 +5741,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 192,
+      "rank": 193,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -5753,7 +5784,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -5773,7 +5804,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -5798,7 +5829,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -5823,7 +5854,7 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -5846,7 +5877,7 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5870,37 +5901,6 @@
       ],
       "createdAt": "2024-07-31T19:58:05.000Z",
       "lastModified": "2024-08-16T14:37:56.000Z"
-    },
-    {
-      "rank": 198,
-      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "downloads": 0,
-      "likes": 27,
-      "trendingScore": 27,
-      "pipelineTag": "text-to-image",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "diffusers",
-        "safetensors",
-        "ternary",
-        "1.58-bit",
-        "apple-silicon",
-        "on-device",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:15:18.000Z",
-      "lastModified": "2026-05-26T16:16:59.000Z"
     },
     {
       "rank": 199,
@@ -7105,6 +7105,50 @@
     },
     {
       "rank": 242,
+      "id": "Jackrong/Qwopus3.6-27B-v2",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
+      "downloads": 4313,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:20:50.000Z",
+      "lastModified": "2026-05-23T00:38:29.000Z"
+    },
+    {
+      "rank": 243,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -7135,7 +7179,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 243,
+      "rank": 244,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -7164,7 +7208,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 244,
+      "rank": 245,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -7209,7 +7253,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 245,
+      "rank": 246,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -7236,7 +7280,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 246,
+      "rank": 247,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -7260,7 +7304,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 247,
+      "rank": 248,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -7298,7 +7342,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 248,
+      "rank": 249,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -7315,7 +7359,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 249,
+      "rank": 250,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -7343,7 +7387,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 250,
+      "rank": 251,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7366,7 +7410,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 251,
+      "rank": 252,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7383,7 +7427,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -7410,7 +7454,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -7455,7 +7499,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -7483,7 +7527,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -7519,7 +7563,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -7546,7 +7590,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -7571,7 +7615,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -7597,7 +7641,7 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7623,51 +7667,36 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 260,
-      "id": "Jackrong/Qwopus3.6-27B-v2",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
-      "downloads": 4313,
+      "rank": 261,
+      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "downloads": 0,
       "likes": 21,
       "trendingScore": 21,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-audio",
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
+        "diffusers",
         "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "image",
-        "conversational",
+        "text-to-audio",
+        "diffusion",
+        "flow-matching",
+        "sound-effects",
+        "audio-generation",
         "en",
         "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "base_model:Qwen/Qwen3-1.7B",
+        "base_model:finetune:Qwen/Qwen3-1.7B",
         "license:apache-2.0",
-        "endpoints_compatible",
+        "diffusers:MossSoundEffectPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-14T08:20:50.000Z",
-      "lastModified": "2026-05-23T00:38:29.000Z"
+      "createdAt": "2026-05-25T14:19:58.000Z",
+      "lastModified": "2026-05-26T09:41:39.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -7695,7 +7724,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -7728,7 +7757,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 263,
+      "rank": 264,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -7753,7 +7782,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 264,
+      "rank": 265,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -7790,7 +7819,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 265,
+      "rank": 266,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -7833,7 +7862,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 266,
+      "rank": 267,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -7857,7 +7886,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 267,
+      "rank": 268,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -7881,7 +7910,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 268,
+      "rank": 269,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -7910,7 +7939,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 269,
+      "rank": 270,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -7928,7 +7957,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 270,
+      "rank": 271,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -7973,7 +8002,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 271,
+      "rank": 272,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -8018,7 +8047,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 272,
+      "rank": 273,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -8047,7 +8076,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 273,
+      "rank": 274,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -8071,7 +8100,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 274,
+      "rank": 275,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -8100,7 +8129,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 275,
+      "rank": 276,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8124,7 +8153,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 276,
+      "rank": 277,
       "id": "netease-youdao/Confucius4",
       "author": "netease-youdao",
       "url": "https://huggingface.co/netease-youdao/Confucius4",
@@ -8142,7 +8171,7 @@
       "lastModified": "2026-05-20T08:42:10.000Z"
     },
     {
-      "rank": 277,
+      "rank": 278,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -8160,7 +8189,7 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 278,
+      "rank": 279,
       "id": "syvai/cohere-transcribe-diarize",
       "author": "syvai",
       "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
@@ -8205,36 +8234,37 @@
       "lastModified": "2026-05-22T20:56:30.000Z"
     },
     {
-      "rank": 279,
-      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "rank": 280,
+      "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
       "downloads": 0,
-      "likes": 20,
+      "likes": 21,
       "trendingScore": 20,
-      "pipelineTag": "text-to-audio",
+      "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
         "safetensors",
-        "text-to-audio",
+        "1-bit",
+        "gemlite",
+        "hqq",
+        "cuda",
+        "text-to-image",
         "diffusion",
-        "flow-matching",
-        "sound-effects",
-        "audio-generation",
-        "en",
-        "zh",
-        "base_model:Qwen/Qwen3-1.7B",
-        "base_model:finetune:Qwen/Qwen3-1.7B",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
         "license:apache-2.0",
-        "diffusers:MossSoundEffectPipeline",
         "region:us"
       ],
-      "createdAt": "2026-05-25T14:19:58.000Z",
-      "lastModified": "2026-05-26T09:41:39.000Z"
+      "createdAt": "2026-05-18T15:40:12.000Z",
+      "lastModified": "2026-05-26T16:16:58.000Z"
     },
     {
-      "rank": 280,
+      "rank": 281,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -8279,7 +8309,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 281,
+      "rank": 282,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -8312,7 +8342,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 282,
+      "rank": 283,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -8334,7 +8364,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 283,
+      "rank": 284,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -8361,7 +8391,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 284,
+      "rank": 285,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -8377,7 +8407,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 285,
+      "rank": 286,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -8400,7 +8430,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 286,
+      "rank": 287,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -8425,7 +8455,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 287,
+      "rank": 288,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -8461,7 +8491,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 288,
+      "rank": 289,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -8490,7 +8520,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 289,
+      "rank": 290,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -8520,7 +8550,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 290,
+      "rank": 291,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -8565,7 +8595,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 291,
+      "rank": 292,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -8592,7 +8622,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 292,
+      "rank": 293,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -8618,7 +8648,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 293,
+      "rank": 294,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -8646,7 +8676,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 294,
+      "rank": 295,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -8675,7 +8705,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 295,
+      "rank": 296,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -8699,7 +8729,31 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 296,
+      "rank": 297,
+      "id": "spiritbuun/buun-Qwen3.6-chat_template",
+      "author": "spiritbuun",
+      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
+      "downloads": 0,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "chat-template",
+        "qwen3",
+        "qwen3.5",
+        "qwen3.6",
+        "jinja",
+        "llama-cpp",
+        "tool-use",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T16:33:22.000Z",
+      "lastModified": "2026-05-26T16:38:59.000Z"
+    },
+    {
+      "rank": 298,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -8721,7 +8775,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 297,
+      "rank": 299,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -8755,7 +8809,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 298,
+      "rank": 300,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -8779,7 +8833,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 299,
+      "rank": 301,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -8801,7 +8855,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 300,
+      "rank": 302,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -8830,7 +8884,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 301,
+      "rank": 303,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -8862,7 +8916,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 302,
+      "rank": 304,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -8880,7 +8934,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 303,
+      "rank": 305,
       "id": "openai/gpt-oss-120b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-120b",
@@ -8909,7 +8963,7 @@
       "lastModified": "2025-08-26T17:25:03.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -8927,7 +8981,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -8953,7 +9007,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 306,
+      "rank": 308,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -8981,7 +9035,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 307,
+      "rank": 309,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -9013,7 +9067,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 308,
+      "rank": 310,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -9040,7 +9094,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 309,
+      "rank": 311,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -9085,7 +9139,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 310,
+      "rank": 312,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -9114,7 +9168,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 311,
+      "rank": 313,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -9143,7 +9197,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 312,
+      "rank": 314,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -9175,7 +9229,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 313,
+      "rank": 315,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -9205,7 +9259,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 314,
+      "rank": 316,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -9226,7 +9280,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 315,
+      "rank": 317,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -9271,7 +9325,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 316,
+      "rank": 318,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -9300,7 +9354,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 317,
+      "rank": 319,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -9328,7 +9382,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -9353,7 +9407,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 319,
+      "rank": 321,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -9376,7 +9430,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 320,
+      "rank": 322,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -9403,7 +9457,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 321,
+      "rank": 323,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -9429,7 +9483,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 322,
+      "rank": 324,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -9458,7 +9512,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 323,
+      "rank": 325,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9477,7 +9531,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 324,
+      "rank": 326,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9505,7 +9559,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 325,
+      "rank": 327,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -9550,7 +9604,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 326,
+      "rank": 328,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -9578,7 +9632,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 327,
+      "rank": 329,
       "id": "numind/NuMarkdown-8B-Thinking",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
@@ -9609,37 +9663,76 @@
       "lastModified": "2026-05-19T19:01:34.000Z"
     },
     {
-      "rank": 328,
-      "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
+      "rank": 330,
+      "id": "rhasspy/piper-voices",
+      "author": "rhasspy",
+      "url": "https://huggingface.co/rhasspy/piper-voices",
       "downloads": 0,
-      "likes": 18,
+      "likes": 528,
+      "trendingScore": 17,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "onnx",
+        "ar",
+        "ca",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "el",
+        "en",
+        "es",
+        "fa",
+        "fi",
+        "fr",
+        "hu",
+        "is",
+        "it",
+        "ka",
+        "kk",
+        "lb",
+        "lv",
+        "ne",
+        "nl",
+        "no",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sk",
+        "sl",
+        "sr"
+      ],
+      "createdAt": "2023-06-22T19:17:27.000Z",
+      "lastModified": "2026-05-15T17:21:53.000Z"
+    },
+    {
+      "rank": 331,
+      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+      "downloads": 0,
+      "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
         "diffusers",
         "safetensors",
-        "1-bit",
-        "gemlite",
-        "hqq",
-        "cuda",
         "text-to-image",
         "diffusion",
         "flux",
         "prismml",
         "bonsai",
-        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-18T15:40:12.000Z",
-      "lastModified": "2026-05-26T16:16:58.000Z"
+      "createdAt": "2026-05-21T16:07:19.000Z",
+      "lastModified": "2026-05-26T16:17:00.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -9664,7 +9757,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -9699,7 +9792,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -9744,7 +9837,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -9771,7 +9864,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -9800,7 +9893,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -9823,7 +9916,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -9867,7 +9960,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -9912,7 +10005,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 337,
+      "rank": 340,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -9930,7 +10023,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 338,
+      "rank": 341,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -9975,7 +10068,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 339,
+      "rank": 342,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -10013,7 +10106,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -10033,7 +10126,7 @@
       "lastModified": "2026-05-24T09:49:46.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -10066,7 +10159,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -10096,7 +10189,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 343,
+      "rank": 346,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -10128,7 +10221,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 344,
+      "rank": 347,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -10153,7 +10246,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 345,
+      "rank": 348,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -10176,7 +10269,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 346,
+      "rank": 349,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -10206,7 +10299,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 347,
+      "rank": 350,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -10230,7 +10323,7 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 348,
+      "rank": 351,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -10258,7 +10351,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 349,
+      "rank": 352,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -10286,52 +10379,7 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 350,
-      "id": "rhasspy/piper-voices",
-      "author": "rhasspy",
-      "url": "https://huggingface.co/rhasspy/piper-voices",
-      "downloads": 0,
-      "likes": 527,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "onnx",
-        "ar",
-        "ca",
-        "cs",
-        "cy",
-        "da",
-        "de",
-        "el",
-        "en",
-        "es",
-        "fa",
-        "fi",
-        "fr",
-        "hu",
-        "is",
-        "it",
-        "ka",
-        "kk",
-        "lb",
-        "lv",
-        "ne",
-        "nl",
-        "no",
-        "pl",
-        "pt",
-        "ro",
-        "ru",
-        "sk",
-        "sl",
-        "sr"
-      ],
-      "createdAt": "2023-06-22T19:17:27.000Z",
-      "lastModified": "2026-05-15T17:21:53.000Z"
-    },
-    {
-      "rank": 351,
+      "rank": 353,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -10354,7 +10402,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 352,
+      "rank": 354,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -10392,7 +10440,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 353,
+      "rank": 355,
       "id": "openbmb/MiniCPM5-1B-SFT",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
@@ -10432,31 +10480,7 @@
       "lastModified": "2026-05-25T11:18:10.000Z"
     },
     {
-      "rank": 354,
-      "id": "spiritbuun/buun-Qwen3.6-chat_template",
-      "author": "spiritbuun",
-      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
-      "downloads": 0,
-      "likes": 16,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "chat-template",
-        "qwen3",
-        "qwen3.5",
-        "qwen3.6",
-        "jinja",
-        "llama-cpp",
-        "tool-use",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T16:33:22.000Z",
-      "lastModified": "2026-05-26T16:38:59.000Z"
-    },
-    {
-      "rank": 355,
+      "rank": 356,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -10483,7 +10507,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 356,
+      "rank": 357,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -10528,7 +10552,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 357,
+      "rank": 358,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -10558,7 +10582,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 358,
+      "rank": 359,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -10588,7 +10612,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 359,
+      "rank": 360,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -10633,7 +10657,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 360,
+      "rank": 361,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -10668,7 +10692,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 361,
+      "rank": 362,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -10697,7 +10721,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 362,
+      "rank": 363,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -10722,7 +10746,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 363,
+      "rank": 364,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -10750,7 +10774,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 364,
+      "rank": 365,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -10778,7 +10802,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 365,
+      "rank": 366,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -10809,7 +10833,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 366,
+      "rank": 367,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -10854,7 +10878,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 367,
+      "rank": 368,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -10886,7 +10910,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 368,
+      "rank": 369,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -10913,7 +10937,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 369,
+      "rank": 370,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -10936,7 +10960,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 370,
+      "rank": 371,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -10963,7 +10987,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 371,
+      "rank": 372,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -10989,7 +11013,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 372,
+      "rank": 373,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -11019,7 +11043,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 373,
+      "rank": 374,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -11046,7 +11070,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 374,
+      "rank": 375,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -11077,7 +11101,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 375,
+      "rank": 376,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -11109,7 +11133,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 376,
+      "rank": 377,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -11154,7 +11178,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 377,
+      "rank": 378,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -11187,7 +11211,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 378,
+      "rank": 379,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -11227,7 +11251,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 379,
+      "rank": 380,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -11268,7 +11292,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 380,
+      "rank": 381,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -11291,7 +11315,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 381,
+      "rank": 382,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11314,7 +11338,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 382,
+      "rank": 383,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -11345,7 +11369,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 383,
+      "rank": 384,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11376,7 +11400,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 384,
+      "rank": 385,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -11405,7 +11429,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 385,
+      "rank": 386,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -11438,7 +11462,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 386,
+      "rank": 387,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -11464,7 +11488,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 387,
+      "rank": 388,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -11508,7 +11532,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 388,
+      "rank": 389,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -11545,7 +11569,7 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 389,
+      "rank": 390,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -11568,30 +11592,6 @@
       ],
       "createdAt": "2026-05-17T02:18:14.000Z",
       "lastModified": "2026-05-19T20:11:14.000Z"
-    },
-    {
-      "rank": 390,
-      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
-      "downloads": 0,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:07:19.000Z",
-      "lastModified": "2026-05-26T16:17:00.000Z"
     },
     {
       "rank": 391,
@@ -12439,7 +12439,7 @@
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
       "downloads": 1252658,
-      "likes": 2214,
+      "likes": 2215,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -12475,7 +12475,7 @@
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
       "downloads": 2079726,
-      "likes": 2155,
+      "likes": 2156,
       "trendingScore": 14,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -12537,6 +12537,53 @@
     },
     {
       "rank": 423,
+      "id": "Qwen/Qwen3.6-35B-A3B-FP8",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
+      "downloads": 5126927,
+      "likes": 237,
+      "trendingScore": 14,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "fp8",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-04-15T06:05:13.000Z",
+      "lastModified": "2026-04-24T02:39:23.000Z"
+    },
+    {
+      "rank": 424,
+      "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
+      "downloads": 4037,
+      "likes": 15,
+      "trendingScore": 14,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T07:13:09.000Z",
+      "lastModified": "2026-05-23T14:54:50.000Z"
+    },
+    {
+      "rank": 425,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -12565,7 +12612,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 424,
+      "rank": 426,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -12610,7 +12657,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 425,
+      "rank": 427,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -12639,34 +12686,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 426,
-      "id": "Qwen/Qwen3.6-35B-A3B-FP8",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
-      "downloads": 5126927,
-      "likes": 236,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "fp8",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-04-15T06:05:13.000Z",
-      "lastModified": "2026-04-24T02:39:23.000Z"
-    },
-    {
-      "rank": 427,
+      "rank": 428,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -12693,7 +12713,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 428,
+      "rank": 429,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -12724,7 +12744,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 429,
+      "rank": 430,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -12748,7 +12768,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 430,
+      "rank": 431,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -12775,7 +12795,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 431,
+      "rank": 432,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -12811,7 +12831,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 432,
+      "rank": 433,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -12842,7 +12862,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 433,
+      "rank": 434,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -12873,7 +12893,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 434,
+      "rank": 435,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -12906,7 +12926,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 435,
+      "rank": 436,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -12935,7 +12955,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 436,
+      "rank": 437,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -12961,7 +12981,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 437,
+      "rank": 438,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -12991,7 +13011,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 438,
+      "rank": 439,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -13009,7 +13029,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 439,
+      "rank": 440,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -13040,7 +13060,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 440,
+      "rank": 441,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -13061,7 +13081,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 441,
+      "rank": 442,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -13081,7 +13101,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 442,
+      "rank": 443,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -13108,7 +13128,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 443,
+      "rank": 444,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -13138,7 +13158,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 444,
+      "rank": 445,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -13155,7 +13175,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 445,
+      "rank": 446,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -13182,7 +13202,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 446,
+      "rank": 447,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -13207,7 +13227,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 447,
+      "rank": 448,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -13250,7 +13270,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 448,
+      "rank": 449,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -13279,7 +13299,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 449,
+      "rank": 450,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -13302,7 +13322,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 450,
+      "rank": 451,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -13329,7 +13349,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 451,
+      "rank": 452,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13359,7 +13379,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 452,
+      "rank": 453,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -13387,7 +13407,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 453,
+      "rank": 454,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
@@ -13418,7 +13438,7 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 454,
+      "rank": 455,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -13440,7 +13460,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 455,
+      "rank": 456,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -13463,7 +13483,7 @@
       "lastModified": "2026-05-26T09:06:09.000Z"
     },
     {
-      "rank": 456,
+      "rank": 457,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -13488,26 +13508,6 @@
       ],
       "createdAt": "2026-05-21T09:34:34.000Z",
       "lastModified": "2026-05-21T09:49:53.000Z"
-    },
-    {
-      "rank": 457,
-      "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "downloads": 4037,
-      "likes": 14,
-      "trendingScore": 13,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T07:13:09.000Z",
-      "lastModified": "2026-05-23T14:54:50.000Z"
     },
     {
       "rank": 458,
@@ -13537,1212 +13537,12 @@
     },
     {
       "rank": 459,
-      "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-      "author": "Lightricks",
-      "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-      "downloads": 4968,
-      "likes": 84,
-      "trendingScore": 12,
-      "pipelineTag": "any-to-any",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "ltx-video",
-        "image-to-video",
-        "text-to-video",
-        "any-to-any",
-        "en",
-        "arxiv:2601.03233",
-        "arxiv:2604.11788",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T09:46:13.000Z",
-      "lastModified": "2026-05-03T09:57:49.000Z"
-    },
-    {
-      "rank": 460,
-      "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
-      "downloads": 876,
-      "likes": 44,
-      "trendingScore": 12,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T13:32:34.000Z",
-      "lastModified": "2026-04-27T15:27:42.000Z"
-    },
-    {
-      "rank": 461,
-      "id": "OpenMed/privacy-filter-nemotron",
-      "author": "OpenMed",
-      "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
-      "downloads": 3956,
-      "likes": 33,
-      "trendingScore": 12,
-      "pipelineTag": "token-classification",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "openai_privacy_filter",
-        "token-classification",
-        "pii",
-        "ner",
-        "privacy",
-        "redaction",
-        "nemotron",
-        "privacy-filter",
-        "openmed",
-        "en",
-        "dataset:nvidia/Nemotron-PII",
-        "base_model:openai/privacy-filter",
-        "base_model:finetune:openai/privacy-filter",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T11:31:59.000Z",
-      "lastModified": "2026-04-28T08:01:07.000Z"
-    },
-    {
-      "rank": 462,
-      "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
-      "author": "Dustoevsky",
-      "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
-      "downloads": 0,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T08:18:59.000Z",
-      "lastModified": "2026-04-30T08:26:18.000Z"
-    },
-    {
-      "rank": 463,
-      "id": "Eyeline-Labs/Vista4D",
-      "author": "Eyeline-Labs",
-      "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
-      "downloads": 227,
-      "likes": 26,
-      "trendingScore": 12,
-      "pipelineTag": "video-to-video",
-      "libraryName": null,
-      "tags": [
-        "video-to-video",
-        "dataset:KlingTeam/MultiCamVideo-Dataset",
-        "dataset:nkp37/OpenVid-1M",
-        "arxiv:2604.21915",
-        "base_model:Wan-AI/Wan2.1-T2V-14B",
-        "base_model:finetune:Wan-AI/Wan2.1-T2V-14B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-11-20T02:18:26.000Z",
-      "lastModified": "2026-04-26T17:38:29.000Z"
-    },
-    {
-      "rank": 464,
-      "id": "nvidia/MiniMax-M2.7-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
-      "downloads": 83748,
-      "likes": 34,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "minimax_m2",
-        "nvidia",
-        "ModelOpt",
-        "MiniMax",
-        "quantized",
-        "NVFP4",
-        "nvfp4",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "base_model:MiniMaxAI/MiniMax-M2.7",
-        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
-        "license:other",
-        "8-bit",
-        "modelopt",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2026-04-13T22:04:24.000Z",
-      "lastModified": "2026-04-24T21:40:54.000Z"
-    },
-    {
-      "rank": 465,
-      "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
-      "author": "am17an",
-      "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
-      "downloads": 4245,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-04T14:54:47.000Z",
-      "lastModified": "2026-05-04T14:59:29.000Z"
-    },
-    {
-      "rank": 466,
-      "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
-      "author": "CoreWorxLab",
-      "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
-      "downloads": 1024,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "qwen",
-        "qwen3",
-        "text-generation",
-        "quantization",
-        "int4",
-        "autoround",
-        "symmetric",
-        "base-model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-        "conversational",
-        "base_model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-        "base_model:quantized:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "4-bit",
-        "auto-round",
-        "region:us"
-      ],
-      "createdAt": "2026-05-02T09:31:48.000Z",
-      "lastModified": "2026-05-03T18:35:34.000Z"
-    },
-    {
-      "rank": 467,
-      "id": "HuggingFaceTB/nanowhale-100m-base",
-      "author": "HuggingFaceTB",
-      "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
-      "downloads": 595,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "deepseek_v4",
-        "text-generation",
-        "deepseek",
-        "moe",
-        "causal-lm",
-        "pretrained",
-        "conversational",
-        "custom_code",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T13:33:34.000Z",
-      "lastModified": "2026-05-04T14:34:18.000Z"
-    },
-    {
-      "rank": 468,
-      "id": "kyutai/pocket-tts",
-      "author": "kyutai",
-      "url": "https://huggingface.co/kyutai/pocket-tts",
-      "downloads": 6729,
-      "likes": 622,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": "pocket-tts",
-      "tags": [
-        "pocket-tts",
-        "safetensors",
-        "en",
-        "arxiv:2509.06926",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-29T14:06:48.000Z",
-      "lastModified": "2026-05-04T12:38:48.000Z"
-    },
-    {
-      "rank": 469,
-      "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
-      "downloads": 98968,
-      "likes": 76,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "image-text-to-text",
-        "base_model:llmfan46/gemma-4-31B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-31B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-03T23:53:42.000Z",
-      "lastModified": "2026-05-05T17:08:34.000Z"
-    },
-    {
-      "rank": 470,
-      "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
-      "author": "cHunter789",
-      "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
-      "downloads": 5989,
-      "likes": 17,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "qwen",
-        "llama.cpp",
-        "quantized",
-        "text-generation",
-        "en",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-28T08:55:33.000Z",
-      "lastModified": "2026-05-02T08:44:09.000Z"
-    },
-    {
-      "rank": 471,
-      "id": "ACE-Step/Ace-Step1.5",
-      "author": "ACE-Step",
-      "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
-      "downloads": 49549,
-      "likes": 747,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "diffusers",
-        "safetensors",
-        "acestep",
-        "feature-extraction",
-        "audio",
-        "music",
-        "text2music",
-        "text-to-audio",
-        "custom_code",
-        "arxiv:2602.00744",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-01-23T09:59:48.000Z",
-      "lastModified": "2026-02-03T11:37:37.000Z"
-    },
-    {
-      "rank": 472,
-      "id": "Qwen/Qwen3-VL-8B-Instruct",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
-      "downloads": 5539938,
-      "likes": 902,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "conversational",
-        "arxiv:2505.09388",
-        "arxiv:2502.13923",
-        "arxiv:2409.12191",
-        "arxiv:2308.12966",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-10-11T07:23:39.000Z",
-      "lastModified": "2025-10-15T16:16:59.000Z"
-    },
-    {
-      "rank": 473,
-      "id": "SeeSee21/Z-Image-Turbo-AIO",
-      "author": "SeeSee21",
-      "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
-      "downloads": 130,
-      "likes": 254,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "z-image-turbo",
-        "text-to-image",
-        "image-generation",
-        "diffusion",
-        "comfyui",
-        "photorealistic",
-        "bilingual",
-        "chinese",
-        "english",
-        "8-step",
-        "fast-generation",
-        "en",
-        "zh",
-        "base_model:Tongyi-MAI/Z-Image-Turbo",
-        "base_model:finetune:Tongyi-MAI/Z-Image-Turbo",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-03T21:24:19.000Z",
-      "lastModified": "2026-01-03T14:49:06.000Z"
-    },
-    {
-      "rank": 474,
-      "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
-      "author": "Naphula",
-      "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
-      "downloads": 250,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "mergekit",
-        "merge",
-        "moe_karcher",
-        "conversational",
-        "eng",
-        "base_model:ApocalypseParty/G4-26B-SFT-6",
-        "base_model:merge:ApocalypseParty/G4-26B-SFT-6",
-        "base_model:AuriAetherwiing/G4-26B-A4B-Musica-v1",
-        "base_model:merge:AuriAetherwiing/G4-26B-A4B-Musica-v1",
-        "base_model:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
-        "base_model:merge:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:merge:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T11:40:11.000Z",
-      "lastModified": "2026-05-08T14:22:31.000Z"
-    },
-    {
-      "rank": 475,
-      "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
-      "downloads": 3058,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_h",
-        "text-generation",
-        "nvidia",
-        "pytorch",
-        "elastic",
-        "conversational",
-        "custom_code",
-        "en",
-        "es",
-        "fr",
-        "de",
-        "ja",
-        "it",
-        "arxiv:2512.20848",
-        "arxiv:2511.16664",
-        "base_model:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "base_model:finetune:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "license:other",
-        "endpoints_compatible",
-        "8-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T16:04:08.000Z",
-      "lastModified": "2026-05-08T03:42:19.000Z"
-    },
-    {
-      "rank": 476,
-      "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
-      "author": "IAAR-Shanghai",
-      "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
-      "downloads": 1024,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "privacy",
-        "privacy-detection",
-        "memory",
-        "personalized-memory",
-        "memory-system",
-        "memory-management",
-        "agent",
-        "agent-memory",
-        "information-security",
-        "information-extraction",
-        "edge-cloud",
-        "conversational",
-        "en",
-        "zh",
-        "arxiv:2605.09530",
-        "base_model:Qwen/Qwen3-1.7B",
-        "base_model:finetune:Qwen/Qwen3-1.7B",
-        "license:cc-by-nc-nd-4.0",
-        "text-generation-inference",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T15:03:21.000Z",
-      "lastModified": "2026-05-15T03:09:28.000Z"
-    },
-    {
-      "rank": 477,
-      "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
-      "author": "Jiunsong",
-      "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
-      "downloads": 26377,
-      "likes": 236,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gemma4",
-        "uncensored",
-        "apple-silicon",
-        "4bit",
-        "quantized",
-        "reasoning",
-        "tool-use",
-        "coding",
-        "browser-automation",
-        "korean",
-        "fast",
-        "text-generation",
-        "conversational",
-        "en",
-        "ko",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:gemma",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-10T07:52:18.000Z",
-      "lastModified": "2026-04-12T13:34:53.000Z"
-    },
-    {
-      "rank": 478,
-      "id": "Qwen/Qwen-Image-Edit-2509",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
-      "downloads": 222047,
-      "likes": 1137,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "license:apache-2.0",
-        "diffusers:QwenImageEditPlusPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-09-22T13:09:40.000Z",
-      "lastModified": "2025-09-22T13:37:12.000Z"
-    },
-    {
-      "rank": 479,
-      "id": "ggerganov/whisper.cpp",
-      "author": "ggerganov",
-      "url": "https://huggingface.co/ggerganov/whisper.cpp",
-      "downloads": 0,
-      "likes": 1409,
-      "trendingScore": 12,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "automatic-speech-recognition",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2023-03-22T08:01:21.000Z",
-      "lastModified": "2024-10-29T18:25:17.000Z"
-    },
-    {
-      "rank": 480,
-      "id": "infly/Infinity-Parser2-Flash",
-      "author": "infly",
-      "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
-      "downloads": 4190,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_5",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-02-27T07:54:48.000Z",
-      "lastModified": "2026-05-16T01:59:44.000Z"
-    },
-    {
-      "rank": 481,
-      "id": "0G-AI/0GM-1.0-35B-A3B-0427",
-      "author": "0G-AI",
-      "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
-      "downloads": 299,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "moe",
-        "mixture-of-experts",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T02:18:11.000Z",
-      "lastModified": "2026-05-14T02:31:20.000Z"
-    },
-    {
-      "rank": 482,
-      "id": "PaddlePaddle/PaddleOCR-VL-1.5",
-      "author": "PaddlePaddle",
-      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
-      "downloads": 33832,
-      "likes": 640,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "PaddleOCR",
-      "tags": [
-        "PaddleOCR",
-        "safetensors",
-        "ERNIE4.5",
-        "PaddlePaddle",
-        "image-to-text",
-        "ocr",
-        "document-parse",
-        "layout",
-        "table",
-        "formula",
-        "chart",
-        "seal",
-        "spotting",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "multilingual",
-        "arxiv:2601.21957",
-        "base_model:baidu/ERNIE-4.5-0.3B-Paddle",
-        "base_model:finetune:baidu/ERNIE-4.5-0.3B-Paddle",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-01-28T12:43:01.000Z",
-      "lastModified": "2026-04-30T09:36:47.000Z"
-    },
-    {
-      "rank": 483,
-      "id": "google/gemma-4-26B-A4B",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-26B-A4B",
-      "downloads": 221885,
-      "likes": 270,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-12T00:38:03.000Z",
-      "lastModified": "2026-04-02T16:13:38.000Z"
-    },
-    {
-      "rank": 484,
-      "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "author": "OsaurusAI",
-      "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "downloads": 5987,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "deepseek_v4",
-        "jang",
-        "jangtq",
-        "jangtq2",
-        "jangtq-prestack",
-        "mxtq",
-        "deepseek",
-        "deepseek-v4",
-        "deepseek-v4-flash",
-        "moe",
-        "mla",
-        "hash-layers",
-        "mtp",
-        "apple-silicon",
-        "osaurus",
-        "text-generation",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T13:08:35.000Z",
-      "lastModified": "2026-05-12T13:09:29.000Z"
-    },
-    {
-      "rank": 485,
-      "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "author": "treadon",
-      "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "downloads": 4918,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "minicpmv4_6",
-        "image-text-to-text",
-        "abliteration",
-        "disinhibition",
-        "minicpm-v",
-        "mechanistic-interpretability",
-        "conversational",
-        "base_model:openbmb/MiniCPM-V-4.6",
-        "base_model:quantized:openbmb/MiniCPM-V-4.6",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T21:34:24.000Z",
-      "lastModified": "2026-05-12T02:18:15.000Z"
-    },
-    {
-      "rank": 486,
-      "id": "Datadog/Toto-2.0-1B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
-      "downloads": 1105,
-      "likes": 14,
-      "trendingScore": 12,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "arxiv:2605.20119",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T20:41:57.000Z",
-      "lastModified": "2026-05-20T14:30:49.000Z"
-    },
-    {
-      "rank": 487,
-      "id": "Qwen/Qwen3-1.7B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
-      "downloads": 3611424,
-      "likes": 473,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "conversational",
-        "arxiv:2505.09388",
-        "base_model:Qwen/Qwen3-1.7B-Base",
-        "base_model:finetune:Qwen/Qwen3-1.7B-Base",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-04-27T03:41:05.000Z",
-      "lastModified": "2025-07-26T03:46:32.000Z"
-    },
-    {
-      "rank": 488,
-      "id": "black-forest-labs/FLUX.1-Kontext-dev",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
-      "downloads": 77442,
-      "likes": 2630,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-generation",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "arxiv:2506.15742",
-        "license:other",
-        "diffusers:FluxKontextPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-05-28T22:23:43.000Z",
-      "lastModified": "2026-01-01T15:35:36.000Z"
-    },
-    {
-      "rank": 489,
-      "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 151146,
-      "likes": 482,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "unsloth",
-        "qwen",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:quantized:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-20T02:31:59.000Z",
-      "lastModified": "2026-01-08T21:13:12.000Z"
-    },
-    {
-      "rank": 490,
-      "id": "openbmb/BitCPM4-CANN-8B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
-      "downloads": 204,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "minicpm",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T13:10:51.000Z",
-      "lastModified": "2026-05-22T10:05:30.000Z"
-    },
-    {
-      "rank": 491,
-      "id": "SeeSee21/AniSee",
-      "author": "SeeSee21",
-      "url": "https://huggingface.co/SeeSee21/AniSee",
-      "downloads": 90,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "anisee",
-        "text-to-image",
-        "anime",
-        "anima",
-        "diffusion",
-        "comfyui",
-        "fine-tune",
-        "safetensors",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T16:28:42.000Z",
-      "lastModified": "2026-05-17T17:06:08.000Z"
-    },
-    {
-      "rank": 492,
-      "id": "unsloth/MiniMax-M2.7-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
-      "downloads": 163268,
-      "likes": 185,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "minimax_m2",
-        "unsloth",
-        "text-generation",
-        "base_model:MiniMaxAI/MiniMax-M2.7",
-        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-11T23:31:02.000Z",
-      "lastModified": "2026-04-14T16:48:17.000Z"
-    },
-    {
-      "rank": 493,
-      "id": "nicolas-dufour/miro",
-      "author": "nicolas-dufour",
-      "url": "https://huggingface.co/nicolas-dufour/miro",
-      "downloads": 514,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "miro-t2i",
-      "tags": [
-        "miro-t2i",
-        "safetensors",
-        "sdxl",
-        "text-to-image",
-        "diffusion",
-        "flow-matching",
-        "miro",
-        "reward-conditioning",
-        "arxiv:2510.25897",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T14:53:08.000Z",
-      "lastModified": "2026-05-19T23:10:01.000Z"
-    },
-    {
-      "rank": 494,
-      "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "author": "mistralai",
-      "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "downloads": 1261358,
-      "likes": 860,
-      "trendingScore": 12,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "vllm",
-      "tags": [
-        "vllm",
-        "safetensors",
-        "voxtral_realtime",
-        "mistral-common",
-        "automatic-speech-recognition",
-        "en",
-        "fr",
-        "es",
-        "de",
-        "ru",
-        "zh",
-        "ja",
-        "it",
-        "pt",
-        "nl",
-        "ar",
-        "hi",
-        "ko",
-        "arxiv:2602.11298",
-        "base_model:mistralai/Ministral-3-3B-Base-2512",
-        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-01-21T17:22:02.000Z",
-      "lastModified": "2026-03-11T15:04:02.000Z"
-    },
-    {
-      "rank": 495,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 13041,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T11:53:48.000Z",
-      "lastModified": "2026-05-19T13:01:22.000Z"
-    },
-    {
-      "rank": 496,
-      "id": "zemelee/qwen2.5-jailbreak",
-      "author": "zemelee",
-      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
-      "downloads": 883,
-      "likes": 24,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "base_model:Qwen/Qwen2.5-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-05-08T06:14:45.000Z",
-      "lastModified": "2025-05-08T06:56:32.000Z"
-    },
-    {
-      "rank": 497,
-      "id": "SupraLabs/Supra-50M-Base",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
-      "downloads": 542,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T05:00:44.000Z",
-      "lastModified": "2026-05-27T13:53:55.000Z"
-    },
-    {
-      "rank": 498,
-      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "author": "alibaba-pai",
-      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "downloads": 9841,
-      "likes": 157,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "videox_fun",
-      "tags": [
-        "videox_fun",
-        "lora",
-        "text-to-image",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-02-02T09:37:39.000Z",
-      "lastModified": "2026-03-02T11:46:41.000Z"
-    },
-    {
-      "rank": 499,
-      "id": "Qwen/Qwen3.5-122B-A10B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
-      "downloads": 843734,
-      "likes": 555,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "conversational",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-02-24T09:43:37.000Z",
-      "lastModified": "2026-04-24T03:55:23.000Z"
-    },
-    {
-      "rank": 500,
-      "id": "ruvnet/wifi-densepose-pretrained",
-      "author": "ruvnet",
-      "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
-      "downloads": 493,
-      "likes": 18,
-      "trendingScore": 12,
-      "pipelineTag": "other",
-      "libraryName": "onnxruntime",
-      "tags": [
-        "onnxruntime",
-        "safetensors",
-        "sona-lora",
-        "wifi-sensing",
-        "vital-signs",
-        "presence-detection",
-        "edge-ai",
-        "esp32",
-        "self-supervised",
-        "cognitum",
-        "through-wall",
-        "privacy-preserving",
-        "spiking-neural-network",
-        "ruvector",
-        "other",
-        "en",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-03T14:07:29.000Z",
-      "lastModified": "2026-04-03T18:21:10.000Z"
-    },
-    {
-      "rank": 501,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "downloads": 146703,
-      "likes": 356,
-      "trendingScore": 12,
+      "likes": 357,
+      "trendingScore": 13,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
@@ -14762,66 +13562,13 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 502,
-      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "author": "opendatalab",
-      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "downloads": 535,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_vl",
-        "image-text-to-text",
-        "conversational",
-        "zh",
-        "en",
-        "arxiv:2604.04771",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T11:00:43.000Z",
-      "lastModified": "2026-05-25T10:58:41.000Z"
-    },
-    {
-      "rank": 503,
-      "id": "joyfox/LTX-2.3-Transition-LORA",
-      "author": "joyfox",
-      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 36829,
-      "likes": 117,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ValiantCat",
-        "Lightricks",
-        "LTX-2.3",
-        "image-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-20T10:25:10.000Z",
-      "lastModified": "2026-03-30T03:28:58.000Z"
-    },
-    {
-      "rank": 504,
+      "rank": 460,
       "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
       "downloads": 1012,
-      "likes": 12,
-      "trendingScore": 12,
+      "likes": 13,
+      "trendingScore": 13,
       "pipelineTag": "text-generation",
       "libraryName": "mlx",
       "tags": [
@@ -14860,7 +13607,1331 @@
       "lastModified": "2026-05-23T00:19:59.000Z"
     },
     {
+      "rank": 461,
+      "id": "agents-course/notebooks",
+      "author": "agents-course",
+      "url": "https://huggingface.co/agents-course/notebooks",
+      "downloads": 0,
+      "likes": 572,
+      "trendingScore": 13,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-02-10T17:02:18.000Z",
+      "lastModified": "2026-04-27T08:00:30.000Z"
+    },
+    {
+      "rank": 462,
+      "id": "prism-ml/bonsai-image-binary-4B-unpacked",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
+      "downloads": 0,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:40:11.000Z",
+      "lastModified": "2026-05-26T16:16:58.000Z"
+    },
+    {
+      "rank": 463,
+      "id": "prism-ml/bonsai-image-binary-4B-mlx-1bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit",
+      "downloads": 0,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-to-image",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "diffusers",
+        "safetensors",
+        "1-bit",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T15:40:10.000Z",
+      "lastModified": "2026-05-26T16:16:57.000Z"
+    },
+    {
+      "rank": 464,
+      "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
+      "author": "Lightricks",
+      "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
+      "downloads": 4968,
+      "likes": 84,
+      "trendingScore": 12,
+      "pipelineTag": "any-to-any",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "ltx-video",
+        "image-to-video",
+        "text-to-video",
+        "any-to-any",
+        "en",
+        "arxiv:2601.03233",
+        "arxiv:2604.11788",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-20T09:46:13.000Z",
+      "lastModified": "2026-05-03T09:57:49.000Z"
+    },
+    {
+      "rank": 465,
+      "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
+      "downloads": 876,
+      "likes": 44,
+      "trendingScore": 12,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T13:32:34.000Z",
+      "lastModified": "2026-04-27T15:27:42.000Z"
+    },
+    {
+      "rank": 466,
+      "id": "OpenMed/privacy-filter-nemotron",
+      "author": "OpenMed",
+      "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
+      "downloads": 3956,
+      "likes": 33,
+      "trendingScore": 12,
+      "pipelineTag": "token-classification",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "openai_privacy_filter",
+        "token-classification",
+        "pii",
+        "ner",
+        "privacy",
+        "redaction",
+        "nemotron",
+        "privacy-filter",
+        "openmed",
+        "en",
+        "dataset:nvidia/Nemotron-PII",
+        "base_model:openai/privacy-filter",
+        "base_model:finetune:openai/privacy-filter",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-24T11:31:59.000Z",
+      "lastModified": "2026-04-28T08:01:07.000Z"
+    },
+    {
+      "rank": 467,
+      "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
+      "author": "Dustoevsky",
+      "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
+      "downloads": 0,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T08:18:59.000Z",
+      "lastModified": "2026-04-30T08:26:18.000Z"
+    },
+    {
+      "rank": 468,
+      "id": "Eyeline-Labs/Vista4D",
+      "author": "Eyeline-Labs",
+      "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
+      "downloads": 227,
+      "likes": 26,
+      "trendingScore": 12,
+      "pipelineTag": "video-to-video",
+      "libraryName": null,
+      "tags": [
+        "video-to-video",
+        "dataset:KlingTeam/MultiCamVideo-Dataset",
+        "dataset:nkp37/OpenVid-1M",
+        "arxiv:2604.21915",
+        "base_model:Wan-AI/Wan2.1-T2V-14B",
+        "base_model:finetune:Wan-AI/Wan2.1-T2V-14B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-11-20T02:18:26.000Z",
+      "lastModified": "2026-04-26T17:38:29.000Z"
+    },
+    {
+      "rank": 469,
+      "id": "nvidia/MiniMax-M2.7-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
+      "downloads": 83748,
+      "likes": 34,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "minimax_m2",
+        "nvidia",
+        "ModelOpt",
+        "MiniMax",
+        "quantized",
+        "NVFP4",
+        "nvfp4",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "base_model:MiniMaxAI/MiniMax-M2.7",
+        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
+        "license:other",
+        "8-bit",
+        "modelopt",
+        "region:us",
+        "deploy:azure"
+      ],
+      "createdAt": "2026-04-13T22:04:24.000Z",
+      "lastModified": "2026-04-24T21:40:54.000Z"
+    },
+    {
+      "rank": 470,
+      "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
+      "author": "am17an",
+      "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
+      "downloads": 4245,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-04T14:54:47.000Z",
+      "lastModified": "2026-05-04T14:59:29.000Z"
+    },
+    {
+      "rank": 471,
+      "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
+      "author": "CoreWorxLab",
+      "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
+      "downloads": 1024,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "qwen",
+        "qwen3",
+        "text-generation",
+        "quantization",
+        "int4",
+        "autoround",
+        "symmetric",
+        "base-model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
+        "conversational",
+        "base_model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
+        "base_model:quantized:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "4-bit",
+        "auto-round",
+        "region:us"
+      ],
+      "createdAt": "2026-05-02T09:31:48.000Z",
+      "lastModified": "2026-05-03T18:35:34.000Z"
+    },
+    {
+      "rank": 472,
+      "id": "HuggingFaceTB/nanowhale-100m-base",
+      "author": "HuggingFaceTB",
+      "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
+      "downloads": 595,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "deepseek_v4",
+        "text-generation",
+        "deepseek",
+        "moe",
+        "causal-lm",
+        "pretrained",
+        "conversational",
+        "custom_code",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-24T13:33:34.000Z",
+      "lastModified": "2026-05-04T14:34:18.000Z"
+    },
+    {
+      "rank": 473,
+      "id": "kyutai/pocket-tts",
+      "author": "kyutai",
+      "url": "https://huggingface.co/kyutai/pocket-tts",
+      "downloads": 6729,
+      "likes": 622,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": "pocket-tts",
+      "tags": [
+        "pocket-tts",
+        "safetensors",
+        "en",
+        "arxiv:2509.06926",
+        "license:cc-by-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-29T14:06:48.000Z",
+      "lastModified": "2026-05-04T12:38:48.000Z"
+    },
+    {
+      "rank": 474,
+      "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
+      "downloads": 98968,
+      "likes": 76,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "image-text-to-text",
+        "base_model:llmfan46/gemma-4-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-03T23:53:42.000Z",
+      "lastModified": "2026-05-05T17:08:34.000Z"
+    },
+    {
+      "rank": 475,
+      "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
+      "author": "cHunter789",
+      "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
+      "downloads": 5989,
+      "likes": 17,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "qwen",
+        "llama.cpp",
+        "quantized",
+        "text-generation",
+        "en",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-28T08:55:33.000Z",
+      "lastModified": "2026-05-02T08:44:09.000Z"
+    },
+    {
+      "rank": 476,
+      "id": "ACE-Step/Ace-Step1.5",
+      "author": "ACE-Step",
+      "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
+      "downloads": 49549,
+      "likes": 747,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "diffusers",
+        "safetensors",
+        "acestep",
+        "feature-extraction",
+        "audio",
+        "music",
+        "text2music",
+        "text-to-audio",
+        "custom_code",
+        "arxiv:2602.00744",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-01-23T09:59:48.000Z",
+      "lastModified": "2026-02-03T11:37:37.000Z"
+    },
+    {
+      "rank": 477,
+      "id": "Qwen/Qwen3-VL-8B-Instruct",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
+      "downloads": 5539938,
+      "likes": 902,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "conversational",
+        "arxiv:2505.09388",
+        "arxiv:2502.13923",
+        "arxiv:2409.12191",
+        "arxiv:2308.12966",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-10-11T07:23:39.000Z",
+      "lastModified": "2025-10-15T16:16:59.000Z"
+    },
+    {
+      "rank": 478,
+      "id": "SeeSee21/Z-Image-Turbo-AIO",
+      "author": "SeeSee21",
+      "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
+      "downloads": 130,
+      "likes": 254,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "z-image-turbo",
+        "text-to-image",
+        "image-generation",
+        "diffusion",
+        "comfyui",
+        "photorealistic",
+        "bilingual",
+        "chinese",
+        "english",
+        "8-step",
+        "fast-generation",
+        "en",
+        "zh",
+        "base_model:Tongyi-MAI/Z-Image-Turbo",
+        "base_model:finetune:Tongyi-MAI/Z-Image-Turbo",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-03T21:24:19.000Z",
+      "lastModified": "2026-01-03T14:49:06.000Z"
+    },
+    {
+      "rank": 479,
+      "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
+      "author": "Naphula",
+      "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
+      "downloads": 250,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "mergekit",
+        "merge",
+        "moe_karcher",
+        "conversational",
+        "eng",
+        "base_model:ApocalypseParty/G4-26B-SFT-6",
+        "base_model:merge:ApocalypseParty/G4-26B-SFT-6",
+        "base_model:AuriAetherwiing/G4-26B-A4B-Musica-v1",
+        "base_model:merge:AuriAetherwiing/G4-26B-A4B-Musica-v1",
+        "base_model:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
+        "base_model:merge:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:merge:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-07T11:40:11.000Z",
+      "lastModified": "2026-05-08T14:22:31.000Z"
+    },
+    {
+      "rank": 480,
+      "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
+      "downloads": 3058,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_h",
+        "text-generation",
+        "nvidia",
+        "pytorch",
+        "elastic",
+        "conversational",
+        "custom_code",
+        "en",
+        "es",
+        "fr",
+        "de",
+        "ja",
+        "it",
+        "arxiv:2512.20848",
+        "arxiv:2511.16664",
+        "base_model:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "base_model:finetune:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "license:other",
+        "endpoints_compatible",
+        "8-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T16:04:08.000Z",
+      "lastModified": "2026-05-08T03:42:19.000Z"
+    },
+    {
+      "rank": 481,
+      "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
+      "author": "IAAR-Shanghai",
+      "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
+      "downloads": 1024,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "privacy",
+        "privacy-detection",
+        "memory",
+        "personalized-memory",
+        "memory-system",
+        "memory-management",
+        "agent",
+        "agent-memory",
+        "information-security",
+        "information-extraction",
+        "edge-cloud",
+        "conversational",
+        "en",
+        "zh",
+        "arxiv:2605.09530",
+        "base_model:Qwen/Qwen3-1.7B",
+        "base_model:finetune:Qwen/Qwen3-1.7B",
+        "license:cc-by-nc-nd-4.0",
+        "text-generation-inference",
+        "region:us"
+      ],
+      "createdAt": "2026-05-09T15:03:21.000Z",
+      "lastModified": "2026-05-15T03:09:28.000Z"
+    },
+    {
+      "rank": 482,
+      "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
+      "author": "Jiunsong",
+      "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
+      "downloads": 26377,
+      "likes": 236,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "gemma4",
+        "uncensored",
+        "apple-silicon",
+        "4bit",
+        "quantized",
+        "reasoning",
+        "tool-use",
+        "coding",
+        "browser-automation",
+        "korean",
+        "fast",
+        "text-generation",
+        "conversational",
+        "en",
+        "ko",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:gemma",
+        "4-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-10T07:52:18.000Z",
+      "lastModified": "2026-04-12T13:34:53.000Z"
+    },
+    {
+      "rank": 483,
+      "id": "Qwen/Qwen-Image-Edit-2509",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
+      "downloads": 222047,
+      "likes": 1137,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "license:apache-2.0",
+        "diffusers:QwenImageEditPlusPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-09-22T13:09:40.000Z",
+      "lastModified": "2025-09-22T13:37:12.000Z"
+    },
+    {
+      "rank": 484,
+      "id": "ggerganov/whisper.cpp",
+      "author": "ggerganov",
+      "url": "https://huggingface.co/ggerganov/whisper.cpp",
+      "downloads": 0,
+      "likes": 1409,
+      "trendingScore": 12,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "automatic-speech-recognition",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2023-03-22T08:01:21.000Z",
+      "lastModified": "2024-10-29T18:25:17.000Z"
+    },
+    {
+      "rank": 485,
+      "id": "infly/Infinity-Parser2-Flash",
+      "author": "infly",
+      "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
+      "downloads": 4190,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-02-27T07:54:48.000Z",
+      "lastModified": "2026-05-16T01:59:44.000Z"
+    },
+    {
+      "rank": 486,
+      "id": "0G-AI/0GM-1.0-35B-A3B-0427",
+      "author": "0G-AI",
+      "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
+      "downloads": 299,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "moe",
+        "mixture-of-experts",
+        "conversational",
+        "en",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T02:18:11.000Z",
+      "lastModified": "2026-05-14T02:31:20.000Z"
+    },
+    {
+      "rank": 487,
+      "id": "PaddlePaddle/PaddleOCR-VL-1.5",
+      "author": "PaddlePaddle",
+      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
+      "downloads": 33832,
+      "likes": 640,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "PaddleOCR",
+      "tags": [
+        "PaddleOCR",
+        "safetensors",
+        "ERNIE4.5",
+        "PaddlePaddle",
+        "image-to-text",
+        "ocr",
+        "document-parse",
+        "layout",
+        "table",
+        "formula",
+        "chart",
+        "seal",
+        "spotting",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "multilingual",
+        "arxiv:2601.21957",
+        "base_model:baidu/ERNIE-4.5-0.3B-Paddle",
+        "base_model:finetune:baidu/ERNIE-4.5-0.3B-Paddle",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-28T12:43:01.000Z",
+      "lastModified": "2026-04-30T09:36:47.000Z"
+    },
+    {
+      "rank": 488,
+      "id": "google/gemma-4-26B-A4B",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-26B-A4B",
+      "downloads": 221885,
+      "likes": 270,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-03-12T00:38:03.000Z",
+      "lastModified": "2026-04-02T16:13:38.000Z"
+    },
+    {
+      "rank": 489,
+      "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+      "author": "OsaurusAI",
+      "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+      "downloads": 5987,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "deepseek_v4",
+        "jang",
+        "jangtq",
+        "jangtq2",
+        "jangtq-prestack",
+        "mxtq",
+        "deepseek",
+        "deepseek-v4",
+        "deepseek-v4-flash",
+        "moe",
+        "mla",
+        "hash-layers",
+        "mtp",
+        "apple-silicon",
+        "osaurus",
+        "text-generation",
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T13:08:35.000Z",
+      "lastModified": "2026-05-12T13:09:29.000Z"
+    },
+    {
+      "rank": 490,
+      "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
+      "author": "treadon",
+      "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
+      "downloads": 4918,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "minicpmv4_6",
+        "image-text-to-text",
+        "abliteration",
+        "disinhibition",
+        "minicpm-v",
+        "mechanistic-interpretability",
+        "conversational",
+        "base_model:openbmb/MiniCPM-V-4.6",
+        "base_model:quantized:openbmb/MiniCPM-V-4.6",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T21:34:24.000Z",
+      "lastModified": "2026-05-12T02:18:15.000Z"
+    },
+    {
+      "rank": 491,
+      "id": "Datadog/Toto-2.0-1B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
+      "downloads": 1105,
+      "likes": 14,
+      "trendingScore": 12,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "arxiv:2605.20119",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:41:57.000Z",
+      "lastModified": "2026-05-20T14:30:49.000Z"
+    },
+    {
+      "rank": 492,
+      "id": "Qwen/Qwen3-1.7B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
+      "downloads": 3611424,
+      "likes": 473,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "conversational",
+        "arxiv:2505.09388",
+        "base_model:Qwen/Qwen3-1.7B-Base",
+        "base_model:finetune:Qwen/Qwen3-1.7B-Base",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-04-27T03:41:05.000Z",
+      "lastModified": "2025-07-26T03:46:32.000Z"
+    },
+    {
+      "rank": 493,
+      "id": "black-forest-labs/FLUX.1-Kontext-dev",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+      "downloads": 77442,
+      "likes": 2630,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-generation",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "arxiv:2506.15742",
+        "license:other",
+        "diffusers:FluxKontextPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-05-28T22:23:43.000Z",
+      "lastModified": "2026-01-01T15:35:36.000Z"
+    },
+    {
+      "rank": 494,
+      "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
+      "downloads": 151146,
+      "likes": 482,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "unsloth",
+        "qwen",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:quantized:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-20T02:31:59.000Z",
+      "lastModified": "2026-01-08T21:13:12.000Z"
+    },
+    {
+      "rank": 495,
+      "id": "openbmb/BitCPM4-CANN-8B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
+      "downloads": 204,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "minicpm",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:51.000Z",
+      "lastModified": "2026-05-22T10:05:30.000Z"
+    },
+    {
+      "rank": 496,
+      "id": "SeeSee21/AniSee",
+      "author": "SeeSee21",
+      "url": "https://huggingface.co/SeeSee21/AniSee",
+      "downloads": 90,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "anisee",
+        "text-to-image",
+        "anime",
+        "anima",
+        "diffusion",
+        "comfyui",
+        "fine-tune",
+        "safetensors",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T16:28:42.000Z",
+      "lastModified": "2026-05-17T17:06:08.000Z"
+    },
+    {
+      "rank": 497,
+      "id": "unsloth/MiniMax-M2.7-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
+      "downloads": 163268,
+      "likes": 185,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "minimax_m2",
+        "unsloth",
+        "text-generation",
+        "base_model:MiniMaxAI/MiniMax-M2.7",
+        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-11T23:31:02.000Z",
+      "lastModified": "2026-04-14T16:48:17.000Z"
+    },
+    {
+      "rank": 498,
+      "id": "nicolas-dufour/miro",
+      "author": "nicolas-dufour",
+      "url": "https://huggingface.co/nicolas-dufour/miro",
+      "downloads": 514,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "miro-t2i",
+      "tags": [
+        "miro-t2i",
+        "safetensors",
+        "sdxl",
+        "text-to-image",
+        "diffusion",
+        "flow-matching",
+        "miro",
+        "reward-conditioning",
+        "arxiv:2510.25897",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T14:53:08.000Z",
+      "lastModified": "2026-05-19T23:10:01.000Z"
+    },
+    {
+      "rank": 499,
+      "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "author": "mistralai",
+      "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "downloads": 1261358,
+      "likes": 860,
+      "trendingScore": 12,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "vllm",
+      "tags": [
+        "vllm",
+        "safetensors",
+        "voxtral_realtime",
+        "mistral-common",
+        "automatic-speech-recognition",
+        "en",
+        "fr",
+        "es",
+        "de",
+        "ru",
+        "zh",
+        "ja",
+        "it",
+        "pt",
+        "nl",
+        "ar",
+        "hi",
+        "ko",
+        "arxiv:2602.11298",
+        "base_model:mistralai/Ministral-3-3B-Base-2512",
+        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-21T17:22:02.000Z",
+      "lastModified": "2026-03-11T15:04:02.000Z"
+    },
+    {
+      "rank": 500,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "downloads": 13041,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T11:53:48.000Z",
+      "lastModified": "2026-05-19T13:01:22.000Z"
+    },
+    {
+      "rank": 501,
+      "id": "zemelee/qwen2.5-jailbreak",
+      "author": "zemelee",
+      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
+      "downloads": 883,
+      "likes": 24,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-05-08T06:14:45.000Z",
+      "lastModified": "2025-05-08T06:56:32.000Z"
+    },
+    {
+      "rank": 502,
+      "id": "SupraLabs/Supra-50M-Base",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
+      "downloads": 542,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:00:44.000Z",
+      "lastModified": "2026-05-27T13:53:55.000Z"
+    },
+    {
+      "rank": 503,
+      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "author": "alibaba-pai",
+      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "downloads": 9841,
+      "likes": 157,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "videox_fun",
+      "tags": [
+        "videox_fun",
+        "lora",
+        "text-to-image",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-02-02T09:37:39.000Z",
+      "lastModified": "2026-03-02T11:46:41.000Z"
+    },
+    {
+      "rank": 504,
+      "id": "Qwen/Qwen3.5-122B-A10B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
+      "downloads": 843734,
+      "likes": 555,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "conversational",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-02-24T09:43:37.000Z",
+      "lastModified": "2026-04-24T03:55:23.000Z"
+    },
+    {
       "rank": 505,
+      "id": "ruvnet/wifi-densepose-pretrained",
+      "author": "ruvnet",
+      "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
+      "downloads": 493,
+      "likes": 18,
+      "trendingScore": 12,
+      "pipelineTag": "other",
+      "libraryName": "onnxruntime",
+      "tags": [
+        "onnxruntime",
+        "safetensors",
+        "sona-lora",
+        "wifi-sensing",
+        "vital-signs",
+        "presence-detection",
+        "edge-ai",
+        "esp32",
+        "self-supervised",
+        "cognitum",
+        "through-wall",
+        "privacy-preserving",
+        "spiking-neural-network",
+        "ruvector",
+        "other",
+        "en",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-03T14:07:29.000Z",
+      "lastModified": "2026-04-03T18:21:10.000Z"
+    },
+    {
+      "rank": 506,
+      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "author": "opendatalab",
+      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "downloads": 535,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_vl",
+        "image-text-to-text",
+        "conversational",
+        "zh",
+        "en",
+        "arxiv:2604.04771",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T11:00:43.000Z",
+      "lastModified": "2026-05-25T10:58:41.000Z"
+    },
+    {
+      "rank": 507,
+      "id": "joyfox/LTX-2.3-Transition-LORA",
+      "author": "joyfox",
+      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
+      "downloads": 36829,
+      "likes": 117,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ValiantCat",
+        "Lightricks",
+        "LTX-2.3",
+        "image-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-20T10:25:10.000Z",
+      "lastModified": "2026-03-30T03:28:58.000Z"
+    },
+    {
+      "rank": 508,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
@@ -14891,48 +14962,7 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 506,
-      "id": "agents-course/notebooks",
-      "author": "agents-course",
-      "url": "https://huggingface.co/agents-course/notebooks",
-      "downloads": 0,
-      "likes": 571,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-02-10T17:02:18.000Z",
-      "lastModified": "2026-04-27T08:00:30.000Z"
-    },
-    {
-      "rank": 507,
-      "id": "prism-ml/bonsai-image-binary-4B-unpacked",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
-      "downloads": 0,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:40:11.000Z",
-      "lastModified": "2026-05-26T16:16:58.000Z"
-    },
-    {
-      "rank": 508,
+      "rank": 509,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -14977,7 +15007,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 509,
+      "rank": 510,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -15019,7 +15049,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 510,
+      "rank": 511,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -15045,7 +15075,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 511,
+      "rank": 512,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -15070,7 +15100,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 512,
+      "rank": 513,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -15087,7 +15117,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 513,
+      "rank": 514,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -15115,7 +15145,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 514,
+      "rank": 515,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -15141,7 +15171,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 515,
+      "rank": 516,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -15168,7 +15198,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 516,
+      "rank": 517,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -15196,7 +15226,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 517,
+      "rank": 518,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -15229,7 +15259,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 518,
+      "rank": 519,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -15263,7 +15293,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 519,
+      "rank": 520,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -15292,7 +15322,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 520,
+      "rank": 521,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -15321,7 +15351,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 521,
+      "rank": 522,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -15354,7 +15384,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 522,
+      "rank": 523,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -15381,7 +15411,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 523,
+      "rank": 524,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -15411,7 +15441,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 524,
+      "rank": 525,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -15437,7 +15467,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 525,
+      "rank": 526,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -15461,7 +15491,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 526,
+      "rank": 527,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -15488,7 +15518,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 527,
+      "rank": 528,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -15522,7 +15552,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 528,
+      "rank": 529,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -15538,7 +15568,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 529,
+      "rank": 530,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -15569,7 +15599,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 530,
+      "rank": 531,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -15591,7 +15621,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 531,
+      "rank": 532,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -15611,7 +15641,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 532,
+      "rank": 533,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -15633,7 +15663,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 533,
+      "rank": 534,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -15662,7 +15692,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 534,
+      "rank": 535,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -15687,7 +15717,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 535,
+      "rank": 536,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -15712,7 +15742,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 536,
+      "rank": 537,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -15747,7 +15777,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 537,
+      "rank": 538,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -15771,7 +15801,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 538,
+      "rank": 539,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -15802,7 +15832,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 539,
+      "rank": 540,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -15832,7 +15862,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 540,
+      "rank": 541,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -15858,7 +15888,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 541,
+      "rank": 542,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -15903,7 +15933,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 542,
+      "rank": 543,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -15930,7 +15960,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 543,
+      "rank": 544,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -15957,7 +15987,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 544,
+      "rank": 545,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -16002,7 +16032,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 545,
+      "rank": 546,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -16028,7 +16058,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 546,
+      "rank": 547,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -16057,7 +16087,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 547,
+      "rank": 548,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -16102,7 +16132,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 548,
+      "rank": 549,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -16134,7 +16164,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 549,
+      "rank": 550,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -16169,7 +16199,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 550,
+      "rank": 551,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -16214,7 +16244,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 551,
+      "rank": 552,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -16255,7 +16285,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 552,
+      "rank": 553,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -16280,7 +16310,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 553,
+      "rank": 554,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -16319,7 +16349,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 554,
+      "rank": 555,
       "id": "Abiray/L2P-model-1k-merge-INT8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
@@ -16344,7 +16374,7 @@
       "lastModified": "2026-05-23T17:24:01.000Z"
     },
     {
-      "rank": 555,
+      "rank": 556,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
@@ -16366,7 +16396,7 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 556,
+      "rank": 557,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
@@ -16396,7 +16426,7 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 557,
+      "rank": 558,
       "id": "mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
@@ -16426,12 +16456,12 @@
       "lastModified": "2026-05-10T04:13:55.000Z"
     },
     {
-      "rank": 558,
+      "rank": 559,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
-      "downloads": 34428,
-      "likes": 3495,
+      "downloads": 34229,
+      "likes": 3496,
       "trendingScore": 11,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -16449,7 +16479,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 559,
+      "rank": 560,
       "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
       "author": "Leon1000",
       "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
@@ -16477,7 +16507,7 @@
       "lastModified": "2026-05-20T00:22:04.000Z"
     },
     {
-      "rank": 560,
+      "rank": 561,
       "id": "UofTCSSLab/Maia3-79M",
       "author": "UofTCSSLab",
       "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
@@ -16501,7 +16531,7 @@
       "lastModified": "2026-05-24T16:12:28.000Z"
     },
     {
-      "rank": 561,
+      "rank": 562,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -16527,37 +16557,68 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 562,
-      "id": "prism-ml/bonsai-image-binary-4B-mlx-1bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit",
-      "downloads": 0,
-      "likes": 11,
+      "rank": 563,
+      "id": "sinimiini/HRM-Text-1B-GGUF",
+      "author": "sinimiini",
+      "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
+      "downloads": 1977,
+      "likes": 12,
       "trendingScore": 11,
-      "pipelineTag": "text-to-image",
-      "libraryName": "mlx",
+      "pipelineTag": "text-generation",
+      "libraryName": "gguf",
       "tags": [
-        "mlx",
-        "diffusers",
-        "safetensors",
-        "1-bit",
-        "apple-silicon",
-        "on-device",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
+        "gguf",
+        "bf16",
+        "q8_0",
+        "q6_k",
+        "q5_k_m",
+        "quantized",
+        "llama.cpp",
+        "hrm",
+        "hierarchical-reasoning",
+        "prefix-lm",
+        "pre-alignment",
+        "non-chat",
+        "non-instruction-tuned",
+        "text-generation",
+        "en",
+        "base_model:sapientinc/HRM-Text-1B",
+        "base_model:quantized:sapientinc/HRM-Text-1B",
         "license:apache-2.0",
+        "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-18T15:40:10.000Z",
-      "lastModified": "2026-05-26T16:16:57.000Z"
+      "createdAt": "2026-05-21T07:34:13.000Z",
+      "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 563,
+      "rank": 564,
+      "id": "Qwen/Qwen-Image-Layered",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
+      "downloads": 57415,
+      "likes": 1087,
+      "trendingScore": 11,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-text-to-image",
+        "en",
+        "zh",
+        "arxiv:2512.15603",
+        "base_model:Qwen/Qwen-Image",
+        "base_model:finetune:Qwen/Qwen-Image",
+        "license:apache-2.0",
+        "diffusers:QwenImageLayeredPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-12-17T06:02:34.000Z",
+      "lastModified": "2025-12-19T09:11:18.000Z"
+    },
+    {
+      "rank": 565,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -16586,7 +16647,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 564,
+      "rank": 566,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -16620,7 +16681,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 565,
+      "rank": 567,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -16665,7 +16726,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 566,
+      "rank": 568,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -16694,7 +16755,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 567,
+      "rank": 569,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -16719,7 +16780,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 568,
+      "rank": 570,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -16754,7 +16815,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 569,
+      "rank": 571,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -16781,7 +16842,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 570,
+      "rank": 572,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -16826,7 +16887,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 571,
+      "rank": 573,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -16848,7 +16909,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 572,
+      "rank": 574,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -16880,7 +16941,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 573,
+      "rank": 575,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -16905,7 +16966,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 574,
+      "rank": 576,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -16929,7 +16990,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 575,
+      "rank": 577,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -16972,7 +17033,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 576,
+      "rank": 578,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -16996,7 +17057,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 577,
+      "rank": 579,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -17025,7 +17086,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 578,
+      "rank": 580,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -17057,7 +17118,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 579,
+      "rank": 581,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -17081,7 +17142,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 580,
+      "rank": 582,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -17103,7 +17164,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 581,
+      "rank": 583,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -17128,7 +17189,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 582,
+      "rank": 584,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -17156,7 +17217,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 583,
+      "rank": 585,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -17180,7 +17241,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 584,
+      "rank": 586,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -17207,7 +17268,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 585,
+      "rank": 587,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -17224,7 +17285,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 586,
+      "rank": 588,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -17248,7 +17309,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 587,
+      "rank": 589,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -17272,7 +17333,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 588,
+      "rank": 590,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -17305,7 +17366,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 589,
+      "rank": 591,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -17339,7 +17400,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 590,
+      "rank": 592,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -17361,7 +17422,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 591,
+      "rank": 593,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -17384,7 +17445,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 592,
+      "rank": 594,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -17404,7 +17465,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 593,
+      "rank": 595,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -17436,7 +17497,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 594,
+      "rank": 596,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -17475,7 +17536,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 595,
+      "rank": 597,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -17509,7 +17570,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 596,
+      "rank": 598,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -17529,7 +17590,7 @@
       "lastModified": "2026-05-05T16:03:53.000Z"
     },
     {
-      "rank": 597,
+      "rank": 599,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -17558,7 +17619,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 598,
+      "rank": 600,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -17580,7 +17641,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 599,
+      "rank": 601,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -17612,7 +17673,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 600,
+      "rank": 602,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -17639,7 +17700,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 601,
+      "rank": 603,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -17683,7 +17744,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 602,
+      "rank": 604,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -17701,7 +17762,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 603,
+      "rank": 605,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -17740,7 +17801,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 604,
+      "rank": 606,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -17779,7 +17840,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 605,
+      "rank": 607,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -17813,7 +17874,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 606,
+      "rank": 608,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -17841,7 +17902,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 607,
+      "rank": 609,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -17863,7 +17924,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 608,
+      "rank": 610,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -17891,7 +17952,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 609,
+      "rank": 611,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -17909,7 +17970,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 610,
+      "rank": 612,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -17937,7 +17998,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 611,
+      "rank": 613,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -17968,7 +18029,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 612,
+      "rank": 614,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -17984,7 +18045,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 613,
+      "rank": 615,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -18011,7 +18072,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 614,
+      "rank": 616,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -18040,7 +18101,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 615,
+      "rank": 617,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -18068,7 +18129,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 616,
+      "rank": 618,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -18097,7 +18158,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 617,
+      "rank": 619,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -18118,7 +18179,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 618,
+      "rank": 620,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -18139,7 +18200,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 619,
+      "rank": 621,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -18169,7 +18230,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 620,
+      "rank": 622,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -18193,7 +18254,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 621,
+      "rank": 623,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -18223,7 +18284,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 622,
+      "rank": 624,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -18254,7 +18315,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 623,
+      "rank": 625,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -18280,7 +18341,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 624,
+      "rank": 626,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -18298,7 +18359,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 625,
+      "rank": 627,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -18331,7 +18392,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 626,
+      "rank": 628,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -18356,7 +18417,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 627,
+      "rank": 629,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -18381,7 +18442,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 628,
+      "rank": 630,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -18415,7 +18476,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 629,
+      "rank": 631,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
@@ -18453,67 +18514,6 @@
       ],
       "createdAt": "2026-05-22T16:46:52.000Z",
       "lastModified": "2026-05-22T20:08:58.000Z"
-    },
-    {
-      "rank": 630,
-      "id": "sinimiini/HRM-Text-1B-GGUF",
-      "author": "sinimiini",
-      "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
-      "downloads": 1977,
-      "likes": 11,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "bf16",
-        "q8_0",
-        "q6_k",
-        "q5_k_m",
-        "quantized",
-        "llama.cpp",
-        "hrm",
-        "hierarchical-reasoning",
-        "prefix-lm",
-        "pre-alignment",
-        "non-chat",
-        "non-instruction-tuned",
-        "text-generation",
-        "en",
-        "base_model:sapientinc/HRM-Text-1B",
-        "base_model:quantized:sapientinc/HRM-Text-1B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T07:34:13.000Z",
-      "lastModified": "2026-05-21T09:49:08.000Z"
-    },
-    {
-      "rank": 631,
-      "id": "Qwen/Qwen-Image-Layered",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
-      "downloads": 57415,
-      "likes": 1086,
-      "trendingScore": 10,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-text-to-image",
-        "en",
-        "zh",
-        "arxiv:2512.15603",
-        "base_model:Qwen/Qwen-Image",
-        "base_model:finetune:Qwen/Qwen-Image",
-        "license:apache-2.0",
-        "diffusers:QwenImageLayeredPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-12-17T06:02:34.000Z",
-      "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
       "rank": 632,
@@ -21042,6 +21042,43 @@
     },
     {
       "rank": 717,
+      "id": "meta-llama/Llama-3.2-3B",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
+      "downloads": 1107796,
+      "likes": 793,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:23:48.000Z",
+      "lastModified": "2024-10-24T15:07:40.000Z"
+    },
+    {
+      "rank": 718,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -21068,7 +21105,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 718,
+      "rank": 719,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -21092,7 +21129,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 719,
+      "rank": 720,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
@@ -21112,7 +21149,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 720,
+      "rank": 721,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -21131,7 +21168,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 721,
+      "rank": 722,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -21165,7 +21202,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 722,
+      "rank": 723,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -21197,7 +21234,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 723,
+      "rank": 724,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -21219,7 +21256,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 724,
+      "rank": 725,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -21264,7 +21301,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 725,
+      "rank": 726,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -21283,7 +21320,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 726,
+      "rank": 727,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -21317,7 +21354,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 727,
+      "rank": 728,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -21345,7 +21382,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 728,
+      "rank": 729,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -21373,7 +21410,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 729,
+      "rank": 730,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -21396,7 +21433,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 730,
+      "rank": 731,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -21423,7 +21460,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 731,
+      "rank": 732,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -21468,7 +21505,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 732,
+      "rank": 733,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -21504,7 +21541,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 733,
+      "rank": 734,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -21544,7 +21581,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 734,
+      "rank": 735,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -21573,7 +21610,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 735,
+      "rank": 736,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -21601,7 +21638,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 736,
+      "rank": 737,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -21620,7 +21657,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 737,
+      "rank": 738,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -21639,7 +21676,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 738,
+      "rank": 739,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -21671,7 +21708,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 739,
+      "rank": 740,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -21698,7 +21735,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 740,
+      "rank": 741,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -21720,7 +21757,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 741,
+      "rank": 742,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -21738,7 +21775,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 742,
+      "rank": 743,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -21767,7 +21804,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 743,
+      "rank": 744,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -21788,7 +21825,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 744,
+      "rank": 745,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -21816,7 +21853,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 745,
+      "rank": 746,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -21837,7 +21874,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 746,
+      "rank": 747,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -21873,7 +21910,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 747,
+      "rank": 748,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -21896,7 +21933,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 748,
+      "rank": 749,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -21921,7 +21958,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 749,
+      "rank": 750,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -21956,7 +21993,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 750,
+      "rank": 751,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -22001,7 +22038,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 751,
+      "rank": 752,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -22028,7 +22065,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 752,
+      "rank": 753,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -22057,7 +22094,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 753,
+      "rank": 754,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -22076,7 +22113,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 754,
+      "rank": 755,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -22097,7 +22134,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 755,
+      "rank": 756,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -22123,7 +22160,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 756,
+      "rank": 757,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -22149,7 +22186,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 757,
+      "rank": 758,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -22186,7 +22223,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 758,
+      "rank": 759,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -22231,7 +22268,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 759,
+      "rank": 760,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -22256,7 +22293,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 760,
+      "rank": 761,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -22273,7 +22310,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 761,
+      "rank": 762,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -22300,7 +22337,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 762,
+      "rank": 763,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -22318,7 +22355,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 763,
+      "rank": 764,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -22343,7 +22380,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 764,
+      "rank": 765,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -22375,7 +22412,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 765,
+      "rank": 766,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -22396,7 +22433,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 766,
+      "rank": 767,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -22415,7 +22452,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 767,
+      "rank": 768,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -22446,7 +22483,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 768,
+      "rank": 769,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -22469,7 +22506,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 769,
+      "rank": 770,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -22486,7 +22523,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 770,
+      "rank": 771,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -22514,7 +22551,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 771,
+      "rank": 772,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -22531,7 +22568,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 772,
+      "rank": 773,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -22567,7 +22604,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 773,
+      "rank": 774,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -22597,7 +22634,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 774,
+      "rank": 775,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -22620,7 +22657,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 775,
+      "rank": 776,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -22653,7 +22690,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 776,
+      "rank": 777,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -22684,7 +22721,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 777,
+      "rank": 778,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -22707,7 +22744,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 778,
+      "rank": 779,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -22740,7 +22777,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 779,
+      "rank": 780,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -22763,7 +22800,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 780,
+      "rank": 781,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -22793,7 +22830,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 781,
+      "rank": 782,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -22822,7 +22859,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 782,
+      "rank": 783,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -22851,7 +22888,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 783,
+      "rank": 784,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -22887,7 +22924,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 784,
+      "rank": 785,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -22910,7 +22947,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 785,
+      "rank": 786,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -22935,7 +22972,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 786,
+      "rank": 787,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -22965,7 +23002,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 787,
+      "rank": 788,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -23001,7 +23038,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 788,
+      "rank": 789,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -23035,7 +23072,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 789,
+      "rank": 790,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -23062,7 +23099,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 790,
+      "rank": 791,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -23093,43 +23130,6 @@
       ],
       "createdAt": "2026-05-16T16:38:57.000Z",
       "lastModified": "2026-05-16T16:50:24.000Z"
-    },
-    {
-      "rank": 791,
-      "id": "meta-llama/Llama-3.2-3B",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
-      "downloads": 1107796,
-      "likes": 791,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:23:48.000Z",
-      "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
       "rank": 792,
@@ -23543,8 +23543,8 @@
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
-      "downloads": 387,
-      "likes": 246,
+      "downloads": 388,
+      "likes": 247,
       "trendingScore": 8,
       "pipelineTag": null,
       "libraryName": "diffusers",
@@ -24116,6 +24116,161 @@
     },
     {
       "rank": 826,
+      "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
+      "author": "spiritbuun",
+      "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
+      "downloads": 781,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "llama-cpp",
+      "tags": [
+        "llama-cpp",
+        "gguf",
+        "nvidia",
+        "diffusion",
+        "self-speculation",
+        "text-generation",
+        "base_model:nvidia/Nemotron-Labs-Diffusion-14B",
+        "base_model:quantized:nvidia/Nemotron-Labs-Diffusion-14B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-20T20:31:12.000Z",
+      "lastModified": "2026-05-20T20:34:29.000Z"
+    },
+    {
+      "rank": 827,
+      "id": "LiquidAI/LFM2-8B-A1B-GGUF",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF",
+      "downloads": 3210,
+      "likes": 107,
+      "trendingScore": 8,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "liquid",
+        "lfm2",
+        "edge",
+        "moe",
+        "llama.cpp",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "base_model:LiquidAI/LFM2-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2025-10-06T16:09:29.000Z",
+      "lastModified": "2026-03-30T13:41:14.000Z"
+    },
+    {
+      "rank": 828,
+      "id": "nhathoangfoto/Flux.2-Klein-9B-Mannequin",
+      "author": "nhathoangfoto",
+      "url": "https://huggingface.co/nhathoangfoto/Flux.2-Klein-9B-Mannequin",
+      "downloads": 1769,
+      "likes": 18,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "flux",
+        "flux.2",
+        "flux.2-klein",
+        "mannequin",
+        "pose-reference",
+        "character-consistency",
+        "image-to-image",
+        "text-to-image",
+        "en",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:adapter:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-19T09:02:46.000Z",
+      "lastModified": "2026-05-07T13:17:14.000Z"
+    },
+    {
+      "rank": 829,
+      "id": "nvidia/PixelDiT-1300M-1024px",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px",
+      "downloads": 53,
+      "likes": 28,
+      "trendingScore": 8,
+      "pipelineTag": "text-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "pixeldit",
+        "image-generation",
+        "text-to-image",
+        "diffusion",
+        "pixel-space",
+        "dit",
+        "arxiv:2511.20645",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-03-30T20:34:47.000Z",
+      "lastModified": "2026-04-15T21:45:01.000Z"
+    },
+    {
+      "rank": 830,
+      "id": "Kaikaku/epicure-cooc",
+      "author": "Kaikaku",
+      "url": "https://huggingface.co/Kaikaku/epicure-cooc",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "feature-extraction",
+      "libraryName": "custom",
+      "tags": [
+        "custom",
+        "ingredient-embeddings",
+        "food",
+        "computational-gastronomy",
+        "metapath2vec",
+        "skip-gram",
+        "word2vec",
+        "retrieval",
+        "feature-extraction",
+        "en",
+        "zh",
+        "ru",
+        "vi",
+        "es",
+        "tr",
+        "id",
+        "de",
+        "dataset:Kaikaku/epicure-corpus-resources",
+        "arxiv:2605.22391",
+        "license:cc-by-4.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T13:43:23.000Z",
+      "lastModified": "2026-05-27T13:44:09.000Z"
+    },
+    {
+      "rank": 831,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -24141,7 +24296,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 827,
+      "rank": 832,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -24158,7 +24313,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 828,
+      "rank": 833,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -24186,7 +24341,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 829,
+      "rank": 834,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -24221,7 +24376,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 830,
+      "rank": 835,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -24246,7 +24401,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 831,
+      "rank": 836,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -24276,7 +24431,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 832,
+      "rank": 837,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -24305,7 +24460,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 833,
+      "rank": 838,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -24332,7 +24487,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 834,
+      "rank": 839,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -24358,7 +24513,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 835,
+      "rank": 840,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -24389,7 +24544,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 836,
+      "rank": 841,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -24407,7 +24562,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 837,
+      "rank": 842,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -24436,7 +24591,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 838,
+      "rank": 843,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -24459,7 +24614,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 839,
+      "rank": 844,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -24504,7 +24659,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 840,
+      "rank": 845,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -24530,7 +24685,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 841,
+      "rank": 846,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -24558,7 +24713,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 842,
+      "rank": 847,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -24596,7 +24751,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 843,
+      "rank": 848,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -24623,7 +24778,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 844,
+      "rank": 849,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -24649,7 +24804,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 845,
+      "rank": 850,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -24667,7 +24822,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 846,
+      "rank": 851,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -24693,7 +24848,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 847,
+      "rank": 852,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -24734,7 +24889,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 848,
+      "rank": 853,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -24751,7 +24906,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 849,
+      "rank": 854,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -24784,7 +24939,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 850,
+      "rank": 855,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -24818,7 +24973,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 851,
+      "rank": 856,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -24857,7 +25012,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 852,
+      "rank": 857,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -24887,7 +25042,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 853,
+      "rank": 858,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -24913,7 +25068,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 854,
+      "rank": 859,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -24949,7 +25104,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 855,
+      "rank": 860,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -24979,7 +25134,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 856,
+      "rank": 861,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -25017,7 +25172,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 857,
+      "rank": 862,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -25052,7 +25207,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 858,
+      "rank": 863,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -25069,7 +25224,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 859,
+      "rank": 864,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -25111,7 +25266,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 860,
+      "rank": 865,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -25141,7 +25296,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 861,
+      "rank": 866,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -25166,7 +25321,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 862,
+      "rank": 867,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -25194,7 +25349,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 863,
+      "rank": 868,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -25211,7 +25366,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 864,
+      "rank": 869,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -25238,7 +25393,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 865,
+      "rank": 870,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -25281,7 +25436,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 866,
+      "rank": 871,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -25321,7 +25476,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 867,
+      "rank": 872,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -25345,7 +25500,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 868,
+      "rank": 873,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -25374,7 +25529,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 869,
+      "rank": 874,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -25400,7 +25555,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 870,
+      "rank": 875,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -25439,7 +25594,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 871,
+      "rank": 876,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -25463,7 +25618,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 872,
+      "rank": 877,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -25491,7 +25646,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 873,
+      "rank": 878,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -25523,7 +25678,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 874,
+      "rank": 879,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -25553,7 +25708,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 875,
+      "rank": 880,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -25582,7 +25737,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 876,
+      "rank": 881,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -25611,7 +25766,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 877,
+      "rank": 882,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -25631,7 +25786,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 878,
+      "rank": 883,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -25661,7 +25816,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 879,
+      "rank": 884,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -25691,7 +25846,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 880,
+      "rank": 885,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -25709,7 +25864,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 881,
+      "rank": 886,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -25726,7 +25881,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 882,
+      "rank": 887,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -25762,7 +25917,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 883,
+      "rank": 888,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -25793,7 +25948,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 884,
+      "rank": 889,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -25824,7 +25979,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 885,
+      "rank": 890,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -25857,7 +26012,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 886,
+      "rank": 891,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -25885,7 +26040,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 887,
+      "rank": 892,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -25910,7 +26065,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 888,
+      "rank": 893,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -25933,7 +26088,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 889,
+      "rank": 894,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -25961,7 +26116,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 890,
+      "rank": 895,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -25994,7 +26149,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 891,
+      "rank": 896,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -26024,7 +26179,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 892,
+      "rank": 897,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -26059,7 +26214,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 893,
+      "rank": 898,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -26091,7 +26246,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 894,
+      "rank": 899,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -26116,7 +26271,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 895,
+      "rank": 900,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -26139,7 +26294,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 896,
+      "rank": 901,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -26166,7 +26321,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 897,
+      "rank": 902,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -26189,7 +26344,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 898,
+      "rank": 903,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -26234,7 +26389,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 899,
+      "rank": 904,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -26266,7 +26421,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 900,
+      "rank": 905,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -26293,7 +26448,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 901,
+      "rank": 906,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -26319,7 +26474,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 902,
+      "rank": 907,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -26351,7 +26506,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 903,
+      "rank": 908,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -26380,7 +26535,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 904,
+      "rank": 909,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -26412,7 +26567,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 905,
+      "rank": 910,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -26442,7 +26597,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 906,
+      "rank": 911,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -26459,7 +26614,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 907,
+      "rank": 912,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -26479,7 +26634,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 908,
+      "rank": 913,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -26518,7 +26673,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 909,
+      "rank": 914,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -26556,7 +26711,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 910,
+      "rank": 915,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -26584,7 +26739,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 911,
+      "rank": 916,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -26629,7 +26784,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 912,
+      "rank": 917,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -26659,7 +26814,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 913,
+      "rank": 918,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -26686,7 +26841,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 914,
+      "rank": 919,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -26712,7 +26867,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 915,
+      "rank": 920,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -26741,7 +26896,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 916,
+      "rank": 921,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -26759,7 +26914,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 917,
+      "rank": 922,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -26791,7 +26946,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 918,
+      "rank": 923,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -26818,7 +26973,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 919,
+      "rank": 924,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -26836,7 +26991,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 920,
+      "rank": 925,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -26863,7 +27018,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 921,
+      "rank": 926,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -26887,7 +27042,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 922,
+      "rank": 927,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -26932,7 +27087,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 923,
+      "rank": 928,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -26963,7 +27118,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 924,
+      "rank": 929,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -26988,7 +27143,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 925,
+      "rank": 930,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -27022,7 +27177,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 926,
+      "rank": 931,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -27063,7 +27218,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 927,
+      "rank": 932,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -27090,7 +27245,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 928,
+      "rank": 933,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -27119,7 +27274,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 929,
+      "rank": 934,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -27151,7 +27306,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 930,
+      "rank": 935,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -27175,7 +27330,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 931,
+      "rank": 936,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -27202,7 +27357,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 932,
+      "rank": 937,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -27241,7 +27396,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 933,
+      "rank": 938,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
@@ -27273,7 +27428,7 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 934,
+      "rank": 939,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -27307,7 +27462,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 935,
+      "rank": 940,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
@@ -27334,7 +27489,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 936,
+      "rank": 941,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -27362,7 +27517,7 @@
       "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 937,
+      "rank": 942,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -27390,7 +27545,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 938,
+      "rank": 943,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
@@ -27419,7 +27574,7 @@
       "lastModified": "2026-05-13T07:13:52.000Z"
     },
     {
-      "rank": 939,
+      "rank": 944,
       "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -27464,7 +27619,7 @@
       "lastModified": "2026-05-15T06:27:56.000Z"
     },
     {
-      "rank": 940,
+      "rank": 945,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
@@ -27490,7 +27645,7 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 941,
+      "rank": 946,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
@@ -27525,7 +27680,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 942,
+      "rank": 947,
       "id": "openbmb/BitCPM-CANN-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-1B",
@@ -27551,7 +27706,7 @@
       "lastModified": "2026-05-23T18:13:08.000Z"
     },
     {
-      "rank": 943,
+      "rank": 948,
       "id": "openbmb/BitCPM-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-3B",
@@ -27577,7 +27732,7 @@
       "lastModified": "2026-05-23T18:13:14.000Z"
     },
     {
-      "rank": 944,
+      "rank": 949,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -27602,7 +27757,7 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 945,
+      "rank": 950,
       "id": "zizhaotong/SCOPE",
       "author": "zizhaotong",
       "url": "https://huggingface.co/zizhaotong/SCOPE",
@@ -27636,7 +27791,7 @@
       "lastModified": "2026-05-25T02:01:22.000Z"
     },
     {
-      "rank": 946,
+      "rank": 951,
       "id": "internlm/CapRL-Video-4B",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/CapRL-Video-4B",
@@ -27656,7 +27811,7 @@
       "lastModified": "2026-05-26T12:13:45.000Z"
     },
     {
-      "rank": 947,
+      "rank": 952,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
@@ -27684,7 +27839,7 @@
       "lastModified": "2026-05-22T19:16:35.000Z"
     },
     {
-      "rank": 948,
+      "rank": 953,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -27729,7 +27884,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 949,
+      "rank": 954,
       "id": "microsoft/SchGen",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/SchGen",
@@ -27757,34 +27912,7 @@
       "lastModified": "2026-05-14T16:50:37.000Z"
     },
     {
-      "rank": 950,
-      "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
-      "author": "spiritbuun",
-      "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
-      "downloads": 781,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "llama-cpp",
-      "tags": [
-        "llama-cpp",
-        "gguf",
-        "nvidia",
-        "diffusion",
-        "self-speculation",
-        "text-generation",
-        "base_model:nvidia/Nemotron-Labs-Diffusion-14B",
-        "base_model:quantized:nvidia/Nemotron-Labs-Diffusion-14B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-20T20:31:12.000Z",
-      "lastModified": "2026-05-20T20:34:29.000Z"
-    },
-    {
-      "rank": 951,
+      "rank": 955,
       "id": "HuggingFaceBio/Carbon-8B-GGUF",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B-GGUF",
@@ -27809,12 +27937,12 @@
       "lastModified": "2026-05-21T21:32:52.000Z"
     },
     {
-      "rank": 952,
+      "rank": 956,
       "id": "google/electra-base-discriminator",
       "author": "google",
       "url": "https://huggingface.co/google/electra-base-discriminator",
       "downloads": 56606743,
-      "likes": 114,
+      "likes": 115,
       "trendingScore": 7,
       "pipelineTag": null,
       "libraryName": "transformers",
@@ -27836,7 +27964,7 @@
       "lastModified": "2024-02-29T10:20:20.000Z"
     },
     {
-      "rank": 953,
+      "rank": 957,
       "id": "stabilityai/stable-video-diffusion-img2vid-xt-1-1",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1",
@@ -27857,44 +27985,7 @@
       "lastModified": "2024-07-10T11:52:10.000Z"
     },
     {
-      "rank": 954,
-      "id": "LiquidAI/LFM2-8B-A1B-GGUF",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF",
-      "downloads": 3210,
-      "likes": 106,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "liquid",
-        "lfm2",
-        "edge",
-        "moe",
-        "llama.cpp",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "base_model:LiquidAI/LFM2-8B-A1B",
-        "base_model:quantized:LiquidAI/LFM2-8B-A1B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2025-10-06T16:09:29.000Z",
-      "lastModified": "2026-03-30T13:41:14.000Z"
-    },
-    {
-      "rank": 955,
+      "rank": 958,
       "id": "EssentialAI/rnj-1.5-instruct",
       "author": "EssentialAI",
       "url": "https://huggingface.co/EssentialAI/rnj-1.5-instruct",
@@ -27928,7 +28019,7 @@
       "lastModified": "2026-05-26T06:18:03.000Z"
     },
     {
-      "rank": 956,
+      "rank": 959,
       "id": "chili-lab/Ouro-hybrid-1.4B",
       "author": "chili-lab",
       "url": "https://huggingface.co/chili-lab/Ouro-hybrid-1.4B",
@@ -27962,7 +28053,7 @@
       "lastModified": "2026-05-19T20:51:28.000Z"
     },
     {
-      "rank": 957,
+      "rank": 960,
       "id": "meituan-longcat/WBench-weights",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/WBench-weights",
@@ -27985,12 +28076,12 @@
       "lastModified": "2026-05-27T03:01:06.000Z"
     },
     {
-      "rank": 958,
+      "rank": 961,
       "id": "briaai/RMBG-1.4",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-1.4",
       "downloads": 385977,
-      "likes": 1981,
+      "likes": 1980,
       "trendingScore": 7,
       "pipelineTag": "image-segmentation",
       "libraryName": "transformers",
@@ -28016,7 +28107,7 @@
       "lastModified": "2025-07-06T08:27:49.000Z"
     },
     {
-      "rank": 959,
+      "rank": 962,
       "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -28056,37 +28147,7 @@
       "lastModified": "2025-05-22T23:44:50.000Z"
     },
     {
-      "rank": 960,
-      "id": "nhathoangfoto/Flux.2-Klein-9B-Mannequin",
-      "author": "nhathoangfoto",
-      "url": "https://huggingface.co/nhathoangfoto/Flux.2-Klein-9B-Mannequin",
-      "downloads": 1769,
-      "likes": 17,
-      "trendingScore": 7,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "flux",
-        "flux.2",
-        "flux.2-klein",
-        "mannequin",
-        "pose-reference",
-        "character-consistency",
-        "image-to-image",
-        "text-to-image",
-        "en",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:adapter:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-19T09:02:46.000Z",
-      "lastModified": "2026-05-07T13:17:14.000Z"
-    },
-    {
-      "rank": 961,
+      "rank": 963,
       "id": "mlx-community/Qwen3.6-27B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-OptiQ-4bit",
@@ -28118,7 +28179,7 @@
       "lastModified": "2026-05-26T06:39:22.000Z"
     },
     {
-      "rank": 962,
+      "rank": 964,
       "id": "BeaverAI/Orion-26B-A4B-v1a-GGUF",
       "author": "BeaverAI",
       "url": "https://huggingface.co/BeaverAI/Orion-26B-A4B-v1a-GGUF",
@@ -28137,7 +28198,78 @@
       "lastModified": "2026-05-24T19:21:53.000Z"
     },
     {
-      "rank": 963,
+      "rank": 965,
+      "id": "google/gemma-2b-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-2b-it",
+      "downloads": 64559,
+      "likes": 894,
+      "trendingScore": 7,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "gemma",
+        "text-generation",
+        "conversational",
+        "arxiv:2312.11805",
+        "arxiv:2009.03300",
+        "arxiv:1905.07830",
+        "arxiv:1911.11641",
+        "arxiv:1904.09728",
+        "arxiv:1905.10044",
+        "arxiv:1907.10641",
+        "arxiv:1811.00937",
+        "arxiv:1809.02789",
+        "arxiv:1911.01547",
+        "arxiv:1705.03551",
+        "arxiv:2107.03374",
+        "arxiv:2108.07732",
+        "arxiv:2110.14168",
+        "arxiv:2304.06364",
+        "arxiv:2206.04615",
+        "arxiv:1804.06876",
+        "arxiv:2110.08193",
+        "arxiv:2009.11462",
+        "arxiv:2101.11718",
+        "arxiv:1804.09301",
+        "arxiv:2109.07958",
+        "arxiv:2203.09509",
+        "license:gemma"
+      ],
+      "createdAt": "2024-02-08T13:23:59.000Z",
+      "lastModified": "2024-09-27T12:19:02.000Z"
+    },
+    {
+      "rank": 966,
+      "id": "Disty0/RaiFlow-v0_01-256px-rough-pre-train",
+      "author": "Disty0",
+      "url": "https://huggingface.co/Disty0/RaiFlow-v0_01-256px-rough-pre-train",
+      "downloads": 105,
+      "likes": 7,
+      "trendingScore": 7,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "raiflow",
+        "text-to-image",
+        "dataset:Disty0/danbooru_curated-jxl_lossless_4mp",
+        "dataset:Disty0/anime-pictures_curated-jxl_lossless_4mp",
+        "dataset:Disty0/pixiv_curated-jxl_lossless_4mp",
+        "dataset:Disty0/vncg_curated-jxl",
+        "license:cc-by-sa-4.0",
+        "diffusers:RaiFlowPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T20:07:55.000Z",
+      "lastModified": "2026-05-27T17:40:48.000Z"
+    },
+    {
+      "rank": 967,
       "id": "mistralai/Voxtral-Small-24B-2507",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Small-24B-2507",
@@ -28170,7 +28302,7 @@
       "lastModified": "2025-12-20T23:34:49.000Z"
     },
     {
-      "rank": 964,
+      "rank": 968,
       "id": "ibm-granite/granitelib-core-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-core-r1.0",
@@ -28199,7 +28331,7 @@
       "lastModified": "2026-05-06T14:30:03.000Z"
     },
     {
-      "rank": 965,
+      "rank": 969,
       "id": "lightonai/LightOnOCR-2-1B",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/LightOnOCR-2-1B",
@@ -28244,7 +28376,7 @@
       "lastModified": "2026-05-04T09:33:08.000Z"
     },
     {
-      "rank": 966,
+      "rank": 970,
       "id": "mlx-community/Qwen3.5-9B-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -28273,7 +28405,7 @@
       "lastModified": "2026-03-23T17:58:27.000Z"
     },
     {
-      "rank": 967,
+      "rank": 971,
       "id": "Crownelius/Crow-9B-HERETIC-4.6",
       "author": "Crownelius",
       "url": "https://huggingface.co/Crownelius/Crow-9B-HERETIC-4.6",
@@ -28318,7 +28450,7 @@
       "lastModified": "2026-03-17T08:41:49.000Z"
     },
     {
-      "rank": 968,
+      "rank": 972,
       "id": "Lightricks/LTX-2.3-fp8",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
@@ -28362,7 +28494,7 @@
       "lastModified": "2026-03-16T12:32:48.000Z"
     },
     {
-      "rank": 969,
+      "rank": 973,
       "id": "ibm-granite/granite-4.1-8b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b-base",
@@ -28388,7 +28520,7 @@
       "lastModified": "2026-04-28T23:26:29.000Z"
     },
     {
-      "rank": 970,
+      "rank": 974,
       "id": "ibm-granite/granite-4.1-30b-base",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b-base",
@@ -28414,7 +28546,7 @@
       "lastModified": "2026-04-28T23:23:32.000Z"
     },
     {
-      "rank": 971,
+      "rank": 975,
       "id": "Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/MiniMax-M2.7-Abliterated-Heretic-GGUF",
@@ -28446,7 +28578,7 @@
       "lastModified": "2026-04-14T04:17:05.000Z"
     },
     {
-      "rank": 972,
+      "rank": 976,
       "id": "unsloth/ERNIE-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/ERNIE-Image-Turbo-GGUF",
@@ -28469,7 +28601,7 @@
       "lastModified": "2026-04-14T23:56:23.000Z"
     },
     {
-      "rank": 973,
+      "rank": 977,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview",
@@ -28512,7 +28644,7 @@
       "lastModified": "2026-04-23T03:21:39.000Z"
     },
     {
-      "rank": 974,
+      "rank": 978,
       "id": "knowledgator/gliclass-multilang-ultra",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-ultra",
@@ -28557,7 +28689,7 @@
       "lastModified": "2026-04-30T15:51:37.000Z"
     },
     {
-      "rank": 975,
+      "rank": 979,
       "id": "knowledgator/gliclass-multilang-mini",
       "author": "knowledgator",
       "url": "https://huggingface.co/knowledgator/gliclass-multilang-mini",
@@ -28602,7 +28734,7 @@
       "lastModified": "2026-04-30T15:52:36.000Z"
     },
     {
-      "rank": 976,
+      "rank": 980,
       "id": "caiovicentino1/qwen36-27b-sae-papergrade",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-papergrade",
@@ -28629,7 +28761,7 @@
       "lastModified": "2026-04-26T23:03:58.000Z"
     },
     {
-      "rank": 977,
+      "rank": 981,
       "id": "sphaela/Qwen3.6-27B-AutoRound-GGUF",
       "author": "sphaela",
       "url": "https://huggingface.co/sphaela/Qwen3.6-27B-AutoRound-GGUF",
@@ -28656,7 +28788,7 @@
       "lastModified": "2026-05-06T12:31:47.000Z"
     },
     {
-      "rank": 978,
+      "rank": 982,
       "id": "morikomorizz/GRM-2.6-Plus-GGUF",
       "author": "morikomorizz",
       "url": "https://huggingface.co/morikomorizz/GRM-2.6-Plus-GGUF",
@@ -28681,7 +28813,7 @@
       "lastModified": "2026-05-11T12:08:48.000Z"
     },
     {
-      "rank": 979,
+      "rank": 983,
       "id": "lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distilled",
@@ -28720,7 +28852,7 @@
       "lastModified": "2026-04-28T17:43:42.000Z"
     },
     {
-      "rank": 980,
+      "rank": 984,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
@@ -28745,7 +28877,7 @@
       "lastModified": "2026-04-30T08:47:26.000Z"
     },
     {
-      "rank": 981,
+      "rank": 985,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro-Base",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base",
@@ -28773,7 +28905,7 @@
       "lastModified": "2026-05-08T08:10:59.000Z"
     },
     {
-      "rank": 982,
+      "rank": 986,
       "id": "jjiaweiyang/FD-Loss",
       "author": "jjiaweiyang",
       "url": "https://huggingface.co/jjiaweiyang/FD-Loss",
@@ -28798,7 +28930,7 @@
       "lastModified": "2026-05-01T01:48:44.000Z"
     },
     {
-      "rank": 983,
+      "rank": 987,
       "id": "oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LTX-2.3-22b-IC-LoRA-MotionDeblur",
@@ -28814,7 +28946,7 @@
       "lastModified": "2026-04-28T16:22:23.000Z"
     },
     {
-      "rank": 984,
+      "rank": 988,
       "id": "mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Ling-2.6-flash-mlx-4bit-DWQ",
@@ -28841,7 +28973,7 @@
       "lastModified": "2026-04-30T05:43:39.000Z"
     },
     {
-      "rank": 985,
+      "rank": 989,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GPTQ-Int4",
@@ -28873,7 +29005,7 @@
       "lastModified": "2026-05-01T17:06:00.000Z"
     },
     {
-      "rank": 986,
+      "rank": 990,
       "id": "RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-IQ4_KS-GGUF",
@@ -28903,7 +29035,7 @@
       "lastModified": "2026-05-02T12:30:47.000Z"
     },
     {
-      "rank": 987,
+      "rank": 991,
       "id": "josephmayo/Qwopus-9B-Unfettered-GGUF",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered-GGUF",
@@ -28935,7 +29067,7 @@
       "lastModified": "2026-05-03T01:09:49.000Z"
     },
     {
-      "rank": 988,
+      "rank": 992,
       "id": "zed-industries/zeta-2",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2",
@@ -28963,7 +29095,7 @@
       "lastModified": "2026-03-23T18:31:36.000Z"
     },
     {
-      "rank": 989,
+      "rank": 993,
       "id": "unsloth/DeepSeek-V4-Flash",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Flash",
@@ -28989,7 +29121,7 @@
       "lastModified": "2026-04-24T15:54:17.000Z"
     },
     {
-      "rank": 990,
+      "rank": 994,
       "id": "z-lab/gemma-4-E2B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-E2B-it-PARO",
@@ -29018,7 +29150,7 @@
       "lastModified": "2026-05-08T06:20:11.000Z"
     },
     {
-      "rank": 991,
+      "rank": 995,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -29060,7 +29192,7 @@
       "lastModified": "2026-04-29T16:15:20.000Z"
     },
     {
-      "rank": 992,
+      "rank": 996,
       "id": "unsloth/Qwen3.6-35B-A3B-MLX-8bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MLX-8bit",
@@ -29087,7 +29219,7 @@
       "lastModified": "2026-04-17T08:26:25.000Z"
     },
     {
-      "rank": 993,
+      "rank": 997,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Text-NVFP4-MTP-XS",
@@ -29132,7 +29264,7 @@
       "lastModified": "2026-05-01T06:44:17.000Z"
     },
     {
-      "rank": 994,
+      "rank": 998,
       "id": "bartowski/ibm-granite_granite-4.1-30b-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/ibm-granite_granite-4.1-30b-GGUF",
@@ -29158,7 +29290,7 @@
       "lastModified": "2026-04-29T21:37:20.000Z"
     },
     {
-      "rank": 995,
+      "rank": 999,
       "id": "black-forest-labs/FLUX.1-dev-FP8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev-FP8",
@@ -29178,7 +29310,7 @@
       "lastModified": "2026-01-01T15:41:40.000Z"
     },
     {
-      "rank": 996,
+      "rank": 1000,
       "id": "openbmb/MiniCPM-o-4_5-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5-gguf",
@@ -29203,131 +29335,6 @@
       ],
       "createdAt": "2026-02-02T04:42:00.000Z",
       "lastModified": "2026-02-12T05:05:50.000Z"
-    },
-    {
-      "rank": 997,
-      "id": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
-      "author": "saricles",
-      "url": "https://huggingface.co/saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
-      "downloads": 16003,
-      "likes": 19,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "minimax_m2",
-        "text-generation",
-        "minimax",
-        "reap",
-        "nvfp4",
-        "4-bit",
-        "quantized",
-        "compressed-tensors",
-        "vllm",
-        "DGX-Spark",
-        "GB10",
-        "MoE",
-        "agentic",
-        "tool-use",
-        "conversational",
-        "custom_code",
-        "en",
-        "zh",
-        "arxiv:2510.13999",
-        "base_model:saricles/MiniMax-M2.7-REAP-172B-A10B-BF16",
-        "base_model:finetune:saricles/MiniMax-M2.7-REAP-172B-A10B-BF16",
-        "license:other",
-        "endpoints_compatible",
-        "8-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-17T05:22:05.000Z",
-      "lastModified": "2026-04-19T14:34:59.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-UD-MLX-4bit",
-      "downloads": 85879,
-      "likes": 42,
-      "trendingScore": 6,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "unsloth",
-        "qwen",
-        "image-text-to-text",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T12:57:17.000Z",
-      "lastModified": "2026-04-22T14:12:35.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "unsloth/GLM-5.1-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/GLM-5.1-GGUF",
-      "downloads": 31077,
-      "likes": 191,
-      "trendingScore": 6,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "glm_moe_dsa",
-        "text-generation",
-        "en",
-        "zh",
-        "arxiv:2602.15763",
-        "base_model:zai-org/GLM-5.1",
-        "base_model:quantized:zai-org/GLM-5.1",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-06T16:10:05.000Z",
-      "lastModified": "2026-04-07T20:09:36.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "briaai/VRMBG-3.0",
-      "author": "briaai",
-      "url": "https://huggingface.co/briaai/VRMBG-3.0",
-      "downloads": 0,
-      "likes": 6,
-      "trendingScore": 6,
-      "pipelineTag": "image-segmentation",
-      "libraryName": null,
-      "tags": [
-        "pytorch",
-        "safetensors",
-        "video",
-        "background-removal",
-        "video-matting",
-        "temporal-consistency",
-        "realtime",
-        "autoregressive",
-        "vision",
-        "image-segmentation",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T17:16:16.000Z",
-      "lastModified": "2026-05-07T14:07:25.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26536893867

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.