### PR TITLE
chore(data): refresh arxiv signals 2026-05-28T21:01:17Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-28T16:45:04.165Z",
+  "ts": "2026-05-28T21:01:17.684Z",
   "count": 1,
-  "durationMs": 60833,
+  "durationMs": 60520,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T16:45:04.213Z",
+  "fetchedAt": "2026-05-28T21:01:17.731Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -7,6 +7,13 @@
   ],
   "count": 160,
   "papers": [
+    {
+      "arxivId": "2605.28820v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
     {
       "arxivId": "2605.28819v1",
       "citationCount": 0,
@@ -22,6 +29,13 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28816v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28814v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -34,6 +48,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28811v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
       "arxivId": "2605.28810v1",
@@ -218,6 +239,13 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28741v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28740v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -230,6 +258,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28735v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
       "arxivId": "2605.28734v1",
@@ -377,6 +412,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28691v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
       "arxivId": "2605.28690v1",
@@ -533,6 +575,13 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28630v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28629v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -554,6 +603,13 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28619v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28617v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -566,6 +622,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28615v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
       "arxivId": "2605.28613v1",
@@ -582,11 +645,25 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28609v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28607v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28605v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
       "arxivId": "2605.28604v1",
@@ -666,6 +743,13 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28587v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28585v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -736,6 +820,27 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
+      "arxivId": "2605.28551v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
+      "arxivId": "2605.28548v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
+      "arxivId": "2605.28544v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
       "arxivId": "2605.28543v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -778,172 +883,18 @@
       "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
-      "arxivId": "2605.28494v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28484v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28465v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28464v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28440v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28438v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28433v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28424v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
-    },
-    {
-      "arxivId": "2605.28820v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28816v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28811v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28741v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28735v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28691v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28630v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28619v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28615v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28609v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28605v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28587v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28551v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28548v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
-      "arxivId": "2605.28544v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
-    },
-    {
       "arxivId": "2605.28495v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
+      "arxivId": "2605.28494v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
       "arxivId": "2605.28491v1",
@@ -960,11 +911,32 @@
       "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
+      "arxivId": "2605.28484v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
       "arxivId": "2605.28477v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
+      "arxivId": "2605.28465v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28464v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
       "arxivId": "2605.28459v1",
@@ -1002,11 +974,39 @@
       "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
     },
     {
+      "arxivId": "2605.28440v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28438v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
+      "arxivId": "2605.28433v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
+    },
+    {
       "arxivId": "2605.28428v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-28T16:45:04.213Z"
+    },
+    {
+      "arxivId": "2605.28424v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-28T05:01:07.071Z"
     },
     {
       "arxivId": "2605.28422v1",

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T16:44:03.353Z",
+  "fetchedAt": "2026-05-28T21:00:17.183Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26601877612

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.