### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-28T00:11:08Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-27T21:08:01.537Z",
+  "ts": "2026-05-28T00:11:08.925Z",
   "count": 1,
-  "durationMs": 14215,
+  "durationMs": 14961,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-27T21:07:56.530Z",
+  "lastFetchedAt": "2026-05-28T00:11:03.916Z",
   "windowDays": 7,
   "launches": [
     {
@@ -866,6 +866,60 @@
       "aiAdjacent": false
     },
     {
+      "id": "1154630",
+      "name": "Bluedot 2.1",
+      "tagline": "Record on Apple Watch. Sync with Claude",
+      "description": "Bluedot 2.1 brings your real-world conversations into Claude. Record conversations directly from your Apple Watch, then sync them with Claude through MCP. Capture customer calls, hallway chats, interviews, coffee meetings, and in-person conversations, without a laptop or meeting bot. Bluedot turns every conversation into searchable, AI-ready context that Claude can summarize, search, and act on.",
+      "url": "https://www.producthunt.com/products/bluedot-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/FBQTRS2UMIX3RW",
+      "votesCount": 337,
+      "commentsCount": 32,
+      "createdAt": "2026-05-27T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/4eecd806-001b-456a-b591-51fe6051d442.png?auto=format",
+      "topics": [
+        "android",
+        "apple-watch",
+        "productivity"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1033481",
       "name": "Bond",
       "tagline": "Outbound campaigns powered by real buying signals",
@@ -1001,60 +1055,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1154630",
-      "name": "Bluedot 2.1",
-      "tagline": "Record on Apple Watch. Sync with Claude",
-      "description": "Bluedot 2.1 brings your real-world conversations into Claude. Record conversations directly from your Apple Watch, then sync them with Claude through MCP. Capture customer calls, hallway chats, interviews, coffee meetings, and in-person conversations, without a laptop or meeting bot. Bluedot turns every conversation into searchable, AI-ready context that Claude can summarize, search, and act on.",
-      "url": "https://www.producthunt.com/products/bluedot-2?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/FBQTRS2UMIX3RW",
-      "votesCount": 324,
-      "commentsCount": 31,
-      "createdAt": "2026-05-27T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/4eecd806-001b-456a-b591-51fe6051d442.png?auto=format",
-      "topics": [
-        "android",
-        "apple-watch",
-        "productivity"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",
@@ -1259,6 +1259,54 @@
         "github",
         "data",
         "vercel-day"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
+      "id": "1147823",
+      "name": "Powabase",
+      "tagline": "Build AI apps with Postgres, RAG, and agents",
+      "description": "Powabase is a backend-as-a-service for AI-native applications, combining Postgres, RAG, agents, memory, workflows, and automation primitives in one platform. It helps agencies and in-house IT teams build new AI apps or add AI automation to existing products without stitching together fragmented infrastructure. Designed to work seamlessly with modern coding agents, Powabase helps teams ship faster while building more robust, token-efficient systems.",
+      "url": "https://www.producthunt.com/products/powabase?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/6BBPF3XTDL5C2Y",
+      "votesCount": 298,
+      "commentsCount": 46,
+      "createdAt": "2026-05-27T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/bc1bdf28-9b59-4509-9db7-3b604380fb3b.png?auto=format",
+      "topics": [
+        "developer-tools",
+        "artificial-intelligence",
+        "database"
       ],
       "makers": [
         {
@@ -1515,54 +1563,6 @@
         "productivity",
         "artificial-intelligence",
         "maker-tools"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1147823",
-      "name": "Powabase",
-      "tagline": "Build AI apps with Postgres, RAG, and agents",
-      "description": "Powabase is a backend-as-a-service for AI-native applications, combining Postgres, RAG, agents, memory, workflows, and automation primitives in one platform. It helps agencies and in-house IT teams build new AI apps or add AI automation to existing products without stitching together fragmented infrastructure. Designed to work seamlessly with modern coding agents, Powabase helps teams ship faster while building more robust, token-efficient systems.",
-      "url": "https://www.producthunt.com/products/powabase?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/6BBPF3XTDL5C2Y",
-      "votesCount": 284,
-      "commentsCount": 43,
-      "createdAt": "2026-05-27T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/bc1bdf28-9b59-4509-9db7-3b604380fb3b.png?auto=format",
-      "topics": [
-        "developer-tools",
-        "artificial-intelligence",
-        "database"
       ],
       "makers": [
         {
@@ -2310,6 +2310,72 @@
       "aiAdjacent": true
     },
     {
+      "id": "1156593",
+      "name": "zero.xyz",
+      "tagline": "Give your AI agent access to ~8k tools, APIs and services",
+      "description": "**Product Hunt: Claim $5 at zero.xyz, the free power tool for AI agents** Zero unblocks your agents so they can discover services to accomplish tasks, no APIs keys or config. Works with Claude Code, Codex, Gemini, OpenClaw, Hermes and most other CLI agents. Make your agents better with Zero.",
+      "url": "https://www.producthunt.com/products/zero-xyz?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/FRR5SI6KDCOK4U",
+      "votesCount": 237,
+      "commentsCount": 68,
+      "createdAt": "2026-05-27T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/3d0ef16a-bc8c-4349-a667-dce80db88456.png?auto=format",
+      "topics": [
+        "productivity",
+        "task-management",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1140851",
       "name": "Tendem by Toloka",
       "tagline": "AI platform to hand off any task to a human expert",
@@ -2399,61 +2465,6 @@
         "vibe-coding"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1153508",
-      "name": "ModelHub",
-      "tagline": "The missing menu bar app for local LLMs on Mac.",
-      "description": "ModelHub is a native macOS menu bar app for developers working with local LLMs. It helps you discover models from Hugging Face, download the right local build, manage your model library, and use Hugging Face models with Ollama, MLX, LM Studio, llama.cpp, and the tools you already have without bouncing between browser tabs, terminal commands, model cards, and local folders. Ollama, MLX, and LM Studio are great tools. ModelHub is the missing discovery and management layer around them.",
-      "url": "https://www.producthunt.com/products/modelhub?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/VKVZCCO3WNW46P",
-      "votesCount": 230,
-      "commentsCount": 27,
-      "createdAt": "2026-05-24T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/289a32f1-5f2b-49ef-9eb7-2aae920bb5e5.png?auto=format",
-      "topics": [
-        "open-source",
-        "developer-tools",
-        "github",
-        "menu-bar-apps"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26546299755

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.