### PR TITLE
chore(data): refresh lobsters signals 2026-05-29T08:58:53Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-29T04:56:43.679Z",
+  "ts": "2026-05-29T08:58:53.352Z",
   "count": 1,
-  "durationMs": 2909,
+  "durationMs": 4546,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T04:56:40.791Z",
+  "fetchedAt": "2026-05-29T08:58:48.828Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -422,14 +422,14 @@
     },
     "google/ax": {
       "count7d": 1,
-      "scoreSum7d": 3,
+      "scoreSum7d": 2,
       "topStory": {
         "shortId": "3k9g2c",
         "title": "ax, Google’s new highly distributed agent executor",
-        "score": 3,
+        "score": 2,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 18.294444444444444
+        "hoursSincePosted": 22.33
       },
       "stories": [
         {
@@ -438,11 +438,11 @@
           "url": "https://github.com/google/ax",
           "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
           "by": "",
-          "score": 3,
+          "score": 2,
           "commentCount": 1,
           "createdUtc": 1779964740,
-          "ageHours": 18.294444444444444,
-          "trendingScore": 0.03281372272943253,
+          "ageHours": 22.33,
+          "trendingScore": 0.016665441838156672,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T04:56:40.791Z",
+  "fetchedAt": "2026-05-29T08:58:48.828Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26628108039

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.