### PR TITLE
chore(data): refresh awesome-skills index 2026-05-28T08:15:18Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-27T08:15:24.855Z",
+  "ts": "2026-05-28T08:15:18.375Z",
   "count": 1,
-  "durationMs": 2486,
+  "durationMs": 2859,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-27T08:15:22.370Z",
+  "fetchedAt": "2026-05-28T08:15:15.517Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",
@@ -156,6 +156,9 @@
     "zebbern/claude-code-guide": [
       "sickn33/antigravity-awesome-skills"
     ],
+    "morsechimwai/lemmaly": [
+      "sickn33/antigravity-awesome-skills"
+    ],
     "alirezarezvani/claude-skills": [
       "sickn33/antigravity-awesome-skills"
     ],
@@ -250,6 +253,12 @@
       "sickn33/antigravity-awesome-skills"
     ],
     "almogbaku/debug-skill": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "sendblue-api/sendblue-cli": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "njerschow/textme": [
       "sickn33/antigravity-awesome-skills"
     ],
     "aptratcn/skill-audit": [
@@ -8701,6 +8710,6 @@
   "counts": {
     "lists": 4,
     "listsAttempted": 5,
-    "uniqueSkills": 2821
+    "uniqueSkills": 2824
   }
 }


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26563033550

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.