### PR TITLE
chore(data): refresh lobsters signals 2026-05-28T22:19:48Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-28T19:56:23.941Z",
+  "ts": "2026-05-28T22:19:48.064Z",
   "count": 1,
-  "durationMs": 2587,
+  "durationMs": 4245,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T19:56:21.376Z",
+  "fetchedAt": "2026-05-28T22:19:43.839Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -466,7 +466,7 @@
         "score": 1,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 9.289166666666667
+        "hoursSincePosted": 11.678611111111111
       },
       "stories": [
         {
@@ -478,8 +478,8 @@
           "score": 1,
           "commentCount": 1,
           "createdUtc": 1779964740,
-          "ageHours": 9.289166666666667,
-          "trendingScore": 0.026363749281785098,
+          "ageHours": 11.678611111111111,
+          "trendingScore": 0.01976682858666418,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-28T19:56:21.376Z",
+  "fetchedAt": "2026-05-28T22:19:43.839Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -422,6 +422,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "4jgpkn",
+      "title": "Announcing Rust 1.96.0",
+      "url": "https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/",
+      "commentsUrl": "https://lobste.rs/s/4jgpkn/announcing_rust_1_96_0",
+      "by": "",
+      "score": 18,
+      "commentCount": 2,
+      "createdUtc": 1779996488,
+      "ageHours": 2.859722222222222,
+      "trendingScore": 1.680178163273357,
+      "tags": [
+        "release",
+        "rust"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "vbit2a",
       "title": "I Will Not Add Query Strings to Your URLs",
       "url": "https://susam.net/no-query-strings.html",
@@ -670,24 +688,6 @@
       "trendingScore": 1.3176993879144157,
       "tags": [
         "philosophy"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "4jgpkn",
-      "title": "Announcing Rust 1.96.0",
-      "url": "https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/",
-      "commentsUrl": "https://lobste.rs/s/4jgpkn/announcing_rust_1_96_0",
-      "by": "",
-      "score": 5,
-      "commentCount": 0,
-      "createdUtc": 1779996488,
-      "ageHours": 0.4702777777777778,
-      "trendingScore": 1.2878085882110084,
-      "tags": [
-        "release",
-        "rust"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26605548415

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.