### PR TITLE
chore(data): refresh huggingface space signals 2026-05-28T04:55:08Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-27T20:37:10.724Z",
+  "ts": "2026-05-28T04:55:08.933Z",
   "count": 1,
-  "durationMs": 9379,
+  "durationMs": 5580,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T20:37:01.347Z",
+  "fetchedAt": "2026-05-28T04:55:03.356Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -95,8 +95,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 126,
-      "trendingScore": 121,
+      "likes": 130,
+      "trendingScore": 125,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -177,6 +177,22 @@
     },
     {
       "rank": 11,
+      "id": "webml-community/bonsai-image-webgpu",
+      "author": "webml-community",
+      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
+      "likes": 81,
+      "trendingScore": 78,
+      "sdk": "static",
+      "tags": [
+        "static",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T17:12:36.000Z",
+      "lastModified": "2026-05-26T20:57:36.000Z",
+      "models": []
+    },
+    {
+      "rank": 12,
       "id": "prithivMLmods/FireRed-Image-Edit-1.0-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/FireRed-Image-Edit-1.0-Fast",
@@ -193,7 +209,7 @@
       "models": []
     },
     {
-      "rank": 12,
+      "rank": 13,
       "id": "HiDream-ai/HiDream-O1-Image",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image",
@@ -209,7 +225,7 @@
       "models": []
     },
     {
-      "rank": 13,
+      "rank": 14,
       "id": "techfreakworm/LTX2.3-Studio",
       "author": "techfreakworm",
       "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
@@ -225,7 +241,7 @@
       "models": []
     },
     {
-      "rank": 14,
+      "rank": 15,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
@@ -241,7 +257,7 @@
       "models": []
     },
     {
-      "rank": 15,
+      "rank": 16,
       "id": "r3gm/wan2-2-fp8da-aoti-preview",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview",
@@ -258,7 +274,7 @@
       "models": []
     },
     {
-      "rank": 16,
+      "rank": 17,
       "id": "kulkas2pintu/wan222",
       "author": "kulkas2pintu",
       "url": "https://huggingface.co/spaces/kulkas2pintu/wan222",
@@ -272,22 +288,6 @@
       ],
       "createdAt": "2026-03-27T08:57:40.000Z",
       "lastModified": "2026-03-26T22:35:15.000Z",
-      "models": []
-    },
-    {
-      "rank": 17,
-      "id": "webml-community/bonsai-image-webgpu",
-      "author": "webml-community",
-      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 71,
-      "trendingScore": 69,
-      "sdk": "static",
-      "tags": [
-        "static",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T17:12:36.000Z",
-      "lastModified": "2026-05-26T20:57:36.000Z",
       "models": []
     },
     {
@@ -458,8 +458,8 @@
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 43,
-      "trendingScore": 42,
+      "likes": 45,
+      "trendingScore": 44,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -471,6 +471,22 @@
     },
     {
       "rank": 29,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 43,
+      "trendingScore": 42,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-27T11:24:58.000Z",
+      "models": []
+    },
+    {
+      "rank": 30,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -483,22 +499,6 @@
       ],
       "createdAt": "2025-12-10T03:50:25.000Z",
       "lastModified": "2025-12-17T06:32:54.000Z",
-      "models": []
-    },
-    {
-      "rank": 30,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 42,
-      "trendingScore": 41,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-27T11:24:58.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26555466220

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.