### PR TITLE
chore(data): refresh lobsters signals 2026-05-28T23:53:41Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-28T22:19:48.064Z",
+  "ts": "2026-05-28T23:53:41.182Z",
   "count": 1,
-  "durationMs": 4245,
+  "durationMs": 3251,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T22:19:43.839Z",
+  "fetchedAt": "2026-05-28T23:53:37.953Z",
   "windowDays": 7,
   "scannedStories": 78,
   "mentions": {
@@ -459,14 +459,14 @@
     },
     "google/ax": {
       "count7d": 1,
-      "scoreSum7d": 1,
+      "scoreSum7d": 2,
       "topStory": {
         "shortId": "3k9g2c",
         "title": "ax, Google’s new highly distributed agent executor",
-        "score": 1,
+        "score": 2,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 11.678611111111111
+        "hoursSincePosted": 13.243611111111111
       },
       "stories": [
         {
@@ -475,11 +475,11 @@
           "url": "https://github.com/google/ax",
           "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
           "by": "",
-          "score": 1,
+          "score": 2,
           "commentCount": 1,
           "createdUtc": 1779964740,
-          "ageHours": 11.678611111111111,
-          "trendingScore": 0.01976682858666418,
+          "ageHours": 13.243611111111111,
+          "trendingScore": 0.03360455932414562,
           "tags": [
             "distributed",
             "vibecoding"
@@ -560,7 +560,7 @@
     {
       "fullName": "google/ax",
       "count7d": 1,
-      "scoreSum7d": 1
+      "scoreSum7d": 2
     }
   ]
 }

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T22:19:43.839Z",
+  "fetchedAt": "2026-05-28T23:53:37.953Z",
   "windowHours": 72,
   "scannedTotal": 78,
   "stories": [


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26609216093

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.