### PR TITLE
chore(data): refresh dev.to signals 2026-05-28T10:08:30Z

### DIFF
--- a/data/_meta/devto.json
+++ b/data/_meta/devto.json
@@ -1,8 +1,8 @@
 {
   "source": "devto",
   "reason": "ok",
-  "ts": "2026-05-28T03:48:45.441Z",
+  "ts": "2026-05-28T10:08:30.385Z",
   "count": 1,
-  "durationMs": 94193,
+  "durationMs": 96357,
   "extra": {}
 }

--- a/data/devto-mentions.json
+++ b/data/devto-mentions.json
@@ -1,8 +1,8 @@
 {
-  "fetchedAt": "2026-05-28T03:47:11.281Z",
+  "fetchedAt": "2026-05-28T10:06:54.064Z",
   "discoveryVersion": "2026-04-21",
   "windowDays": 7,
-  "scannedArticles": 1444,
+  "scannedArticles": 1431,
   "bodyFetchMode": "full",
   "priorityTags": [
     "ai",
@@ -179,12 +179,12 @@
   ],
   "sliceCounts": {
     "global-top-7d": 100,
-    "global-rising": 19,
+    "global-rising": 16,
     "global-fresh": 100,
     "tag-ai-top-7d": 100,
     "tag-artificialintelligence-top-7d": 0,
     "tag-agents-top-7d": 100,
-    "tag-agentic-top-7d": 5,
+    "tag-agentic-top-7d": 4,
     "tag-claudecode-top-7d": 100,
     "tag-claude-top-7d": 100,
     "tag-codex-top-7d": 8,
@@ -193,7 +193,7 @@
     "tag-llms-top-7d": 5,
     "tag-mcp-top-7d": 100,
     "tag-rag-top-7d": 100,
-    "tag-promptengineering-top-7d": 33,
+    "tag-promptengineering-top-7d": 34,
     "tag-workflow-top-7d": 41,
     "tag-workflows-top-7d": 4,
     "tag-automation-top-7d": 100,
@@ -216,7 +216,7 @@
         "author": "rohitg00",
         "reactions": 24,
         "comments": 9,
-        "hoursSincePosted": 86,
+        "hoursSincePosted": 92.3,
         "readingTime": 6
       },
       "articles": [
@@ -240,7 +240,7 @@
             "agents",
             "opensource"
           ],
-          "trendingScore": 0.73,
+          "trendingScore": 0.68,
           "linkedRepos": [
             {
               "fullName": "rohitg00/ai-engineering-from-scratch",
@@ -252,7 +252,7 @@
     },
     "vercel-labs/skills": {
       "count7d": 2,
-      "reactionsSum7d": 9,
+      "reactionsSum7d": 10,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3740141,
@@ -261,7 +261,7 @@
         "author": "deraileddash",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 89.2,
+        "hoursSincePosted": 95.5,
         "readingTime": 8
       },
       "articles": [
@@ -311,7 +311,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -321,7 +321,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -349,7 +349,7 @@
     },
     "coreyhaines31/marketingskills": {
       "count7d": 2,
-      "reactionsSum7d": 9,
+      "reactionsSum7d": 10,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3740141,
@@ -358,7 +358,7 @@
         "author": "deraileddash",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 89.2,
+        "hoursSincePosted": 95.5,
         "readingTime": 8
       },
       "articles": [
@@ -408,7 +408,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -418,7 +418,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -446,7 +446,7 @@
     },
     "vercel-labs/agent-skills": {
       "count7d": 2,
-      "reactionsSum7d": 9,
+      "reactionsSum7d": 10,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3740141,
@@ -455,7 +455,7 @@
         "author": "deraileddash",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 89.2,
+        "hoursSincePosted": 95.5,
         "readingTime": 8
       },
       "articles": [
@@ -505,7 +505,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -515,7 +515,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -552,7 +552,7 @@
         "author": "blackgirlbytes",
         "reactions": 6,
         "comments": 5,
-        "hoursSincePosted": 103.9,
+        "hoursSincePosted": 110.2,
         "readingTime": 4
       },
       "articles": [
@@ -576,7 +576,7 @@
             "opensource",
             "entire"
           ],
-          "trendingScore": 0.07,
+          "trendingScore": 0.06,
           "linkedRepos": [
             {
               "fullName": "aaif-goose/goose",
@@ -597,7 +597,7 @@
         "author": "dvddpl",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 36.8,
+        "hoursSincePosted": 43.1,
         "readingTime": 16
       },
       "articles": [
@@ -621,7 +621,7 @@
             "agenticai",
             "ainativedevelopment"
           ],
-          "trendingScore": 0.02,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "github/github-mcp-server",
@@ -642,7 +642,7 @@
         "author": "webmaxru",
         "reactions": 26,
         "comments": 0,
-        "hoursSincePosted": 55.5,
+        "hoursSincePosted": 61.9,
         "readingTime": 12
       },
       "articles": [
@@ -666,7 +666,7 @@
             "github",
             "productivity"
           ],
-          "trendingScore": 0.66,
+          "trendingScore": 0.59,
           "linkedRepos": [
             {
               "fullName": "rtk-ai/rtk",
@@ -740,113 +740,6 @@
         }
       ]
     },
-    "Lum1104/Understand-Anything": {
-      "count7d": 3,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3767071,
-        "title": "Understand-Anything: Turn Your Codebase Into a Knowledge Graph (39.6K ⭐)",
-        "url": "https://dev.to/tenglongai2026/understand-anything-turn-your-codebase-into-a-knowledge-graph-396k--49np",
-        "author": "tenglongai2026",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 4.5,
-        "readingTime": 1
-      },
-      "articles": [
-        {
-          "id": 3767071,
-          "title": "Understand-Anything: Turn Your Codebase Into a Knowledge Graph (39.6K ⭐)",
-          "description": "You know that feeling when you open a 3-year-old codebase and have zero idea where anything...",
-          "url": "https://dev.to/tenglongai2026/understand-anything-turn-your-codebase-into-a-knowledge-graph-396k--49np",
-          "author": {
-            "username": "tenglongai2026",
-            "name": "TengLongAI2026",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3953270%2Fb0f3ce1e-2eb7-410c-ad9c-d187d63fd465.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 1,
-          "publishedAt": "2026-05-27T23:20:01Z",
-          "tags": [
-            "ai",
-            "productivity"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Lum1104/Understand-Anything",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3744982,
-          "title": "One Open Source Project a Day (No. 75): Understand Anything - The AI Engine That Turns Any Codebase Into an Explorable Knowledge Graph",
-          "description": "Introduction    \"Graphs that teach &gt; graphs that impress.\"   This is the 75th article in...",
-          "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-75-understand-anything-the-ai-engine-that-turns-any-codebase-5d3i",
-          "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-25T02:50:56Z",
-          "tags": [
-            "opensource",
-            "ai",
-            "claude",
-            "agents"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Lum1104/Understand-Anything",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3759155,
-          "title": "The Representation Problem: Why RAG vs. Agentic Search Is the Wrong Debate",
-          "description": "The industry has been asking the wrong question.  When Boris Cherny — the creator and Head of Claude...",
-          "url": "https://dev.to/chen115y/the-representation-problem-why-rag-vs-agentic-search-is-the-wrong-debate-4j8f",
-          "author": {
-            "username": "chen115y",
-            "name": "Yaohua Chen",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2671324%2F3ca83c79-d0fd-40c0-b5ac-349326e71725.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 17,
-          "publishedAt": "2026-05-26T20:02:49Z",
-          "tags": [
-            "rag",
-            "ai",
-            "llm",
-            "architecture"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Lum1104/Understand-Anything",
-              "location": "body"
-            },
-            {
-              "fullName": "VectifyAI/PageIndex",
-              "location": "body"
-            },
-            {
-              "fullName": "garrytan/gbrain",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "openclaw/openclaw": {
       "count7d": 2,
       "reactionsSum7d": 10,
@@ -858,7 +751,7 @@
         "author": "numbpill3d",
         "reactions": 5,
         "comments": 0,
-        "hoursSincePosted": 126,
+        "hoursSincePosted": 132.4,
         "readingTime": 7
       },
       "articles": [
@@ -914,7 +807,7 @@
             "mcp",
             "aws"
           ],
-          "trendingScore": 0.28,
+          "trendingScore": 0.19,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -935,7 +828,7 @@
         "author": "numbpill3d",
         "reactions": 5,
         "comments": 0,
-        "hoursSincePosted": 126,
+        "hoursSincePosted": 132.4,
         "readingTime": 7
       },
       "articles": [
@@ -973,10 +866,55 @@
         }
       ]
     },
+    "anthropics/anthropic-sdk-csharp": {
+      "count7d": 1,
+      "reactionsSum7d": 8,
+      "commentsSum7d": 2,
+      "topArticle": {
+        "id": 3764750,
+        "title": "An Official Claude SDK for .NET? Yes, Really.",
+        "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
+        "author": "iamprincejkc",
+        "reactions": 8,
+        "comments": 2,
+        "hoursSincePosted": 20.5,
+        "readingTime": 3
+      },
+      "articles": [
+        {
+          "id": 3764750,
+          "title": "An Official Claude SDK for .NET? Yes, Really.",
+          "description": "If you've been building with Claude in .NET, you've probably leaned on one of the lovely community...",
+          "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
+          "author": {
+            "username": "iamprincejkc",
+            "name": "JKC",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F820392%2Fd8052783-fad7-46ae-8c9e-61391ecff65a.jpeg"
+          },
+          "reactionsCount": 8,
+          "commentsCount": 2,
+          "readingTime": 3,
+          "publishedAt": "2026-05-27T13:39:12Z",
+          "tags": [
+            "dotnet",
+            "csharp",
+            "ai",
+            "claude"
+          ],
+          "trendingScore": 0.42,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/anthropic-sdk-csharp",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "NousResearch/hermes-agent": {
-      "count7d": 11,
-      "reactionsSum7d": 23,
-      "commentsSum7d": 4,
+      "count7d": 10,
+      "reactionsSum7d": 24,
+      "commentsSum7d": 8,
       "topArticle": {
         "id": 3711818,
         "title": "How to Deploy Hermes' Self-Improving AI Agent",
@@ -984,7 +922,7 @@
         "author": "haimantika",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 35.8,
+        "hoursSincePosted": 42.1,
         "readingTime": 8
       },
       "articles": [
@@ -1008,7 +946,7 @@
             "agents",
             "tutorial"
           ],
-          "trendingScore": 0.2,
+          "trendingScore": 0.17,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -1026,8 +964,8 @@
             "name": "Stephen Sebastian",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3936117%2Faaa3e3a0-dba3-4fe6-8b19-b08e05277a74.png"
           },
-          "reactionsCount": 5,
-          "commentsCount": 1,
+          "reactionsCount": 6,
+          "commentsCount": 5,
           "readingTime": 6,
           "publishedAt": "2026-05-27T17:45:36Z",
           "tags": [
@@ -1036,7 +974,7 @@
             "agents",
             "ai"
           ],
-          "trendingScore": 0.38,
+          "trendingScore": 0.43,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -1211,33 +1149,6 @@
           ]
         },
         {
-          "id": 3753833,
-          "title": "Why Hermes Agent Compounds While LangChain Stays Flat — A Deep Architectural Breakdown",
-          "description": "This is a submission for the Hermes Agent Challenge     Every AI agent framework promises to make...",
-          "url": "https://dev.to/tejas164321/why-hermes-agent-compounds-while-langchain-stays-flat-a-deep-architectural-breakdown-pck",
-          "author": {
-            "username": "tejas164321",
-            "name": "Tejas Patil",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3828498%2Ff99fdd48-f37e-48e0-abdd-ba64eb016704.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-26T04:49:17Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3718625,
           "title": "The Coding Agent Stack Has Two Layers",
           "description": "The current \"Hermes Agent vs Claude Code\" framing is the wrong comparison. The two tools live at...",
@@ -1295,51 +1206,6 @@
         }
       ]
     },
-    "anthropics/anthropic-sdk-csharp": {
-      "count7d": 1,
-      "reactionsSum7d": 6,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3764750,
-        "title": "An Official Claude SDK for .NET? Yes, Really.",
-        "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
-        "author": "iamprincejkc",
-        "reactions": 6,
-        "comments": 0,
-        "hoursSincePosted": 14.1,
-        "readingTime": 3
-      },
-      "articles": [
-        {
-          "id": 3764750,
-          "title": "An Official Claude SDK for .NET? Yes, Really.",
-          "description": "If you've been building with Claude in .NET, you've probably leaned on one of the lovely community...",
-          "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
-          "author": {
-            "username": "iamprincejkc",
-            "name": "JKC",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F820392%2Fd8052783-fad7-46ae-8c9e-61391ecff65a.jpeg"
-          },
-          "reactionsCount": 6,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-27T13:39:12Z",
-          "tags": [
-            "dotnet",
-            "csharp",
-            "ai",
-            "claude"
-          ],
-          "trendingScore": 0.33,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/anthropic-sdk-csharp",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "github/spec-kit": {
       "count7d": 2,
       "reactionsSum7d": 2,
@@ -1351,7 +1217,7 @@
         "author": "shy",
         "reactions": 1,
         "comments": 5,
-        "hoursSincePosted": 47.8,
+        "hoursSincePosted": 54.1,
         "readingTime": 12
       },
       "articles": [
@@ -1424,7 +1290,7 @@
         "author": "nkalra0123",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 87.9,
+        "hoursSincePosted": 94.2,
         "readingTime": 8
       },
       "articles": [
@@ -1469,7 +1335,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 149.7,
+        "hoursSincePosted": 156,
         "readingTime": 4
       },
       "articles": [
@@ -1493,7 +1359,7 @@
             "python",
             "programming"
           ],
-          "trendingScore": 0.03,
+          "trendingScore": 0.02,
           "linkedRepos": [
             {
               "fullName": "multica-ai/multica",
@@ -1504,7 +1370,7 @@
       ]
     },
     "anthropics/claude-code": {
-      "count7d": 8,
+      "count7d": 7,
       "reactionsSum7d": 0,
       "commentsSum7d": 5,
       "topArticle": {
@@ -1514,7 +1380,7 @@
         "author": "arthurpro",
         "reactions": 0,
         "comments": 1,
-        "hoursSincePosted": 179.8,
+        "hoursSincePosted": 186.1,
         "readingTime": 8
       },
       "articles": [
@@ -1631,34 +1497,6 @@
           ]
         },
         {
-          "id": 3728002,
-          "title": "We didn't ship a feature, we shipped an agentic opt-in beta",
-          "description": "Wednesday afternoon a customer asked me if we'd considered adding an MCP server. By Thursday night...",
-          "url": "https://dev.to/brian_becker_0b40adcf07f9/we-didnt-ship-a-feature-we-shipped-an-opt-in-beta-271",
-          "author": {
-            "username": "brian_becker_0b40adcf07f9",
-            "name": "Brian Becker",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1521563%2F3c9a6893-3687-48c3-9319-9ee08ca81da4.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 4,
-          "readingTime": 5,
-          "publishedAt": "2026-05-22T20:14:52Z",
-          "tags": [
-            "claude",
-            "mcp",
-            "ai",
-            "receipts"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/claude-code",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3725770,
           "title": "I built two Claude Code hooks to stop it from leaking my .env files and wiping my dev DB",
           "description": "A small open-source project, the GitHub issues that made me build it, and what I learned about Claude...",
@@ -1677,6 +1515,34 @@
             "security",
             "showdev",
             "tooling"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-code",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3728002,
+          "title": "We didn't ship a feature, we shipped an agentic opt-in beta",
+          "description": "Wednesday afternoon a customer asked me if we'd considered adding an MCP server. By Thursday night...",
+          "url": "https://dev.to/brian_becker_0b40adcf07f9/we-didnt-ship-a-feature-we-shipped-an-opt-in-beta-271",
+          "author": {
+            "username": "brian_becker_0b40adcf07f9",
+            "name": "Brian Becker",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1521563%2F3c9a6893-3687-48c3-9319-9ee08ca81da4.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 4,
+          "readingTime": 5,
+          "publishedAt": "2026-05-22T20:14:52Z",
+          "tags": [
+            "claude",
+            "mcp",
+            "ai",
+            "receipts"
           ],
           "trendingScore": 0,
           "linkedRepos": [
@@ -1713,34 +1579,6 @@
               "location": "body"
             }
           ]
-        },
-        {
-          "id": 3734738,
-          "title": "Why Claude Code Sessions Diverge: A Mechanism Catalog",
-          "description": "Anthropic's April 2026 postmortem confirmed: Claude Code A/B-routes sessions, behavior is session-sticky, restart actually works. Six mechanisms catalog.",
-          "url": "https://dev.to/vainamoinen/why-claude-code-sessions-diverge-a-mechanism-catalog-4j63",
-          "author": {
-            "username": "vainamoinen",
-            "name": "Vainamoinen | Pulsed Media",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3879600%2Fce3a6ec3-4bde-4859-baeb-e6f99ed3c817.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-23T17:50:30Z",
-          "tags": [
-            "ai",
-            "llm",
-            "agents",
-            "devops"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/claude-code",
-              "location": "body"
-            }
-          ]
         }
       ]
     },
@@ -1755,7 +1593,7 @@
         "author": "klymentiev",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 103.5,
+        "hoursSincePosted": 109.8,
         "readingTime": 7
       },
       "articles": [
@@ -1790,7 +1628,7 @@
       ]
     },
     "bmad-code-org/BMAD-METHOD": {
-      "count7d": 2,
+      "count7d": 1,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
@@ -1800,7 +1638,7 @@
         "author": "bspann",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 25.3,
+        "hoursSincePosted": 31.6,
         "readingTime": 5
       },
       "articles": [
@@ -1831,34 +1669,6 @@
               "location": "body"
             }
           ]
-        },
-        {
-          "id": 3715408,
-          "title": "The Future Is Going to B(e) MAD",
-          "description": "The Dirty Secret Nobody Talks About   Everyone is excited about AI writing code. Cursor,...",
-          "url": "https://dev.to/yahya_bin_naveed/the-future-is-going-to-be-mad-4757",
-          "author": {
-            "username": "yahya_bin_naveed",
-            "name": "Yahya Bin Naveed",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3942111%2Fefc75db3-09f8-4096-8ca6-f773cc5b3c40.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 12,
-          "publishedAt": "2026-05-21T08:25:11Z",
-          "tags": [
-            "vibecoding",
-            "ai",
-            "claude",
-            "bmad"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "bmad-code-org/BMAD-METHOD",
-              "location": "body"
-            }
-          ]
         }
       ]
     },
