### PR TITLE
chore(data): refresh huggingface space signals 2026-05-28T16:42:19Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-28T10:41:20.599Z",
+  "ts": "2026-05-28T16:42:19.589Z",
   "count": 1,
-  "durationMs": 4393,
+  "durationMs": 6159,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T10:41:16.207Z",
+  "fetchedAt": "2026-05-28T16:42:13.431Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -75,6 +75,22 @@
     },
     {
       "rank": 5,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 139,
+      "trendingScore": 132,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-26T16:44:17.000Z",
+      "models": []
+    },
+    {
+      "rank": 6,
       "id": "r3gm/wan2-2-fp8da-aoti-preview-2",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview-2",
@@ -88,22 +104,6 @@
       ],
       "createdAt": "2025-11-18T23:17:30.000Z",
       "lastModified": "2026-05-15T03:44:05.000Z",
-      "models": []
-    },
-    {
-      "rank": 6,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 133,
-      "trendingScore": 127,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-26T16:44:17.000Z",
       "models": []
     },
     {
@@ -144,6 +144,22 @@
     },
     {
       "rank": 9,
+      "id": "webml-community/bonsai-image-webgpu",
+      "author": "webml-community",
+      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
+      "likes": 91,
+      "trendingScore": 88,
+      "sdk": "static",
+      "tags": [
+        "static",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T17:12:36.000Z",
+      "lastModified": "2026-05-26T20:57:36.000Z",
+      "models": []
+    },
+    {
+      "rank": 10,
       "id": "cbensimon/wan2-2-fp8da-aoti-preview2",
       "author": "cbensimon",
       "url": "https://huggingface.co/spaces/cbensimon/wan2-2-fp8da-aoti-preview2",
@@ -160,7 +176,7 @@
       "models": []
     },
     {
-      "rank": 10,
+      "rank": 11,
       "id": "HuggingFaceBio/carbon-demo",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/spaces/HuggingFaceBio/carbon-demo",
@@ -173,22 +189,6 @@
       ],
       "createdAt": "2026-05-19T14:18:55.000Z",
       "lastModified": "2026-05-20T10:03:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 11,
-      "id": "webml-community/bonsai-image-webgpu",
-      "author": "webml-community",
-      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 86,
-      "trendingScore": 83,
-      "sdk": "static",
-      "tags": [
-        "static",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T17:12:36.000Z",
-      "lastModified": "2026-05-26T20:57:36.000Z",
       "models": []
     },
     {
@@ -391,6 +391,22 @@
     },
     {
       "rank": 24,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 56,
+      "trendingScore": 54,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-27T11:24:58.000Z",
+      "models": []
+    },
+    {
+      "rank": 25,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -406,11 +422,27 @@
       "models": []
     },
     {
-      "rank": 25,
+      "rank": 26,
+      "id": "multimodalart/z-image-6b-pixel-space",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
+      "likes": 50,
+      "trendingScore": 48,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T12:46:34.000Z",
+      "lastModified": "2026-05-22T19:37:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 27,
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1777,
+      "likes": 1778,
       "trendingScore": 47,
       "sdk": "gradio",
       "tags": [
@@ -422,23 +454,7 @@
       "models": []
     },
     {
-      "rank": 26,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 48,
-      "trendingScore": 47,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-27T11:24:58.000Z",
-      "models": []
-    },
-    {
-      "rank": 27,
+      "rank": 28,
       "id": "FrameAI4687/Omni-Video-Factory",
       "author": "FrameAI4687",
       "url": "https://huggingface.co/spaces/FrameAI4687/Omni-Video-Factory",
@@ -454,7 +470,7 @@
       "models": []
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
       "author": "akhaliq",
       "url": "https://huggingface.co/spaces/akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
@@ -467,22 +483,6 @@
       ],
       "createdAt": "2026-05-07T16:52:45.000Z",
       "lastModified": "2026-05-07T19:19:41.000Z",
-      "models": []
-    },
-    {
-      "rank": 29,
-      "id": "multimodalart/z-image-6b-pixel-space",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 45,
-      "trendingScore": 44,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T12:46:34.000Z",
-      "lastModified": "2026-05-22T19:37:35.000Z",
       "models": []
     },
     {
@@ -506,7 +506,7 @@
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
-      "likes": 3234,
+      "likes": 3248,
       "trendingScore": 38,
       "sdk": "gradio",
       "tags": [
@@ -552,6 +552,23 @@
     },
     {
       "rank": 34,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 35,
+      "trendingScore": 35,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "arxiv:2605.27365",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-27T09:35:37.000Z",
+      "models": []
+    },
+    {
+      "rank": 35,
       "id": "multimodalart/qwen-image-multiple-angles-3d-camera",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/qwen-image-multiple-angles-3d-camera",
@@ -567,7 +584,7 @@
       "models": []
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "suraj291/Survival_Island_Game",
       "author": "suraj291",
       "url": "https://huggingface.co/spaces/suraj291/Survival_Island_Game",
@@ -584,7 +601,7 @@
       "models": []
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "r3gm/wan2-2-fp8da-aoti-previewG",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewG",
@@ -601,7 +618,7 @@
       "models": []
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -617,7 +634,7 @@
       "models": []
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -634,7 +651,7 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -651,7 +668,7 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -667,7 +684,7 @@
       "models": []
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -683,7 +700,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -699,7 +716,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
@@ -716,7 +733,7 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "CohereLabs/command-a-plus-05-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
@@ -732,7 +749,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -748,7 +765,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -765,7 +782,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -781,7 +798,7 @@
       "models": []
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -797,7 +814,7 @@
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "mrfakename/anima-v1",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
@@ -814,23 +831,6 @@
       ],
       "createdAt": "2026-05-15T02:42:26.000Z",
       "lastModified": "2026-05-22T03:20:51.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 25,
-      "trendingScore": 25,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26588416493

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.