### PR TITLE
chore(data): refresh lobsters signals 2026-05-28T19:56:23Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-28T17:09:47.400Z",
+  "ts": "2026-05-28T19:56:23.941Z",
   "count": 1,
-  "durationMs": 2955,
+  "durationMs": 2587,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T17:09:44.465Z",
+  "fetchedAt": "2026-05-28T19:56:21.376Z",
   "windowDays": 7,
-  "scannedStories": 81,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -466,7 +466,7 @@
         "score": 1,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 6.512222222222222
+        "hoursSincePosted": 9.289166666666667
       },
       "stories": [
         {
@@ -478,8 +478,8 @@
           "score": 1,
           "commentCount": 1,
           "createdUtc": 1779964740,
-          "ageHours": 6.512222222222222,
-          "trendingScore": 0.040265729404901744,
+          "ageHours": 9.289166666666667,
+          "trendingScore": 0.026363749281785098,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T17:09:44.465Z",
+  "fetchedAt": "2026-05-28T19:56:21.376Z",
   "windowHours": 72,
-  "scannedTotal": 81,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -353,6 +353,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "4msjpt",
+      "title": "Garnix is shutting down",
+      "url": "https://discourse.nixos.org/t/garnix-is-shutting-down-not-oc/77895",
+      "commentsUrl": "https://lobste.rs/s/4msjpt/garnix_is_shutting_down",
+      "by": "",
+      "score": 16,
+      "commentCount": 4,
+      "createdUtc": 1779989447,
+      "ageHours": 2.426111111111111,
+      "trendingScore": 1.718250640866198,
+      "tags": [
+        "devops",
+        "nix"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "nx1xwo",
       "title": "Why Gentoo?",
       "url": "https://blogs.gentoo.org/mgorny/2026/05/28/why-gentoo/",
@@ -657,6 +675,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "4jgpkn",
+      "title": "Announcing Rust 1.96.0",
+      "url": "https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/",
+      "commentsUrl": "https://lobste.rs/s/4jgpkn/announcing_rust_1_96_0",
+      "by": "",
+      "score": 5,
+      "commentCount": 0,
+      "createdUtc": 1779996488,
+      "ageHours": 0.4702777777777778,
+      "trendingScore": 1.2878085882110084,
+      "tags": [
+        "release",
+        "rust"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "e7lsqn",
       "title": "Chromium publishes fixed exploit 4 years later, turns out it's actually unfixed",
       "url": "https://infosec.exchange/@rebane2001/116606719764376414",
@@ -859,42 +895,6 @@
         "programming"
       ],
       "description": "<p>Developers are so opinionated that it's difficult to pin down one favourite tool !</p>\n",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "msrczi",
-      "title": "What is BusyBox?",
-      "url": "https://specular.fi/post/what-is-busybox",
-      "commentsUrl": "https://lobste.rs/s/msrczi/what_is_busybox",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1778607968,
-      "ageHours": 0.6333333333333333,
-      "trendingScore": 1.1700683971771915,
-      "tags": [
-        "linux"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ac0akx",
-      "title": "Programming as Theory Building (1985)",
-      "url": "https://gwern.net/doc/cs/algorithm/1985-naur.pdf",
-      "commentsUrl": "https://lobste.rs/s/ac0akx/programming_as_theory_building_1985",
-      "by": "",
-      "score": 9,
-      "commentCount": 0,
-      "createdUtc": 1779140566,
-      "ageHours": 1.9572222222222222,
-      "trendingScore": 1.1432911733342348,
-      "tags": [
-        "pdf",
-        "practices",
-        "programming"
-      ],
-      "description": "",
       "linkedRepos": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26598605620

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.