### PR TITLE
chore(data): refresh lobsters signals 2026-05-28T17:09:47Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-28T12:52:42.327Z",
+  "ts": "2026-05-28T17:09:47.400Z",
   "count": 1,
-  "durationMs": 29225,
+  "durationMs": 2955,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T12:52:13.123Z",
+  "fetchedAt": "2026-05-28T17:09:44.465Z",
   "windowDays": 7,
-  "scannedStories": 80,
+  "scannedStories": 81,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -466,7 +466,7 @@
         "score": 1,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 2.2202777777777776
+        "hoursSincePosted": 6.512222222222222
       },
       "stories": [
         {
@@ -476,13 +476,13 @@
           "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
           "by": "",
           "score": 1,
-          "commentCount": 0,
+          "commentCount": 1,
           "createdUtc": 1779964740,
-          "ageHours": 2.2202777777777776,
-          "trendingScore": 0.115342256740933,
+          "ageHours": 6.512222222222222,
+          "trendingScore": 0.040265729404901744,
           "tags": [
-            "ai",
-            "distributed"
+            "distributed",
+            "vibecoding"
           ],
           "description": "",
           "linkedRepos": [

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T12:52:13.123Z",
+  "fetchedAt": "2026-05-28T17:09:44.465Z",
   "windowHours": 72,
-  "scannedTotal": 80,
+  "scannedTotal": 81,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -370,6 +370,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "jowjkj",
+      "title": "What's cooking on SourceHut? Q2 2026",
+      "url": "https://sourcehut.org/blog/2026-05-28-whats-cooking-q2-2026/",
+      "commentsUrl": "https://lobste.rs/s/jowjkj/what_s_cooking_on_sourcehut_q2_2026",
+      "by": "",
+      "score": 41,
+      "commentCount": 3,
+      "createdUtc": 1779965188,
+      "ageHours": 6.387777777777778,
+      "trendingScore": 1.6877708540378678,
+      "tags": [
+        "devops"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "fu5qzo",
       "title": "On Google declaring war on the Web",
       "url": "https://tante.cc/2026/05/20/on-google-declaring-war-on-the-web/",
@@ -399,6 +416,23 @@
       "trendingScore": 1.65427236943472,
       "tags": [
         "web"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "0zltfs",
+      "title": "Nitpicking the shell history scene in ‘Tron: Legacy’",
+      "url": "https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/tron-legacy/",
+      "commentsUrl": "https://lobste.rs/s/0zltfs/nitpicking_shell_history_scene_tron",
+      "by": "",
+      "score": 27,
+      "commentCount": 2,
+      "createdUtc": 1779972153,
+      "ageHours": 4.453055555555555,
+      "trendingScore": 1.6470836574440113,
+      "tags": [
+        "unix"
       ],
       "description": "",
       "linkedRepos": []
@@ -786,23 +820,6 @@
       "linkedRepos": []
     },
     {
-      "shortId": "jowjkj",
-      "title": "What's cooking on SourceHut? Q2 2026",
-      "url": "https://sourcehut.org/blog/2026-05-28-whats-cooking-q2-2026/",
-      "commentsUrl": "https://lobste.rs/s/jowjkj/what_s_cooking_on_sourcehut_q2_2026",
-      "by": "",
-      "score": 10,
-      "commentCount": 0,
-      "createdUtc": 1779965188,
-      "ageHours": 2.095833333333333,
-      "trendingScore": 1.2063868255985037,
-      "tags": [
-        "devops"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
       "shortId": "wskhre",
       "title": "linux 0-day, access root-owned files as an unprivileged user",
       "url": "https://github.com/0xdeadbeefnetwork/ssh-keysign-pwn/",
@@ -876,24 +893,6 @@
         "pdf",
         "practices",
         "programming"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "bnfm0h",
-      "title": "Let's Encrypt Stopping Issuance for Potential Incident",
-      "url": "https://letsencrypt.status.io/",
-      "commentsUrl": "https://lobste.rs/s/bnfm0h/let_s_encrypt_stopping_issuance_for",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1778273645,
-      "ageHours": 0.71,
-      "trendingScore": 1.1207688915697178,
-      "tags": [
-        "networking",
-        "security"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26589914274

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.