@@ -1873,7 +1683,7 @@
         "author": "judy_miranttie",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 122.8,
+        "hoursSincePosted": 129.1,
         "readingTime": 14
       },
       "articles": [
@@ -1907,127 +1717,71 @@
         }
       ]
     },
-    "obra/superpowers": {
-      "count7d": 3,
-      "reactionsSum7d": 2,
-      "commentsSum7d": 1,
+    "mattpocock/skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
       "topArticle": {
-        "id": 3712540,
-        "title": "Stop Re-Teaching Claude Every Session",
-        "url": "https://dev.to/chen115y/stop-re-teaching-claude-every-session-43c9",
-        "author": "chen115y",
-        "reactions": 1,
+        "id": 3663204,
+        "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
+        "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
+        "author": "leolr",
+        "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 170.8,
-        "readingTime": 20
+        "hoursSincePosted": 45.5,
+        "readingTime": 9
       },
       "articles": [
         {
-          "id": 3712540,
-          "title": "Stop Re-Teaching Claude Every Session",
-          "description": "The .claude/ Playbook: Hooks, Agents, Permissions, and Everything Your Team Should Be Sharing       ...",
-          "url": "https://dev.to/chen115y/stop-re-teaching-claude-every-session-43c9",
+          "id": 3663204,
+          "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
+          "description": "AI Coding Standards at Scale: How We Versioned Our Team's AI Rules with Claude Code   \"AI amplifies...",
+          "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
           "author": {
-            "username": "chen115y",
-            "name": "Yaohua Chen",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2671324%2F3ca83c79-d0fd-40c0-b5ac-349326e71725.jpg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 20,
-          "publishedAt": "2026-05-21T00:59:13Z",
-          "tags": [
-            "agents",
-            "claude",
-            "productivity",
-            "tooling"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3764786,
-          "title": "How I Make Claude Code's 5-Hour Usage Window Last Longer on Claude Pro",
-          "description": "Practical notes on managing Claude Code usage limits on Claude Pro: /clear, prompt caching, /schedule, plans/specs, and model selection.",
-          "url": "https://dev.to/trknhr/how-i-make-claude-codes-5-hour-usage-window-last-longer-on-claude-pro-jkb",
-          "author": {
-            "username": "trknhr",
-            "name": "Teruo Kunihiro",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F41546%2F717de37a-8306-4328-8010-f38b0c5ed560.jpg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-27T13:46:15Z",
-          "tags": [
-            "ai",
-            "claude",
-            "productivity",
-            "devtools"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3751652,
-          "title": "How Superpowers Forces Skill Execution",
-          "description": "A look at how Superpowers improves skill execution by injecting the full using-superpowers skill into context through a SessionStart hook.",
-          "url": "https://dev.to/sonim1/how-superpowers-forces-skill-execution-3e6e",
-          "author": {
-            "username": "sonim1",
-            "name": "Kendrick B. Jung",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3772700%2Fa93f9bcb-42a5-4678-a9e8-b26f841ff3f6.png"
+            "username": "leolr",
+            "name": "Léo Le Roy",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3928836%2F1b448e20-f99c-47c9-8184-7d49849201b9.png"
           },
           "reactionsCount": 0,
-          "commentsCount": 1,
-          "readingTime": 7,
-          "publishedAt": "2026-05-26T15:30:59Z",
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-26T12:34:36Z",
           "tags": [
-            "agents",
             "ai",
-            "cli",
-            "llm"
+            "automation",
+            "claude",
+            "cursor"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "obra/superpowers",
+              "fullName": "mattpocock/skills",
               "location": "body"
             }
           ]
         }
       ]
     },
-    "colbymchenry/codegraph": {
-      "count7d": 1,
+    "Lum1104/Understand-Anything": {
+      "count7d": 2,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3712719,
-        "title": "One Open Source Project a Day (No. 71): CodeGraph — Pre-Index Your Codebase for AI Agents, Save 35% Cost and 70% Tool Calls",
-        "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-71-codegraph-pre-index-your-codebase-for-ai-agents-save-35-50f3",
+        "id": 3744982,
+        "title": "One Open Source Project a Day (No. 75): Understand Anything - The AI Engine That Turns Any Codebase Into an Explorable Knowledge Graph",
+        "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-75-understand-anything-the-ai-engine-that-turns-any-codebase-5d3i",
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 169.9,
-        "readingTime": 9
+        "hoursSincePosted": 79.3,
+        "readingTime": 6
       },
       "articles": [
         {
-          "id": 3712719,
-          "title": "One Open Source Project a Day (No. 71): CodeGraph — Pre-Index Your Codebase for AI Agents, Save 35% Cost and 70% Tool Calls",
-          "description": "Introduction    \"~35% cheaper · ~70% fewer tool calls · 100% local\"   This is the No.71...",
-          "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-71-codegraph-pre-index-your-codebase-for-ai-agents-save-35-50f3",
+          "id": 3744982,
+          "title": "One Open Source Project a Day (No. 75): Understand Anything - The AI Engine That Turns Any Codebase Into an Explorable Knowledge Graph",
+          "description": "Introduction    \"Graphs that teach &gt; graphs that impress.\"   This is the 75th article in...",
+          "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-75-understand-anything-the-ai-engine-that-turns-any-codebase-5d3i",
           "author": {
             "username": "wonderlab",
             "name": "WonderLab",
@@ -2035,18 +1789,54 @@
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-21T01:51:49Z",
+          "readingTime": 6,
+          "publishedAt": "2026-05-25T02:50:56Z",
           "tags": [
             "opensource",
+            "ai",
             "claude",
-            "mcp",
-            "sqlite"
+            "agents"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "colbymchenry/codegraph",
+              "fullName": "Lum1104/Understand-Anything",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3759155,
+          "title": "The Representation Problem: Why RAG vs. Agentic Search Is the Wrong Debate",
+          "description": "The industry has been asking the wrong question.  When Boris Cherny — the creator and Head of Claude...",
+          "url": "https://dev.to/chen115y/the-representation-problem-why-rag-vs-agentic-search-is-the-wrong-debate-4j8f",
+          "author": {
+            "username": "chen115y",
+            "name": "Yaohua Chen",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2671324%2F3ca83c79-d0fd-40c0-b5ac-349326e71725.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 17,
+          "publishedAt": "2026-05-26T20:02:49Z",
+          "tags": [
+            "rag",
+            "ai",
+            "llm",
+            "architecture"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Lum1104/Understand-Anything",
+              "location": "body"
+            },
+            {
+              "fullName": "VectifyAI/PageIndex",
+              "location": "body"
+            },
+            {
+              "fullName": "garrytan/gbrain",
               "location": "body"
             }
           ]
@@ -2064,7 +1854,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 140.8,
+        "hoursSincePosted": 147.1,
         "readingTime": 10
       },
       "articles": [
@@ -2100,16 +1890,16 @@
     },
     "anthropics/skills": {
       "count7d": 1,
-      "reactionsSum7d": 1,
+      "reactionsSum7d": 2,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3737654,
         "title": "How I Indexed 2,000 Claude Code Skills (And What the Install Data Says About AI Coding in 2026)",
         "url": "https://dev.to/shenhuang/how-i-indexed-2000-claude-code-skills-and-what-the-install-data-says-about-ai-coding-in-2026-3k80",
         "author": "shenhuang",
-        "reactions": 1,
+        "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 94.8,
+        "hoursSincePosted": 101.2,
         "readingTime": 10
       },
       "articles": [
@@ -2123,7 +1913,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -2133,7 +1923,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -2161,51 +1951,19 @@
     },
     "github/awesome-copilot": {
       "count7d": 2,
-      "reactionsSum7d": 3,
+      "reactionsSum7d": 4,
       "commentsSum7d": 1,
       "topArticle": {
-        "id": 3764842,
-        "title": "GitHub Copilot CLI Plugins and Marketplaces: Extend Your Terminal Agent",
-        "url": "https://dev.to/pwd9000/github-copilot-cli-plugins-and-marketplaces-extend-your-terminal-agent-16pc",
-        "author": "pwd9000",
+        "id": 3737654,
+        "title": "How I Indexed 2,000 Claude Code Skills (And What the Install Data Says About AI Coding in 2026)",
+        "url": "https://dev.to/shenhuang/how-i-indexed-2000-claude-code-skills-and-what-the-install-data-says-about-ai-coding-in-2026-3k80",
+        "author": "shenhuang",
         "reactions": 2,
-        "comments": 1,
-        "hoursSincePosted": 13.7,
-        "readingTime": 11
+        "comments": 0,
+        "hoursSincePosted": 101.2,
+        "readingTime": 10
       },
       "articles": [
-        {
-          "id": 3764842,
-          "title": "GitHub Copilot CLI Plugins and Marketplaces: Extend Your Terminal Agent",
-          "description": "Learn how GitHub Copilot CLI plugins and marketplaces work, how to install them, and how to build your own.",
-          "url": "https://dev.to/pwd9000/github-copilot-cli-plugins-and-marketplaces-extend-your-terminal-agent-16pc",
-          "author": {
-            "username": "pwd9000",
-            "name": "Marcel.L",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F620034%2F93be2c72-3a13-478e-8af1-a4bedc1b2331.jpeg"
-          },
-          "reactionsCount": 2,
-          "commentsCount": 1,
-          "readingTime": 11,
-          "publishedAt": "2026-05-27T14:02:50Z",
-          "tags": [
-            "githubcopilot",
-            "cli",
-            "devops",
-            "tutorial"
-          ],
-          "trendingScore": 0.05,
-          "linkedRepos": [
-            {
-              "fullName": "github/awesome-copilot",
-              "location": "body"
-            },
-            {
-              "fullName": "dotnet/skills",
-              "location": "body"
-            }
-          ]
-        },
         {
           "id": 3737654,
           "title": "How I Indexed 2,000 Claude Code Skills (And What the Install Data Says About AI Coding in 2026)",
@@ -2216,7 +1974,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -2226,7 +1984,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -2249,6 +2007,38 @@
               "location": "body"
             }
           ]
+        },
+        {
+          "id": 3764842,
+          "title": "GitHub Copilot CLI Plugins and Marketplaces: Extend Your Terminal Agent",
+          "description": "Learn how GitHub Copilot CLI plugins and marketplaces work, how to install them, and how to build your own.",
+          "url": "https://dev.to/pwd9000/github-copilot-cli-plugins-and-marketplaces-extend-your-terminal-agent-16pc",
+          "author": {
+            "username": "pwd9000",
+            "name": "Marcel.L",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F620034%2F93be2c72-3a13-478e-8af1-a4bedc1b2331.jpeg"
+          },
+          "reactionsCount": 2,
+          "commentsCount": 1,
+          "readingTime": 11,
+          "publishedAt": "2026-05-27T14:02:50Z",
+          "tags": [
+            "githubcopilot",
+            "cli",
+            "devops",
+            "tutorial"
+          ],
+          "trendingScore": 0.03,
+          "linkedRepos": [
+            {
+              "fullName": "github/awesome-copilot",
+              "location": "body"
+            },
+            {
+              "fullName": "dotnet/skills",
+              "location": "body"
+            }
+          ]
         }
       ]
     },
@@ -2263,7 +2053,7 @@
         "author": "schoaib",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 18.2,
+        "hoursSincePosted": 24.5,
         "readingTime": 3
       },
       "articles": [
@@ -2333,51 +2123,6 @@
         }
       ]
     },
-    "mattpocock/skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3663204,
-        "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
-        "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
-        "author": "leolr",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 39.2,
-        "readingTime": 9
-      },
-      "articles": [
-        {
-          "id": 3663204,
-          "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
-          "description": "AI Coding Standards at Scale: How We Versioned Our Team's AI Rules with Claude Code   \"AI amplifies...",
-          "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
-          "author": {
-            "username": "leolr",
-            "name": "Léo Le Roy",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3928836%2F1b448e20-f99c-47c9-8184-7d49849201b9.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-26T12:34:36Z",
-          "tags": [
-            "ai",
-            "automation",
-            "claude",
-            "cursor"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "forrestchang/andrej-karpathy-skills": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -2389,7 +2134,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 140.8,
+        "hoursSincePosted": 147.1,
         "readingTime": 8
       },
       "articles": [
@@ -2423,45 +2168,73 @@
         }
       ]
     },
-    "Wei-Shaw/sub2api": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
+    "obra/superpowers": {
+      "count7d": 2,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 1,
       "topArticle": {
-        "id": 3728964,
-        "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
-        "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
-        "author": "wonderlab",
-        "reactions": 0,
+        "id": 3764786,
+        "title": "How I Make Claude Code's 5-Hour Usage Window Last Longer on Claude Pro",
+        "url": "https://dev.to/trknhr/how-i-make-claude-codes-5-hour-usage-window-last-longer-on-claude-pro-jkb",
+        "author": "trknhr",
+        "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 123.2,
-        "readingTime": 4
+        "hoursSincePosted": 20.3,
+        "readingTime": 6
       },
       "articles": [
         {
-          "id": 3728964,
-          "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
-          "description": "Introduction    \"Fluidize your AI subscription quotas and maximize the value of every...",
-          "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
+          "id": 3764786,
+          "title": "How I Make Claude Code's 5-Hour Usage Window Last Longer on Claude Pro",
+          "description": "Practical notes on managing Claude Code usage limits on Claude Pro: /clear, prompt caching, /schedule, plans/specs, and model selection.",
+          "url": "https://dev.to/trknhr/how-i-make-claude-codes-5-hour-usage-window-last-longer-on-claude-pro-jkb",
           "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+            "username": "trknhr",
+            "name": "Teruo Kunihiro",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F41546%2F717de37a-8306-4328-8010-f38b0c5ed560.jpg"
           },
-          "reactionsCount": 0,
+          "reactionsCount": 1,
           "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-23T00:37:58Z",
+          "readingTime": 6,
+          "publishedAt": "2026-05-27T13:46:15Z",
           "tags": [
             "ai",
-            "opensource",
-            "apigateway",
-            "claude"
+            "claude",
+            "productivity",
+            "devtools"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "Wei-Shaw/sub2api",
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3751652,
+          "title": "How Superpowers Forces Skill Execution",
+          "description": "A look at how Superpowers improves skill execution by injecting the full using-superpowers skill into context through a SessionStart hook.",
+          "url": "https://dev.to/sonim1/how-superpowers-forces-skill-execution-3e6e",
+          "author": {
+            "username": "sonim1",
+            "name": "Kendrick B. Jung",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3772700%2Fa93f9bcb-42a5-4678-a9e8-b26f841ff3f6.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 1,
+          "readingTime": 7,
+          "publishedAt": "2026-05-26T15:30:59Z",
+          "tags": [
+            "agents",
+            "ai",
+            "cli",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "obra/superpowers",
               "location": "body"
             }
           ]
@@ -2479,7 +2252,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 48.4,
+        "hoursSincePosted": 54.7,
         "readingTime": 7
       },
       "articles": [
@@ -2513,6 +2286,51 @@
         }
       ]
     },
+    "Wei-Shaw/sub2api": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3728964,
+        "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
+        "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
+        "author": "wonderlab",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 129.5,
+        "readingTime": 4
+      },
+      "articles": [
+        {
+          "id": 3728964,
+          "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
+          "description": "Introduction    \"Fluidize your AI subscription quotas and maximize the value of every...",
+          "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-23T00:37:58Z",
+          "tags": [
+            "ai",
+            "opensource",
+            "apigateway",
+            "claude"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Wei-Shaw/sub2api",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "openai/codex": {
       "count7d": 2,
       "reactionsSum7d": 0,
@@ -2524,7 +2342,7 @@
         "author": "rkttu",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 36.1,
+        "hoursSincePosted": 42.4,
         "readingTime": 8
       },
       "articles": [
@@ -2597,7 +2415,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 123.1,
+        "hoursSincePosted": 129.4,
         "readingTime": 11
       },
       "articles": [
@@ -2688,79 +2506,20 @@
       ]
     },
     "maximhq/bifrost": {
-      "count7d": 4,
+      "count7d": 5,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3751239,
-        "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
-        "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
         "author": "marcorinaldi_ai",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 58.9,
+        "hoursSincePosted": 161.2,
         "readingTime": 4
       },
       "articles": [
-        {
-          "id": 3751239,
-          "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
-          "description": "TL;DR: We needed to caption 1.2M reconstructed event-camera frames using vision-language models for...",
-          "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
-          "author": {
-            "username": "marcorinaldi_ai",
-            "name": "Marco Rinaldi",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-25T16:53:43Z",
-          "tags": [
-            "computervision",
-            "mlops",
-            "llm"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            },
-            {
-              "fullName": "BerriAI/litellm",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3722306,
-          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
-          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
-          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
-          "author": {
-            "username": "elise_moreau",
-            "name": "Elise Moreau",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-22T05:37:23Z",
-          "tags": [
-            "machinelearning",
-            "llm",
-            "mlops",
-            "pytorch"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            }
-          ]
-        },
         {
           "id": 3719101,
           "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
@@ -2820,24 +2579,34 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "BerriAI/litellm": {
-      "count7d": 2,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3751239,
-        "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
-        "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
-        "author": "marcorinaldi_ai",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 58.9,
-        "readingTime": 4
-      },
-      "articles": [
+        },
+        {
+          "id": 3754817,
+          "title": "Falling back from edge detection to a cloud VLM when confidence drops",
+          "description": "TL;DR: We deploy a 4MB SSD detector on an ARM edge box and cascade low-confidence frames to a cloud...",
+          "url": "https://dev.to/marcorinaldi_ai/falling-back-from-edge-detection-to-a-cloud-vlm-when-confidence-drops-5bgh",
+          "author": {
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-26T07:22:10Z",
+          "tags": [
+            "computervision",
+            "mlops",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            }
+          ]
+        },
         {
           "id": 3751239,
           "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
@@ -2870,6 +2639,51 @@
           ]
         },
         {
+          "id": 3722306,
+          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
+          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
+          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
+          "author": {
+            "username": "elise_moreau",
+            "name": "Elise Moreau",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-22T05:37:23Z",
+          "tags": [
+            "machinelearning",
+            "llm",
+            "mlops",
+            "pytorch"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "BerriAI/litellm": {
+      "count7d": 2,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+        "author": "marcorinaldi_ai",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 161.2,
+        "readingTime": 4
+      },
+      "articles": [
+        {
           "id": 3719101,
           "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
           "description": "TL;DR: We added a vision-language stage to an event-camera pipeline at Prophesee and the LLM provider...",
@@ -2900,93 +2714,34 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "microsoft/playwright-cli": {
-      "count7d": 1,
-      "reactionsSum7d": 2,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3764759,
-        "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
-        "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
-        "author": "rendershot",
-        "reactions": 2,
-        "comments": 1,
-        "hoursSincePosted": 14.1,
-        "readingTime": 6
-      },
-      "articles": [
+        },
         {
-          "id": 3764759,
-          "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
-          "description": "Two MCP servers, both built around Playwright, that solve almost completely different problems. Here's when to use each — and the cost tradeoff that's hiding in the choice.",
-          "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
+          "id": 3751239,
+          "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
+          "description": "TL;DR: We needed to caption 1.2M reconstructed event-camera frames using vision-language models for...",
+          "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
           "author": {
-            "username": "rendershot",
-            "name": "Ohad Badihi",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3901160%2Fb62d72eb-8d63-4de4-a6a3-9ea35a0e40eb.jpeg"
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
           },
-          "reactionsCount": 2,
-          "commentsCount": 1,
-          "readingTime": 6,
-          "publishedAt": "2026-05-27T13:40:49Z",
-          "tags": [
-            "ai",
-            "webdev",
-            "playwright",
-            "mcp"
-          ],
-          "trendingScore": 0.05,
-          "linkedRepos": [
-            {
-              "fullName": "microsoft/playwright-cli",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "andrewyng/context-hub": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3766493,
-        "title": "The Internet Is for Agents",
-        "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
-        "author": "keithjmackay",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 7.5,
-        "readingTime": 14
-      },
-      "articles": [
-        {
-          "id": 3766493,
-          "title": "The Internet Is for Agents",
-          "description": "The Internet Is for Agents   For over a year now, more than half of internet traffic has not...",
-          "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
-          "author": {
-            "username": "keithjmackay",
-            "name": "Keith MacKay",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1499463%2Fdc7d3636-8482-4d6e-b619-fb4367cf4dfd.jpg"
-          },
-          "reactionsCount": 1,
+          "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 14,
-          "publishedAt": "2026-05-27T20:19:56Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-25T16:53:43Z",
           "tags": [
-            "agents",
-            "infrastructure",
-            "mcp",
-            "security"
+            "computervision",
+            "mlops",
+            "llm"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "andrewyng/context-hub",
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            },
+            {
+              "fullName": "BerriAI/litellm",
               "location": "body"
             }
           ]
@@ -3004,7 +2759,7 @@
         "author": "chen115y",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 31.7,
+        "hoursSincePosted": 38.1,
         "readingTime": 17
       },
       "articles": [
@@ -3057,7 +2812,7 @@
         "author": "chen115y",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 31.7,
+        "hoursSincePosted": 38.1,
         "readingTime": 17
       },
       "articles": [
@@ -3099,6 +2854,96 @@
         }
       ]
     },
+    "microsoft/playwright-cli": {
+      "count7d": 1,
+      "reactionsSum7d": 2,
+      "commentsSum7d": 1,
+      "topArticle": {
+        "id": 3764759,
+        "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
+        "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
+        "author": "rendershot",
+        "reactions": 2,
+        "comments": 1,
+        "hoursSincePosted": 20.4,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3764759,
+          "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
+          "description": "Two MCP servers, both built around Playwright, that solve almost completely different problems. Here's when to use each — and the cost tradeoff that's hiding in the choice.",
+          "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
+          "author": {
+            "username": "rendershot",
+            "name": "Ohad Badihi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3901160%2Fb62d72eb-8d63-4de4-a6a3-9ea35a0e40eb.jpeg"
+          },
+          "reactionsCount": 2,
+          "commentsCount": 1,
+          "readingTime": 6,
+          "publishedAt": "2026-05-27T13:40:49Z",
+          "tags": [
+            "ai",
+            "webdev",
+            "playwright",
+            "mcp"
+          ],
+          "trendingScore": 0.03,
+          "linkedRepos": [
+            {
+              "fullName": "microsoft/playwright-cli",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "andrewyng/context-hub": {
+      "count7d": 1,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3766493,
+        "title": "The Internet Is for Agents",
+        "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
+        "author": "keithjmackay",
+        "reactions": 1,
+        "comments": 0,
+        "hoursSincePosted": 13.8,
+        "readingTime": 14
+      },
+      "articles": [
+        {
+          "id": 3766493,
+          "title": "The Internet Is for Agents",
+          "description": "The Internet Is for Agents   For over a year now, more than half of internet traffic has not...",
+          "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
+          "author": {
+            "username": "keithjmackay",
+            "name": "Keith MacKay",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1499463%2Fdc7d3636-8482-4d6e-b619-fb4367cf4dfd.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 14,
+          "publishedAt": "2026-05-27T20:19:56Z",
+          "tags": [
+            "agents",
+            "infrastructure",
+            "mcp",
+            "security"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "andrewyng/context-hub",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "teng-lin/notebooklm-py": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -3110,7 +2955,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 26.3,
+        "hoursSincePosted": 32.6,
         "readingTime": 7
       },
       "articles": [
@@ -3155,7 +3000,7 @@
         "author": "venkatakrishna_s",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 71.1,
+        "hoursSincePosted": 77.5,
         "readingTime": 3
       },
       "articles": [
@@ -3200,7 +3045,7 @@
         "author": "pwd9000",
         "reactions": 2,
         "comments": 1,
-        "hoursSincePosted": 13.7,
+        "hoursSincePosted": 20.1,
         "readingTime": 11
       },
       "articles": [
@@ -3224,7 +3069,7 @@
             "devops",
             "tutorial"
           ],
-          "trendingScore": 0.05,
+          "trendingScore": 0.03,
           "linkedRepos": [
             {
               "fullName": "github/awesome-copilot",
@@ -3249,7 +3094,7 @@
         "author": "tenglongai2026",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 3.9,
+        "hoursSincePosted": 10.3,
         "readingTime": 1
       },
       "articles": [
@@ -3292,7 +3137,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 135.1,
+        "hoursSincePosted": 141.4,
         "readingTime": 4
       },
       "articles": [
@@ -3341,7 +3186,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 135.1,
+        "hoursSincePosted": 141.4,
         "readingTime": 4
       },
       "articles": [
@@ -3390,7 +3235,7 @@
         "author": "grimicorn",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 52.4,
+        "hoursSincePosted": 58.7,
         "readingTime": 3
       },
       "articles": [
@@ -3423,51 +3268,6 @@
         }
       ]
     },
-    "tashfeenahmed/freellmapi": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3715372,
-        "title": "Turn ~800M Free AI Tokens Into a Single OpenAI API with FreeLLMAPI",
-        "url": "https://dev.to/mervindublin/turn-800m-free-ai-tokens-into-a-single-openai-api-with-freellmapi-2gm9",
-        "author": "mervindublin",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 163.4,
-        "readingTime": 3
-      },
-      "articles": [
-        {
-          "id": 3715372,
-          "title": "Turn ~800M Free AI Tokens Into a Single OpenAI API with FreeLLMAPI",
-          "description": "An honest look at FreeLLMAPI — an open-source proxy that aggregates 14 free-tier AI providers into one OpenAI-compatible endpoint.",
-          "url": "https://dev.to/mervindublin/turn-800m-free-ai-tokens-into-a-single-openai-api-with-freellmapi-2gm9",
-          "author": {
-            "username": "mervindublin",
-            "name": "Mervin",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3906971%2F89876791-af06-4c66-a1b7-99df14df1b85.png"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-21T08:21:17Z",
-          "tags": [
-            "opensource",
-            "ai",
-            "devtools",
-            "llm"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "tashfeenahmed/freellmapi",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "charmbracelet/bubbletea": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -3479,7 +3279,7 @@
         "author": "earthbound_misfit",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 133.7,
+        "hoursSincePosted": 140,
         "readingTime": 6
       },
       "articles": [
@@ -3518,7 +3318,7 @@
       ]
     },
     "ratatui/ratatui": {
-      "count7d": 1,
+      "count7d": 2,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
@@ -3528,7 +3328,7 @@
         "author": "earthbound_misfit",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 133.7,
+        "hoursSincePosted": 140,
         "readingTime": 6
       },
       "articles": [
@@ -3563,6 +3363,34 @@
               "location": "body"
             }
           ]
+        },
+        {
+          "id": 3734631,
+          "title": "Glyph v0.2: the release is the joinery",
+          "description": "Seven new Bubble Tea components and three single-binary TUIs that compose them. A note on why the unit test for a component library is the demo, not the catalog.",
+          "url": "https://dev.to/earthbound_misfit/glyph-v02-the-release-is-the-joinery-28bj",
+          "author": {
+            "username": "earthbound_misfit",
+            "name": "Truffle",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3894869%2Fd8eb128c-d56f-4996-b0d6-4d9a10950086.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-23T17:25:18Z",
+          "tags": [
+            "go",
+            "tui",
+            "bubbletea",
+            "opensource"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "ratatui/ratatui",
+              "location": "body"
+            }
+          ]
         }
       ]
     }
@@ -3579,7 +3407,7 @@
         "author": "rohitg00",
         "reactions": 24,
         "comments": 9,
-        "hoursSincePosted": 86,
+        "hoursSincePosted": 92.3,
         "readingTime": 6
       },
       "articles": [
@@ -3603,7 +3431,7 @@
             "agents",
             "opensource"
           ],
-          "trendingScore": 0.73,
+          "trendingScore": 0.68,
           "linkedRepos": [
             {
               "fullName": "rohitg00/ai-engineering-from-scratch",
@@ -3615,7 +3443,7 @@
     },
     "vercel-labs--skills": {
       "count7d": 2,
-      "reactionsSum7d": 9,
+      "reactionsSum7d": 10,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3740141,
@@ -3624,7 +3452,7 @@
         "author": "deraileddash",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 89.2,
+        "hoursSincePosted": 95.5,
         "readingTime": 8
       },
       "articles": [
@@ -3674,7 +3502,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -3684,7 +3512,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -3712,7 +3540,7 @@
     },
     "coreyhaines31--marketingskills": {
       "count7d": 2,
-      "reactionsSum7d": 9,
+      "reactionsSum7d": 10,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3740141,
@@ -3721,7 +3549,7 @@
         "author": "deraileddash",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 89.2,
+        "hoursSincePosted": 95.5,
         "readingTime": 8
       },
       "articles": [
@@ -3771,7 +3599,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -3781,7 +3609,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -3809,7 +3637,7 @@
     },
     "vercel-labs--agent-skills": {
       "count7d": 2,
-      "reactionsSum7d": 9,
+      "reactionsSum7d": 10,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3740141,
@@ -3818,7 +3646,7 @@
         "author": "deraileddash",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 89.2,
+        "hoursSincePosted": 95.5,
         "readingTime": 8
       },
       "articles": [
@@ -3868,7 +3696,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -3878,7 +3706,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -3915,7 +3743,7 @@
         "author": "blackgirlbytes",
         "reactions": 6,
         "comments": 5,
-        "hoursSincePosted": 103.9,
+        "hoursSincePosted": 110.2,
         "readingTime": 4
       },
       "articles": [
@@ -3939,7 +3767,7 @@
             "opensource",
             "entire"
           ],
-          "trendingScore": 0.07,
+          "trendingScore": 0.06,
           "linkedRepos": [
             {
               "fullName": "aaif-goose/goose",
@@ -3960,7 +3788,7 @@
         "author": "dvddpl",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 36.8,
+        "hoursSincePosted": 43.1,
         "readingTime": 16
       },
       "articles": [
@@ -3984,7 +3812,7 @@
             "agenticai",
             "ainativedevelopment"
           ],
-          "trendingScore": 0.02,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "github/github-mcp-server",
@@ -4005,7 +3833,7 @@
         "author": "webmaxru",
         "reactions": 26,
         "comments": 0,
-        "hoursSincePosted": 55.5,
+        "hoursSincePosted": 61.9,
         "readingTime": 12
       },
       "articles": [
@@ -4029,7 +3857,7 @@
             "github",
             "productivity"
           ],
-          "trendingScore": 0.66,
+          "trendingScore": 0.59,
           "linkedRepos": [
             {
               "fullName": "rtk-ai/rtk",
@@ -4103,113 +3931,6 @@
         }
       ]
     },
-    "lum1104--understand-anything": {
-      "count7d": 3,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3767071,
-        "title": "Understand-Anything: Turn Your Codebase Into a Knowledge Graph (39.6K ⭐)",
-        "url": "https://dev.to/tenglongai2026/understand-anything-turn-your-codebase-into-a-knowledge-graph-396k--49np",
-        "author": "tenglongai2026",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 4.5,
-        "readingTime": 1
-      },
-      "articles": [
-        {
-          "id": 3767071,
-          "title": "Understand-Anything: Turn Your Codebase Into a Knowledge Graph (39.6K ⭐)",
-          "description": "You know that feeling when you open a 3-year-old codebase and have zero idea where anything...",
-          "url": "https://dev.to/tenglongai2026/understand-anything-turn-your-codebase-into-a-knowledge-graph-396k--49np",
-          "author": {
-            "username": "tenglongai2026",
-            "name": "TengLongAI2026",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3953270%2Fb0f3ce1e-2eb7-410c-ad9c-d187d63fd465.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 1,
-          "publishedAt": "2026-05-27T23:20:01Z",
-          "tags": [
-            "ai",
-            "productivity"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Lum1104/Understand-Anything",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3744982,
-          "title": "One Open Source Project a Day (No. 75): Understand Anything - The AI Engine That Turns Any Codebase Into an Explorable Knowledge Graph",
-          "description": "Introduction    \"Graphs that teach &gt; graphs that impress.\"   This is the 75th article in...",
-          "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-75-understand-anything-the-ai-engine-that-turns-any-codebase-5d3i",
-          "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-25T02:50:56Z",
-          "tags": [
-            "opensource",
-            "ai",
-            "claude",
-            "agents"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Lum1104/Understand-Anything",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3759155,
-          "title": "The Representation Problem: Why RAG vs. Agentic Search Is the Wrong Debate",
-          "description": "The industry has been asking the wrong question.  When Boris Cherny — the creator and Head of Claude...",
-          "url": "https://dev.to/chen115y/the-representation-problem-why-rag-vs-agentic-search-is-the-wrong-debate-4j8f",
-          "author": {
-            "username": "chen115y",
-            "name": "Yaohua Chen",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2671324%2F3ca83c79-d0fd-40c0-b5ac-349326e71725.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 17,
-          "publishedAt": "2026-05-26T20:02:49Z",
-          "tags": [
-            "rag",
-            "ai",
-            "llm",
-            "architecture"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "Lum1104/Understand-Anything",
-              "location": "body"
-            },
-            {
-              "fullName": "VectifyAI/PageIndex",
-              "location": "body"
-            },
-            {
-              "fullName": "garrytan/gbrain",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "openclaw--openclaw": {
       "count7d": 2,
       "reactionsSum7d": 10,
@@ -4221,7 +3942,7 @@
         "author": "numbpill3d",
         "reactions": 5,
         "comments": 0,
-        "hoursSincePosted": 126,
+        "hoursSincePosted": 132.4,
         "readingTime": 7
       },
       "articles": [
@@ -4277,7 +3998,7 @@
             "mcp",
             "aws"
           ],
-          "trendingScore": 0.28,
+          "trendingScore": 0.19,
           "linkedRepos": [
             {
               "fullName": "openclaw/openclaw",
@@ -4298,7 +4019,7 @@
         "author": "numbpill3d",
         "reactions": 5,
         "comments": 0,
-        "hoursSincePosted": 126,
+        "hoursSincePosted": 132.4,
         "readingTime": 7
       },
       "articles": [
@@ -4336,10 +4057,55 @@
         }
       ]
     },
+    "anthropics--anthropic-sdk-csharp": {
+      "count7d": 1,
+      "reactionsSum7d": 8,
+      "commentsSum7d": 2,
+      "topArticle": {
+        "id": 3764750,
+        "title": "An Official Claude SDK for .NET? Yes, Really.",
+        "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
+        "author": "iamprincejkc",
+        "reactions": 8,
+        "comments": 2,
+        "hoursSincePosted": 20.5,
+        "readingTime": 3
+      },
+      "articles": [
+        {
+          "id": 3764750,
+          "title": "An Official Claude SDK for .NET? Yes, Really.",
+          "description": "If you've been building with Claude in .NET, you've probably leaned on one of the lovely community...",
+          "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
+          "author": {
+            "username": "iamprincejkc",
+            "name": "JKC",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F820392%2Fd8052783-fad7-46ae-8c9e-61391ecff65a.jpeg"
+          },
+          "reactionsCount": 8,
+          "commentsCount": 2,
+          "readingTime": 3,
+          "publishedAt": "2026-05-27T13:39:12Z",
+          "tags": [
+            "dotnet",
+            "csharp",
+            "ai",
+            "claude"
+          ],
+          "trendingScore": 0.42,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/anthropic-sdk-csharp",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "nousresearch--hermes-agent": {
-      "count7d": 11,
-      "reactionsSum7d": 23,
-      "commentsSum7d": 4,
+      "count7d": 10,
+      "reactionsSum7d": 24,
+      "commentsSum7d": 8,
       "topArticle": {
         "id": 3711818,
         "title": "How to Deploy Hermes' Self-Improving AI Agent",
@@ -4347,7 +4113,7 @@
         "author": "haimantika",
         "reactions": 8,
         "comments": 0,
-        "hoursSincePosted": 35.8,
+        "hoursSincePosted": 42.1,
         "readingTime": 8
       },
       "articles": [
@@ -4371,7 +4137,7 @@
             "agents",
             "tutorial"
           ],
-          "trendingScore": 0.2,
+          "trendingScore": 0.17,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4389,8 +4155,8 @@
             "name": "Stephen Sebastian",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3936117%2Faaa3e3a0-dba3-4fe6-8b19-b08e05277a74.png"
           },
-          "reactionsCount": 5,
-          "commentsCount": 1,
+          "reactionsCount": 6,
+          "commentsCount": 5,
           "readingTime": 6,
           "publishedAt": "2026-05-27T17:45:36Z",
           "tags": [
@@ -4399,7 +4165,7 @@
             "agents",
             "ai"
           ],
-          "trendingScore": 0.38,
+          "trendingScore": 0.43,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -4574,33 +4340,6 @@
           ]
         },
         {
-          "id": 3753833,
-          "title": "Why Hermes Agent Compounds While LangChain Stays Flat — A Deep Architectural Breakdown",
-          "description": "This is a submission for the Hermes Agent Challenge     Every AI agent framework promises to make...",
-          "url": "https://dev.to/tejas164321/why-hermes-agent-compounds-while-langchain-stays-flat-a-deep-architectural-breakdown-pck",
-          "author": {
-            "username": "tejas164321",
-            "name": "Tejas Patil",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3828498%2Ff99fdd48-f37e-48e0-abdd-ba64eb016704.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 7,
-          "publishedAt": "2026-05-26T04:49:17Z",
-          "tags": [
-            "hermesagentchallenge",
-            "devchallenge",
-            "agents"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "NousResearch/hermes-agent",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3718625,
           "title": "The Coding Agent Stack Has Two Layers",
           "description": "The current \"Hermes Agent vs Claude Code\" framing is the wrong comparison. The two tools live at...",
@@ -4658,51 +4397,6 @@
         }
       ]
     },
-    "anthropics--anthropic-sdk-csharp": {
-      "count7d": 1,
-      "reactionsSum7d": 6,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3764750,
-        "title": "An Official Claude SDK for .NET? Yes, Really.",
-        "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
-        "author": "iamprincejkc",
-        "reactions": 6,
-        "comments": 0,
-        "hoursSincePosted": 14.1,
-        "readingTime": 3
-      },
-      "articles": [
-        {
-          "id": 3764750,
-          "title": "An Official Claude SDK for .NET? Yes, Really.",
-          "description": "If you've been building with Claude in .NET, you've probably leaned on one of the lovely community...",
-          "url": "https://dev.to/iamprincejkc/an-official-claude-sdk-for-net-yes-really-2bdn",
-          "author": {
-            "username": "iamprincejkc",
-            "name": "JKC",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F820392%2Fd8052783-fad7-46ae-8c9e-61391ecff65a.jpeg"
-          },
-          "reactionsCount": 6,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-27T13:39:12Z",
-          "tags": [
-            "dotnet",
-            "csharp",
-            "ai",
-            "claude"
-          ],
-          "trendingScore": 0.33,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/anthropic-sdk-csharp",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "github--spec-kit": {
       "count7d": 2,
       "reactionsSum7d": 2,
@@ -4714,7 +4408,7 @@
         "author": "shy",
         "reactions": 1,
         "comments": 5,
-        "hoursSincePosted": 47.8,
+        "hoursSincePosted": 54.1,
         "readingTime": 12
       },
       "articles": [
@@ -4787,7 +4481,7 @@
         "author": "nkalra0123",
         "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 87.9,
+        "hoursSincePosted": 94.2,
         "readingTime": 8
       },
       "articles": [
@@ -4832,7 +4526,7 @@
         "author": "arshtechpro",
         "reactions": 5,
         "comments": 1,
-        "hoursSincePosted": 149.7,
+        "hoursSincePosted": 156,
         "readingTime": 4
       },
       "articles": [
@@ -4856,7 +4550,7 @@
             "python",
             "programming"
           ],
-          "trendingScore": 0.03,
+          "trendingScore": 0.02,
           "linkedRepos": [
             {
               "fullName": "multica-ai/multica",
@@ -4867,7 +4561,7 @@
       ]
     },
     "anthropics--claude-code": {
-      "count7d": 8,
+      "count7d": 7,
       "reactionsSum7d": 0,
       "commentsSum7d": 5,
       "topArticle": {
@@ -4877,7 +4571,7 @@
         "author": "arthurpro",
         "reactions": 0,
         "comments": 1,
-        "hoursSincePosted": 179.8,
+        "hoursSincePosted": 186.1,
         "readingTime": 8
       },
       "articles": [
@@ -4994,34 +4688,6 @@
           ]
         },
         {
-          "id": 3728002,
-          "title": "We didn't ship a feature, we shipped an agentic opt-in beta",
-          "description": "Wednesday afternoon a customer asked me if we'd considered adding an MCP server. By Thursday night...",
-          "url": "https://dev.to/brian_becker_0b40adcf07f9/we-didnt-ship-a-feature-we-shipped-an-opt-in-beta-271",
-          "author": {
-            "username": "brian_becker_0b40adcf07f9",
-            "name": "Brian Becker",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1521563%2F3c9a6893-3687-48c3-9319-9ee08ca81da4.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 4,
-          "readingTime": 5,
-          "publishedAt": "2026-05-22T20:14:52Z",
-          "tags": [
-            "claude",
-            "mcp",
-            "ai",
-            "receipts"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/claude-code",
-              "location": "body"
-            }
-          ]
-        },
-        {
           "id": 3725770,
           "title": "I built two Claude Code hooks to stop it from leaking my .env files and wiping my dev DB",
           "description": "A small open-source project, the GitHub issues that made me build it, and what I learned about Claude...",
@@ -5040,6 +4706,34 @@
             "security",
             "showdev",
             "tooling"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "anthropics/claude-code",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3728002,
+          "title": "We didn't ship a feature, we shipped an agentic opt-in beta",
+          "description": "Wednesday afternoon a customer asked me if we'd considered adding an MCP server. By Thursday night...",
+          "url": "https://dev.to/brian_becker_0b40adcf07f9/we-didnt-ship-a-feature-we-shipped-an-opt-in-beta-271",
+          "author": {
+            "username": "brian_becker_0b40adcf07f9",
+            "name": "Brian Becker",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1521563%2F3c9a6893-3687-48c3-9319-9ee08ca81da4.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 4,
+          "readingTime": 5,
+          "publishedAt": "2026-05-22T20:14:52Z",
+          "tags": [
+            "claude",
+            "mcp",
+            "ai",
+            "receipts"
           ],
           "trendingScore": 0,
           "linkedRepos": [
@@ -5076,34 +4770,6 @@
               "location": "body"
             }
           ]
-        },
-        {
-          "id": 3734738,
-          "title": "Why Claude Code Sessions Diverge: A Mechanism Catalog",
-          "description": "Anthropic's April 2026 postmortem confirmed: Claude Code A/B-routes sessions, behavior is session-sticky, restart actually works. Six mechanisms catalog.",
-          "url": "https://dev.to/vainamoinen/why-claude-code-sessions-diverge-a-mechanism-catalog-4j63",
-          "author": {
-            "username": "vainamoinen",
-            "name": "Vainamoinen | Pulsed Media",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3879600%2Fce3a6ec3-4bde-4859-baeb-e6f99ed3c817.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-23T17:50:30Z",
-          "tags": [
-            "ai",
-            "llm",
-            "agents",
-            "devops"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "anthropics/claude-code",
-              "location": "body"
-            }
-          ]
         }
       ]
     },
@@ -5118,7 +4784,7 @@
         "author": "klymentiev",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 103.5,
+        "hoursSincePosted": 109.8,
         "readingTime": 7
       },
       "articles": [
@@ -5153,7 +4819,7 @@
       ]
     },
     "bmad-code-org--bmad-method": {
-      "count7d": 2,
+      "count7d": 1,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
@@ -5163,7 +4829,7 @@
         "author": "bspann",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 25.3,
+        "hoursSincePosted": 31.6,
         "readingTime": 5
       },
       "articles": [
@@ -5194,34 +4860,6 @@
               "location": "body"
             }
           ]
-        },
-        {
-          "id": 3715408,
-          "title": "The Future Is Going to B(e) MAD",
-          "description": "The Dirty Secret Nobody Talks About   Everyone is excited about AI writing code. Cursor,...",
-          "url": "https://dev.to/yahya_bin_naveed/the-future-is-going-to-be-mad-4757",
-          "author": {
-            "username": "yahya_bin_naveed",
-            "name": "Yahya Bin Naveed",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3942111%2Fefc75db3-09f8-4096-8ca6-f773cc5b3c40.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 12,
-          "publishedAt": "2026-05-21T08:25:11Z",
-          "tags": [
-            "vibecoding",
-            "ai",
-            "claude",
-            "bmad"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "bmad-code-org/BMAD-METHOD",
-              "location": "body"
-            }
-          ]
         }
       ]
     },
@@ -5236,7 +4874,7 @@
         "author": "judy_miranttie",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 122.8,
+        "hoursSincePosted": 129.1,
         "readingTime": 14
       },
       "articles": [
@@ -5270,127 +4908,71 @@
         }
       ]
     },
-    "obra--superpowers": {
-      "count7d": 3,
-      "reactionsSum7d": 2,
-      "commentsSum7d": 1,
+    "mattpocock--skills": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
       "topArticle": {
-        "id": 3712540,
-        "title": "Stop Re-Teaching Claude Every Session",
-        "url": "https://dev.to/chen115y/stop-re-teaching-claude-every-session-43c9",
-        "author": "chen115y",
-        "reactions": 1,
+        "id": 3663204,
+        "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
+        "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
+        "author": "leolr",
+        "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 170.8,
-        "readingTime": 20
+        "hoursSincePosted": 45.5,
+        "readingTime": 9
       },
       "articles": [
         {
-          "id": 3712540,
-          "title": "Stop Re-Teaching Claude Every Session",
-          "description": "The .claude/ Playbook: Hooks, Agents, Permissions, and Everything Your Team Should Be Sharing       ...",
-          "url": "https://dev.to/chen115y/stop-re-teaching-claude-every-session-43c9",
+          "id": 3663204,
+          "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
+          "description": "AI Coding Standards at Scale: How We Versioned Our Team's AI Rules with Claude Code   \"AI amplifies...",
+          "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
           "author": {
-            "username": "chen115y",
-            "name": "Yaohua Chen",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2671324%2F3ca83c79-d0fd-40c0-b5ac-349326e71725.jpg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 20,
-          "publishedAt": "2026-05-21T00:59:13Z",
-          "tags": [
-            "agents",
-            "claude",
-            "productivity",
-            "tooling"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3764786,
-          "title": "How I Make Claude Code's 5-Hour Usage Window Last Longer on Claude Pro",
-          "description": "Practical notes on managing Claude Code usage limits on Claude Pro: /clear, prompt caching, /schedule, plans/specs, and model selection.",
-          "url": "https://dev.to/trknhr/how-i-make-claude-codes-5-hour-usage-window-last-longer-on-claude-pro-jkb",
-          "author": {
-            "username": "trknhr",
-            "name": "Teruo Kunihiro",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F41546%2F717de37a-8306-4328-8010-f38b0c5ed560.jpg"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 6,
-          "publishedAt": "2026-05-27T13:46:15Z",
-          "tags": [
-            "ai",
-            "claude",
-            "productivity",
-            "devtools"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "obra/superpowers",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3751652,
-          "title": "How Superpowers Forces Skill Execution",
-          "description": "A look at how Superpowers improves skill execution by injecting the full using-superpowers skill into context through a SessionStart hook.",
-          "url": "https://dev.to/sonim1/how-superpowers-forces-skill-execution-3e6e",
-          "author": {
-            "username": "sonim1",
-            "name": "Kendrick B. Jung",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3772700%2Fa93f9bcb-42a5-4678-a9e8-b26f841ff3f6.png"
+            "username": "leolr",
+            "name": "Léo Le Roy",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3928836%2F1b448e20-f99c-47c9-8184-7d49849201b9.png"
           },
           "reactionsCount": 0,
-          "commentsCount": 1,
-          "readingTime": 7,
-          "publishedAt": "2026-05-26T15:30:59Z",
+          "commentsCount": 0,
+          "readingTime": 9,
+          "publishedAt": "2026-05-26T12:34:36Z",
           "tags": [
-            "agents",
             "ai",
-            "cli",
-            "llm"
+            "automation",
+            "claude",
+            "cursor"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "obra/superpowers",
+              "fullName": "mattpocock/skills",
               "location": "body"
             }
           ]
         }
       ]
     },
-    "colbymchenry--codegraph": {
-      "count7d": 1,
+    "lum1104--understand-anything": {
+      "count7d": 2,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3712719,
-        "title": "One Open Source Project a Day (No. 71): CodeGraph — Pre-Index Your Codebase for AI Agents, Save 35% Cost and 70% Tool Calls",
-        "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-71-codegraph-pre-index-your-codebase-for-ai-agents-save-35-50f3",
+        "id": 3744982,
+        "title": "One Open Source Project a Day (No. 75): Understand Anything - The AI Engine That Turns Any Codebase Into an Explorable Knowledge Graph",
+        "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-75-understand-anything-the-ai-engine-that-turns-any-codebase-5d3i",
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 169.9,
-        "readingTime": 9
+        "hoursSincePosted": 79.3,
+        "readingTime": 6
       },
       "articles": [
         {
-          "id": 3712719,
-          "title": "One Open Source Project a Day (No. 71): CodeGraph — Pre-Index Your Codebase for AI Agents, Save 35% Cost and 70% Tool Calls",
-          "description": "Introduction    \"~35% cheaper · ~70% fewer tool calls · 100% local\"   This is the No.71...",
-          "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-71-codegraph-pre-index-your-codebase-for-ai-agents-save-35-50f3",
+          "id": 3744982,
+          "title": "One Open Source Project a Day (No. 75): Understand Anything - The AI Engine That Turns Any Codebase Into an Explorable Knowledge Graph",
+          "description": "Introduction    \"Graphs that teach &gt; graphs that impress.\"   This is the 75th article in...",
+          "url": "https://dev.to/wonderlab/one-open-source-project-a-day-no-75-understand-anything-the-ai-engine-that-turns-any-codebase-5d3i",
           "author": {
             "username": "wonderlab",
             "name": "WonderLab",
@@ -5398,18 +4980,54 @@
           },
           "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-21T01:51:49Z",
+          "readingTime": 6,
+          "publishedAt": "2026-05-25T02:50:56Z",
           "tags": [
             "opensource",
+            "ai",
             "claude",
-            "mcp",
-            "sqlite"
+            "agents"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "colbymchenry/codegraph",
+              "fullName": "Lum1104/Understand-Anything",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3759155,
+          "title": "The Representation Problem: Why RAG vs. Agentic Search Is the Wrong Debate",
+          "description": "The industry has been asking the wrong question.  When Boris Cherny — the creator and Head of Claude...",
+          "url": "https://dev.to/chen115y/the-representation-problem-why-rag-vs-agentic-search-is-the-wrong-debate-4j8f",
+          "author": {
+            "username": "chen115y",
+            "name": "Yaohua Chen",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F2671324%2F3ca83c79-d0fd-40c0-b5ac-349326e71725.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 17,
+          "publishedAt": "2026-05-26T20:02:49Z",
+          "tags": [
+            "rag",
+            "ai",
+            "llm",
+            "architecture"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Lum1104/Understand-Anything",
+              "location": "body"
+            },
+            {
+              "fullName": "VectifyAI/PageIndex",
+              "location": "body"
+            },
+            {
+              "fullName": "garrytan/gbrain",
               "location": "body"
             }
           ]
@@ -5427,7 +5045,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 140.8,
+        "hoursSincePosted": 147.1,
         "readingTime": 10
       },
       "articles": [
@@ -5463,16 +5081,16 @@
     },
     "anthropics--skills": {
       "count7d": 1,
-      "reactionsSum7d": 1,
+      "reactionsSum7d": 2,
       "commentsSum7d": 0,
       "topArticle": {
         "id": 3737654,
         "title": "How I Indexed 2,000 Claude Code Skills (And What the Install Data Says About AI Coding in 2026)",
         "url": "https://dev.to/shenhuang/how-i-indexed-2000-claude-code-skills-and-what-the-install-data-says-about-ai-coding-in-2026-3k80",
         "author": "shenhuang",
-        "reactions": 1,
+        "reactions": 2,
         "comments": 0,
-        "hoursSincePosted": 94.8,
+        "hoursSincePosted": 101.2,
         "readingTime": 10
       },
       "articles": [
@@ -5486,7 +5104,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -5496,7 +5114,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -5524,51 +5142,19 @@
     },
     "github--awesome-copilot": {
       "count7d": 2,
-      "reactionsSum7d": 3,
+      "reactionsSum7d": 4,
       "commentsSum7d": 1,
       "topArticle": {
-        "id": 3764842,
-        "title": "GitHub Copilot CLI Plugins and Marketplaces: Extend Your Terminal Agent",
-        "url": "https://dev.to/pwd9000/github-copilot-cli-plugins-and-marketplaces-extend-your-terminal-agent-16pc",
-        "author": "pwd9000",
+        "id": 3737654,
+        "title": "How I Indexed 2,000 Claude Code Skills (And What the Install Data Says About AI Coding in 2026)",
+        "url": "https://dev.to/shenhuang/how-i-indexed-2000-claude-code-skills-and-what-the-install-data-says-about-ai-coding-in-2026-3k80",
+        "author": "shenhuang",
         "reactions": 2,
-        "comments": 1,
-        "hoursSincePosted": 13.7,
-        "readingTime": 11
+        "comments": 0,
+        "hoursSincePosted": 101.2,
+        "readingTime": 10
       },
       "articles": [
-        {
-          "id": 3764842,
-          "title": "GitHub Copilot CLI Plugins and Marketplaces: Extend Your Terminal Agent",
-          "description": "Learn how GitHub Copilot CLI plugins and marketplaces work, how to install them, and how to build your own.",
-          "url": "https://dev.to/pwd9000/github-copilot-cli-plugins-and-marketplaces-extend-your-terminal-agent-16pc",
-          "author": {
-            "username": "pwd9000",
-            "name": "Marcel.L",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F620034%2F93be2c72-3a13-478e-8af1-a4bedc1b2331.jpeg"
-          },
-          "reactionsCount": 2,
-          "commentsCount": 1,
-          "readingTime": 11,
-          "publishedAt": "2026-05-27T14:02:50Z",
-          "tags": [
-            "githubcopilot",
-            "cli",
-            "devops",
-            "tutorial"
-          ],
-          "trendingScore": 0.05,
-          "linkedRepos": [
-            {
-              "fullName": "github/awesome-copilot",
-              "location": "body"
-            },
-            {
-              "fullName": "dotnet/skills",
-              "location": "body"
-            }
-          ]
-        },
         {
           "id": 3737654,
           "title": "How I Indexed 2,000 Claude Code Skills (And What the Install Data Says About AI Coding in 2026)",
@@ -5579,7 +5165,7 @@
             "name": "Shen Huang",
             "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F936104%2F47f8fca8-4790-49fe-889b-9f4179202580.jpg"
           },
-          "reactionsCount": 1,
+          "reactionsCount": 2,
           "commentsCount": 0,
           "readingTime": 10,
           "publishedAt": "2026-05-24T04:57:53Z",
@@ -5589,7 +5175,7 @@
             "webdev",
             "seo"
           ],
-          "trendingScore": 0,
+          "trendingScore": 0.01,
           "linkedRepos": [
             {
               "fullName": "vercel-labs/skills",
@@ -5612,6 +5198,38 @@
               "location": "body"
             }
           ]
+        },
+        {
+          "id": 3764842,
+          "title": "GitHub Copilot CLI Plugins and Marketplaces: Extend Your Terminal Agent",
+          "description": "Learn how GitHub Copilot CLI plugins and marketplaces work, how to install them, and how to build your own.",
+          "url": "https://dev.to/pwd9000/github-copilot-cli-plugins-and-marketplaces-extend-your-terminal-agent-16pc",
+          "author": {
+            "username": "pwd9000",
+            "name": "Marcel.L",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F620034%2F93be2c72-3a13-478e-8af1-a4bedc1b2331.jpeg"
+          },
+          "reactionsCount": 2,
+          "commentsCount": 1,
+          "readingTime": 11,
+          "publishedAt": "2026-05-27T14:02:50Z",
+          "tags": [
+            "githubcopilot",
+            "cli",
+            "devops",
+            "tutorial"
+          ],
+          "trendingScore": 0.03,
+          "linkedRepos": [
+            {
+              "fullName": "github/awesome-copilot",
+              "location": "body"
+            },
+            {
+              "fullName": "dotnet/skills",
+              "location": "body"
+            }
+          ]
         }
       ]
     },
@@ -5626,7 +5244,7 @@
         "author": "schoaib",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 18.2,
+        "hoursSincePosted": 24.5,
         "readingTime": 3
       },
       "articles": [
@@ -5696,51 +5314,6 @@
         }
       ]
     },
-    "mattpocock--skills": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3663204,
-        "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
-        "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
-        "author": "leolr",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 39.2,
-        "readingTime": 9
-      },
-      "articles": [
-        {
-          "id": 3663204,
-          "title": "AI Coding Standards at Scale: Versioned AI Rules for Cursor, Claude Code, and Beyond",
-          "description": "AI Coding Standards at Scale: How We Versioned Our Team's AI Rules with Claude Code   \"AI amplifies...",
-          "url": "https://dev.to/leolr/ai-coding-standards-at-scale-versioned-ai-rules-for-cursor-claude-code-and-beyond-2j84",
-          "author": {
-            "username": "leolr",
-            "name": "Léo Le Roy",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3928836%2F1b448e20-f99c-47c9-8184-7d49849201b9.png"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 9,
-          "publishedAt": "2026-05-26T12:34:36Z",
-          "tags": [
-            "ai",
-            "automation",
-            "claude",
-            "cursor"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "mattpocock/skills",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "forrestchang--andrej-karpathy-skills": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -5752,7 +5325,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 140.8,
+        "hoursSincePosted": 147.1,
         "readingTime": 8
       },
       "articles": [
@@ -5786,45 +5359,73 @@
         }
       ]
     },
-    "wei-shaw--sub2api": {
-      "count7d": 1,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
+    "obra--superpowers": {
+      "count7d": 2,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 1,
       "topArticle": {
-        "id": 3728964,
-        "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
-        "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
-        "author": "wonderlab",
-        "reactions": 0,
+        "id": 3764786,
+        "title": "How I Make Claude Code's 5-Hour Usage Window Last Longer on Claude Pro",
+        "url": "https://dev.to/trknhr/how-i-make-claude-codes-5-hour-usage-window-last-longer-on-claude-pro-jkb",
+        "author": "trknhr",
+        "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 123.2,
-        "readingTime": 4
+        "hoursSincePosted": 20.3,
+        "readingTime": 6
       },
       "articles": [
         {
-          "id": 3728964,
-          "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
-          "description": "Introduction    \"Fluidize your AI subscription quotas and maximize the value of every...",
-          "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
+          "id": 3764786,
+          "title": "How I Make Claude Code's 5-Hour Usage Window Last Longer on Claude Pro",
+          "description": "Practical notes on managing Claude Code usage limits on Claude Pro: /clear, prompt caching, /schedule, plans/specs, and model selection.",
+          "url": "https://dev.to/trknhr/how-i-make-claude-codes-5-hour-usage-window-last-longer-on-claude-pro-jkb",
           "author": {
-            "username": "wonderlab",
-            "name": "WonderLab",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+            "username": "trknhr",
+            "name": "Teruo Kunihiro",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F41546%2F717de37a-8306-4328-8010-f38b0c5ed560.jpg"
           },
-          "reactionsCount": 0,
+          "reactionsCount": 1,
           "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-23T00:37:58Z",
+          "readingTime": 6,
+          "publishedAt": "2026-05-27T13:46:15Z",
           "tags": [
             "ai",
-            "opensource",
-            "apigateway",
-            "claude"
+            "claude",
+            "productivity",
+            "devtools"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "Wei-Shaw/sub2api",
+              "fullName": "obra/superpowers",
+              "location": "body"
+            }
+          ]
+        },
+        {
+          "id": 3751652,
+          "title": "How Superpowers Forces Skill Execution",
+          "description": "A look at how Superpowers improves skill execution by injecting the full using-superpowers skill into context through a SessionStart hook.",
+          "url": "https://dev.to/sonim1/how-superpowers-forces-skill-execution-3e6e",
+          "author": {
+            "username": "sonim1",
+            "name": "Kendrick B. Jung",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3772700%2Fa93f9bcb-42a5-4678-a9e8-b26f841ff3f6.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 1,
+          "readingTime": 7,
+          "publishedAt": "2026-05-26T15:30:59Z",
+          "tags": [
+            "agents",
+            "ai",
+            "cli",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "obra/superpowers",
               "location": "body"
             }
           ]
@@ -5842,7 +5443,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 48.4,
+        "hoursSincePosted": 54.7,
         "readingTime": 7
       },
       "articles": [
@@ -5876,6 +5477,51 @@
         }
       ]
     },
+    "wei-shaw--sub2api": {
+      "count7d": 1,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3728964,
+        "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
+        "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
+        "author": "wonderlab",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 129.5,
+        "readingTime": 4
+      },
+      "articles": [
+        {
+          "id": 3728964,
+          "title": "Open Source Project (No.73): Sub2API - All-in-One Claude/OpenAI/Gemini Subscription-to-API Relay",
+          "description": "Introduction    \"Fluidize your AI subscription quotas and maximize the value of every...",
+          "url": "https://dev.to/wonderlab/open-source-project-no73-sub2api-all-in-one-claudeopenaigemini-subscription-to-api-relay-235n",
+          "author": {
+            "username": "wonderlab",
+            "name": "WonderLab",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3797373%2F25beba30-d8d4-4d2e-9ec6-170356089350.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-23T00:37:58Z",
+          "tags": [
+            "ai",
+            "opensource",
+            "apigateway",
+            "claude"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "Wei-Shaw/sub2api",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "openai--codex": {
       "count7d": 2,
       "reactionsSum7d": 0,
@@ -5887,7 +5533,7 @@
         "author": "rkttu",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 36.1,
+        "hoursSincePosted": 42.4,
         "readingTime": 8
       },
       "articles": [
@@ -5960,7 +5606,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 123.1,
+        "hoursSincePosted": 129.4,
         "readingTime": 11
       },
       "articles": [
@@ -6051,79 +5697,20 @@
       ]
     },
     "maximhq--bifrost": {
-      "count7d": 4,
+      "count7d": 5,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
-        "id": 3751239,
-        "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
-        "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
         "author": "marcorinaldi_ai",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 58.9,
+        "hoursSincePosted": 161.2,
         "readingTime": 4
       },
       "articles": [
-        {
-          "id": 3751239,
-          "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
-          "description": "TL;DR: We needed to caption 1.2M reconstructed event-camera frames using vision-language models for...",
-          "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
-          "author": {
-            "username": "marcorinaldi_ai",
-            "name": "Marco Rinaldi",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-25T16:53:43Z",
-          "tags": [
-            "computervision",
-            "mlops",
-            "llm"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            },
-            {
-              "fullName": "BerriAI/litellm",
-              "location": "body"
-            }
-          ]
-        },
-        {
-          "id": 3722306,
-          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
-          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
-          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
-          "author": {
-            "username": "elise_moreau",
-            "name": "Elise Moreau",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
-          },
-          "reactionsCount": 0,
-          "commentsCount": 0,
-          "readingTime": 4,
-          "publishedAt": "2026-05-22T05:37:23Z",
-          "tags": [
-            "machinelearning",
-            "llm",
-            "mlops",
-            "pytorch"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "maximhq/bifrost",
-              "location": "body"
-            }
-          ]
-        },
         {
           "id": 3719101,
           "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
@@ -6183,24 +5770,34 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "berriai--litellm": {
-      "count7d": 2,
-      "reactionsSum7d": 0,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3751239,
-        "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
-        "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
-        "author": "marcorinaldi_ai",
-        "reactions": 0,
-        "comments": 0,
-        "hoursSincePosted": 58.9,
-        "readingTime": 4
-      },
-      "articles": [
+        },
+        {
+          "id": 3754817,
+          "title": "Falling back from edge detection to a cloud VLM when confidence drops",
+          "description": "TL;DR: We deploy a 4MB SSD detector on an ARM edge box and cascade low-confidence frames to a cloud...",
+          "url": "https://dev.to/marcorinaldi_ai/falling-back-from-edge-detection-to-a-cloud-vlm-when-confidence-drops-5bgh",
+          "author": {
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-26T07:22:10Z",
+          "tags": [
+            "computervision",
+            "mlops",
+            "llm"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            }
+          ]
+        },
         {
           "id": 3751239,
           "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
@@ -6233,6 +5830,51 @@
           ]
         },
         {
+          "id": 3722306,
+          "title": "Why your diffusion model is slow at batch size 1 (and what actually helps)",
+          "description": "TL;DR: Single-image diffusion inference is bottlenecked by kernel launch overhead and attention...",
+          "url": "https://dev.to/elise_moreau/why-your-diffusion-model-is-slow-at-batch-size-1-and-what-actually-helps-16e0",
+          "author": {
+            "username": "elise_moreau",
+            "name": "Elise Moreau",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3864909%2F72833c18-30db-4456-82ee-e7d2016cc38f.jpg"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-22T05:37:23Z",
+          "tags": [
+            "machinelearning",
+            "llm",
+            "mlops",
+            "pytorch"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "berriai--litellm": {
+      "count7d": 2,
+      "reactionsSum7d": 0,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3719101,
+        "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
+        "url": "https://dev.to/marcorinaldi_ai/routing-event-camera-pipelines-through-an-llm-gateway-a-field-report-3len",
+        "author": "marcorinaldi_ai",
+        "reactions": 0,
+        "comments": 0,
+        "hoursSincePosted": 161.2,
+        "readingTime": 4
+      },
+      "articles": [
+        {
           "id": 3719101,
           "title": "Routing Event-Camera Pipelines Through an LLM Gateway: A Field Report",
           "description": "TL;DR: We added a vision-language stage to an event-camera pipeline at Prophesee and the LLM provider...",
@@ -6263,93 +5905,34 @@
               "location": "body"
             }
           ]
-        }
-      ]
-    },
-    "microsoft--playwright-cli": {
-      "count7d": 1,
-      "reactionsSum7d": 2,
-      "commentsSum7d": 1,
-      "topArticle": {
-        "id": 3764759,
-        "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
-        "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
-        "author": "rendershot",
-        "reactions": 2,
-        "comments": 1,
-        "hoursSincePosted": 14.1,
-        "readingTime": 6
-      },
-      "articles": [
+        },
         {
-          "id": 3764759,
-          "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
-          "description": "Two MCP servers, both built around Playwright, that solve almost completely different problems. Here's when to use each — and the cost tradeoff that's hiding in the choice.",
-          "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
+          "id": 3751239,
+          "title": "Auto-labelling 1.2M robotics frames with VLMs: a failover story",
+          "description": "TL;DR: We needed to caption 1.2M reconstructed event-camera frames using vision-language models for...",
+          "url": "https://dev.to/marcorinaldi_ai/auto-labelling-12m-robotics-frames-with-vlms-a-failover-story-1dje",
           "author": {
-            "username": "rendershot",
-            "name": "Ohad Badihi",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3901160%2Fb62d72eb-8d63-4de4-a6a3-9ea35a0e40eb.jpeg"
+            "username": "marcorinaldi_ai",
+            "name": "Marco Rinaldi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3851217%2Fce3e7721-f256-4c07-bec2-4bdbc0121b10.jpg"
           },
-          "reactionsCount": 2,
-          "commentsCount": 1,
-          "readingTime": 6,
-          "publishedAt": "2026-05-27T13:40:49Z",
-          "tags": [
-            "ai",
-            "webdev",
-            "playwright",
-            "mcp"
-          ],
-          "trendingScore": 0.05,
-          "linkedRepos": [
-            {
-              "fullName": "microsoft/playwright-cli",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
-    "andrewyng--context-hub": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3766493,
-        "title": "The Internet Is for Agents",
-        "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
-        "author": "keithjmackay",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 7.5,
-        "readingTime": 14
-      },
-      "articles": [
-        {
-          "id": 3766493,
-          "title": "The Internet Is for Agents",
-          "description": "The Internet Is for Agents   For over a year now, more than half of internet traffic has not...",
-          "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
-          "author": {
-            "username": "keithjmackay",
-            "name": "Keith MacKay",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1499463%2Fdc7d3636-8482-4d6e-b619-fb4367cf4dfd.jpg"
-          },
-          "reactionsCount": 1,
+          "reactionsCount": 0,
           "commentsCount": 0,
-          "readingTime": 14,
-          "publishedAt": "2026-05-27T20:19:56Z",
+          "readingTime": 4,
+          "publishedAt": "2026-05-25T16:53:43Z",
           "tags": [
-            "agents",
-            "infrastructure",
-            "mcp",
-            "security"
+            "computervision",
+            "mlops",
+            "llm"
           ],
           "trendingScore": 0,
           "linkedRepos": [
             {
-              "fullName": "andrewyng/context-hub",
+              "fullName": "maximhq/bifrost",
+              "location": "body"
+            },
+            {
+              "fullName": "BerriAI/litellm",
               "location": "body"
             }
           ]
@@ -6367,7 +5950,7 @@
         "author": "chen115y",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 31.7,
+        "hoursSincePosted": 38.1,
         "readingTime": 17
       },
       "articles": [
@@ -6420,7 +6003,7 @@
         "author": "chen115y",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 31.7,
+        "hoursSincePosted": 38.1,
         "readingTime": 17
       },
       "articles": [
@@ -6462,6 +6045,96 @@
         }
       ]
     },
+    "microsoft--playwright-cli": {
+      "count7d": 1,
+      "reactionsSum7d": 2,
+      "commentsSum7d": 1,
+      "topArticle": {
+        "id": 3764759,
+        "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
+        "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
+        "author": "rendershot",
+        "reactions": 2,
+        "comments": 1,
+        "hoursSincePosted": 20.4,
+        "readingTime": 6
+      },
+      "articles": [
+        {
+          "id": 3764759,
+          "title": "Playwright MCP vs Rendershot MCP: choosing a browser MCP server in 2026",
+          "description": "Two MCP servers, both built around Playwright, that solve almost completely different problems. Here's when to use each — and the cost tradeoff that's hiding in the choice.",
+          "url": "https://dev.to/rendershot/playwright-mcp-vs-rendershot-mcp-choosing-a-browser-mcp-server-in-2026-3kk2",
+          "author": {
+            "username": "rendershot",
+            "name": "Ohad Badihi",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3901160%2Fb62d72eb-8d63-4de4-a6a3-9ea35a0e40eb.jpeg"
+          },
+          "reactionsCount": 2,
+          "commentsCount": 1,
+          "readingTime": 6,
+          "publishedAt": "2026-05-27T13:40:49Z",
+          "tags": [
+            "ai",
+            "webdev",
+            "playwright",
+            "mcp"
+          ],
+          "trendingScore": 0.03,
+          "linkedRepos": [
+            {
+              "fullName": "microsoft/playwright-cli",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
+    "andrewyng--context-hub": {
+      "count7d": 1,
+      "reactionsSum7d": 1,
+      "commentsSum7d": 0,
+      "topArticle": {
+        "id": 3766493,
+        "title": "The Internet Is for Agents",
+        "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
+        "author": "keithjmackay",
+        "reactions": 1,
+        "comments": 0,
+        "hoursSincePosted": 13.8,
+        "readingTime": 14
+      },
+      "articles": [
+        {
+          "id": 3766493,
+          "title": "The Internet Is for Agents",
+          "description": "The Internet Is for Agents   For over a year now, more than half of internet traffic has not...",
+          "url": "https://dev.to/keithjmackay/the-internet-is-for-agents-1iif",
+          "author": {
+            "username": "keithjmackay",
+            "name": "Keith MacKay",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1499463%2Fdc7d3636-8482-4d6e-b619-fb4367cf4dfd.jpg"
+          },
+          "reactionsCount": 1,
+          "commentsCount": 0,
+          "readingTime": 14,
+          "publishedAt": "2026-05-27T20:19:56Z",
+          "tags": [
+            "agents",
+            "infrastructure",
+            "mcp",
+            "security"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "andrewyng/context-hub",
+              "location": "body"
+            }
+          ]
+        }
+      ]
+    },
     "teng-lin--notebooklm-py": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -6473,7 +6146,7 @@
         "author": "wonderlab",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 26.3,
+        "hoursSincePosted": 32.6,
         "readingTime": 7
       },
       "articles": [
@@ -6518,7 +6191,7 @@
         "author": "venkatakrishna_s",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 71.1,
+        "hoursSincePosted": 77.5,
         "readingTime": 3
       },
       "articles": [
@@ -6563,7 +6236,7 @@
         "author": "pwd9000",
         "reactions": 2,
         "comments": 1,
-        "hoursSincePosted": 13.7,
+        "hoursSincePosted": 20.1,
         "readingTime": 11
       },
       "articles": [
@@ -6587,7 +6260,7 @@
             "devops",
             "tutorial"
           ],
-          "trendingScore": 0.05,
+          "trendingScore": 0.03,
           "linkedRepos": [
             {
               "fullName": "github/awesome-copilot",
@@ -6612,7 +6285,7 @@
         "author": "tenglongai2026",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 3.9,
+        "hoursSincePosted": 10.3,
         "readingTime": 1
       },
       "articles": [
@@ -6655,7 +6328,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 135.1,
+        "hoursSincePosted": 141.4,
         "readingTime": 4
       },
       "articles": [
@@ -6704,7 +6377,7 @@
         "author": "adityamitra",
         "reactions": 1,
         "comments": 0,
-        "hoursSincePosted": 135.1,
+        "hoursSincePosted": 141.4,
         "readingTime": 4
       },
       "articles": [
@@ -6753,7 +6426,7 @@
         "author": "grimicorn",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 52.4,
+        "hoursSincePosted": 58.7,
         "readingTime": 3
       },
       "articles": [
@@ -6786,51 +6459,6 @@
         }
       ]
     },
-    "tashfeenahmed--freellmapi": {
-      "count7d": 1,
-      "reactionsSum7d": 1,
-      "commentsSum7d": 0,
-      "topArticle": {
-        "id": 3715372,
-        "title": "Turn ~800M Free AI Tokens Into a Single OpenAI API with FreeLLMAPI",
-        "url": "https://dev.to/mervindublin/turn-800m-free-ai-tokens-into-a-single-openai-api-with-freellmapi-2gm9",
-        "author": "mervindublin",
-        "reactions": 1,
-        "comments": 0,
-        "hoursSincePosted": 163.4,
-        "readingTime": 3
-      },
-      "articles": [
-        {
-          "id": 3715372,
-          "title": "Turn ~800M Free AI Tokens Into a Single OpenAI API with FreeLLMAPI",
-          "description": "An honest look at FreeLLMAPI — an open-source proxy that aggregates 14 free-tier AI providers into one OpenAI-compatible endpoint.",
-          "url": "https://dev.to/mervindublin/turn-800m-free-ai-tokens-into-a-single-openai-api-with-freellmapi-2gm9",
-          "author": {
-            "username": "mervindublin",
-            "name": "Mervin",
-            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3906971%2F89876791-af06-4c66-a1b7-99df14df1b85.png"
-          },
-          "reactionsCount": 1,
-          "commentsCount": 0,
-          "readingTime": 3,
-          "publishedAt": "2026-05-21T08:21:17Z",
-          "tags": [
-            "opensource",
-            "ai",
-            "devtools",
-            "llm"
-          ],
-          "trendingScore": 0,
-          "linkedRepos": [
-            {
-              "fullName": "tashfeenahmed/freellmapi",
-              "location": "body"
-            }
-          ]
-        }
-      ]
-    },
     "charmbracelet--bubbletea": {
       "count7d": 1,
       "reactionsSum7d": 0,
@@ -6842,7 +6470,7 @@
         "author": "earthbound_misfit",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 133.7,
+        "hoursSincePosted": 140,
         "readingTime": 6
       },
       "articles": [
@@ -6881,7 +6509,7 @@
       ]
     },
     "ratatui--ratatui": {
-      "count7d": 1,
+      "count7d": 2,
       "reactionsSum7d": 0,
       "commentsSum7d": 0,
       "topArticle": {
@@ -6891,7 +6519,7 @@
         "author": "earthbound_misfit",
         "reactions": 0,
         "comments": 0,
-        "hoursSincePosted": 133.7,
+        "hoursSincePosted": 140,
         "readingTime": 6
       },
       "articles": [
@@ -6926,6 +6554,34 @@
               "location": "body"
             }
           ]
+        },
+        {
+          "id": 3734631,
+          "title": "Glyph v0.2: the release is the joinery",
+          "description": "Seven new Bubble Tea components and three single-binary TUIs that compose them. A note on why the unit test for a component library is the demo, not the catalog.",
+          "url": "https://dev.to/earthbound_misfit/glyph-v02-the-release-is-the-joinery-28bj",
+          "author": {
+            "username": "earthbound_misfit",
+            "name": "Truffle",
+            "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3894869%2Fd8eb128c-d56f-4996-b0d6-4d9a10950086.png"
+          },
+          "reactionsCount": 0,
+          "commentsCount": 0,
+          "readingTime": 4,
+          "publishedAt": "2026-05-23T17:25:18Z",
+          "tags": [
+            "go",
+            "tui",
+            "bubbletea",
+            "opensource"
+          ],
+          "trendingScore": 0,
+          "linkedRepos": [
+            {
+              "fullName": "ratatui/ratatui",
+              "location": "body"
+            }
+          ]
         }
       ]
     }
@@ -6937,14 +6593,19 @@
       "reactionsSum7d": 27
     },
     {
+      "fullName": "NousResearch/hermes-agent",
+      "count7d": 10,
+      "reactionsSum7d": 24
+    },
+    {
       "fullName": "rohitg00/ai-engineering-from-scratch",
       "count7d": 1,
       "reactionsSum7d": 24
     },
     {
-      "fullName": "NousResearch/hermes-agent",
-      "count7d": 11,
-      "reactionsSum7d": 23
+      "fullName": "coreyhaines31/marketingskills",
+      "count7d": 2,
+      "reactionsSum7d": 10
     },
     {
       "fullName": "openclaw/openclaw",
@@ -6952,27 +6613,22 @@
       "reactionsSum7d": 10
     },
     {
-      "fullName": "coreyhaines31/marketingskills",
-      "count7d": 2,
-      "reactionsSum7d": 9
-    },
-    {
       "fullName": "vercel-labs/agent-skills",
       "count7d": 2,
-      "reactionsSum7d": 9
+      "reactionsSum7d": 10
     },
     {
       "fullName": "vercel-labs/skills",
       "count7d": 2,
-      "reactionsSum7d": 9
-    },
-    {
-      "fullName": "aaif-goose/goose",
-      "count7d": 1,
-      "reactionsSum7d": 6
+      "reactionsSum7d": 10
     },
     {
       "fullName": "anthropics/anthropic-sdk-csharp",
+      "count7d": 1,
+      "reactionsSum7d": 8
+    },
+    {
+      "fullName": "aaif-goose/goose",
       "count7d": 1,
       "reactionsSum7d": 6
     },
@@ -6989,16 +6645,16 @@
     {
       "fullName": "github/awesome-copilot",
       "count7d": 2,
-      "reactionsSum7d": 3
-    },
-    {
-      "fullName": "obra/superpowers",
-      "count7d": 3,
-      "reactionsSum7d": 2
+      "reactionsSum7d": 4
     },
     {
       "fullName": "github/spec-kit",
       "count7d": 2,
+      "reactionsSum7d": 2
+    },
+    {
+      "fullName": "anthropics/skills",
+      "count7d": 1,
       "reactionsSum7d": 2
     },
     {
@@ -7027,12 +6683,12 @@
       "reactionsSum7d": 1
     },
     {
-      "fullName": "andrewyng/context-hub",
-      "count7d": 1,
+      "fullName": "obra/superpowers",
+      "count7d": 2,
       "reactionsSum7d": 1
     },
     {
-      "fullName": "anthropics/skills",
+      "fullName": "andrewyng/context-hub",
       "count7d": 1,
       "reactionsSum7d": 1
     },
@@ -7047,27 +6703,17 @@
       "reactionsSum7d": 1
     },
     {
-      "fullName": "tashfeenahmed/freellmapi",
-      "count7d": 1,
-      "reactionsSum7d": 1
-    },
-    {
       "fullName": "anthropics/claude-code",
-      "count7d": 8,
+      "count7d": 7,
       "reactionsSum7d": 0
     },
     {
       "fullName": "maximhq/bifrost",
-      "count7d": 4,
+      "count7d": 5,
       "reactionsSum7d": 0
     },
     {
       "fullName": "datawhalechina/hello-agents",
-      "count7d": 3,
-      "reactionsSum7d": 0
-    },
-    {
-      "fullName": "Lum1104/Understand-Anything",
       "count7d": 3,
       "reactionsSum7d": 0
     },
@@ -7077,7 +6723,7 @@
       "reactionsSum7d": 0
     },
     {
-      "fullName": "bmad-code-org/BMAD-METHOD",
+      "fullName": "Lum1104/Understand-Anything",
       "count7d": 2,
       "reactionsSum7d": 0
     },
@@ -7087,17 +6733,22 @@
       "reactionsSum7d": 0
     },
     {
+      "fullName": "ratatui/ratatui",
+      "count7d": 2,
+      "reactionsSum7d": 0
+    },
+    {
       "fullName": "anthropics/knowledge-work-plugins",
       "count7d": 1,
       "reactionsSum7d": 0
     },
     {
-      "fullName": "charmbracelet/bubbletea",
+      "fullName": "bmad-code-org/BMAD-METHOD",
       "count7d": 1,
       "reactionsSum7d": 0
     },
     {
-      "fullName": "colbymchenry/codegraph",
+      "fullName": "charmbracelet/bubbletea",
       "count7d": 1,
       "reactionsSum7d": 0
     },
@@ -7128,11 +6779,6 @@
     },
     {
       "fullName": "openai/symphony",
-      "count7d": 1,
-      "reactionsSum7d": 0
-    },
-    {
-      "fullName": "ratatui/ratatui",
       "count7d": 1,
       "reactionsSum7d": 0
     },

--- a/data/devto-trending.json
+++ b/data/devto-trending.json
@@ -1,8 +1,8 @@
 {
-  "fetchedAt": "2026-05-28T03:47:11.281Z",
+  "fetchedAt": "2026-05-28T10:06:54.064Z",
   "discoveryVersion": "2026-04-21",
   "windowDays": 7,
-  "scannedArticles": 1444,
+  "scannedArticles": 1431,
   "bodyFetchMode": "full",
   "priorityTags": [
     "ai",
@@ -179,12 +179,12 @@
   ],
   "sliceCounts": {
     "global-top-7d": 100,
-    "global-rising": 19,
+    "global-rising": 16,
     "global-fresh": 100,
     "tag-ai-top-7d": 100,
     "tag-artificialintelligence-top-7d": 0,
     "tag-agents-top-7d": 100,
-    "tag-agentic-top-7d": 5,
+    "tag-agentic-top-7d": 4,
     "tag-claudecode-top-7d": 100,
     "tag-claude-top-7d": 100,
     "tag-codex-top-7d": 8,
@@ -193,7 +193,7 @@
     "tag-llms-top-7d": 5,
     "tag-mcp-top-7d": 100,
     "tag-rag-top-7d": 100,
-    "tag-promptengineering-top-7d": 33,
+    "tag-promptengineering-top-7d": 34,
     "tag-workflow-top-7d": 41,
     "tag-workflows-top-7d": 4,
     "tag-automation-top-7d": 100,
@@ -560,15 +560,15 @@
         "name": "Sylwia Laskowska",
         "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3535771%2Fe22860d5-274b-43c9-819b-56b162e5bd5a.jpeg"
       },
-      "reactionsCount": 56,
-      "commentsCount": 52,
+      "reactionsCount": 71,
+      "commentsCount": 90,
       "readingTime": 4,
       "publishedAt": "2026-05-27T07:11:18Z",
       "tags": [
         "discuss",
         "ai"
       ],
-      "trendingScore": 46.04,
+      "trendingScore": 48.81,
       "linkedRepos": []
     },
     {
@@ -1882,6 +1882,29 @@
       "linkedRepos": []
     },
     {
+      "id": 3751280,
+      "title": "Top API Gateways for AI Applications and Agentic Workflows (2026 Developer Guide)",
+      "description": "A lot of AI apps die in the same place.  Not during the prototype phase. Not while testing...",
+      "url": "https://dev.to/hadil/top-api-gateways-for-ai-applications-and-agentic-workflows-2026-developer-guide-1e82",
+      "author": {
+        "username": "hadil",
+        "name": "Hadil Ben Abdallah",
+        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F1209000%2Fb29d37d8-2efe-4391-9796-a6f8a483f1bd.png"
+      },
+      "reactionsCount": 10,
+      "commentsCount": 1,
+      "readingTime": 10,
+      "publishedAt": "2026-05-28T09:02:28Z",
+      "tags": [
+        "ai",
+        "api",
+        "apigateway",
+        "backend"
+      ],
+      "trendingScore": 10.24,
+      "linkedRepos": []
+    },
+    {
       "id": 3655326,
       "title": "Open Vibe -- Ship your SaaS with AI. Without getting stuck.",
       "description": "Open SaaS is live today on Product Hunt! 🎉   Check us out →       You watch a twelve-hour tutorial,...",
@@ -2523,29 +2546,6 @@
         "beginners"
       ],
       "trendingScore": 6.43,
-      "linkedRepos": []
-    },
-    {
-      "id": 3732936,
-      "title": "From YAML to AI Agents: Building Smarter DevOps Pipelines with MCP",
-      "description": "How DevOps, SRE, platform, cloud, release, DevSecOps, and AI infrastructure teams can use MCP, skills, and plugins to build faster and safer CI/CD pipelines.",
-      "url": "https://dev.to/nimay_04/from-yaml-to-ai-agents-building-smarter-devops-pipelines-with-mcp-3go3",
-      "author": {
-        "username": "nimay_04",
-        "name": "Nimesh Kulkarni",
-        "profileImage": "https://media2.dev.to/dynamic/image/width=90,height=90,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3604005%2F962463d0-717a-46e7-b0ea-0d7cd72431e0.jpg"
-      },
-      "reactionsCount": 5,
-      "commentsCount": 0,
-      "readingTime": 8,
-      "publishedAt": "2026-05-23T12:56:51Z",
-      "tags": [
-        "devops",
-        "ai",
-        "mcp",
-        "cicd"
-      ],
-      "trendingScore": 6.35,
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh dev.to signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26568213615

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.