### PR TITLE
chore(data): refresh huggingface space signals 2026-05-29T04:57:18Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-28T20:59:28.087Z",
+  "ts": "2026-05-29T04:57:18.178Z",
   "count": 1,
-  "durationMs": 4431,
+  "durationMs": 3773,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-28T20:59:23.658Z",
+  "fetchedAt": "2026-05-29T04:57:14.407Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -58,8 +58,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 142,
-      "trendingScore": 134,
+      "likes": 147,
+      "trendingScore": 137,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -147,15 +147,15 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 97,
-      "trendingScore": 93,
+      "likes": 101,
+      "trendingScore": 97,
       "sdk": "static",
       "tags": [
         "static",
         "region:us"
       ],
       "createdAt": "2026-05-26T17:12:36.000Z",
-      "lastModified": "2026-05-26T20:57:36.000Z",
+      "lastModified": "2026-05-29T02:57:22.000Z",
       "models": []
     },
     {
@@ -308,6 +308,22 @@
     },
     {
       "rank": 19,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 64,
+      "trendingScore": 62,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-28T17:00:43.000Z",
+      "models": []
+    },
+    {
+      "rank": 20,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/spaces/k2-fsa/OmniVoice",
@@ -323,7 +339,7 @@
       "models": []
     },
     {
-      "rank": 20,
+      "rank": 21,
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
@@ -337,22 +353,6 @@
       ],
       "createdAt": "2025-12-19T05:20:19.000Z",
       "lastModified": "2026-05-19T14:05:12.000Z",
-      "models": []
-    },
-    {
-      "rank": 21,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 61,
-      "trendingScore": 59,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-28T17:00:43.000Z",
       "models": []
     },
     {
@@ -407,6 +407,55 @@
     },
     {
       "rank": 25,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 51,
+      "trendingScore": 51,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "arxiv:2605.27365",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-27T09:35:37.000Z",
+      "models": []
+    },
+    {
+      "rank": 26,
+      "id": "multimodalart/z-image-6b-pixel-space",
+      "author": "multimodalart",
+      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
+      "likes": 54,
+      "trendingScore": 50,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T12:46:34.000Z",
+      "lastModified": "2026-05-22T19:37:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 27,
+      "id": "selfit-camera/Omni-Image-Editor",
+      "author": "selfit-camera",
+      "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
+      "likes": 1783,
+      "trendingScore": 48,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-13T03:04:18.000Z",
+      "lastModified": "2026-04-19T00:08:34.000Z",
+      "models": []
+    },
+    {
+      "rank": 28,
       "id": "smolagents/ml-intern",
       "author": "smolagents",
       "url": "https://huggingface.co/spaces/smolagents/ml-intern",
@@ -422,39 +471,7 @@
       "models": []
     },
     {
-      "rank": 26,
-      "id": "multimodalart/z-image-6b-pixel-space",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 51,
-      "trendingScore": 48,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T12:46:34.000Z",
-      "lastModified": "2026-05-22T19:37:35.000Z",
-      "models": []
-    },
-    {
-      "rank": 27,
-      "id": "selfit-camera/Omni-Image-Editor",
-      "author": "selfit-camera",
-      "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1780,
-      "trendingScore": 47,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-13T03:04:18.000Z",
-      "lastModified": "2026-04-19T00:08:34.000Z",
-      "models": []
-    },
-    {
-      "rank": 28,
+      "rank": 29,
       "id": "FrameAI4687/Omni-Video-Factory",
       "author": "FrameAI4687",
       "url": "https://huggingface.co/spaces/FrameAI4687/Omni-Video-Factory",
@@ -470,7 +487,7 @@
       "models": []
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
       "author": "akhaliq",
       "url": "https://huggingface.co/spaces/akhaliq/Qwen-Image-Edit-2509-LoRAs-Fast",
@@ -486,7 +503,7 @@
       "models": []
     },
     {
-      "rank": 30,
+      "rank": 31,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -502,7 +519,7 @@
       "models": []
     },
     {
-      "rank": 31,
+      "rank": 32,
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
@@ -519,7 +536,7 @@
       "models": []
     },
     {
-      "rank": 32,
+      "rank": 33,
       "id": "Saravutw/Omni-Video-Factory-Iframe-API",
       "author": "Saravutw",
       "url": "https://huggingface.co/spaces/Saravutw/Omni-Video-Factory-Iframe-API",
@@ -532,23 +549,6 @@
       ],
       "createdAt": "2025-12-09T19:01:39.000Z",
       "lastModified": "2026-03-13T17:12:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 33,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 37,
-      "trendingScore": 37,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
       "models": []
     },
     {
@@ -786,8 +786,8 @@
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
-      "likes": 502,
-      "trendingScore": 26,
+      "likes": 510,
+      "trendingScore": 28,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -799,6 +799,22 @@
     },
     {
       "rank": 49,
+      "id": "facebook/vggt-omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
+      "likes": 40,
+      "trendingScore": 26,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T23:39:56.000Z",
+      "lastModified": "2026-05-18T21:46:03.000Z",
+      "models": []
+    },
+    {
+      "rank": 50,
       "id": "multimodalart/scenema-audio",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
@@ -811,26 +827,6 @@
       ],
       "createdAt": "2026-05-14T10:12:08.000Z",
       "lastModified": "2026-05-16T00:07:35.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "mrfakename/anima-v1",
-      "author": "mrfakename",
-      "url": "https://huggingface.co/spaces/mrfakename/anima-v1",
-      "likes": 42,
-      "trendingScore": 25,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "text-to-image",
-        "anima",
-        "zerogpu",
-        "anime",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T02:42:26.000Z",
-      "lastModified": "2026-05-22T03:20:51.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26618841787

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.