### PR TITLE
chore(data): refresh lobsters signals 2026-05-28T12:52:42Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-28T09:01:44.652Z",
+  "ts": "2026-05-28T12:52:42.327Z",
   "count": 1,
-  "durationMs": 3205,
+  "durationMs": 29225,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T09:01:41.468Z",
+  "fetchedAt": "2026-05-28T12:52:13.123Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -456,6 +456,44 @@
           ]
         }
       ]
+    },
+    "google/ax": {
+      "count7d": 1,
+      "scoreSum7d": 1,
+      "topStory": {
+        "shortId": "3k9g2c",
+        "title": "ax, Google’s new highly distributed agent executor",
+        "score": 1,
+        "url": "https://github.com/google/ax",
+        "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
+        "hoursSincePosted": 2.2202777777777776
+      },
+      "stories": [
+        {
+          "shortId": "3k9g2c",
+          "title": "ax, Google’s new highly distributed agent executor",
+          "url": "https://github.com/google/ax",
+          "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
+          "by": "",
+          "score": 1,
+          "commentCount": 0,
+          "createdUtc": 1779964740,
+          "ageHours": 2.2202777777777776,
+          "trendingScore": 0.115342256740933,
+          "tags": [
+            "ai",
+            "distributed"
+          ],
+          "description": "",
+          "linkedRepos": [
+            {
+              "fullName": "google/ax",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "leaderboard": [
@@ -518,6 +556,11 @@
       "fullName": "withastro/flue",
       "count7d": 1,
       "scoreSum7d": 2
+    },
+    {
+      "fullName": "google/ax",
+      "count7d": 1,
+      "scoreSum7d": 1
     }
   ]
 }

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T09:01:41.468Z",
+  "fetchedAt": "2026-05-28T12:52:13.123Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -348,6 +348,23 @@
       "trendingScore": 1.9117489668003358,
       "tags": [
         "culture"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "nx1xwo",
+      "title": "Why Gentoo?",
+      "url": "https://blogs.gentoo.org/mgorny/2026/05/28/why-gentoo/",
+      "commentsUrl": "https://lobste.rs/s/nx1xwo/why_gentoo",
+      "by": "",
+      "score": 19,
+      "commentCount": 6,
+      "createdUtc": 1779961925,
+      "ageHours": 3.002222222222222,
+      "trendingScore": 1.6982793508767686,
+      "tags": [
+        "linux"
       ],
       "description": "",
       "linkedRepos": []
@@ -769,6 +786,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "jowjkj",
+      "title": "What's cooking on SourceHut? Q2 2026",
+      "url": "https://sourcehut.org/blog/2026-05-28-whats-cooking-q2-2026/",
+      "commentsUrl": "https://lobste.rs/s/jowjkj/what_s_cooking_on_sourcehut_q2_2026",
+      "by": "",
+      "score": 10,
+      "commentCount": 0,
+      "createdUtc": 1779965188,
+      "ageHours": 2.095833333333333,
+      "trendingScore": 1.2063868255985037,
+      "tags": [
+        "devops"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "wskhre",
       "title": "linux 0-day, access root-owned files as an unprivileged user",
       "url": "https://github.com/0xdeadbeefnetwork/ssh-keysign-pwn/",
@@ -860,41 +894,6 @@
       "tags": [
         "networking",
         "security"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "b6fyzj",
-      "title": "So you've installed `fzf`. Now what? (2023)",
-      "url": "https://andrew-quinn.me/fzf/",
-      "commentsUrl": "https://lobste.rs/s/b6fyzj/so_you_ve_installed_fzf_now_what_2023",
-      "by": "",
-      "score": 11,
-      "commentCount": 0,
-      "createdUtc": 1778424911,
-      "ageHours": 2.6005555555555557,
-      "trendingScore": 1.1147494476958622,
-      "tags": [
-        "programming"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "lkv0sh",
-      "title": "Using AI to write better code more slowly",
-      "url": "https://nolanlawson.com/2026/05/25/using-ai-to-write-better-code-more-slowly/",
-      "commentsUrl": "https://lobste.rs/s/lkv0sh/using_ai_write_better_code_more_slowly",
-      "by": "",
-      "score": 4,
-      "commentCount": 0,
-      "createdUtc": 1779725954,
-      "ageHours": 0.35944444444444446,
-      "trendingScore": 1.1036855523080105,
-      "tags": [
-        "practices",
-        "vibecoding"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26575725693

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.