### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-28T04:47:05Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-27T20:32:28.499Z",
+  "ts": "2026-05-28T04:47:05.126Z",
   "count": 1,
-  "durationMs": 5424,
+  "durationMs": 1614,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T20:32:23.077Z",
+  "fetchedAt": "2026-05-28T04:47:03.514Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -128,8 +128,8 @@
       "author": "wikimedia",
       "url": "https://huggingface.co/datasets/wikimedia/structured-wikipedia",
       "downloads": 3574,
-      "likes": 188,
-      "trendingScore": 78,
+      "likes": 194,
+      "trendingScore": 83,
       "tags": [
         "language:en",
         "language:fr",
@@ -161,8 +161,8 @@
       "author": "GD-ML",
       "url": "https://huggingface.co/datasets/GD-ML/TransitLM",
       "downloads": 1115,
-      "likes": 81,
-      "trendingScore": 76,
+      "likes": 82,
+      "trendingScore": 77,
       "tags": [
         "task_categories:text-generation",
         "language:zh",
@@ -291,8 +291,8 @@
       "author": "armand0e",
       "url": "https://huggingface.co/datasets/armand0e/qwen3.7-max-pi-traces",
       "downloads": 574,
-      "likes": 47,
-      "trendingScore": 45,
+      "likes": 48,
+      "trendingScore": 46,
       "tags": [
         "task_categories:text-generation",
         "size_categories:n<1K",
@@ -870,7 +870,7 @@
       "author": "HuggingFaceFW",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb",
       "downloads": 1033822,
-      "likes": 2835,
+      "likes": 2838,
       "trendingScore": 24,
       "tags": [
         "task_categories:text-generation",


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26555221844

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.