### PR TITLE
chore(data): refresh huggingface space signals 2026-05-28T20:59:28Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-28T16:42:19.589Z",
+  "ts": "2026-05-28T20:59:28.087Z",
   "count": 1,
-  "durationMs": 6159,
+  "durationMs": 4431,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T16:42:13.431Z",
+  "fetchedAt": "2026-05-28T20:59:23.658Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -55,6 +55,22 @@
     },
     {
       "rank": 4,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 142,
+      "trendingScore": 134,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-26T16:44:17.000Z",
+      "models": []
+    },
+    {
+      "rank": 5,
       "id": "AdithyaSK/rl-environments-guide",
       "author": "AdithyaSK",
       "url": "https://huggingface.co/spaces/AdithyaSK/rl-environments-guide",
@@ -71,22 +87,6 @@
       ],
       "createdAt": "2026-04-29T10:00:16.000Z",
       "lastModified": "2026-05-06T19:39:20.000Z",
-      "models": []
-    },
-    {
-      "rank": 5,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 139,
-      "trendingScore": 132,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-26T16:44:17.000Z",
       "models": []
     },
     {
@@ -147,8 +147,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 91,
-      "trendingScore": 88,
+      "likes": 97,
+      "trendingScore": 93,
       "sdk": "static",
       "tags": [
         "static",
@@ -341,6 +341,22 @@
     },
     {
       "rank": 21,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 61,
+      "trendingScore": 59,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-28T17:00:43.000Z",
+      "models": []
+    },
+    {
+      "rank": 22,
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
@@ -357,7 +373,7 @@
       "models": []
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "stabilityai/stable-audio-3",
       "author": "stabilityai",
       "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
@@ -373,7 +389,7 @@
       "models": []
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "zerogpu-aoti/wan2-2-fp8da-aoti-faster",
       "author": "zerogpu-aoti",
       "url": "https://huggingface.co/spaces/zerogpu-aoti/wan2-2-fp8da-aoti-faster",
@@ -387,22 +403,6 @@
       ],
       "createdAt": "2025-07-30T19:03:28.000Z",
       "lastModified": "2025-12-16T14:37:58.000Z",
-      "models": []
-    },
-    {
-      "rank": 24,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 56,
-      "trendingScore": 54,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-27T11:24:58.000Z",
       "models": []
     },
     {
@@ -426,7 +426,7 @@
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 50,
+      "likes": 51,
       "trendingScore": 48,
       "sdk": "gradio",
       "tags": [
@@ -442,7 +442,7 @@
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1778,
+      "likes": 1780,
       "trendingScore": 47,
       "sdk": "gradio",
       "tags": [
@@ -506,8 +506,8 @@
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
-      "likes": 3248,
-      "trendingScore": 38,
+      "likes": 3249,
+      "trendingScore": 39,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -536,6 +536,23 @@
     },
     {
       "rank": 33,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 37,
+      "trendingScore": 37,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "arxiv:2605.27365",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-27T09:35:37.000Z",
+      "models": []
+    },
+    {
+      "rank": 34,
       "id": "ibuildproducts/wan22-i2v-v4-demo",
       "author": "ibuildproducts",
       "url": "https://huggingface.co/spaces/ibuildproducts/wan22-i2v-v4-demo",
@@ -548,23 +565,6 @@
       ],
       "createdAt": "2026-05-17T23:34:01.000Z",
       "lastModified": "2026-05-18T00:16:12.000Z",
-      "models": []
-    },
-    {
-      "rank": 34,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 35,
-      "trendingScore": 35,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26601831310

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.