### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-28T14:45:53Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-28T00:11:08.925Z",
+  "ts": "2026-05-28T14:45:53.323Z",
   "count": 1,
-  "durationMs": 14961,
+  "durationMs": 9743,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-28T00:11:03.916Z",
+  "lastFetchedAt": "2026-05-28T14:45:51.928Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1597,6 +1597,60 @@
       "aiAdjacent": true
     },
     {
+      "id": "1152111",
+      "name": "Pancake",
+      "tagline": "OpenClaw in Slack that makes your company autonomous",
+      "description": "Every other AI product is a tool that makes you more productive. A copilot. An assistant. A coworker. Something you use. Pancake makes your company autonomous. Agents with roles, goals, and a heartbeat working while you sleep. You set direction, approve the irreversible, the rest runs. Prepare yourself to be prompted by Pancake.",
+      "url": "https://www.producthunt.com/products/pancake-6?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/AYXK7CGT2LEPGB",
+      "votesCount": 285,
+      "commentsCount": 44,
+      "createdAt": "2026-05-28T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/97c3d3e6-3484-4fe5-9a56-bf795d31eaa5.png?auto=format",
+      "topics": [
+        "slack",
+        "artificial-intelligence",
+        "maker-tools"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1052099",
       "name": "Graphbit PRFlow",
       "tagline": "AI code reviewer that catches what others miss",
@@ -2167,6 +2221,72 @@
       "aiAdjacent": true
     },
     {
+      "id": "1146232",
+      "name": "SpotsNow",
+      "tagline": "Track who's advertising across podcasts w/ campaign insights",
+      "description": "Track who's advertising on every podcast, what they're spending, and where their campaigns are running — then buy open inventory directly from publishers, all in one place. The competitive intelligence layer for podcast ads.",
+      "url": "https://www.producthunt.com/products/spotsnow?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/IXZOC4RHEEXJVY",
+      "votesCount": 249,
+      "commentsCount": 34,
+      "createdAt": "2026-05-28T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/dd079df8-e8a8-428c-b263-4239b32c3ad8.jpeg?auto=format",
+      "topics": [
+        "analytics",
+        "advertising",
+        "radio"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": false
+    },
+    {
       "id": "1151355",
       "name": "Google Antigravity 2.0",
       "tagline": "Orchestrate multi-agent workflows from a desktop app",
@@ -2356,115 +2476,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1140851",
-      "name": "Tendem by Toloka",
-      "tagline": "AI platform to hand off any task to a human expert",
-      "description": "Tendem is a platform where human experts and AI agents complete high-stakes tasks. Submit a task in plain language. AI agents handle the volume. Human experts level up the the final output. What comes back is complete, accurate, and ready to act on. Built by Toloka.ai, a company that has spent more than a decade building human-in-the-loop quality systems for frontier AI labs. Trusted by founders, operators, and AI-native users who need reliable results.",
-      "url": "https://www.producthunt.com/products/tendem-by-toloka?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/VU7DEOLLKRGOW4",
-      "votesCount": 235,
-      "commentsCount": 64,
-      "createdAt": "2026-05-14T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/b18f1c41-98fa-4ae8-a0da-549be2be9a72.jpeg?auto=format",
-      "topics": [
-        "design-tools",
-        "productivity",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1138787",
-      "name": "Open Vibe",
-      "tagline": "Ship your SaaS with AI, without getting stuck",
-      "description": "Build the skills of a pro coder while you ship a real SaaS app! Open Vibe turns Claude Code (or your agent of choice) into the ultimate SaaS tutor, teaching the most important concepts while you build.",
-      "url": "https://www.producthunt.com/products/open-vibe?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/74MX3XTFNJVI5S",
-      "votesCount": 234,
-      "commentsCount": 39,
-      "createdAt": "2026-05-12T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/fbaad5be-8e3d-452d-844f-3557574e0d3d.png?auto=format",
-      "topics": [
-        "education",
-        "saas",
-        "github",
-        "vibe-coding"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26581923685

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.