### PR TITLE
chore(data): refresh huggingface signals 2026-05-29T10:16:07Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-29T04:45:06.577Z",
+  "ts": "2026-05-29T10:16:07.327Z",
   "count": 1,
-  "durationMs": 5152,
+  "durationMs": 10382,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T04:45:01.427Z",
+  "fetchedAt": "2026-05-29T10:15:56.947Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -130,35 +130,12 @@
     },
     {
       "rank": 5,
-      "id": "Zyphra/ZAYA1-8B",
-      "author": "Zyphra",
-      "url": "https://huggingface.co/Zyphra/ZAYA1-8B",
-      "downloads": 110182,
-      "likes": 457,
-      "trendingScore": 451,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "zaya",
-        "arxiv:2605.05365",
-        "base_model:Zyphra/ZAYA1-reasoning-base",
-        "base_model:finetune:Zyphra/ZAYA1-reasoning-base",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-04T19:45:38.000Z",
-      "lastModified": "2026-05-11T22:43:52.000Z"
-    },
-    {
-      "rank": 6,
       "id": "openbmb/MiniCPM5-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
-      "downloads": 15629,
-      "likes": 502,
-      "trendingScore": 447,
+      "downloads": 23629,
+      "likes": 521,
+      "trendingScore": 464,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -190,6 +167,29 @@
       ],
       "createdAt": "2026-05-21T07:27:59.000Z",
       "lastModified": "2026-05-26T04:24:04.000Z"
+    },
+    {
+      "rank": 6,
+      "id": "Zyphra/ZAYA1-8B",
+      "author": "Zyphra",
+      "url": "https://huggingface.co/Zyphra/ZAYA1-8B",
+      "downloads": 110182,
+      "likes": 457,
+      "trendingScore": 451,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "zaya",
+        "arxiv:2605.05365",
+        "base_model:Zyphra/ZAYA1-reasoning-base",
+        "base_model:finetune:Zyphra/ZAYA1-reasoning-base",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-04T19:45:38.000Z",
+      "lastModified": "2026-05-11T22:43:52.000Z"
     },
     {
       "rank": 7,
@@ -449,40 +449,12 @@
     },
     {
       "rank": 15,
-      "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
-      "downloads": 268305,
-      "likes": 292,
-      "trendingScore": 271,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-11T12:57:11.000Z",
-      "lastModified": "2026-05-18T05:58:01.000Z"
-    },
-    {
-      "rank": 16,
       "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 1956558,
-      "likes": 1009,
-      "trendingScore": 271,
+      "downloads": 2114938,
+      "likes": 1020,
+      "trendingScore": 281,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -508,41 +480,13 @@
       "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
-      "rank": 17,
-      "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
-      "downloads": 296380,
-      "likes": 255,
-      "trendingScore": 229,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "unsloth",
-        "qwen",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-11T12:57:12.000Z",
-      "lastModified": "2026-05-18T03:25:15.000Z"
-    },
-    {
-      "rank": 18,
+      "rank": 16,
       "id": "nvidia/LocateAnything-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/LocateAnything-3B",
-      "downloads": 1755,
-      "likes": 229,
-      "trendingScore": 223,
+      "downloads": 7861,
+      "likes": 281,
+      "trendingScore": 272,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -574,6 +518,62 @@
       ],
       "createdAt": "2026-03-02T20:05:49.000Z",
       "lastModified": "2026-05-27T08:30:54.000Z"
+    },
+    {
+      "rank": 17,
+      "id": "unsloth/Qwen3.6-27B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF",
+      "downloads": 268305,
+      "likes": 292,
+      "trendingScore": 271,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-11T12:57:11.000Z",
+      "lastModified": "2026-05-18T05:58:01.000Z"
+    },
+    {
+      "rank": 18,
+      "id": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+      "downloads": 296380,
+      "likes": 255,
+      "trendingScore": 229,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "unsloth",
+        "qwen",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-05-11T12:57:12.000Z",
+      "lastModified": "2026-05-18T03:25:15.000Z"
     },
     {
       "rank": 19,
@@ -771,9 +771,9 @@
       "id": "Jackrong/Qwopus3.6-27B-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-GGUF",
-      "downloads": 24336,
-      "likes": 175,
-      "trendingScore": 167,
+      "downloads": 29306,
+      "likes": 177,
+      "trendingScore": 169,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -813,6 +813,33 @@
     },
     {
       "rank": 27,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 389,
+      "likes": 168,
+      "trendingScore": 165,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 28,
       "id": "Jackrong/Qwopus3.5-9B-Coder-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder-GGUF",
@@ -855,7 +882,7 @@
       "lastModified": "2026-05-19T23:41:58.000Z"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "id": "froggeric/Qwen-Fixed-Chat-Templates",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates",
@@ -883,7 +910,7 @@
       "lastModified": "2026-05-16T13:44:07.000Z"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "id": "tencent/Hy-MT2-7B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B",
@@ -928,40 +955,13 @@
       "lastModified": "2026-05-26T09:05:54.000Z"
     },
     {
-      "rank": 30,
-      "id": "nvidia/PiD",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/PiD",
-      "downloads": 335,
-      "likes": 163,
-      "trendingScore": 160,
-      "pipelineTag": "image-to-image",
-      "libraryName": "pytorch",
-      "tags": [
-        "pytorch",
-        "diffusers",
-        "safetensors",
-        "super-resolution",
-        "diffusion",
-        "pixel-diffusion-decoder",
-        "vae-decoder",
-        "image-to-image",
-        "arxiv:2605.23902",
-        "base_model:Tongyi-MAI/Z-Image",
-        "base_model:finetune:Tongyi-MAI/Z-Image",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T00:41:46.000Z",
-      "lastModified": "2026-05-26T01:17:21.000Z"
-    },
-    {
       "rank": 31,
       "id": "Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MTP-GGUF",
-      "downloads": 65968,
-      "likes": 152,
-      "trendingScore": 149,
+      "downloads": 85680,
+      "likes": 153,
+      "trendingScore": 150,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -1001,6 +1001,45 @@
     },
     {
       "rank": 32,
+      "id": "LiquidAI/LFM2.5-8B-A1B",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B",
+      "downloads": 8854,
+      "likes": 151,
+      "trendingScore": 149,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "lfm2_moe",
+        "text-generation",
+        "liquid",
+        "lfm2.5",
+        "edge",
+        "conversational",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "pt",
+        "arxiv:2511.23404",
+        "base_model:LiquidAI/LFM2.5-8B-A1B-Base",
+        "base_model:finetune:LiquidAI/LFM2.5-8B-A1B-Base",
+        "license:other",
+        "eval-results",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-28T09:43:54.000Z",
+      "lastModified": "2026-05-29T09:08:45.000Z"
+    },
+    {
+      "rank": 33,
       "id": "numind/NuExtract3",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3",
@@ -1037,7 +1076,7 @@
       "lastModified": "2026-05-20T09:24:47.000Z"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -1066,7 +1105,7 @@
       "lastModified": "2026-04-28T07:01:37.000Z"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "id": "TencentARC/Pixal3D",
       "author": "TencentARC",
       "url": "https://huggingface.co/TencentARC/Pixal3D",
@@ -1085,7 +1124,7 @@
       "lastModified": "2026-05-12T23:37:47.000Z"
     },
     {
-      "rank": 35,
+      "rank": 36,
       "id": "Qwen/Qwen3.6-27B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B",
@@ -1110,7 +1149,7 @@
       "lastModified": "2026-04-24T02:39:16.000Z"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "id": "mistralai/Mistral-Medium-3.5-128B",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B",
@@ -1155,7 +1194,7 @@
       "lastModified": "2026-05-04T14:16:22.000Z"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "id": "microsoft/Lens",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens",
@@ -1177,7 +1216,7 @@
       "lastModified": "2026-05-22T03:09:59.000Z"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
@@ -1222,7 +1261,7 @@
       "lastModified": "2026-05-22T14:40:13.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "microsoft/Lens-Turbo",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Turbo",
@@ -1243,44 +1282,6 @@
       ],
       "createdAt": "2026-05-15T06:06:39.000Z",
       "lastModified": "2026-05-22T03:10:02.000Z"
-    },
-    {
-      "rank": 40,
-      "id": "LiquidAI/LFM2.5-8B-A1B",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B",
-      "downloads": 0,
-      "likes": 122,
-      "trendingScore": 121,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "lfm2_moe",
-        "text-generation",
-        "liquid",
-        "lfm2.5",
-        "edge",
-        "conversational",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "arxiv:2511.23404",
-        "base_model:LiquidAI/LFM2.5-8B-A1B-Base",
-        "base_model:finetune:LiquidAI/LFM2.5-8B-A1B-Base",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-28T09:43:54.000Z",
-      "lastModified": "2026-05-28T13:41:19.000Z"
     },
     {
       "rank": 41,
@@ -1377,7 +1378,7 @@
       "id": "OBLITERATUS/Qwen3.6-27B-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/Qwen3.6-27B-OBLITERATED",
-      "downloads": 13911,
+      "downloads": 16849,
       "likes": 115,
       "trendingScore": 109,
       "pipelineTag": "text-generation",
@@ -1986,6 +1987,41 @@
     },
     {
       "rank": 65,
+      "id": "LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "downloads": 5293,
+      "likes": 83,
+      "trendingScore": 83,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "liquid",
+        "lfm2",
+        "edge",
+        "llama.cpp",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "base_model:LiquidAI/LFM2.5-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T22:16:45.000Z",
+      "lastModified": "2026-05-28T14:59:45.000Z"
+    },
+    {
+      "rank": 66,
       "id": "antirez/deepseek-v4-gguf",
       "author": "antirez",
       "url": "https://huggingface.co/antirez/deepseek-v4-gguf",
@@ -2023,7 +2059,7 @@
       "lastModified": "2026-05-12T16:08:16.000Z"
     },
     {
-      "rank": 66,
+      "rank": 67,
       "id": "RuneXX/LTX-2.3-Workflows",
       "author": "RuneXX",
       "url": "https://huggingface.co/RuneXX/LTX-2.3-Workflows",
@@ -2051,7 +2087,7 @@
       "lastModified": "2026-05-13T05:49:49.000Z"
     },
     {
-      "rank": 67,
+      "rank": 68,
       "id": "facebook/VGGT-Omega",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/VGGT-Omega",
@@ -2071,7 +2107,47 @@
       "lastModified": "2026-05-14T21:23:21.000Z"
     },
     {
-      "rank": 68,
+      "rank": 69,
+      "id": "PaddlePaddle/PaddleOCR-VL-1.6",
+      "author": "PaddlePaddle",
+      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6",
+      "downloads": 1171,
+      "likes": 84,
+      "trendingScore": 80,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "PaddleOCR",
+      "tags": [
+        "PaddleOCR",
+        "safetensors",
+        "paddleocr_vl",
+        "ERNIE4.5",
+        "PaddlePaddle",
+        "image-to-text",
+        "ocr",
+        "document-parse",
+        "layout",
+        "table",
+        "formula",
+        "chart",
+        "seal",
+        "spotting",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "zh",
+        "multilingual",
+        "arxiv:2601.21957",
+        "base_model:PaddlePaddle/PaddleOCR-VL-1.6",
+        "base_model:finetune:PaddlePaddle/PaddleOCR-VL-1.6",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T06:27:27.000Z",
+      "lastModified": "2026-05-29T09:38:09.000Z"
+    },
+    {
+      "rank": 70,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit",
@@ -2100,7 +2176,7 @@
       "lastModified": "2026-05-09T07:37:22.000Z"
     },
     {
-      "rank": 69,
+      "rank": 71,
       "id": "poolside/Laguna-XS.2",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2",
@@ -2126,7 +2202,7 @@
       "lastModified": "2026-05-06T18:58:37.000Z"
     },
     {
-      "rank": 70,
+      "rank": 72,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF",
@@ -2155,7 +2231,7 @@
       "lastModified": "2026-04-20T12:42:25.000Z"
     },
     {
-      "rank": 71,
+      "rank": 73,
       "id": "zhen-nan/L2P",
       "author": "zhen-nan",
       "url": "https://huggingface.co/zhen-nan/L2P",
@@ -2173,7 +2249,7 @@
       "lastModified": "2026-05-22T07:53:35.000Z"
     },
     {
-      "rank": 72,
+      "rank": 74,
       "id": "FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-Early-Checkpoint",
@@ -2206,7 +2282,7 @@
       "lastModified": "2026-05-17T19:46:30.000Z"
     },
     {
-      "rank": 73,
+      "rank": 75,
       "id": "z-lab/Qwen3.6-27B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-DFlash",
@@ -2239,7 +2315,7 @@
       "lastModified": "2026-04-27T04:19:13.000Z"
     },
     {
-      "rank": 74,
+      "rank": 76,
       "id": "DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-Heretic-Uncensored-FINETUNE-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -2284,48 +2360,13 @@
       "lastModified": "2026-04-30T23:50:48.000Z"
     },
     {
-      "rank": 75,
-      "id": "LiquidAI/LFM2.5-8B-A1B-GGUF",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF",
-      "downloads": 42,
-      "likes": 75,
-      "trendingScore": 75,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "liquid",
-        "lfm2",
-        "edge",
-        "llama.cpp",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "base_model:LiquidAI/LFM2.5-8B-A1B",
-        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T22:16:45.000Z",
-      "lastModified": "2026-05-28T14:59:45.000Z"
-    },
-    {
-      "rank": 76,
+      "rank": 77,
       "id": "pyannote/speaker-diarization-3.1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-3.1",
-      "downloads": 9845884,
-      "likes": 2043,
-      "trendingScore": 74,
+      "downloads": 9818666,
+      "likes": 2050,
+      "trendingScore": 75,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "pyannote-audio",
       "tags": [
@@ -2351,7 +2392,7 @@
       "lastModified": "2024-05-10T19:43:23.000Z"
     },
     {
-      "rank": 77,
+      "rank": 78,
       "id": "talkie-lm/talkie-1930-13b-it",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
@@ -2371,7 +2412,36 @@
       "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
-      "rank": 78,
+      "rank": 79,
+      "id": "stepfun-ai/Step-3.7-Flash",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash",
+      "downloads": 1421,
+      "likes": 71,
+      "trendingScore": 70,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T02:13:46.000Z",
+      "lastModified": "2026-05-29T10:03:47.000Z"
+    },
+    {
+      "rank": 80,
       "id": "google/gemma-4-E4B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it-assistant",
@@ -2394,7 +2464,7 @@
       "lastModified": "2026-05-11T07:50:40.000Z"
     },
     {
-      "rank": 79,
+      "rank": 81,
       "id": "tencent/Hy-MT2-1.8B-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF",
@@ -2417,7 +2487,7 @@
       "lastModified": "2026-05-26T09:06:16.000Z"
     },
     {
-      "rank": 80,
+      "rank": 82,
       "id": "HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma4-26B-A4B-Uncensored-HauhauCS-Balanced",
@@ -2449,7 +2519,7 @@
       "lastModified": "2026-05-14T17:07:52.000Z"
     },
     {
-      "rank": 81,
+      "rank": 83,
       "id": "z-lab/gemma-4-31B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-DFlash",
@@ -2481,7 +2551,7 @@
       "lastModified": "2026-05-08T11:43:45.000Z"
     },
     {
-      "rank": 82,
+      "rank": 84,
       "id": "Aratako/Irodori-TTS-500M-v3",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v3",
@@ -2506,47 +2576,7 @@
       "lastModified": "2026-05-12T14:25:54.000Z"
     },
     {
-      "rank": 83,
-      "id": "PaddlePaddle/PaddleOCR-VL-1.6",
-      "author": "PaddlePaddle",
-      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6",
-      "downloads": 1,
-      "likes": 71,
-      "trendingScore": 67,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "PaddleOCR",
-      "tags": [
-        "PaddleOCR",
-        "safetensors",
-        "paddleocr_vl",
-        "ERNIE4.5",
-        "PaddlePaddle",
-        "image-to-text",
-        "ocr",
-        "document-parse",
-        "layout",
-        "table",
-        "formula",
-        "chart",
-        "seal",
-        "spotting",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "zh",
-        "multilingual",
-        "arxiv:2601.21957",
-        "base_model:PaddlePaddle/PaddleOCR-VL-1.5",
-        "base_model:finetune:PaddlePaddle/PaddleOCR-VL-1.5",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-27T06:27:27.000Z",
-      "lastModified": "2026-05-28T11:08:29.000Z"
-    },
-    {
-      "rank": 84,
+      "rank": 85,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -2591,7 +2621,7 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 85,
+      "rank": 86,
       "id": "moonshotai/Kimi-K2.6",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
@@ -2618,7 +2648,7 @@
       "lastModified": "2026-05-12T03:12:21.000Z"
     },
     {
-      "rank": 86,
+      "rank": 87,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -2651,7 +2681,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
       "id": "zhifeixie/Mega-ASR",
       "author": "zhifeixie",
       "url": "https://huggingface.co/zhifeixie/Mega-ASR",
@@ -2677,7 +2707,7 @@
       "lastModified": "2026-05-27T03:03:58.000Z"
     },
     {
-      "rank": 88,
+      "rank": 89,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -2706,11 +2736,11 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 89,
+      "rank": 90,
       "id": "jedisct1/MiMo-V2.5-coder-Q2",
       "author": "jedisct1",
       "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
-      "downloads": 1546,
+      "downloads": 1648,
       "likes": 62,
       "trendingScore": 61,
       "pipelineTag": "text-generation",
@@ -2738,7 +2768,38 @@
       "lastModified": "2026-05-25T23:53:02.000Z"
     },
     {
-      "rank": 90,
+      "rank": 91,
+      "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
+      "downloads": 0,
+      "likes": 61,
+      "trendingScore": 61,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "gemlite",
+        "hqq",
+        "cuda",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:12:41.000Z",
+      "lastModified": "2026-05-26T16:16:59.000Z"
+    },
+    {
+      "rank": 92,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -2763,7 +2824,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 91,
+      "rank": 93,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2807,38 +2868,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 92,
-      "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
-      "downloads": 0,
-      "likes": 59,
-      "trendingScore": 59,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "ternary",
-        "1.58-bit",
-        "gemlite",
-        "hqq",
-        "cuda",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:12:41.000Z",
-      "lastModified": "2026-05-26T16:16:59.000Z"
-    },
-    {
-      "rank": 93,
+      "rank": 94,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -2866,7 +2896,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -2893,7 +2923,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 95,
+      "rank": 96,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -2920,7 +2950,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 96,
+      "rank": 97,
       "id": "openbmb/BitCPM-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
@@ -2945,7 +2975,7 @@
       "lastModified": "2026-05-24T10:43:34.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
       "id": "vantagewithai/LTX2.3-10Eros-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
@@ -2968,7 +2998,7 @@
       "lastModified": "2026-05-08T18:31:07.000Z"
     },
     {
-      "rank": 98,
+      "rank": 99,
       "id": "fastino/gliguard-LLMGuardrails-300M",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
@@ -2999,7 +3029,7 @@
       "lastModified": "2026-05-14T16:04:55.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -3029,7 +3059,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 100,
+      "rank": 101,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -3047,7 +3077,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 101,
+      "rank": 102,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -3074,7 +3104,7 @@
       "lastModified": "2026-05-14T02:37:15.000Z"
     },
     {
-      "rank": 102,
+      "rank": 103,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3099,11 +3129,11 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 103,
+      "rank": 104,
       "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
-      "downloads": 5447,
+      "downloads": 8307,
       "likes": 56,
       "trendingScore": 54,
       "pipelineTag": "text-to-speech",
@@ -3144,7 +3174,7 @@
       "lastModified": "2026-05-26T08:49:43.000Z"
     },
     {
-      "rank": 104,
+      "rank": 105,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -3174,7 +3204,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 105,
+      "rank": 106,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -3201,7 +3231,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 106,
+      "rank": 107,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -3234,7 +3264,46 @@
       "lastModified": "2026-05-07T09:30:56.000Z"
     },
     {
-      "rank": 107,
+      "rank": 108,
+      "id": "openbmb/MiniCPM5-1B-GGUF",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
+      "downloads": 14018,
+      "likes": 112,
+      "trendingScore": 52.5,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
+        "long-context",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "en",
+        "zh",
+        "dataset:openbmb/Ultra-FineWeb",
+        "dataset:openbmb/Ultra-FineWeb-L3",
+        "dataset:openbmb/UltraData-Math",
+        "dataset:openbmb/UltraData-SFT-2605",
+        "arxiv:2506.07900",
+        "arxiv:2602.09003",
+        "arxiv:2512.16649",
+        "arxiv:2604.13016",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T09:49:47.000Z",
+      "lastModified": "2026-05-25T10:55:40.000Z"
+    },
+    {
+      "rank": 109,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -3279,7 +3348,7 @@
       "lastModified": "2026-05-02T01:27:57.000Z"
     },
     {
-      "rank": 108,
+      "rank": 110,
       "id": "RunDiffusion/Juggernaut-Z-Image",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-Z-Image",
@@ -3306,46 +3375,33 @@
       "lastModified": "2026-05-13T18:41:56.000Z"
     },
     {
-      "rank": 109,
-      "id": "openbmb/MiniCPM5-1B-GGUF",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
-      "downloads": 10742,
-      "likes": 110,
-      "trendingScore": 51.5,
-      "pipelineTag": "text-generation",
+      "rank": 111,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 318,
+      "likes": 52,
+      "trendingScore": 52,
+      "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "minicpm",
-        "minicpm5",
-        "llama",
-        "text-generation",
-        "long-context",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
         "en",
-        "zh",
-        "dataset:openbmb/Ultra-FineWeb",
-        "dataset:openbmb/Ultra-FineWeb-L3",
-        "dataset:openbmb/UltraData-Math",
-        "dataset:openbmb/UltraData-SFT-2605",
-        "arxiv:2506.07900",
-        "arxiv:2602.09003",
-        "arxiv:2512.16649",
-        "arxiv:2604.13016",
         "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "region:us"
       ],
-      "createdAt": "2026-05-24T09:49:47.000Z",
-      "lastModified": "2026-05-25T10:55:40.000Z"
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-29T03:57:43.000Z"
     },
     {
-      "rank": 110,
+      "rank": 112,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -3373,33 +3429,7 @@
       "lastModified": "2026-05-04T17:31:52.000Z"
     },
     {
-      "rank": 111,
-      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "author": "Kwai-Keye",
-      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "downloads": 290,
-      "likes": 50,
-      "trendingScore": 50,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "KeyeVL2",
-        "feature-extraction",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:32:15.000Z",
-      "lastModified": "2026-05-29T03:57:43.000Z"
-    },
-    {
-      "rank": 112,
+      "rank": 113,
       "id": "HuggingFaceTB/nanowhale-100m",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m",
@@ -3433,7 +3463,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 113,
+      "rank": 114,
       "id": "snwy/SD1.5-DALLE-2",
       "author": "snwy",
       "url": "https://huggingface.co/snwy/SD1.5-DALLE-2",
@@ -3453,7 +3483,7 @@
       "lastModified": "2026-05-14T05:39:47.000Z"
     },
     {
-      "rank": 114,
+      "rank": 115,
       "id": "stabilityai/stable-audio-3-small-music",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music",
@@ -3480,7 +3510,7 @@
       "lastModified": "2026-05-19T20:02:42.000Z"
     },
     {
-      "rank": 115,
+      "rank": 116,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
@@ -3511,7 +3541,7 @@
       "lastModified": "2026-04-24T00:21:01.000Z"
     },
     {
-      "rank": 116,
+      "rank": 117,
       "id": "inclusionAI/Ling-2.6-1T",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-1T",
@@ -3536,7 +3566,7 @@
       "lastModified": "2026-05-03T15:01:59.000Z"
     },
     {
-      "rank": 117,
+      "rank": 118,
       "id": "vantagewithai/Sulphur-2-Base-GGUF",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-GGUF",
@@ -3573,7 +3603,7 @@
       "lastModified": "2026-05-06T14:22:57.000Z"
     },
     {
-      "rank": 118,
+      "rank": 119,
       "id": "jinaai/jina-embeddings-v5-omni-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small",
@@ -3610,7 +3640,7 @@
       "lastModified": "2026-05-17T10:58:37.000Z"
     },
     {
-      "rank": 119,
+      "rank": 120,
       "id": "Kijai/LTX2.3_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/LTX2.3_comfy",
@@ -3629,7 +3659,7 @@
       "lastModified": "2026-05-20T20:31:07.000Z"
     },
     {
-      "rank": 120,
+      "rank": 121,
       "id": "LatitudeGames/Equinox-31B",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B",
@@ -3653,7 +3683,7 @@
       "lastModified": "2026-05-22T04:55:49.000Z"
     },
     {
-      "rank": 121,
+      "rank": 122,
       "id": "unsloth/gemma-4-26B-A4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF",
@@ -3681,7 +3711,7 @@
       "lastModified": "2026-05-04T09:45:46.000Z"
     },
     {
-      "rank": 122,
+      "rank": 123,
       "id": "HiDream-ai/HiDream-O1-Image-Dev-2604",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
@@ -3705,11 +3735,11 @@
       "lastModified": "2026-05-15T10:41:43.000Z"
     },
     {
-      "rank": 123,
+      "rank": 124,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "downloads": 1799571,
+      "downloads": 1821209,
       "likes": 1544,
       "trendingScore": 46,
       "pipelineTag": "text-to-speech",
@@ -3726,7 +3756,7 @@
       "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
-      "rank": 124,
+      "rank": 125,
       "id": "google/gemma-4-E2B-it-assistant",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it-assistant",
@@ -3749,7 +3779,7 @@
       "lastModified": "2026-05-11T07:51:55.000Z"
     },
     {
-      "rank": 125,
+      "rank": 126,
       "id": "unsloth/Qwen3.5-9B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF",
@@ -3776,7 +3806,7 @@
       "lastModified": "2026-05-16T12:39:00.000Z"
     },
     {
-      "rank": 126,
+      "rank": 127,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -3803,7 +3833,7 @@
       "lastModified": "2025-11-20T22:05:08.000Z"
     },
     {
-      "rank": 127,
+      "rank": 128,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -3836,7 +3866,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 128,
+      "rank": 129,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -3867,7 +3897,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 129,
+      "rank": 130,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -3883,7 +3913,7 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 130,
+      "rank": 131,
       "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -3910,11 +3940,11 @@
       "lastModified": "2026-05-20T01:46:59.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
       "id": "openbmb/BitCPM-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B-gguf",
-      "downloads": 2152,
+      "downloads": 2618,
       "likes": 46,
       "trendingScore": 42,
       "pipelineTag": "text-generation",
@@ -3934,7 +3964,7 @@
       "lastModified": "2026-05-23T18:12:57.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive",
@@ -3960,7 +3990,7 @@
       "lastModified": "2026-04-05T19:01:05.000Z"
     },
     {
-      "rank": 133,
+      "rank": 134,
       "id": "Zyphra/ZAYA1-74B-preview",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-74B-preview",
@@ -3979,7 +4009,7 @@
       "lastModified": "2026-05-08T23:21:12.000Z"
     },
     {
-      "rank": 134,
+      "rank": 135,
       "id": "Tongyi-MAI/Z-Image-Turbo",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo",
@@ -4005,7 +4035,7 @@
       "lastModified": "2026-01-30T16:58:07.000Z"
     },
     {
-      "rank": 135,
+      "rank": 136,
       "id": "HuggingFaceBio/Carbon-3B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-3B",
@@ -4028,7 +4058,7 @@
       "lastModified": "2026-05-20T13:39:48.000Z"
     },
     {
-      "rank": 136,
+      "rank": 137,
       "id": "Phr00t/Qwen-Image-Edit-Rapid-AIO",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/Qwen-Image-Edit-Rapid-AIO",
@@ -4053,7 +4083,7 @@
       "lastModified": "2026-02-03T02:10:35.000Z"
     },
     {
-      "rank": 137,
+      "rank": 138,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -4085,11 +4115,11 @@
       "lastModified": "2026-05-19T21:13:27.000Z"
     },
     {
-      "rank": 138,
+      "rank": 139,
       "id": "Comfy-Org/Lens",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Lens",
-      "downloads": 0,
+      "downloads": 30917,
       "likes": 38,
       "trendingScore": 38,
       "pipelineTag": null,
@@ -4104,7 +4134,7 @@
       "lastModified": "2026-05-28T15:02:44.000Z"
     },
     {
-      "rank": 139,
+      "rank": 140,
       "id": "zai-org/GLM-5.1",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-5.1",
@@ -4131,7 +4161,7 @@
       "lastModified": "2026-05-13T08:10:58.000Z"
     },
     {
-      "rank": 140,
+      "rank": 141,
       "id": "Qwen/Qwen3.5-9B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-9B",
@@ -4158,7 +4188,7 @@
       "lastModified": "2026-03-02T00:51:43.000Z"
     },
     {
-      "rank": 141,
+      "rank": 142,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF",
@@ -4190,7 +4220,7 @@
       "lastModified": "2026-05-21T21:34:50.000Z"
     },
     {
-      "rank": 142,
+      "rank": 143,
       "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
@@ -4221,7 +4251,7 @@
       "lastModified": "2026-05-28T15:51:28.000Z"
     },
     {
-      "rank": 143,
+      "rank": 144,
       "id": "Alissonerdx/BFS-Best-Face-Swap",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
@@ -4254,7 +4284,7 @@
       "lastModified": "2026-03-08T12:54:54.000Z"
     },
     {
-      "rank": 144,
+      "rank": 145,
       "id": "hexgrad/Kokoro-82M",
       "author": "hexgrad",
       "url": "https://huggingface.co/hexgrad/Kokoro-82M",
@@ -4278,7 +4308,7 @@
       "lastModified": "2025-04-10T18:12:48.000Z"
     },
     {
-      "rank": 145,
+      "rank": 146,
       "id": "HuggingFaceBio/Carbon-8B",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B",
@@ -4303,7 +4333,7 @@
       "lastModified": "2026-05-20T13:40:10.000Z"
     },
     {
-      "rank": 146,
+      "rank": 147,
       "id": "nvidia/Gemma-4-26B-A4B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4",
@@ -4335,7 +4365,7 @@
       "lastModified": "2026-05-07T00:43:59.000Z"
     },
     {
-      "rank": 147,
+      "rank": 148,
       "id": "SicariusSicariiStuff/Assistant_Pepe_32B",
       "author": "SicariusSicariiStuff",
       "url": "https://huggingface.co/SicariusSicariiStuff/Assistant_Pepe_32B",
@@ -4358,7 +4388,7 @@
       "lastModified": "2026-05-07T17:11:54.000Z"
     },
     {
-      "rank": 148,
+      "rank": 149,
       "id": "Datadog/Toto-2.0-2.5B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-2.5B",
@@ -4387,7 +4417,7 @@
       "lastModified": "2026-05-20T14:30:55.000Z"
     },
     {
-      "rank": 149,
+      "rank": 150,
       "id": "OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
       "author": "OBLITERATUS",
       "url": "https://huggingface.co/OBLITERATUS/gemma-4-E4B-it-OBLITERATED",
@@ -4416,7 +4446,7 @@
       "lastModified": "2026-04-19T21:43:06.000Z"
     },
     {
-      "rank": 150,
+      "rank": 151,
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
@@ -4456,7 +4486,7 @@
       "lastModified": "2024-09-25T17:00:57.000Z"
     },
     {
-      "rank": 151,
+      "rank": 152,
       "id": "stabilityai/stable-audio-3-small-sfx",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx",
@@ -4483,7 +4513,7 @@
       "lastModified": "2026-05-19T20:02:45.000Z"
     },
     {
-      "rank": 152,
+      "rank": 153,
       "id": "inclusionAI/Ling-2.6-flash",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/Ling-2.6-flash",
@@ -4507,7 +4537,7 @@
       "lastModified": "2026-05-03T15:00:07.000Z"
     },
     {
-      "rank": 153,
+      "rank": 154,
       "id": "facebook/tribev2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/tribev2",
@@ -4524,7 +4554,7 @@
       "lastModified": "2026-03-27T09:07:48.000Z"
     },
     {
-      "rank": 154,
+      "rank": 155,
       "id": "zerofata/G4-MeroMero-31B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B",
@@ -4548,7 +4578,7 @@
       "lastModified": "2026-05-02T09:06:30.000Z"
     },
     {
-      "rank": 155,
+      "rank": 156,
       "id": "TenStrip/LTX2.3-10Eros_Workflows",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros_Workflows",
@@ -4564,7 +4594,7 @@
       "lastModified": "2026-05-11T00:19:43.000Z"
     },
     {
-      "rank": 156,
+      "rank": 157,
       "id": "unsloth/gemma-4-E4B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF",
@@ -4591,7 +4621,7 @@
       "lastModified": "2026-05-04T09:02:45.000Z"
     },
     {
-      "rank": 157,
+      "rank": 158,
       "id": "kohya-ss/Anima-LLLite",
       "author": "kohya-ss",
       "url": "https://huggingface.co/kohya-ss/Anima-LLLite",
@@ -4610,7 +4640,7 @@
       "lastModified": "2026-05-20T13:33:56.000Z"
     },
     {
-      "rank": 158,
+      "rank": 159,
       "id": "fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
       "author": "fal",
       "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA",
@@ -4640,34 +4670,6 @@
       ],
       "createdAt": "2026-01-07T17:01:15.000Z",
       "lastModified": "2026-01-07T17:06:01.000Z"
-    },
-    {
-      "rank": 159,
-      "id": "stepfun-ai/Step-3.7-Flash",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash",
-      "downloads": 1397,
-      "likes": 35,
-      "trendingScore": 34,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "step3p7",
-        "text-generation",
-        "vision-language",
-        "multimodal",
-        "moe",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T02:13:46.000Z",
-      "lastModified": "2026-05-29T03:41:31.000Z"
     },
     {
       "rank": 160,
@@ -5691,7 +5693,7 @@
       "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "downloads": 52,
+      "downloads": 78,
       "likes": 29,
       "trendingScore": 29,
       "pipelineTag": "text-to-audio",
@@ -5717,6 +5719,50 @@
     },
     {
       "rank": 192,
+      "id": "Jackrong/Qwopus3.6-27B-v2",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
+      "downloads": 7111,
+      "likes": 29,
+      "trendingScore": 29,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_6",
+        "reasoning",
+        "chain-of-thought",
+        "lora",
+        "sft",
+        "multimodal",
+        "vision",
+        "tool-use",
+        "function-calling",
+        "long-context",
+        "agent",
+        "image",
+        "conversational",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T08:20:50.000Z",
+      "lastModified": "2026-05-23T00:38:29.000Z"
+    },
+    {
+      "rank": 193,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -5738,7 +5784,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 193,
+      "rank": 194,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -5775,7 +5821,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -5797,7 +5843,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -5830,7 +5876,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -5857,7 +5903,40 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
+      "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
+      "author": "LuffyTheFox",
+      "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
+      "downloads": 40017,
+      "likes": 29,
+      "trendingScore": 28,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.6",
+        "moe",
+        "vision",
+        "multimodal",
+        "genesis",
+        "image-text-to-text",
+        "conversational",
+        "en",
+        "zh",
+        "multilingual",
+        "base_model:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "base_model:quantized:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix"
+      ],
+      "createdAt": "2026-05-21T12:23:23.000Z",
+      "lastModified": "2026-05-28T07:44:54.000Z"
+    },
+    {
+      "rank": 199,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -5897,7 +5976,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 198,
+      "rank": 200,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -5934,7 +6013,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 199,
+      "rank": 201,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -5977,7 +6056,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 200,
+      "rank": 202,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -5997,7 +6076,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 201,
+      "rank": 203,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -6022,7 +6101,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 202,
+      "rank": 204,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -6047,7 +6126,7 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 203,
+      "rank": 205,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -6070,7 +6149,7 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 204,
+      "rank": 206,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -6096,11 +6175,11 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 205,
-      "id": "Jackrong/Qwopus3.6-27B-v2",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
-      "downloads": 6805,
+      "rank": 207,
+      "id": "Qwen/Qwen-Image-Bench",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Bench",
+      "downloads": 202,
       "likes": 27,
       "trendingScore": 27,
       "pipelineTag": "image-text-to-text",
@@ -6110,70 +6189,26 @@
         "safetensors",
         "qwen3_5",
         "image-text-to-text",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_6",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "sft",
-        "multimodal",
-        "vision",
-        "tool-use",
-        "function-calling",
-        "long-context",
-        "agent",
-        "image",
+        "judge-model",
+        "text-to-image",
+        "evaluation",
+        "benchmark",
+        "qwen",
         "conversational",
         "en",
         "zh",
-        "es",
-        "ru",
-        "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "arxiv:2605.28091",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:finetune:Qwen/Qwen3.6-27B",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-14T08:20:50.000Z",
-      "lastModified": "2026-05-23T00:38:29.000Z"
+      "createdAt": "2026-05-21T04:15:56.000Z",
+      "lastModified": "2026-05-28T08:07:27.000Z"
     },
     {
-      "rank": 206,
-      "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "author": "LuffyTheFox",
-      "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
-      "downloads": 36182,
-      "likes": 28,
-      "trendingScore": 27,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.6",
-        "moe",
-        "vision",
-        "multimodal",
-        "genesis",
-        "image-text-to-text",
-        "conversational",
-        "en",
-        "zh",
-        "multilingual",
-        "base_model:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-        "base_model:quantized:HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix"
-      ],
-      "createdAt": "2026-05-21T12:23:23.000Z",
-      "lastModified": "2026-05-28T07:44:54.000Z"
-    },
-    {
-      "rank": 207,
+      "rank": 208,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -6218,7 +6253,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 208,
+      "rank": 209,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -6245,7 +6280,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 209,
+      "rank": 210,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -6290,7 +6325,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 210,
+      "rank": 211,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -6316,7 +6351,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 211,
+      "rank": 212,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -6338,7 +6373,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 212,
+      "rank": 213,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -6354,7 +6389,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 213,
+      "rank": 214,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -6390,7 +6425,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 214,
+      "rank": 215,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -6408,7 +6443,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 215,
+      "rank": 216,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -6440,7 +6475,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 216,
+      "rank": 217,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
@@ -6463,7 +6498,7 @@
       "lastModified": "2026-05-26T09:06:32.000Z"
     },
     {
-      "rank": 217,
+      "rank": 218,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -6488,7 +6523,7 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 218,
+      "rank": 219,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -6526,7 +6561,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 219,
+      "rank": 220,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -6544,7 +6579,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 220,
+      "rank": 221,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -6564,7 +6599,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 221,
+      "rank": 222,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -6591,7 +6626,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 222,
+      "rank": 223,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -6617,7 +6652,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 223,
+      "rank": 224,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -6643,7 +6678,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 224,
+      "rank": 225,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -6680,7 +6715,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 225,
+      "rank": 226,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -6696,7 +6731,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 226,
+      "rank": 227,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -6719,7 +6754,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 227,
+      "rank": 228,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -6761,7 +6796,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 228,
+      "rank": 229,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -6800,7 +6835,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 229,
+      "rank": 230,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6845,7 +6880,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 230,
+      "rank": 231,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -6871,7 +6906,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 231,
+      "rank": 232,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -6903,7 +6938,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 232,
+      "rank": 233,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -6927,7 +6962,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 233,
+      "rank": 234,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -6954,7 +6989,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 234,
+      "rank": 235,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -6979,7 +7014,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 235,
+      "rank": 236,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -7015,7 +7050,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 236,
+      "rank": 237,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -7031,7 +7066,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 237,
+      "rank": 238,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -7052,7 +7087,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 238,
+      "rank": 239,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -7075,7 +7110,7 @@
       "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 239,
+      "rank": 240,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7102,7 +7137,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 240,
+      "rank": 241,
       "id": "SupraLabs/Supra-50M-Instruct",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
@@ -7139,39 +7174,6 @@
       ],
       "createdAt": "2026-05-21T12:06:17.000Z",
       "lastModified": "2026-05-27T13:52:37.000Z"
-    },
-    {
-      "rank": 241,
-      "id": "Qwen/Qwen-Image-Bench",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Bench",
-      "downloads": 2,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "judge-model",
-        "text-to-image",
-        "evaluation",
-        "benchmark",
-        "qwen",
-        "conversational",
-        "en",
-        "zh",
-        "arxiv:2605.28091",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:finetune:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T04:15:56.000Z",
-      "lastModified": "2026-05-28T08:07:27.000Z"
     },
     {
       "rank": 242,
@@ -7383,6 +7385,48 @@
     },
     {
       "rank": 250,
+      "id": "stepfun-ai/Step-3.7-Flash-GGUF",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-GGUF",
+      "downloads": 476,
+      "likes": 23,
+      "trendingScore": 23,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "llama.cpp",
+        "quantized",
+        "imatrix",
+        "moe",
+        "agent",
+        "tool-calling",
+        "reasoning",
+        "vision",
+        "multimodal",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "ja",
+        "ko",
+        "ar",
+        "hi",
+        "de",
+        "fr",
+        "es",
+        "ru",
+        "base_model:stepfun-ai/Step-3.7-Flash",
+        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-28T11:34:17.000Z",
+      "lastModified": "2026-05-29T03:48:51.000Z"
+    },
+    {
+      "rank": 251,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -7413,7 +7457,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 251,
+      "rank": 252,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -7442,7 +7486,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -7487,7 +7531,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -7514,7 +7558,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -7538,7 +7582,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -7576,7 +7620,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -7593,7 +7637,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -7621,7 +7665,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7644,7 +7688,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7661,7 +7705,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -7688,7 +7732,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7714,7 +7758,32 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
+      "id": "Qwen/Qwen3-Coder-Next",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
+      "downloads": 998320,
+      "likes": 1400,
+      "trendingScore": 22,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_next",
+        "text-generation",
+        "conversational",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-01-30T15:08:18.000Z",
+      "lastModified": "2026-02-03T16:16:38.000Z"
+    },
+    {
+      "rank": 264,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -7759,7 +7828,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 263,
+      "rank": 265,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -7787,7 +7856,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 264,
+      "rank": 266,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -7823,7 +7892,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 265,
+      "rank": 267,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -7850,7 +7919,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 266,
+      "rank": 268,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -7875,7 +7944,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 267,
+      "rank": 269,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -7901,7 +7970,7 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 268,
+      "rank": 270,
       "id": "syvai/cohere-transcribe-diarize",
       "author": "syvai",
       "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
@@ -7946,7 +8015,7 @@
       "lastModified": "2026-05-22T20:56:30.000Z"
     },
     {
-      "rank": 269,
+      "rank": 271,
       "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
@@ -7972,36 +8041,11 @@
       "lastModified": "2026-05-28T22:23:51.000Z"
     },
     {
-      "rank": 270,
-      "id": "Qwen/Qwen3-Coder-Next",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
-      "downloads": 1011826,
-      "likes": 1399,
-      "trendingScore": 21,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_next",
-        "text-generation",
-        "conversational",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-01-30T15:08:18.000Z",
-      "lastModified": "2026-02-03T16:16:38.000Z"
-    },
-    {
-      "rank": 271,
+      "rank": 272,
       "id": "Kaikaku/epicure-cooc",
       "author": "Kaikaku",
       "url": "https://huggingface.co/Kaikaku/epicure-cooc",
-      "downloads": 106,
+      "downloads": 194,
       "likes": 21,
       "trendingScore": 21,
       "pipelineTag": "feature-extraction",
@@ -8033,7 +8077,60 @@
       "lastModified": "2026-05-27T13:44:09.000Z"
     },
     {
-      "rank": 272,
+      "rank": 273,
+      "id": "spiritbuun/buun-Qwen3.6-chat_template",
+      "author": "spiritbuun",
+      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
+      "downloads": 0,
+      "likes": 22,
+      "trendingScore": 21,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "chat-template",
+        "qwen3",
+        "qwen3.5",
+        "qwen3.6",
+        "jinja",
+        "llama-cpp",
+        "tool-use",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T16:33:22.000Z",
+      "lastModified": "2026-05-28T19:36:56.000Z"
+    },
+    {
+      "rank": 274,
+      "id": "openai/gpt-oss-120b",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/gpt-oss-120b",
+      "downloads": 4847208,
+      "likes": 4818,
+      "trendingScore": 21,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gpt_oss",
+        "text-generation",
+        "vllm",
+        "conversational",
+        "arxiv:2508.10925",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "8-bit",
+        "mxfp4",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-08-04T22:33:06.000Z",
+      "lastModified": "2025-08-26T17:25:03.000Z"
+    },
+    {
+      "rank": 275,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -8061,7 +8158,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 273,
+      "rank": 276,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -8094,7 +8191,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 274,
+      "rank": 277,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -8119,7 +8216,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 275,
+      "rank": 278,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -8156,7 +8253,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 276,
+      "rank": 279,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -8199,7 +8296,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 277,
+      "rank": 280,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -8223,7 +8320,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 278,
+      "rank": 281,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -8247,7 +8344,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 279,
+      "rank": 282,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -8276,7 +8373,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 280,
+      "rank": 283,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -8294,7 +8391,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 281,
+      "rank": 284,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -8339,7 +8436,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 282,
+      "rank": 285,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -8384,7 +8481,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 283,
+      "rank": 286,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -8413,7 +8510,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 284,
+      "rank": 287,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -8437,7 +8534,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 285,
+      "rank": 288,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -8466,7 +8563,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 286,
+      "rank": 289,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8490,7 +8587,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 287,
+      "rank": 290,
       "id": "netease-youdao/Confucius4",
       "author": "netease-youdao",
       "url": "https://huggingface.co/netease-youdao/Confucius4",
@@ -8508,7 +8605,7 @@
       "lastModified": "2026-05-20T08:42:10.000Z"
     },
     {
-      "rank": 288,
+      "rank": 291,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -8526,60 +8623,7 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 289,
-      "id": "spiritbuun/buun-Qwen3.6-chat_template",
-      "author": "spiritbuun",
-      "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
-      "downloads": 0,
-      "likes": 21,
-      "trendingScore": 20,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "chat-template",
-        "qwen3",
-        "qwen3.5",
-        "qwen3.6",
-        "jinja",
-        "llama-cpp",
-        "tool-use",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T16:33:22.000Z",
-      "lastModified": "2026-05-28T19:36:56.000Z"
-    },
-    {
-      "rank": 290,
-      "id": "openai/gpt-oss-120b",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/gpt-oss-120b",
-      "downloads": 4919457,
-      "likes": 4817,
-      "trendingScore": 20,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gpt_oss",
-        "text-generation",
-        "vllm",
-        "conversational",
-        "arxiv:2508.10925",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "8-bit",
-        "mxfp4",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-08-04T22:33:06.000Z",
-      "lastModified": "2025-08-26T17:25:03.000Z"
-    },
-    {
-      "rank": 291,
+      "rank": 292,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -8606,7 +8650,46 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 292,
+      "rank": 293,
+      "id": "FINAL-Bench/Darwin-60B-DUO",
+      "author": "FINAL-Bench",
+      "url": "https://huggingface.co/FINAL-Bench/Darwin-60B-DUO",
+      "downloads": 327,
+      "likes": 26,
+      "trendingScore": 20,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "darwin",
+        "darwin-family",
+        "darwin-duo",
+        "duo",
+        "ensemble",
+        "mixture-of-models",
+        "router",
+        "korean",
+        "reasoning",
+        "finalbench",
+        "vidraft",
+        "text-generation",
+        "en",
+        "ko",
+        "multilingual",
+        "base_model:Anserwise/AWAXIS-Think-31B",
+        "base_model:finetune:Anserwise/AWAXIS-Think-31B",
+        "license:gemma",
+        "model-index",
+        "eval-results",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T14:49:20.000Z",
+      "lastModified": "2026-05-28T03:21:23.000Z"
+    },
+    {
+      "rank": 294,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -8651,7 +8734,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 293,
+      "rank": 295,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -8684,7 +8767,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 294,
+      "rank": 296,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -8706,7 +8789,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 295,
+      "rank": 297,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -8733,7 +8816,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 296,
+      "rank": 298,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -8749,7 +8832,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 297,
+      "rank": 299,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -8772,7 +8855,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 298,
+      "rank": 300,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -8808,7 +8891,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 299,
+      "rank": 301,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -8837,7 +8920,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 300,
+      "rank": 302,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -8867,7 +8950,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 301,
+      "rank": 303,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -8912,7 +8995,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 302,
+      "rank": 304,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -8939,7 +9022,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 303,
+      "rank": 305,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -8965,7 +9048,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 304,
+      "rank": 306,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -8993,7 +9076,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 305,
+      "rank": 307,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -9022,7 +9105,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 306,
+      "rank": 308,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9046,46 +9129,26 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 307,
-      "id": "FINAL-Bench/Darwin-60B-DUO",
-      "author": "FINAL-Bench",
-      "url": "https://huggingface.co/FINAL-Bench/Darwin-60B-DUO",
-      "downloads": 113,
-      "likes": 25,
+      "rank": 309,
+      "id": "Comfy-Org/PixelDiT",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+      "downloads": 13714,
+      "likes": 19,
       "trendingScore": 19,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
       "tags": [
-        "transformers",
-        "safetensors",
-        "darwin",
-        "darwin-family",
-        "darwin-duo",
-        "duo",
-        "ensemble",
-        "mixture-of-models",
-        "router",
-        "korean",
-        "reasoning",
-        "finalbench",
-        "vidraft",
-        "text-generation",
-        "en",
-        "ko",
-        "multilingual",
-        "base_model:Anserwise/AWAXIS-Think-31B",
-        "base_model:finetune:Anserwise/AWAXIS-Think-31B",
-        "license:gemma",
-        "model-index",
-        "eval-results",
-        "endpoints_compatible",
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
         "region:us"
       ],
-      "createdAt": "2026-05-27T14:49:20.000Z",
-      "lastModified": "2026-05-28T03:21:23.000Z"
+      "createdAt": "2026-05-25T14:05:48.000Z",
+      "lastModified": "2026-05-28T15:02:28.000Z"
     },
     {
-      "rank": 308,
+      "rank": 310,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -9107,7 +9170,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 309,
+      "rank": 311,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -9141,7 +9204,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 310,
+      "rank": 312,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -9165,7 +9228,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 311,
+      "rank": 313,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -9187,7 +9250,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 312,
+      "rank": 314,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -9216,7 +9279,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 313,
+      "rank": 315,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -9248,7 +9311,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 314,
+      "rank": 316,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -9266,7 +9329,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 315,
+      "rank": 317,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -9284,7 +9347,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 316,
+      "rank": 318,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -9310,7 +9373,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 317,
+      "rank": 319,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -9338,7 +9401,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 318,
+      "rank": 320,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -9370,7 +9433,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 319,
+      "rank": 321,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -9415,11 +9478,11 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 320,
+      "rank": 322,
       "id": "openbmb/MiniCPM5-1B-SFT",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
-      "downloads": 1120,
+      "downloads": 1800,
       "likes": 20,
       "trendingScore": 18,
       "pipelineTag": "text-generation",
@@ -9455,7 +9518,7 @@
       "lastModified": "2026-05-25T11:18:10.000Z"
     },
     {
-      "rank": 321,
+      "rank": 323,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -9492,26 +9555,61 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 322,
-      "id": "Comfy-Org/PixelDiT",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+      "rank": 324,
+      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
+      "downloads": 10995,
+      "likes": 19,
+      "trendingScore": 18,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "dataset:zerofata/Instruct-Anime",
+        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
+        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
+        "dataset:zerofata/Roleplay-Anime-Characters",
+        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-23T00:40:03.000Z",
+      "lastModified": "2026-05-25T00:33:13.000Z"
+    },
+    {
+      "rank": 325,
+      "id": "bageldotcom/paris2",
+      "author": "bageldotcom",
+      "url": "https://huggingface.co/bageldotcom/paris2",
       "downloads": 0,
       "likes": 18,
       "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
+      "pipelineTag": "image-to-video",
+      "libraryName": null,
       "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
+        "safetensors",
+        "paris2",
+        "text-to-video",
+        "image-to-video",
+        "mixture-of-experts",
+        "decentralized-diffusion-model",
+        "arxiv:2605.26064",
+        "license:mit",
         "region:us"
       ],
-      "createdAt": "2026-05-25T14:05:48.000Z",
-      "lastModified": "2026-05-28T15:02:28.000Z"
+      "createdAt": "2026-05-24T17:46:11.000Z",
+      "lastModified": "2026-05-28T16:32:17.000Z"
     },
     {
-      "rank": 323,
+      "rank": 326,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -9556,7 +9654,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 324,
+      "rank": 327,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -9585,7 +9683,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 325,
+      "rank": 328,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -9614,7 +9712,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 326,
+      "rank": 329,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -9646,7 +9744,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 327,
+      "rank": 330,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -9676,7 +9774,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 328,
+      "rank": 331,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -9697,7 +9795,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 329,
+      "rank": 332,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -9742,7 +9840,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 330,
+      "rank": 333,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -9771,7 +9869,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 331,
+      "rank": 334,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -9799,7 +9897,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 332,
+      "rank": 335,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -9824,7 +9922,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 333,
+      "rank": 336,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -9847,7 +9945,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 334,
+      "rank": 337,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -9874,7 +9972,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 335,
+      "rank": 338,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -9900,7 +9998,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -9929,7 +10027,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 337,
+      "rank": 340,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -9948,7 +10046,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 338,
+      "rank": 341,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -9976,7 +10074,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 339,
+      "rank": 342,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10021,7 +10119,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 340,
+      "rank": 343,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -10049,7 +10147,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 341,
+      "rank": 344,
       "id": "numind/NuMarkdown-8B-Thinking",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
@@ -10080,11 +10178,11 @@
       "lastModified": "2026-05-19T19:01:34.000Z"
     },
     {
-      "rank": 342,
+      "rank": 345,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
-      "downloads": 6670,
+      "downloads": 9355,
       "likes": 18,
       "trendingScore": 17,
       "pipelineTag": "image-text-to-text",
@@ -10125,41 +10223,11 @@
       "lastModified": "2026-05-28T04:24:45.000Z"
     },
     {
-      "rank": 343,
-      "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
-      "downloads": 10437,
-      "likes": 18,
-      "trendingScore": 17,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "dataset:zerofata/Instruct-Anime",
-        "dataset:zerofata/Gemini-3.1-Pro-SmallWiki",
-        "dataset:zerofata/Gemini-3.1-Pro-GLM5-Characters",
-        "dataset:zerofata/Roleplay-Anime-Characters",
-        "base_model:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-23T00:40:03.000Z",
-      "lastModified": "2026-05-25T00:33:13.000Z"
-    },
-    {
-      "rank": 344,
+      "rank": 346,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
-      "downloads": 8289031,
+      "downloads": 8258782,
       "likes": 1443,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -10193,7 +10261,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 345,
+      "rank": 347,
       "id": "meta-llama/Llama-3.2-3B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
@@ -10231,11 +10299,11 @@
       "lastModified": "2024-10-24T15:07:29.000Z"
     },
     {
-      "rank": 346,
+      "rank": 348,
       "id": "nvidia/GLM-5.1-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
-      "downloads": 7462,
+      "downloads": 8248,
       "likes": 20,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -10264,7 +10332,56 @@
       "lastModified": "2026-05-27T17:03:55.000Z"
     },
     {
-      "rank": 347,
+      "rank": 349,
+      "id": "allura-org/Qwen3.6-35B-A3B-Anko",
+      "author": "allura-org",
+      "url": "https://huggingface.co/allura-org/Qwen3.6-35B-A3B-Anko",
+      "downloads": 72,
+      "likes": 23,
+      "trendingScore": 17,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5_moe",
+        "en",
+        "zh",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-20T03:54:01.000Z",
+      "lastModified": "2026-04-23T15:43:25.000Z"
+    },
+    {
+      "rank": 350,
+      "id": "avaturn-live/avtr-1",
+      "author": "avaturn-live",
+      "url": "https://huggingface.co/avaturn-live/avtr-1",
+      "downloads": 164,
+      "likes": 17,
+      "trendingScore": 17,
+      "pipelineTag": "image-to-video",
+      "libraryName": "tensorrt",
+      "tags": [
+        "tensorrt",
+        "onnx",
+        "talking-head",
+        "lip-sync",
+        "avatar",
+        "real-time",
+        "audio-driven",
+        "non-commercial",
+        "image-to-video",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:26:51.000Z",
+      "lastModified": "2026-05-25T21:18:34.000Z"
+    },
+    {
+      "rank": 351,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -10289,7 +10406,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 348,
+      "rank": 352,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -10324,7 +10441,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 349,
+      "rank": 353,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -10369,7 +10486,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 350,
+      "rank": 354,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -10396,7 +10513,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 351,
+      "rank": 355,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -10425,7 +10542,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 352,
+      "rank": 356,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -10448,7 +10565,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 353,
+      "rank": 357,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -10492,7 +10609,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 354,
+      "rank": 358,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -10537,7 +10654,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 355,
+      "rank": 359,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -10555,7 +10672,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 356,
+      "rank": 360,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -10600,7 +10717,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 357,
+      "rank": 361,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -10638,7 +10755,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 358,
+      "rank": 362,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -10658,7 +10775,7 @@
       "lastModified": "2026-05-24T09:49:46.000Z"
     },
     {
-      "rank": 359,
+      "rank": 363,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -10691,7 +10808,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 360,
+      "rank": 364,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -10721,7 +10838,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 361,
+      "rank": 365,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -10753,7 +10870,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 362,
+      "rank": 366,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -10778,7 +10895,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 363,
+      "rank": 367,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -10801,7 +10918,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 364,
+      "rank": 368,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -10831,7 +10948,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 365,
+      "rank": 369,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -10855,7 +10972,7 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 366,
+      "rank": 370,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -10883,7 +11000,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 367,
+      "rank": 371,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -10911,12 +11028,12 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 368,
+      "rank": 372,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
-      "downloads": 1956090,
-      "likes": 832,
+      "downloads": 1951497,
+      "likes": 834,
       "trendingScore": 16,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": null,
@@ -10934,7 +11051,7 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 369,
+      "rank": 373,
       "id": "prism-ml/bonsai-image-binary-4B-unpacked",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
@@ -10960,11 +11077,11 @@
       "lastModified": "2026-05-28T22:22:27.000Z"
     },
     {
-      "rank": 370,
+      "rank": 374,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
-      "downloads": 1263595,
+      "downloads": 1273051,
       "likes": 2217,
       "trendingScore": 16,
       "pipelineTag": "text-generation",
@@ -10996,7 +11113,7 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 371,
+      "rank": 375,
       "id": "prism-ml/bonsai-image-binary-4B-mlx-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit",
@@ -11026,30 +11143,7 @@
       "lastModified": "2026-05-28T15:52:11.000Z"
     },
     {
-      "rank": 372,
-      "id": "allura-org/Qwen3.6-35B-A3B-Anko",
-      "author": "allura-org",
-      "url": "https://huggingface.co/allura-org/Qwen3.6-35B-A3B-Anko",
-      "downloads": 21,
-      "likes": 22,
-      "trendingScore": 16,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_5_moe",
-        "en",
-        "zh",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T03:54:01.000Z",
-      "lastModified": "2026-04-23T15:43:25.000Z"
-    },
-    {
-      "rank": 373,
+      "rank": 376,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -11076,7 +11170,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 374,
+      "rank": 377,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -11121,7 +11215,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 375,
+      "rank": 378,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -11151,7 +11245,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 376,
+      "rank": 379,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -11181,7 +11275,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 377,
+      "rank": 380,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -11226,7 +11320,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 378,
+      "rank": 381,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -11261,7 +11355,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 379,
+      "rank": 382,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -11290,7 +11384,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 380,
+      "rank": 383,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -11315,7 +11409,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 381,
+      "rank": 384,
       "id": "unsloth/Qwen3-Coder-Next-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
@@ -11343,7 +11437,7 @@
       "lastModified": "2026-03-06T14:38:33.000Z"
     },
     {
-      "rank": 382,
+      "rank": 385,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -11371,7 +11465,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 383,
+      "rank": 386,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -11402,7 +11496,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 384,
+      "rank": 387,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -11447,7 +11541,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 385,
+      "rank": 388,
       "id": "mistralai/Voxtral-4B-TTS-2603",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
@@ -11479,7 +11573,7 @@
       "lastModified": "2026-03-31T13:43:59.000Z"
     },
     {
-      "rank": 386,
+      "rank": 389,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -11506,7 +11600,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 387,
+      "rank": 390,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -11529,7 +11623,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 388,
+      "rank": 391,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -11556,7 +11650,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 389,
+      "rank": 392,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -11582,7 +11676,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 390,
+      "rank": 393,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -11612,7 +11706,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 391,
+      "rank": 394,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -11639,7 +11733,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 392,
+      "rank": 395,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -11670,7 +11764,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 393,
+      "rank": 396,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -11702,7 +11796,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 394,
+      "rank": 397,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -11747,7 +11841,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 395,
+      "rank": 398,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -11780,7 +11874,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 396,
+      "rank": 399,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -11820,7 +11914,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 397,
+      "rank": 400,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -11861,7 +11955,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 398,
+      "rank": 401,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -11884,7 +11978,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 399,
+      "rank": 402,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -11907,7 +12001,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 400,
+      "rank": 403,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -11938,7 +12032,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 401,
+      "rank": 404,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -11969,7 +12063,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 402,
+      "rank": 405,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -11998,7 +12092,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 403,
+      "rank": 406,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -12031,7 +12125,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 404,
+      "rank": 407,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -12057,11 +12151,11 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 405,
+      "rank": 408,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
-      "downloads": 314855,
+      "downloads": 316528,
       "likes": 964,
       "trendingScore": 15,
       "pipelineTag": "automatic-speech-recognition",
@@ -12099,7 +12193,7 @@
       "lastModified": "2026-05-04T13:29:45.000Z"
     },
     {
-      "rank": 406,
+      "rank": 409,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12124,7 +12218,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 407,
+      "rank": 410,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -12169,7 +12263,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 408,
+      "rank": 411,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -12199,7 +12293,7 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 409,
+      "rank": 412,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -12222,33 +12316,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 410,
-      "id": "avaturn-live/avtr-1",
-      "author": "avaturn-live",
-      "url": "https://huggingface.co/avaturn-live/avtr-1",
-      "downloads": 106,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "image-to-video",
-      "libraryName": "tensorrt",
-      "tags": [
-        "tensorrt",
-        "onnx",
-        "talking-head",
-        "lip-sync",
-        "avatar",
-        "real-time",
-        "audio-driven",
-        "non-commercial",
-        "image-to-video",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:26:51.000Z",
-      "lastModified": "2026-05-25T21:18:34.000Z"
-    },
-    {
-      "rank": 411,
+      "rank": 413,
       "id": "AmmarkoV/SAM3DBody-cpp-onnx-models",
       "author": "AmmarkoV",
       "url": "https://huggingface.co/AmmarkoV/SAM3DBody-cpp-onnx-models",
@@ -12266,7 +12334,36 @@
       "lastModified": "2026-05-28T20:44:53.000Z"
     },
     {
-      "rank": 412,
+      "rank": 414,
+      "id": "datalab-to/surya-ocr-2",
+      "author": "datalab-to",
+      "url": "https://huggingface.co/datalab-to/surya-ocr-2",
+      "downloads": 3152,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "ocr",
+        "pdf",
+        "markdown",
+        "layout",
+        "conversational",
+        "arxiv:2105.15203",
+        "license:openrail",
+        "eval-results",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T21:01:33.000Z",
+      "lastModified": "2026-05-27T20:33:29.000Z"
+    },
+    {
+      "rank": 415,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -12290,7 +12387,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 413,
+      "rank": 416,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -12317,7 +12414,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 414,
+      "rank": 417,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -12345,7 +12442,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 415,
+      "rank": 418,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -12364,7 +12461,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 416,
+      "rank": 419,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -12396,7 +12493,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 417,
+      "rank": 420,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -12425,7 +12522,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 418,
+      "rank": 421,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -12451,7 +12548,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 419,
+      "rank": 422,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -12479,7 +12576,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 420,
+      "rank": 423,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -12513,7 +12610,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 421,
+      "rank": 424,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -12539,7 +12636,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 422,
+      "rank": 425,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -12581,7 +12678,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 423,
+      "rank": 426,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -12619,7 +12716,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 424,
+      "rank": 427,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -12638,7 +12735,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 425,
+      "rank": 428,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -12658,7 +12755,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 426,
+      "rank": 429,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -12685,7 +12782,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 427,
+      "rank": 430,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -12711,7 +12808,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 428,
+      "rank": 431,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -12736,7 +12833,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 429,
+      "rank": 432,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -12765,7 +12862,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 430,
+      "rank": 433,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -12810,7 +12907,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 431,
+      "rank": 434,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -12837,7 +12934,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 432,
+      "rank": 435,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -12866,7 +12963,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 433,
+      "rank": 436,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -12892,7 +12989,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 434,
+      "rank": 437,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -12917,11 +13014,11 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 435,
+      "rank": 438,
       "id": "nvidia/vgg-ttt",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/vgg-ttt",
-      "downloads": 444,
+      "downloads": 511,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": "image-to-3d",
@@ -12946,7 +13043,7 @@
       "lastModified": "2026-05-25T15:55:35.000Z"
     },
     {
-      "rank": 436,
+      "rank": 439,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
@@ -12983,7 +13080,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 437,
+      "rank": 440,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13011,7 +13108,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 438,
+      "rank": 441,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -13038,12 +13135,12 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 439,
+      "rank": 442,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
       "downloads": 0,
-      "likes": 573,
+      "likes": 575,
       "trendingScore": 14,
       "pipelineTag": null,
       "libraryName": null,
@@ -13055,7 +13152,7 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 440,
+      "rank": 443,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -13080,12 +13177,12 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 441,
+      "rank": 444,
       "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 144886,
-      "likes": 359,
+      "downloads": 145447,
+      "likes": 360,
       "trendingScore": 14,
       "pipelineTag": null,
       "libraryName": null,
@@ -13106,31 +13203,7 @@
       "lastModified": "2026-04-05T19:01:02.000Z"
     },
     {
-      "rank": 442,
-      "id": "bageldotcom/paris2",
-      "author": "bageldotcom",
-      "url": "https://huggingface.co/bageldotcom/paris2",
-      "downloads": 0,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "image-to-video",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "paris2",
-        "text-to-video",
-        "image-to-video",
-        "mixture-of-experts",
-        "decentralized-diffusion-model",
-        "arxiv:2605.26064",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-24T17:46:11.000Z",
-      "lastModified": "2026-05-28T16:32:17.000Z"
-    },
-    {
-      "rank": 443,
+      "rank": 445,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -13159,7 +13232,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 444,
+      "rank": 446,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -13204,7 +13277,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 445,
+      "rank": 447,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -13233,7 +13306,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 446,
+      "rank": 448,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -13260,7 +13333,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 447,
+      "rank": 449,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -13291,7 +13364,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 448,
+      "rank": 450,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -13315,7 +13388,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 449,
+      "rank": 451,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -13342,7 +13415,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 450,
+      "rank": 452,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -13378,7 +13451,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 451,
+      "rank": 453,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -13409,7 +13482,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 452,
+      "rank": 454,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -13440,7 +13513,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 453,
+      "rank": 455,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -13473,7 +13546,7 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 454,
+      "rank": 456,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
@@ -13502,7 +13575,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 455,
+      "rank": 457,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -13528,7 +13601,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 456,
+      "rank": 458,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -13558,7 +13631,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 457,
+      "rank": 459,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -13576,7 +13649,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 458,
+      "rank": 460,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -13607,7 +13680,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 459,
+      "rank": 461,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -13628,7 +13701,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 460,
+      "rank": 462,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -13648,7 +13721,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 461,
+      "rank": 463,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -13675,7 +13748,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 462,
+      "rank": 464,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -13705,7 +13778,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 463,
+      "rank": 465,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -13722,7 +13795,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 464,
+      "rank": 466,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -13749,7 +13822,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 465,
+      "rank": 467,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -13774,7 +13847,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 466,
+      "rank": 468,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -13817,7 +13890,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 467,
+      "rank": 469,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -13846,12 +13919,12 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 468,
+      "rank": 470,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
-      "downloads": 13421,
-      "likes": 534,
+      "downloads": 13457,
+      "likes": 536,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -13873,7 +13946,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 469,
+      "rank": 471,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -13903,7 +13976,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 470,
+      "rank": 472,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -13931,11 +14004,11 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 471,
+      "rank": 473,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
-      "downloads": 911,
+      "downloads": 945,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
@@ -13962,7 +14035,7 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 472,
+      "rank": 474,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -13984,7 +14057,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 473,
+      "rank": 475,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -14007,7 +14080,7 @@
       "lastModified": "2026-05-26T09:06:09.000Z"
     },
     {
-      "rank": 474,
+      "rank": 476,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -14034,11 +14107,11 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 475,
+      "rank": 477,
       "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
-      "downloads": 1769,
+      "downloads": 2180,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
@@ -14079,7 +14152,7 @@
       "lastModified": "2026-05-23T00:19:59.000Z"
     },
     {
-      "rank": 476,
+      "rank": 478,
       "id": "UofTCSSLab/Maia3-79M",
       "author": "UofTCSSLab",
       "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
@@ -14103,11 +14176,11 @@
       "lastModified": "2026-05-24T16:12:28.000Z"
     },
     {
-      "rank": 477,
+      "rank": 479,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
-      "downloads": 155,
+      "downloads": 166,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
@@ -14143,11 +14216,11 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 478,
+      "rank": 480,
       "id": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "downloads": 4295,
+      "downloads": 5321,
       "likes": 13,
       "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
@@ -14173,7 +14246,7 @@
       "lastModified": "2026-05-25T03:44:12.000Z"
     },
     {
-      "rank": 479,
+      "rank": 481,
       "id": "fuckSelf/GPT-SoVITS-Russian",
       "author": "fuckSelf",
       "url": "https://huggingface.co/fuckSelf/GPT-SoVITS-Russian",
@@ -14197,36 +14270,64 @@
       "lastModified": "2025-09-11T14:59:49.000Z"
     },
     {
-      "rank": 480,
-      "id": "datalab-to/surya-ocr-2",
-      "author": "datalab-to",
-      "url": "https://huggingface.co/datalab-to/surya-ocr-2",
-      "downloads": 692,
-      "likes": 13,
+      "rank": 482,
+      "id": "bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
+      "author": "bartowski",
+      "url": "https://huggingface.co/bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
+      "downloads": 5171,
+      "likes": 17,
       "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "text-generation",
+      "libraryName": null,
       "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "ocr",
-        "pdf",
-        "markdown",
-        "layout",
-        "conversational",
-        "arxiv:2105.15203",
-        "license:openrail",
-        "eval-results",
+        "gguf",
+        "text-generation",
+        "en",
+        "zh",
+        "base_model:allura-org/Qwen3.6-35B-A3B-Anko",
+        "base_model:quantized:allura-org/Qwen3.6-35B-A3B-Anko",
+        "license:apache-2.0",
         "endpoints_compatible",
-        "region:us"
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-14T21:01:33.000Z",
-      "lastModified": "2026-05-27T20:33:29.000Z"
+      "createdAt": "2026-04-21T17:45:30.000Z",
+      "lastModified": "2026-05-22T17:02:24.000Z"
     },
     {
-      "rank": 481,
+      "rank": 483,
+      "id": "nvidia/DeepSeek-V4-Pro-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4",
+      "downloads": 1506,
+      "likes": 14,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "deepseek_v4",
+        "nvidia",
+        "ModelOpt",
+        "DeepSeekV4",
+        "quantized",
+        "NVFP4",
+        "nvfp4",
+        "text-generation",
+        "base_model:deepseek-ai/DeepSeek-V4-Pro",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Pro",
+        "license:mit",
+        "8-bit",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T19:48:36.000Z",
+      "lastModified": "2026-05-29T05:47:42.000Z"
+    },
+    {
+      "rank": 484,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -14253,7 +14354,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 482,
+      "rank": 485,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -14281,7 +14382,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 483,
+      "rank": 486,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -14314,7 +14415,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 484,
+      "rank": 487,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -14330,7 +14431,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 485,
+      "rank": 488,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -14353,7 +14454,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 486,
+      "rank": 489,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -14387,7 +14488,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 487,
+      "rank": 490,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -14407,7 +14508,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 488,
+      "rank": 491,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -14442,7 +14543,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 489,
+      "rank": 492,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -14472,7 +14573,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 490,
+      "rank": 493,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -14493,7 +14594,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 491,
+      "rank": 494,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -14522,7 +14623,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 492,
+      "rank": 495,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -14552,7 +14653,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 493,
+      "rank": 496,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -14580,7 +14681,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 494,
+      "rank": 497,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -14609,7 +14710,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 495,
+      "rank": 498,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -14641,7 +14742,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 496,
+      "rank": 499,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -14676,7 +14777,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 497,
+      "rank": 500,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -14714,7 +14815,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 498,
+      "rank": 501,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -14753,7 +14854,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 499,
+      "rank": 502,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -14790,7 +14891,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 500,
+      "rank": 503,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -14814,7 +14915,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 501,
+      "rank": 504,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -14832,7 +14933,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 502,
+      "rank": 505,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -14851,7 +14952,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 503,
+      "rank": 506,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -14879,7 +14980,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 504,
+      "rank": 507,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -14917,7 +15018,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 505,
+      "rank": 508,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -14939,7 +15040,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 506,
+      "rank": 509,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -14976,7 +15077,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 507,
+      "rank": 510,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -15006,7 +15107,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 508,
+      "rank": 511,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -15035,7 +15136,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 509,
+      "rank": 512,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -15063,7 +15164,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 510,
+      "rank": 513,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -15089,7 +15190,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 511,
+      "rank": 514,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -15116,7 +15217,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 512,
+      "rank": 515,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -15141,7 +15242,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 513,
+      "rank": 516,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -15170,7 +15271,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 514,
+      "rank": 517,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -15195,7 +15296,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 515,
+      "rank": 518,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -15221,7 +15322,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 516,
+      "rank": 519,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -15260,7 +15361,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 517,
+      "rank": 520,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
@@ -15288,7 +15389,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 518,
+      "rank": 521,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -15314,7 +15415,7 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 519,
+      "rank": 522,
       "id": "SupraLabs/Supra-50M-Base",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
@@ -15348,7 +15449,7 @@
       "lastModified": "2026-05-27T13:53:55.000Z"
     },
     {
-      "rank": 520,
+      "rank": 523,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -15368,7 +15469,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 521,
+      "rank": 524,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -15401,7 +15502,7 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 522,
+      "rank": 525,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -15428,7 +15529,7 @@
       "lastModified": "2026-05-25T10:58:41.000Z"
     },
     {
-      "rank": 523,
+      "rank": 526,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -15454,7 +15555,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 524,
+      "rank": 527,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
@@ -15485,7 +15586,7 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 525,
+      "rank": 528,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -15508,11 +15609,11 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 526,
+      "rank": 529,
       "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
-      "downloads": 2494,
+      "downloads": 3096,
       "likes": 12,
       "trendingScore": 12,
       "pipelineTag": "image-text-to-text",
@@ -15553,7 +15654,7 @@
       "lastModified": "2026-05-24T04:55:49.000Z"
     },
     {
-      "rank": 527,
+      "rank": 530,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -15594,11 +15695,11 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 528,
+      "rank": 531,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
-      "downloads": 8244,
+      "downloads": 9961,
       "likes": 14,
       "trendingScore": 12,
       "pipelineTag": null,
@@ -15616,7 +15717,7 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 529,
+      "rank": 532,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -15661,7 +15762,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 530,
+      "rank": 533,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -15688,33 +15789,95 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 531,
-      "id": "bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
-      "author": "bartowski",
-      "url": "https://huggingface.co/bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
-      "downloads": 4513,
-      "likes": 16,
+      "rank": 534,
+      "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "author": "Leon1000",
+      "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
+      "downloads": 0,
+      "likes": 12,
       "trendingScore": 12,
-      "pipelineTag": "text-generation",
+      "pipelineTag": "image-to-image",
       "libraryName": null,
       "tags": [
-        "gguf",
-        "text-generation",
+        "flux",
+        "flux.2",
+        "flux-lora",
+        "lora",
+        "multi-angle",
+        "camera-angles",
+        "image-to-image",
+        "fal-ai",
         "en",
-        "zh",
-        "base_model:allura-org/Qwen3.6-35B-A3B-Anko",
-        "base_model:quantized:allura-org/Qwen3.6-35B-A3B-Anko",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
+        "base_model:black-forest-labs/FLUX.2-dev",
+        "base_model:adapter:black-forest-labs/FLUX.2-dev",
+        "license:creativeml-openrail-m",
+        "region:us"
       ],
-      "createdAt": "2026-04-21T17:45:30.000Z",
-      "lastModified": "2026-05-22T17:02:24.000Z"
+      "createdAt": "2026-05-20T00:22:03.000Z",
+      "lastModified": "2026-05-20T00:22:04.000Z"
     },
     {
-      "rank": 532,
+      "rank": 535,
+      "id": "Qwen/Qwen2.5-1.5B-Instruct",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
+      "downloads": 14716195,
+      "likes": 719,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "chat",
+        "conversational",
+        "en",
+        "arxiv:2407.10671",
+        "base_model:Qwen/Qwen2.5-1.5B",
+        "base_model:finetune:Qwen/Qwen2.5-1.5B",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2024-09-17T14:10:29.000Z",
+      "lastModified": "2024-09-25T12:32:50.000Z"
+    },
+    {
+      "rank": 536,
+      "id": "stepfun-ai/Step-3.7-Flash-NVFP4",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-NVFP4",
+      "downloads": 769,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "8-bit",
+        "modelopt",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T12:35:59.000Z",
+      "lastModified": "2026-05-29T10:04:39.000Z"
+    },
+    {
+      "rank": 537,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -15759,7 +15922,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 533,
+      "rank": 538,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -15801,7 +15964,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 534,
+      "rank": 539,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -15827,7 +15990,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 535,
+      "rank": 540,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -15852,7 +16015,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 536,
+      "rank": 541,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -15869,7 +16032,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 537,
+      "rank": 542,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -15897,7 +16060,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 538,
+      "rank": 543,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -15923,7 +16086,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 539,
+      "rank": 544,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -15950,7 +16113,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 540,
+      "rank": 545,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -15978,7 +16141,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 541,
+      "rank": 546,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -16011,7 +16174,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 542,
+      "rank": 547,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -16045,7 +16208,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 543,
+      "rank": 548,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -16074,7 +16237,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 544,
+      "rank": 549,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -16103,7 +16266,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 545,
+      "rank": 550,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -16136,7 +16299,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 546,
+      "rank": 551,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -16163,7 +16326,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 547,
+      "rank": 552,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -16193,7 +16356,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 548,
+      "rank": 553,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -16219,7 +16382,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 549,
+      "rank": 554,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -16243,7 +16406,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 550,
+      "rank": 555,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -16270,7 +16433,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 551,
+      "rank": 556,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -16304,7 +16467,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 552,
+      "rank": 557,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -16320,7 +16483,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 553,
+      "rank": 558,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -16351,7 +16514,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 554,
+      "rank": 559,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -16373,7 +16536,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 555,
+      "rank": 560,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -16393,7 +16556,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 556,
+      "rank": 561,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -16415,7 +16578,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 557,
+      "rank": 562,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -16444,7 +16607,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 558,
+      "rank": 563,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -16469,7 +16632,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 559,
+      "rank": 564,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -16494,7 +16657,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 560,
+      "rank": 565,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -16529,7 +16692,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 561,
+      "rank": 566,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -16553,7 +16716,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 562,
+      "rank": 567,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -16584,7 +16747,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 563,
+      "rank": 568,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -16614,7 +16777,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 564,
+      "rank": 569,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -16640,7 +16803,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 565,
+      "rank": 570,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -16685,7 +16848,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 566,
+      "rank": 571,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -16712,7 +16875,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 567,
+      "rank": 572,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -16739,7 +16902,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 568,
+      "rank": 573,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -16784,7 +16947,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 569,
+      "rank": 574,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -16810,7 +16973,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 570,
+      "rank": 575,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -16839,7 +17002,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 571,
+      "rank": 576,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -16884,7 +17047,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 572,
+      "rank": 577,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -16916,7 +17079,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 573,
+      "rank": 578,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -16951,7 +17114,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 574,
+      "rank": 579,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -16996,7 +17159,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 575,
+      "rank": 580,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -17021,7 +17184,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 576,
+      "rank": 581,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -17060,7 +17223,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 577,
+      "rank": 582,
       "id": "Abiray/L2P-model-1k-merge-INT8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
@@ -17085,7 +17248,7 @@
       "lastModified": "2026-05-23T17:24:01.000Z"
     },
     {
-      "rank": 578,
+      "rank": 583,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
@@ -17115,7 +17278,7 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 579,
+      "rank": 584,
       "id": "mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
@@ -17145,35 +17308,7 @@
       "lastModified": "2026-05-10T04:13:55.000Z"
     },
     {
-      "rank": 580,
-      "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
-      "author": "Leon1000",
-      "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
-      "downloads": 0,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "flux",
-        "flux.2",
-        "flux-lora",
-        "lora",
-        "multi-angle",
-        "camera-angles",
-        "image-to-image",
-        "fal-ai",
-        "en",
-        "base_model:black-forest-labs/FLUX.2-dev",
-        "base_model:adapter:black-forest-labs/FLUX.2-dev",
-        "license:creativeml-openrail-m",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T00:22:03.000Z",
-      "lastModified": "2026-05-20T00:22:04.000Z"
-    },
-    {
-      "rank": 581,
+      "rank": 585,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -17199,7 +17334,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 582,
+      "rank": 586,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
@@ -17234,7 +17369,7 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 583,
+      "rank": 587,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -17260,11 +17395,11 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 584,
+      "rank": 588,
       "id": "FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
-      "downloads": 175,
+      "downloads": 236,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -17293,7 +17428,7 @@
       "lastModified": "2026-05-27T07:55:25.000Z"
     },
     {
-      "rank": 585,
+      "rank": 589,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
@@ -17318,79 +17453,97 @@
       "lastModified": "2026-05-26T05:28:12.000Z"
     },
     {
-      "rank": 586,
-      "id": "Qwen/Qwen2.5-1.5B-Instruct",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
-      "downloads": 14774160,
-      "likes": 718,
+      "rank": 590,
+      "id": "litert-community/gemma-4-E4B-it-litert-lm",
+      "author": "litert-community",
+      "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
+      "downloads": 519170,
+      "likes": 110,
       "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": null,
+      "libraryName": "litert-lm",
       "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "chat",
-        "conversational",
-        "en",
-        "arxiv:2407.10671",
-        "base_model:Qwen/Qwen2.5-1.5B",
-        "base_model:finetune:Qwen/Qwen2.5-1.5B",
+        "litert-lm",
+        "base_model:google/gemma-4-E4B-it",
+        "base_model:finetune:google/gemma-4-E4B-it",
         "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2024-09-17T14:10:29.000Z",
-      "lastModified": "2024-09-25T12:32:50.000Z"
+      "createdAt": "2026-03-26T00:20:57.000Z",
+      "lastModified": "2026-05-20T21:47:36.000Z"
     },
     {
-      "rank": 587,
-      "id": "stepfun-ai/Step-3.7-Flash-GGUF",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-GGUF",
-      "downloads": 0,
+      "rank": 591,
+      "id": "Abiray/MiniCPM5-1B-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
+      "downloads": 3607,
       "likes": 11,
       "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "gguf",
+      "pipelineTag": "text-generation",
+      "libraryName": null,
       "tags": [
         "gguf",
-        "llama.cpp",
-        "quantized",
-        "imatrix",
-        "moe",
-        "agent",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
         "tool-calling",
-        "reasoning",
-        "vision",
-        "multimodal",
-        "image-text-to-text",
+        "on-device",
+        "edge-ai",
+        "llama.cpp",
         "en",
         "zh",
-        "ja",
-        "ko",
-        "ar",
-        "hi",
-        "de",
-        "fr",
-        "es",
-        "ru",
-        "base_model:stepfun-ai/Step-3.7-Flash",
-        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "base_model:openbmb/MiniCPM5-1B",
+        "base_model:quantized:openbmb/MiniCPM5-1B",
         "license:apache-2.0",
         "endpoints_compatible",
         "region:us",
         "conversational"
       ],
-      "createdAt": "2026-05-28T11:34:17.000Z",
-      "lastModified": "2026-05-29T03:48:51.000Z"
+      "createdAt": "2026-05-26T04:47:48.000Z",
+      "lastModified": "2026-05-28T14:08:39.000Z"
     },
     {
-      "rank": 588,
+      "rank": 592,
+      "id": "dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
+      "author": "dealignai",
+      "url": "https://huggingface.co/dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
+      "downloads": 1810,
+      "likes": 12,
+      "trendingScore": 11,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "qwen3_5_moe",
+        "apple-silicon",
+        "abliterated",
+        "uncensored",
+        "crack",
+        "mtp",
+        "speculative-decoding",
+        "vision",
+        "video",
+        "reasoning",
+        "thinking",
+        "harmbench",
+        "mmlu",
+        "qwen3_6",
+        "image-text-to-text",
+        "moe",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-24T19:35:48.000Z",
+      "lastModified": "2026-05-24T21:04:29.000Z"
+    },
+    {
+      "rank": 593,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -17419,7 +17572,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 589,
+      "rank": 594,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -17453,7 +17606,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 590,
+      "rank": 595,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -17498,7 +17651,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 591,
+      "rank": 596,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -17527,7 +17680,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 592,
+      "rank": 597,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -17552,7 +17705,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 593,
+      "rank": 598,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -17587,7 +17740,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 594,
+      "rank": 599,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -17614,7 +17767,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 595,
+      "rank": 600,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -17659,7 +17812,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 596,
+      "rank": 601,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -17681,7 +17834,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 597,
+      "rank": 602,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -17713,7 +17866,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 598,
+      "rank": 603,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -17738,7 +17891,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 599,
+      "rank": 604,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -17762,7 +17915,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 600,
+      "rank": 605,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -17805,7 +17958,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 601,
+      "rank": 606,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -17829,7 +17982,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 602,
+      "rank": 607,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -17858,7 +18011,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 603,
+      "rank": 608,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -17890,7 +18043,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 604,
+      "rank": 609,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -17914,7 +18067,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 605,
+      "rank": 610,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -17936,7 +18089,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 606,
+      "rank": 611,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -17961,7 +18114,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 607,
+      "rank": 612,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -17989,7 +18142,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 608,
+      "rank": 613,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -18013,7 +18166,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 609,
+      "rank": 614,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -18040,7 +18193,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 610,
+      "rank": 615,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -18057,7 +18210,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 611,
+      "rank": 616,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -18081,7 +18234,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 612,
+      "rank": 617,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -18105,7 +18258,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 613,
+      "rank": 618,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -18138,7 +18291,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 614,
+      "rank": 619,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -18172,7 +18325,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 615,
+      "rank": 620,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -18194,7 +18347,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 616,
+      "rank": 621,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -18217,7 +18370,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 617,
+      "rank": 622,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -18237,7 +18390,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 618,
+      "rank": 623,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -18269,7 +18422,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 619,
+      "rank": 624,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -18308,7 +18461,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 620,
+      "rank": 625,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -18342,27 +18495,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 621,
-      "id": "litert-community/gemma-4-E4B-it-litert-lm",
-      "author": "litert-community",
-      "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
-      "downloads": 499963,
-      "likes": 109,
-      "trendingScore": 10,
-      "pipelineTag": null,
-      "libraryName": "litert-lm",
-      "tags": [
-        "litert-lm",
-        "base_model:google/gemma-4-E4B-it",
-        "base_model:finetune:google/gemma-4-E4B-it",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-26T00:20:57.000Z",
-      "lastModified": "2026-05-20T21:47:36.000Z"
-    },
-    {
-      "rank": 622,
+      "rank": 626,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -18391,7 +18524,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 623,
+      "rank": 627,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -18413,7 +18546,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 624,
+      "rank": 628,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -18445,7 +18578,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 625,
+      "rank": 629,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -18472,7 +18605,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 626,
+      "rank": 630,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -18516,7 +18649,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 627,
+      "rank": 631,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -18534,7 +18667,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 628,
+      "rank": 632,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -18573,7 +18706,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 629,
+      "rank": 633,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -18612,7 +18745,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 630,
+      "rank": 634,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -18646,7 +18779,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 631,
+      "rank": 635,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -18674,7 +18807,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 632,
+      "rank": 636,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -18696,7 +18829,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 633,
+      "rank": 637,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -18724,7 +18857,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 634,
+      "rank": 638,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -18742,7 +18875,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 635,
+      "rank": 639,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -18770,12 +18903,12 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 636,
+      "rank": 640,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
-      "downloads": 5153880,
-      "likes": 1552,
+      "downloads": 5229408,
+      "likes": 1553,
       "trendingScore": 10,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -18801,7 +18934,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 637,
+      "rank": 641,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -18817,7 +18950,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 638,
+      "rank": 642,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -18844,7 +18977,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 639,
+      "rank": 643,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -18873,11 +19006,11 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 640,
+      "rank": 644,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
-      "downloads": 100955,
+      "downloads": 101430,
       "likes": 219,
       "trendingScore": 10,
       "pipelineTag": "image-to-image",
@@ -18901,7 +19034,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 641,
+      "rank": 645,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -18930,7 +19063,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 642,
+      "rank": 646,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -18951,7 +19084,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 643,
+      "rank": 647,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -18972,7 +19105,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 644,
+      "rank": 648,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -19002,7 +19135,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 645,
+      "rank": 649,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -19026,7 +19159,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 646,
+      "rank": 650,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -19056,7 +19189,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 647,
+      "rank": 651,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -19087,7 +19220,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 648,
+      "rank": 652,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -19113,7 +19246,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 649,
+      "rank": 653,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -19131,7 +19264,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 650,
+      "rank": 654,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -19164,7 +19297,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 651,
+      "rank": 655,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -19189,7 +19322,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 652,
+      "rank": 656,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -19214,7 +19347,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 653,
+      "rank": 657,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -19248,7 +19381,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 654,
+      "rank": 658,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
@@ -19277,7 +19410,7 @@
       "lastModified": "2026-05-22T20:32:34.000Z"
     },
     {
-      "rank": 655,
+      "rank": 659,
       "id": "kepeng/PRSIMVL-LoRA-V1",
       "author": "kepeng",
       "url": "https://huggingface.co/kepeng/PRSIMVL-LoRA-V1",
@@ -19308,7 +19441,7 @@
       "lastModified": "2026-05-27T06:35:24.000Z"
     },
     {
-      "rank": 656,
+      "rank": 660,
       "id": "Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
       "author": "Andycurrent",
       "url": "https://huggingface.co/Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
@@ -19336,11 +19469,11 @@
       "lastModified": "2026-02-18T10:06:23.000Z"
     },
     {
-      "rank": 657,
+      "rank": 661,
       "id": "FunAudioLLM/SenseVoiceSmall",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/SenseVoiceSmall",
-      "downloads": 3987,
+      "downloads": 4211,
       "likes": 406,
       "trendingScore": 10,
       "pipelineTag": "automatic-speech-recognition",
@@ -19369,11 +19502,11 @@
       "lastModified": "2026-05-25T17:28:01.000Z"
     },
     {
-      "rank": 658,
+      "rank": 662,
       "id": "Anbeeld/Qwen3.6-27B-DFlash-GGUF",
       "author": "Anbeeld",
       "url": "https://huggingface.co/Anbeeld/Qwen3.6-27B-DFlash-GGUF",
-      "downloads": 5421,
+      "downloads": 5892,
       "likes": 12,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -19390,11 +19523,11 @@
       "lastModified": "2026-05-22T17:31:30.000Z"
     },
     {
-      "rank": 659,
+      "rank": 663,
       "id": "huytd189/Qwen3.6-27B-pure-GGUF",
       "author": "huytd189",
       "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
-      "downloads": 3724,
+      "downloads": 4031,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -19413,74 +19546,11 @@
       "lastModified": "2026-05-27T05:35:38.000Z"
     },
     {
-      "rank": 660,
-      "id": "Abiray/MiniCPM5-1B-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
-      "downloads": 2342,
-      "likes": 10,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "minicpm",
-        "minicpm5",
-        "llama",
-        "text-generation",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "llama.cpp",
-        "en",
-        "zh",
-        "base_model:openbmb/MiniCPM5-1B",
-        "base_model:quantized:openbmb/MiniCPM5-1B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-26T04:47:48.000Z",
-      "lastModified": "2026-05-28T14:08:39.000Z"
-    },
-    {
-      "rank": 661,
-      "id": "nvidia/DeepSeek-V4-Pro-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4",
-      "downloads": 1204,
-      "likes": 11,
-      "trendingScore": 10,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "deepseek_v4",
-        "nvidia",
-        "ModelOpt",
-        "DeepSeekV4",
-        "quantized",
-        "NVFP4",
-        "nvfp4",
-        "text-generation",
-        "base_model:deepseek-ai/DeepSeek-V4-Pro",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Pro",
-        "license:mit",
-        "8-bit",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T19:48:36.000Z",
-      "lastModified": "2026-05-27T23:37:21.000Z"
-    },
-    {
-      "rank": 662,
+      "rank": 664,
       "id": "lightx2v/Wan2.2-NVFP4-Sparse",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-NVFP4-Sparse",
-      "downloads": 0,
+      "downloads": 292,
       "likes": 10,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -19500,7 +19570,119 @@
       "lastModified": "2026-05-28T07:10:10.000Z"
     },
     {
-      "rank": 663,
+      "rank": 665,
+      "id": "google/gemma-3-4b-it",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-3-4b-it",
+      "downloads": 1855262,
+      "likes": 1344,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "image-text-to-text",
+        "arxiv:1905.07830",
+        "arxiv:1905.10044",
+        "arxiv:1911.11641",
+        "arxiv:1904.09728",
+        "arxiv:1705.03551",
+        "arxiv:1911.01547",
+        "arxiv:1907.10641",
+        "arxiv:1903.00161",
+        "arxiv:2009.03300",
+        "arxiv:2304.06364",
+        "arxiv:2103.03874",
+        "arxiv:2110.14168",
+        "arxiv:2311.12022",
+        "arxiv:2108.07732",
+        "arxiv:2107.03374",
+        "arxiv:2210.03057",
+        "arxiv:2106.03193",
+        "arxiv:1910.11856",
+        "arxiv:2502.12404",
+        "arxiv:2502.21228",
+        "arxiv:2404.16816",
+        "arxiv:2104.12756",
+        "arxiv:2311.16502",
+        "arxiv:2203.10244",
+        "arxiv:2404.12390",
+        "arxiv:1810.12440",
+        "arxiv:1908.02660"
+      ],
+      "createdAt": "2025-02-20T21:20:07.000Z",
+      "lastModified": "2025-03-21T20:20:53.000Z"
+    },
+    {
+      "rank": 666,
+      "id": "Roboflow/rf-detr-segmentation",
+      "author": "Roboflow",
+      "url": "https://huggingface.co/Roboflow/rf-detr-segmentation",
+      "downloads": 55,
+      "likes": 11,
+      "trendingScore": 10,
+      "pipelineTag": "image-segmentation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "rf_detr",
+        "image-segmentation",
+        "instance-segmentation",
+        "vision",
+        "dataset:coco",
+        "arxiv:2511.09554",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T09:05:51.000Z",
+      "lastModified": "2026-05-20T16:47:13.000Z"
+    },
+    {
+      "rank": 667,
+      "id": "huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
+      "downloads": 5180,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "quantized",
+        "deepseek",
+        "deepseek-v4",
+        "deepseek-v4-flash",
+        "moe",
+        "mixture-of-experts",
+        "2-bit",
+        "4-bit",
+        "iq2_xxs",
+        "q2_k",
+        "q4_k",
+        "ds4",
+        "apple-silicon",
+        "metal",
+        "llama.cpp",
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-26T10:31:39.000Z",
+      "lastModified": "2026-05-27T18:15:42.000Z"
+    },
+    {
+      "rank": 668,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -19526,7 +19708,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 664,
+      "rank": 669,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -19554,7 +19736,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 665,
+      "rank": 670,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -19580,7 +19762,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 666,
+      "rank": 671,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -19620,7 +19802,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 667,
+      "rank": 672,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -19656,7 +19838,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 668,
+      "rank": 673,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -19700,7 +19882,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 669,
+      "rank": 674,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -19725,7 +19907,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 670,
+      "rank": 675,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -19770,7 +19952,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 671,
+      "rank": 676,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -19789,7 +19971,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 672,
+      "rank": 677,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -19814,7 +19996,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 673,
+      "rank": 678,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -19853,7 +20035,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 674,
+      "rank": 679,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -19870,7 +20052,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 675,
+      "rank": 680,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -19898,7 +20080,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 676,
+      "rank": 681,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -19927,7 +20109,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 677,
+      "rank": 682,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -19952,7 +20134,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 678,
+      "rank": 683,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -19987,7 +20169,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 679,
+      "rank": 684,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -20017,7 +20199,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 680,
+      "rank": 685,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -20053,7 +20235,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 681,
+      "rank": 686,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -20076,7 +20258,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 682,
+      "rank": 687,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -20093,7 +20275,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 683,
+      "rank": 688,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -20113,7 +20295,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 684,
+      "rank": 689,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -20140,7 +20322,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 685,
+      "rank": 690,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -20164,7 +20346,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 686,
+      "rank": 691,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -20186,7 +20368,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 687,
+      "rank": 692,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -20218,7 +20400,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 688,
+      "rank": 693,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -20246,7 +20428,7 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 689,
+      "rank": 694,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
@@ -20264,7 +20446,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 690,
+      "rank": 695,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -20289,7 +20471,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 691,
+      "rank": 696,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -20312,7 +20494,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 692,
+      "rank": 697,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -20330,7 +20512,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 693,
+      "rank": 698,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -20365,7 +20547,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 694,
+      "rank": 699,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -20393,7 +20575,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 695,
+      "rank": 700,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -20415,7 +20597,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 696,
+      "rank": 701,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -20442,7 +20624,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 697,
+      "rank": 702,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -20467,7 +20649,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 698,
+      "rank": 703,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -20501,7 +20683,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 699,
+      "rank": 704,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -20528,7 +20710,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 700,
+      "rank": 705,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -20555,7 +20737,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 701,
+      "rank": 706,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -20596,7 +20778,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 702,
+      "rank": 707,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -20626,7 +20808,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 703,
+      "rank": 708,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -20663,7 +20845,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 704,
+      "rank": 709,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -20695,7 +20877,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 705,
+      "rank": 710,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -20737,7 +20919,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 706,
+      "rank": 711,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -20782,7 +20964,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 707,
+      "rank": 712,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -20809,7 +20991,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 708,
+      "rank": 713,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -20841,7 +21023,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 709,
+      "rank": 714,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -20875,7 +21057,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 710,
+      "rank": 715,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -20905,7 +21087,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 711,
+      "rank": 716,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -20930,7 +21112,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 712,
+      "rank": 717,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -20957,7 +21139,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 713,
+      "rank": 718,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -20989,7 +21171,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 714,
+      "rank": 719,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -21034,7 +21216,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 715,
+      "rank": 720,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -21062,7 +21244,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 716,
+      "rank": 721,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -21088,7 +21270,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 717,
+      "rank": 722,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -21117,7 +21299,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 718,
+      "rank": 723,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -21159,7 +21341,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 719,
+      "rank": 724,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -21187,7 +21369,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 720,
+      "rank": 725,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -21216,7 +21398,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 721,
+      "rank": 726,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -21246,7 +21428,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 722,
+      "rank": 727,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -21273,7 +21455,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 723,
+      "rank": 728,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -21302,7 +21484,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 724,
+      "rank": 729,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -21329,7 +21511,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 725,
+      "rank": 730,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -21358,7 +21540,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 726,
+      "rank": 731,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -21398,7 +21580,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 727,
+      "rank": 732,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -21416,7 +21598,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 728,
+      "rank": 733,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -21441,7 +21623,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 729,
+      "rank": 734,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -21457,12 +21639,12 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 730,
+      "rank": 735,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
-      "downloads": 104595,
-      "likes": 3329,
+      "downloads": 86564,
+      "likes": 3336,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -21502,7 +21684,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 731,
+      "rank": 736,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -21525,7 +21707,7 @@
       "lastModified": "2026-05-26T09:06:26.000Z"
     },
     {
-      "rank": 732,
+      "rank": 737,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -21558,7 +21740,7 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 733,
+      "rank": 738,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
@@ -21588,7 +21770,7 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 734,
+      "rank": 739,
       "id": "tencent/Hy-MT2-1.8B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
@@ -21611,11 +21793,11 @@
       "lastModified": "2026-05-26T09:06:01.000Z"
     },
     {
-      "rank": 735,
+      "rank": 740,
       "id": "zeroentropy/zembed-1-embedding",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
-      "downloads": 333879,
+      "downloads": 325757,
       "likes": 109,
       "trendingScore": 9,
       "pipelineTag": "feature-extraction",
@@ -21645,7 +21827,7 @@
       "lastModified": "2026-03-12T21:10:43.000Z"
     },
     {
-      "rank": 736,
+      "rank": 741,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -21669,7 +21851,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 737,
+      "rank": 742,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -21706,7 +21888,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 738,
+      "rank": 743,
       "id": "tencent/Hy-MT2-7B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
@@ -21729,11 +21911,11 @@
       "lastModified": "2026-05-26T09:06:05.000Z"
     },
     {
-      "rank": 739,
+      "rank": 744,
       "id": "Convence/Aroow-Rust-Coder-9B",
       "author": "Convence",
       "url": "https://huggingface.co/Convence/Aroow-Rust-Coder-9B",
-      "downloads": 125,
+      "downloads": 159,
       "likes": 10,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -21761,7 +21943,7 @@
       "lastModified": "2026-05-23T19:16:54.000Z"
     },
     {
-      "rank": 740,
+      "rank": 745,
       "id": "google/gemma-3-12b-it-qat-q4_0-unquantized",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized",
@@ -21806,11 +21988,11 @@
       "lastModified": "2025-04-15T21:07:07.000Z"
     },
     {
-      "rank": 741,
+      "rank": 746,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
-      "downloads": 12320,
+      "downloads": 12496,
       "likes": 29,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -21832,11 +22014,11 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 742,
+      "rank": 747,
       "id": "openbmb/BitCPM-CANN-0.5B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-0.5B-gguf",
-      "downloads": 1195,
+      "downloads": 1631,
       "likes": 12,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -21856,7 +22038,7 @@
       "lastModified": "2026-05-23T18:11:41.000Z"
     },
     {
-      "rank": 743,
+      "rank": 748,
       "id": "nhathoangfoto/Flux.2-Klein-9B-Mannequin",
       "author": "nhathoangfoto",
       "url": "https://huggingface.co/nhathoangfoto/Flux.2-Klein-9B-Mannequin",
@@ -21886,7 +22068,7 @@
       "lastModified": "2026-05-07T13:17:14.000Z"
     },
     {
-      "rank": 744,
+      "rank": 749,
       "id": "meituan-longcat/WBench-weights",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/WBench-weights",
@@ -21909,11 +22091,11 @@
       "lastModified": "2026-05-29T02:38:08.000Z"
     },
     {
-      "rank": 745,
+      "rank": 750,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
-      "downloads": 2028796,
+      "downloads": 2040858,
       "likes": 402,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -21929,7 +22111,7 @@
       "lastModified": "2026-01-23T05:25:33.000Z"
     },
     {
-      "rank": 746,
+      "rank": 751,
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
@@ -21958,11 +22140,11 @@
       "lastModified": "2025-12-17T05:12:35.000Z"
     },
     {
-      "rank": 747,
+      "rank": 752,
       "id": "nvidia/PixelDiT-1300M-1024px",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px",
-      "downloads": 59,
+      "downloads": 63,
       "likes": 29,
       "trendingScore": 9,
       "pipelineTag": "text-to-image",
@@ -21983,56 +22165,11 @@
       "lastModified": "2026-04-15T21:45:01.000Z"
     },
     {
-      "rank": 748,
-      "id": "google/gemma-3-4b-it",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-3-4b-it",
-      "downloads": 1886789,
-      "likes": 1343,
-      "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "image-text-to-text",
-        "arxiv:1905.07830",
-        "arxiv:1905.10044",
-        "arxiv:1911.11641",
-        "arxiv:1904.09728",
-        "arxiv:1705.03551",
-        "arxiv:1911.01547",
-        "arxiv:1907.10641",
-        "arxiv:1903.00161",
-        "arxiv:2009.03300",
-        "arxiv:2304.06364",
-        "arxiv:2103.03874",
-        "arxiv:2110.14168",
-        "arxiv:2311.12022",
-        "arxiv:2108.07732",
-        "arxiv:2107.03374",
-        "arxiv:2210.03057",
-        "arxiv:2106.03193",
-        "arxiv:1910.11856",
-        "arxiv:2502.12404",
-        "arxiv:2502.21228",
-        "arxiv:2404.16816",
-        "arxiv:2104.12756",
-        "arxiv:2311.16502",
-        "arxiv:2203.10244",
-        "arxiv:2404.12390",
-        "arxiv:1810.12440",
-        "arxiv:1908.02660"
-      ],
-      "createdAt": "2025-02-20T21:20:07.000Z",
-      "lastModified": "2025-03-21T20:20:53.000Z"
-    },
-    {
-      "rank": 749,
+      "rank": 753,
       "id": "w-ahmad/Qwen3.5-9B-GGUF-MoQ",
       "author": "w-ahmad",
       "url": "https://huggingface.co/w-ahmad/Qwen3.5-9B-GGUF-MoQ",
-      "downloads": 105063,
+      "downloads": 92106,
       "likes": 12,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -22057,45 +22194,131 @@
       "lastModified": "2026-05-27T19:18:10.000Z"
     },
     {
-      "rank": 750,
-      "id": "dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
-      "author": "dealignai",
-      "url": "https://huggingface.co/dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
-      "downloads": 1453,
-      "likes": 10,
+      "rank": 754,
+      "id": "Jackrong/Qwopus3.5-27B-v3",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-27B-v3",
+      "downloads": 1384,
+      "likes": 240,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
-      "libraryName": "mlx",
+      "libraryName": null,
       "tags": [
-        "mlx",
         "safetensors",
-        "qwen3_5_moe",
-        "apple-silicon",
-        "abliterated",
-        "uncensored",
-        "crack",
-        "mtp",
-        "speculative-decoding",
-        "vision",
-        "video",
+        "unsloth",
+        "qwen",
+        "qwen3.5",
         "reasoning",
-        "thinking",
-        "harmbench",
-        "mmlu",
-        "qwen3_6",
+        "chain-of-thought",
+        "lora",
+        "competitive-programming",
         "image-text-to-text",
-        "moe",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "en",
+        "zh",
+        "ko",
+        "arxiv:2303.11366",
+        "arxiv:2505.24726",
+        "base_model:unsloth/Qwen3.5-27B",
+        "base_model:adapter:unsloth/Qwen3.5-27B",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-24T19:35:48.000Z",
-      "lastModified": "2026-05-24T21:04:29.000Z"
+      "createdAt": "2026-04-01T10:07:51.000Z",
+      "lastModified": "2026-04-16T09:12:00.000Z"
     },
     {
-      "rank": 751,
+      "rank": 755,
+      "id": "biohub/ESMFold2",
+      "author": "biohub",
+      "url": "https://huggingface.co/biohub/ESMFold2",
+      "downloads": 9263,
+      "likes": 12,
+      "trendingScore": 9,
+      "pipelineTag": null,
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "esmfold2",
+        "biology",
+        "esm",
+        "protein",
+        "protein-structure-prediction",
+        "structure-prediction",
+        "protein-design",
+        "3d-structure",
+        "confidence-estimation",
+        "molecular-dynamics",
+        "en",
+        "license:mit",
+        "license:other",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T16:59:56.000Z",
+      "lastModified": "2026-05-27T16:46:45.000Z"
+    },
+    {
+      "rank": 756,
+      "id": "LiquidAI/LFM2.5-8B-A1B-Base",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-Base",
+      "downloads": 267,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "lfm2_moe",
+        "text-generation",
+        "liquid",
+        "lfm2.5",
+        "edge",
+        "conversational",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "pt",
+        "arxiv:2511.23404",
+        "license:other",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-28T10:01:08.000Z",
+      "lastModified": "2026-05-28T20:22:31.000Z"
+    },
+    {
+      "rank": 757,
+      "id": "stabilityai/stable-diffusion-3.5-medium",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-medium",
+      "downloads": 329185,
+      "likes": 951,
+      "trendingScore": 9,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "stable-diffusion",
+        "en",
+        "arxiv:2403.03206",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2024-10-29T10:27:32.000Z",
+      "lastModified": "2024-10-31T08:18:43.000Z"
+    },
+    {
+      "rank": 758,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -22122,7 +22345,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 752,
+      "rank": 759,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -22146,7 +22369,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 753,
+      "rank": 760,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -22165,7 +22388,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 754,
+      "rank": 761,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -22199,7 +22422,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 755,
+      "rank": 762,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -22231,7 +22454,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 756,
+      "rank": 763,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -22253,7 +22476,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 757,
+      "rank": 764,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -22298,7 +22521,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 758,
+      "rank": 765,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -22317,7 +22540,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 759,
+      "rank": 766,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -22351,7 +22574,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 760,
+      "rank": 767,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -22379,7 +22602,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 761,
+      "rank": 768,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -22407,7 +22630,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 762,
+      "rank": 769,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -22430,7 +22653,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 763,
+      "rank": 770,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -22457,7 +22680,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 764,
+      "rank": 771,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -22502,7 +22725,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 765,
+      "rank": 772,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -22538,7 +22761,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 766,
+      "rank": 773,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -22578,7 +22801,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 767,
+      "rank": 774,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -22607,7 +22830,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 768,
+      "rank": 775,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -22635,7 +22858,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 769,
+      "rank": 776,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -22654,7 +22877,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 770,
+      "rank": 777,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -22673,7 +22896,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 771,
+      "rank": 778,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -22705,7 +22928,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 772,
+      "rank": 779,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -22732,7 +22955,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 773,
+      "rank": 780,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -22754,7 +22977,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 774,
+      "rank": 781,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -22772,7 +22995,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 775,
+      "rank": 782,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -22801,7 +23024,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 776,
+      "rank": 783,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -22822,7 +23045,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 777,
+      "rank": 784,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -22850,7 +23073,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 778,
+      "rank": 785,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -22871,7 +23094,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 779,
+      "rank": 786,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -22907,7 +23130,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 780,
+      "rank": 787,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -22930,7 +23153,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 781,
+      "rank": 788,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -22955,7 +23178,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 782,
+      "rank": 789,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -22990,7 +23213,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 783,
+      "rank": 790,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -23035,11 +23258,11 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 784,
+      "rank": 791,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
-      "downloads": 230039,
+      "downloads": 215032,
       "likes": 694,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -23062,7 +23285,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 785,
+      "rank": 792,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -23091,7 +23314,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 786,
+      "rank": 793,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -23110,7 +23333,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 787,
+      "rank": 794,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -23131,7 +23354,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 788,
+      "rank": 795,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -23157,7 +23380,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 789,
+      "rank": 796,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -23183,7 +23406,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 790,
+      "rank": 797,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -23220,7 +23443,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 791,
+      "rank": 798,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -23265,7 +23488,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 792,
+      "rank": 799,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -23290,7 +23513,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 793,
+      "rank": 800,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -23307,7 +23530,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 794,
+      "rank": 801,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -23334,7 +23557,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 795,
+      "rank": 802,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -23352,7 +23575,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 796,
+      "rank": 803,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -23377,7 +23600,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 797,
+      "rank": 804,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -23409,7 +23632,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 798,
+      "rank": 805,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -23430,7 +23653,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 799,
+      "rank": 806,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -23449,7 +23672,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 800,
+      "rank": 807,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -23480,7 +23703,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 801,
+      "rank": 808,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -23503,7 +23726,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 802,
+      "rank": 809,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -23520,7 +23743,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 803,
+      "rank": 810,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -23548,7 +23771,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 804,
+      "rank": 811,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -23565,7 +23788,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 805,
+      "rank": 812,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -23601,7 +23824,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 806,
+      "rank": 813,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -23631,7 +23854,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 807,
+      "rank": 814,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -23654,7 +23877,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 808,
+      "rank": 815,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -23687,7 +23910,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 809,
+      "rank": 816,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -23718,7 +23941,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 810,
+      "rank": 817,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -23741,7 +23964,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 811,
+      "rank": 818,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -23774,7 +23997,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 812,
+      "rank": 819,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -23797,7 +24020,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 813,
+      "rank": 820,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -23827,7 +24050,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 814,
+      "rank": 821,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -23856,7 +24079,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 815,
+      "rank": 822,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -23885,7 +24108,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 816,
+      "rank": 823,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -23921,7 +24144,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 817,
+      "rank": 824,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -23944,7 +24167,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 818,
+      "rank": 825,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -23969,7 +24192,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 819,
+      "rank": 826,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -23999,7 +24222,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 820,
+      "rank": 827,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -24035,7 +24258,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 821,
+      "rank": 828,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -24069,7 +24292,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 822,
+      "rank": 829,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -24096,7 +24319,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 823,
+      "rank": 830,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -24129,7 +24352,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 824,
+      "rank": 831,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -24157,7 +24380,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 825,
+      "rank": 832,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -24177,7 +24400,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 826,
+      "rank": 833,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -24200,7 +24423,7 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 827,
+      "rank": 834,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -24245,7 +24468,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 828,
+      "rank": 835,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -24277,7 +24500,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 829,
+      "rank": 836,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -24302,7 +24525,7 @@
       "lastModified": "2026-05-26T08:37:41.000Z"
     },
     {
-      "rank": 830,
+      "rank": 837,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -24324,7 +24547,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 831,
+      "rank": 838,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -24352,7 +24575,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 832,
+      "rank": 839,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -24376,7 +24599,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 833,
+      "rank": 840,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -24421,7 +24644,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 834,
+      "rank": 841,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
@@ -24451,7 +24674,7 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 835,
+      "rank": 842,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -24467,7 +24690,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 836,
+      "rank": 843,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -24487,11 +24710,11 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 837,
+      "rank": 844,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
-      "downloads": 1173291,
+      "downloads": 1172177,
       "likes": 1493,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -24511,7 +24734,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 838,
+      "rank": 845,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -24544,7 +24767,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 839,
+      "rank": 846,
       "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
@@ -24564,7 +24787,7 @@
       "lastModified": "2026-05-22T21:06:00.000Z"
     },
     {
-      "rank": 840,
+      "rank": 847,
       "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
@@ -24609,7 +24832,7 @@
       "lastModified": "2026-05-20T02:34:32.000Z"
     },
     {
-      "rank": 841,
+      "rank": 848,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -24633,7 +24856,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 842,
+      "rank": 849,
       "id": "huihui-ai/DeepSeek-V4-Flash-BF16",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/DeepSeek-V4-Flash-BF16",
@@ -24659,11 +24882,11 @@
       "lastModified": "2026-05-25T09:42:03.000Z"
     },
     {
-      "rank": 843,
+      "rank": 850,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
-      "downloads": 1300,
+      "downloads": 1207,
       "likes": 46,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -24686,7 +24909,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 844,
+      "rank": 851,
       "id": "Danrisi/UltraReal_FineTune_Anima_base1",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
@@ -24710,7 +24933,7 @@
       "lastModified": "2026-05-22T13:40:23.000Z"
     },
     {
-      "rank": 845,
+      "rank": 852,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -24755,7 +24978,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 846,
+      "rank": 853,
       "id": "MassivDash/Gemma-4-Rust-Coder",
       "author": "MassivDash",
       "url": "https://huggingface.co/MassivDash/Gemma-4-Rust-Coder",
@@ -24784,11 +25007,11 @@
       "lastModified": "2026-04-24T09:46:25.000Z"
     },
     {
-      "rank": 847,
+      "rank": 854,
       "id": "Jackrong/Qwopus3.5-4B-v3-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-4B-v3-MTP-GGUF",
-      "downloads": 3179,
+      "downloads": 3760,
       "likes": 9,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -24806,7 +25029,7 @@
       "lastModified": "2026-05-22T11:38:18.000Z"
     },
     {
-      "rank": 848,
+      "rank": 855,
       "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
@@ -24833,11 +25056,11 @@
       "lastModified": "2026-05-20T20:34:29.000Z"
     },
     {
-      "rank": 849,
+      "rank": 856,
       "id": "LiquidAI/LFM2-8B-A1B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF",
-      "downloads": 3397,
+      "downloads": 3703,
       "likes": 107,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -24870,7 +25093,7 @@
       "lastModified": "2026-03-30T13:41:14.000Z"
     },
     {
-      "rank": 850,
+      "rank": 857,
       "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -24910,11 +25133,11 @@
       "lastModified": "2025-05-22T23:44:50.000Z"
     },
     {
-      "rank": 851,
+      "rank": 858,
       "id": "google/gemma-2b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-2b-it",
-      "downloads": 62242,
+      "downloads": 60127,
       "likes": 896,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -24955,7 +25178,7 @@
       "lastModified": "2024-09-27T12:19:02.000Z"
     },
     {
-      "rank": 852,
+      "rank": 859,
       "id": "QuantStack/Wan2.2-I2V-A14B-GGUF",
       "author": "QuantStack",
       "url": "https://huggingface.co/QuantStack/Wan2.2-I2V-A14B-GGUF",
@@ -24978,37 +25201,11 @@
       "lastModified": "2025-07-29T13:04:00.000Z"
     },
     {
-      "rank": 853,
-      "id": "Roboflow/rf-detr-segmentation",
-      "author": "Roboflow",
-      "url": "https://huggingface.co/Roboflow/rf-detr-segmentation",
-      "downloads": 43,
-      "likes": 9,
-      "trendingScore": 8,
-      "pipelineTag": "image-segmentation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "rf_detr",
-        "image-segmentation",
-        "instance-segmentation",
-        "vision",
-        "dataset:coco",
-        "arxiv:2511.09554",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T09:05:51.000Z",
-      "lastModified": "2026-05-20T16:47:13.000Z"
-    },
-    {
-      "rank": 854,
+      "rank": 860,
       "id": "llmfan46/Gemma-4-Harmonia-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Harmonia-31B-uncensored-heretic-GGUF",
-      "downloads": 284,
+      "downloads": 4327,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": null,
@@ -25034,12 +25231,12 @@
       "lastModified": "2026-05-28T19:02:45.000Z"
     },
     {
-      "rank": 855,
+      "rank": 861,
       "id": "mlx-community/Qwen3.6-27B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-OptiQ-4bit",
-      "downloads": 14074,
-      "likes": 24,
+      "downloads": 14251,
+      "likes": 23,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "mlx",
@@ -25066,11 +25263,11 @@
       "lastModified": "2026-05-26T06:39:22.000Z"
     },
     {
-      "rank": 856,
+      "rank": 862,
       "id": "Jackrong/Qwopus3.5-9B-v3-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-v3-GGUF",
-      "downloads": 33529,
+      "downloads": 33787,
       "likes": 354,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
@@ -25099,44 +25296,11 @@
       "lastModified": "2026-04-12T15:46:14.000Z"
     },
     {
-      "rank": 857,
-      "id": "Jackrong/Qwopus3.5-27B-v3",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-27B-v3",
-      "downloads": 1417,
-      "likes": 239,
-      "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "unsloth",
-        "qwen",
-        "qwen3.5",
-        "reasoning",
-        "chain-of-thought",
-        "lora",
-        "competitive-programming",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "ko",
-        "arxiv:2303.11366",
-        "arxiv:2505.24726",
-        "base_model:unsloth/Qwen3.5-27B",
-        "base_model:adapter:unsloth/Qwen3.5-27B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-01T10:07:51.000Z",
-      "lastModified": "2026-04-16T09:12:00.000Z"
-    },
-    {
-      "rank": 858,
+      "rank": 863,
       "id": "EssentialAI/rnj-1.5-instruct",
       "author": "EssentialAI",
       "url": "https://huggingface.co/EssentialAI/rnj-1.5-instruct",
-      "downloads": 1569,
+      "downloads": 1606,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -25166,48 +25330,7 @@
       "lastModified": "2026-05-26T06:18:03.000Z"
     },
     {
-      "rank": 859,
-      "id": "huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
-      "downloads": 3500,
-      "likes": 8,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "quantized",
-        "deepseek",
-        "deepseek-v4",
-        "deepseek-v4-flash",
-        "moe",
-        "mixture-of-experts",
-        "2-bit",
-        "4-bit",
-        "iq2_xxs",
-        "q2_k",
-        "q4_k",
-        "ds4",
-        "apple-silicon",
-        "metal",
-        "llama.cpp",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-26T10:31:39.000Z",
-      "lastModified": "2026-05-27T18:15:42.000Z"
-    },
-    {
-      "rank": 860,
+      "rank": 864,
       "id": "circlestone-labs/Anima-Official-LoRAs",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Official-LoRAs",
@@ -25223,11 +25346,11 @@
       "lastModified": "2026-05-26T18:57:37.000Z"
     },
     {
-      "rank": 861,
+      "rank": 865,
       "id": "daydreamlive/DreamVAE",
       "author": "daydreamlive",
       "url": "https://huggingface.co/daydreamlive/DreamVAE",
-      "downloads": 16,
+      "downloads": 17,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "audio-to-audio",
@@ -25257,43 +25380,11 @@
       "lastModified": "2026-04-22T15:11:47.000Z"
     },
     {
-      "rank": 862,
-      "id": "biohub/ESMFold2",
-      "author": "biohub",
-      "url": "https://huggingface.co/biohub/ESMFold2",
-      "downloads": 1194,
-      "likes": 10,
-      "trendingScore": 8,
-      "pipelineTag": null,
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "esmfold2",
-        "biology",
-        "esm",
-        "protein",
-        "protein-structure-prediction",
-        "structure-prediction",
-        "protein-design",
-        "3d-structure",
-        "confidence-estimation",
-        "molecular-dynamics",
-        "en",
-        "license:mit",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T16:59:56.000Z",
-      "lastModified": "2026-05-27T16:46:45.000Z"
-    },
-    {
-      "rank": 863,
+      "rank": 866,
       "id": "Kaikaku/epicure-core",
       "author": "Kaikaku",
       "url": "https://huggingface.co/Kaikaku/epicure-core",
-      "downloads": 154,
+      "downloads": 249,
       "likes": 9,
       "trendingScore": 8,
       "pipelineTag": "feature-extraction",
@@ -25325,7 +25416,7 @@
       "lastModified": "2026-05-27T13:44:13.000Z"
     },
     {
-      "rank": 864,
+      "rank": 867,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
@@ -25351,43 +25442,73 @@
       "lastModified": "2026-01-29T08:04:19.000Z"
     },
     {
-      "rank": 865,
-      "id": "LiquidAI/LFM2.5-8B-A1B-Base",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-Base",
-      "downloads": 0,
-      "likes": 8,
+      "rank": 868,
+      "id": "google/paligemma-3b-pt-224",
+      "author": "google",
+      "url": "https://huggingface.co/google/paligemma-3b-pt-224",
+      "downloads": 554414,
+      "likes": 454,
       "trendingScore": 8,
-      "pipelineTag": "text-generation",
+      "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
         "transformers",
         "safetensors",
-        "lfm2_moe",
-        "text-generation",
-        "liquid",
-        "lfm2.5",
-        "edge",
-        "conversational",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "arxiv:2511.23404",
-        "license:other",
+        "paligemma",
+        "image-text-to-text",
+        "arxiv:2310.09199",
+        "arxiv:2303.15343",
+        "arxiv:2403.08295",
+        "arxiv:1706.03762",
+        "arxiv:2010.11929",
+        "arxiv:2209.06794",
+        "arxiv:2209.04372",
+        "arxiv:2103.01913",
+        "arxiv:2205.12522",
+        "arxiv:2110.11624",
+        "arxiv:2108.03353",
+        "arxiv:2010.04295",
+        "arxiv:2401.06209",
+        "arxiv:2305.10355",
+        "arxiv:2203.10244",
+        "arxiv:1810.12440",
+        "arxiv:1905.13648",
+        "arxiv:1608.00272",
+        "arxiv:1908.04913",
+        "arxiv:2407.07726",
+        "license:gemma",
+        "text-generation-inference",
         "endpoints_compatible",
         "region:us"
       ],
-      "createdAt": "2026-05-28T10:01:08.000Z",
-      "lastModified": "2026-05-28T20:22:31.000Z"
+      "createdAt": "2024-05-12T22:53:40.000Z",
+      "lastModified": "2024-09-21T10:14:25.000Z"
     },
     {
-      "rank": 866,
+      "rank": 869,
+      "id": "ControlLight/ControlLight",
+      "author": "ControlLight",
+      "url": "https://huggingface.co/ControlLight/ControlLight",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "en",
+        "zh",
+        "dataset:ControlLight/Light100K",
+        "arxiv:2605.25569",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:46:43.000Z",
+      "lastModified": "2026-05-26T04:28:29.000Z"
+    },
+    {
+      "rank": 870,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -25413,7 +25534,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 867,
+      "rank": 871,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -25430,7 +25551,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 868,
+      "rank": 872,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -25458,7 +25579,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 869,
+      "rank": 873,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -25493,7 +25614,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 870,
+      "rank": 874,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -25518,7 +25639,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 871,
+      "rank": 875,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -25548,7 +25669,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 872,
+      "rank": 876,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -25577,7 +25698,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 873,
+      "rank": 877,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -25604,7 +25725,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 874,
+      "rank": 878,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -25630,7 +25751,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 875,
+      "rank": 879,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -25661,7 +25782,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 876,
+      "rank": 880,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -25679,7 +25800,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 877,
+      "rank": 881,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -25708,7 +25829,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 878,
+      "rank": 882,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -25731,7 +25852,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 879,
+      "rank": 883,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -25776,7 +25897,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 880,
+      "rank": 884,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -25802,7 +25923,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 881,
+      "rank": 885,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -25830,7 +25951,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 882,
+      "rank": 886,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -25868,7 +25989,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 883,
+      "rank": 887,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -25895,7 +26016,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 884,
+      "rank": 888,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -25921,7 +26042,7 @@
       "lastModified": "2026-03-31T03:26:20.000Z"
     },
     {
-      "rank": 885,
+      "rank": 889,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -25939,7 +26060,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 886,
+      "rank": 890,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -25965,7 +26086,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 887,
+      "rank": 891,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -26006,7 +26127,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 888,
+      "rank": 892,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -26023,7 +26144,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 889,
+      "rank": 893,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -26056,7 +26177,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 890,
+      "rank": 894,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -26090,7 +26211,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 891,
+      "rank": 895,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -26129,7 +26250,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 892,
+      "rank": 896,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -26159,7 +26280,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 893,
+      "rank": 897,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -26185,7 +26306,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 894,
+      "rank": 898,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -26221,7 +26342,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 895,
+      "rank": 899,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -26251,7 +26372,7 @@
       "lastModified": "2026-05-05T16:58:45.000Z"
     },
     {
-      "rank": 896,
+      "rank": 900,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -26289,7 +26410,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 897,
+      "rank": 901,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -26324,7 +26445,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 898,
+      "rank": 902,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -26341,7 +26462,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 899,
+      "rank": 903,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -26383,7 +26504,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 900,
+      "rank": 904,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -26413,7 +26534,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 901,
+      "rank": 905,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -26438,7 +26559,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 902,
+      "rank": 906,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -26466,7 +26587,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 903,
+      "rank": 907,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -26483,7 +26604,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 904,
+      "rank": 908,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -26510,7 +26631,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 905,
+      "rank": 909,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -26553,7 +26674,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 906,
+      "rank": 910,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -26593,7 +26714,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 907,
+      "rank": 911,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -26617,7 +26738,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 908,
+      "rank": 912,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -26646,7 +26767,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 909,
+      "rank": 913,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -26672,7 +26793,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 910,
+      "rank": 914,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -26711,7 +26832,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 911,
+      "rank": 915,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -26735,7 +26856,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 912,
+      "rank": 916,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -26763,7 +26884,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 913,
+      "rank": 917,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -26795,7 +26916,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 914,
+      "rank": 918,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -26825,7 +26946,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 915,
+      "rank": 919,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -26854,7 +26975,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 916,
+      "rank": 920,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -26883,7 +27004,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 917,
+      "rank": 921,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -26903,7 +27024,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 918,
+      "rank": 922,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -26933,7 +27054,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 919,
+      "rank": 923,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -26963,7 +27084,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 920,
+      "rank": 924,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -26981,7 +27102,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 921,
+      "rank": 925,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -26998,7 +27119,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 922,
+      "rank": 926,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -27034,7 +27155,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 923,
+      "rank": 927,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -27065,7 +27186,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 924,
+      "rank": 928,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -27096,7 +27217,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 925,
+      "rank": 929,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -27129,7 +27250,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 926,
+      "rank": 930,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -27157,7 +27278,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 927,
+      "rank": 931,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -27182,7 +27303,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 928,
+      "rank": 932,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -27205,7 +27326,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 929,
+      "rank": 933,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -27233,7 +27354,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 930,
+      "rank": 934,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -27266,7 +27387,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 931,
+      "rank": 935,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -27296,7 +27417,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 932,
+      "rank": 936,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -27331,7 +27452,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 933,
+      "rank": 937,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -27363,7 +27484,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 934,
+      "rank": 938,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -27388,7 +27509,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 935,
+      "rank": 939,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -27411,7 +27532,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 936,
+      "rank": 940,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -27438,7 +27559,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 937,
+      "rank": 941,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -27461,7 +27582,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 938,
+      "rank": 942,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -27506,7 +27627,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 939,
+      "rank": 943,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -27538,7 +27659,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 940,
+      "rank": 944,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -27565,7 +27686,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 941,
+      "rank": 945,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -27591,7 +27712,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 942,
+      "rank": 946,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -27623,7 +27744,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 943,
+      "rank": 947,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -27652,7 +27773,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 944,
+      "rank": 948,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -27684,7 +27805,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 945,
+      "rank": 949,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -27714,7 +27835,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 946,
+      "rank": 950,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -27731,7 +27852,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 947,
+      "rank": 951,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -27751,7 +27872,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 948,
+      "rank": 952,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -27790,7 +27911,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 949,
+      "rank": 953,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -27828,7 +27949,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 950,
+      "rank": 954,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -27856,7 +27977,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 951,
+      "rank": 955,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -27901,7 +28022,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 952,
+      "rank": 956,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -27931,7 +28052,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 953,
+      "rank": 957,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -27958,7 +28079,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 954,
+      "rank": 958,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -27984,7 +28105,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 955,
+      "rank": 959,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -28013,7 +28134,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 956,
+      "rank": 960,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -28031,7 +28152,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 957,
+      "rank": 961,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -28063,7 +28184,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 958,
+      "rank": 962,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -28090,7 +28211,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 959,
+      "rank": 963,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -28108,7 +28229,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 960,
+      "rank": 964,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -28135,7 +28256,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 961,
+      "rank": 965,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -28159,7 +28280,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 962,
+      "rank": 966,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -28204,7 +28325,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 963,
+      "rank": 967,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -28235,7 +28356,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 964,
+      "rank": 968,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -28260,7 +28381,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 965,
+      "rank": 969,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -28294,7 +28415,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 966,
+      "rank": 970,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -28335,7 +28456,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 967,
+      "rank": 971,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -28362,7 +28483,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 968,
+      "rank": 972,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -28391,7 +28512,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 969,
+      "rank": 973,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -28423,7 +28544,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 970,
+      "rank": 974,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -28447,7 +28568,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 971,
+      "rank": 975,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -28474,7 +28595,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 972,
+      "rank": 976,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -28513,7 +28634,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 973,
+      "rank": 977,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
@@ -28545,7 +28666,7 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 974,
+      "rank": 978,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -28579,11 +28700,11 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 975,
+      "rank": 979,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
-      "downloads": 72744,
+      "downloads": 69785,
       "likes": 368,
       "trendingScore": 7,
       "pipelineTag": "text-to-image",
@@ -28606,7 +28727,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 976,
+      "rank": 980,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -28634,7 +28755,7 @@
       "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 977,
+      "rank": 981,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -28662,7 +28783,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 978,
+      "rank": 982,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
@@ -28691,7 +28812,7 @@
       "lastModified": "2026-05-13T07:13:52.000Z"
     },
     {
-      "rank": 979,
+      "rank": 983,
       "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -28736,7 +28857,7 @@
       "lastModified": "2026-05-15T06:27:56.000Z"
     },
     {
-      "rank": 980,
+      "rank": 984,
       "id": "cross-encoder/ettin-reranker-17m-v1",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ettin-reranker-17m-v1",
@@ -28771,7 +28892,7 @@
       "lastModified": "2026-05-19T13:58:35.000Z"
     },
     {
-      "rank": 981,
+      "rank": 985,
       "id": "openbmb/BitCPM-CANN-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-1B",
@@ -28797,7 +28918,7 @@
       "lastModified": "2026-05-23T18:13:08.000Z"
     },
     {
-      "rank": 982,
+      "rank": 986,
       "id": "openbmb/BitCPM-CANN-3B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-3B",
@@ -28823,7 +28944,7 @@
       "lastModified": "2026-05-23T18:13:14.000Z"
     },
     {
-      "rank": 983,
+      "rank": 987,
       "id": "stabilityai/stable-audio-3-small-sfx-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-sfx-base",
@@ -28848,7 +28969,7 @@
       "lastModified": "2026-05-20T15:05:26.000Z"
     },
     {
-      "rank": 984,
+      "rank": 988,
       "id": "zizhaotong/SCOPE",
       "author": "zizhaotong",
       "url": "https://huggingface.co/zizhaotong/SCOPE",
@@ -28882,11 +29003,11 @@
       "lastModified": "2026-05-25T02:01:22.000Z"
     },
     {
-      "rank": 985,
+      "rank": 989,
       "id": "internlm/CapRL-Video-4B",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/CapRL-Video-4B",
-      "downloads": 57,
+      "downloads": 75,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -28902,11 +29023,11 @@
       "lastModified": "2026-05-28T14:20:43.000Z"
     },
     {
-      "rank": 986,
+      "rank": 990,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic",
-      "downloads": 685,
+      "downloads": 689,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -28930,7 +29051,7 @@
       "lastModified": "2026-05-22T19:16:35.000Z"
     },
     {
-      "rank": 987,
+      "rank": 991,
       "id": "DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Llama-3.2-8X3B-MOE-Dark-Champion-Instruct-uncensored-abliterated-18.4B-GGUF",
@@ -28975,7 +29096,7 @@
       "lastModified": "2026-04-28T07:32:57.000Z"
     },
     {
-      "rank": 988,
+      "rank": 992,
       "id": "microsoft/SchGen",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/SchGen",
@@ -29003,7 +29124,7 @@
       "lastModified": "2026-05-14T16:50:37.000Z"
     },
     {
-      "rank": 989,
+      "rank": 993,
       "id": "HuggingFaceBio/Carbon-8B-GGUF",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-8B-GGUF",
@@ -29028,7 +29149,7 @@
       "lastModified": "2026-05-21T21:32:52.000Z"
     },
     {
-      "rank": 990,
+      "rank": 994,
       "id": "google/electra-base-discriminator",
       "author": "google",
       "url": "https://huggingface.co/google/electra-base-discriminator",
@@ -29055,7 +29176,7 @@
       "lastModified": "2024-02-29T10:20:20.000Z"
     },
     {
-      "rank": 991,
+      "rank": 995,
       "id": "stabilityai/stable-video-diffusion-img2vid-xt-1-1",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt-1-1",
@@ -29076,7 +29197,7 @@
       "lastModified": "2024-07-10T11:52:10.000Z"
     },
     {
-      "rank": 992,
+      "rank": 996,
       "id": "chili-lab/Ouro-hybrid-1.4B",
       "author": "chili-lab",
       "url": "https://huggingface.co/chili-lab/Ouro-hybrid-1.4B",
@@ -29110,7 +29231,7 @@
       "lastModified": "2026-05-19T20:51:28.000Z"
     },
     {
-      "rank": 993,
+      "rank": 997,
       "id": "briaai/RMBG-1.4",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-1.4",
@@ -29141,11 +29262,11 @@
       "lastModified": "2025-07-06T08:27:49.000Z"
     },
     {
-      "rank": 994,
+      "rank": 998,
       "id": "BeaverAI/Orion-26B-A4B-v1a-GGUF",
       "author": "BeaverAI",
       "url": "https://huggingface.co/BeaverAI/Orion-26B-A4B-v1a-GGUF",
-      "downloads": 3655,
+      "downloads": 4221,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": null,
@@ -29160,11 +29281,11 @@
       "lastModified": "2026-05-24T19:21:53.000Z"
     },
     {
-      "rank": 995,
+      "rank": 999,
       "id": "Disty0/RaiFlow-v0_01-256px-rough-pre-train",
       "author": "Disty0",
       "url": "https://huggingface.co/Disty0/RaiFlow-v0_01-256px-rough-pre-train",
-      "downloads": 123,
+      "downloads": 125,
       "likes": 7,
       "trendingScore": 7,
       "pipelineTag": "text-to-image",
@@ -29186,30 +29307,7 @@
       "lastModified": "2026-05-27T17:40:48.000Z"
     },
     {
-      "rank": 996,
-      "id": "stabilityai/stable-diffusion-3.5-medium",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-medium",
-      "downloads": 334318,
-      "likes": 949,
-      "trendingScore": 7,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "stable-diffusion",
-        "en",
-        "arxiv:2403.03206",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2024-10-29T10:27:32.000Z",
-      "lastModified": "2024-10-31T08:18:43.000Z"
-    },
-    {
-      "rank": 997,
+      "rank": 1000,
       "id": "black-forest-labs/FLUX.1-Fill-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Fill-dev",
@@ -29231,87 +29329,6 @@
       ],
       "createdAt": "2024-11-20T19:45:33.000Z",
       "lastModified": "2025-06-27T16:23:07.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "NeoQuasar/Kronos-base",
-      "author": "NeoQuasar",
-      "url": "https://huggingface.co/NeoQuasar/Kronos-base",
-      "downloads": 1366019,
-      "likes": 165,
-      "trendingScore": 7,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "Finance",
-        "Candlestick",
-        "K-line",
-        "time-series-forecasting",
-        "arxiv:2508.02739",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-06-30T17:11:20.000Z",
-      "lastModified": "2025-09-09T14:08:15.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "nhathoangfoto/Flux.2-Klein-9B-MatchingPose",
-      "author": "nhathoangfoto",
-      "url": "https://huggingface.co/nhathoangfoto/Flux.2-Klein-9B-MatchingPose",
-      "downloads": 3981,
-      "likes": 18,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "flux",
-        "flux.2",
-        "flux.2-klein",
-        "matchingpose",
-        "pose-transfer",
-        "character-consistency",
-        "image-to-image",
-        "text-to-image",
-        "image-text-to-image",
-        "en",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:adapter:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-19T09:03:32.000Z",
-      "lastModified": "2026-04-20T10:13:57.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "dealignai/DeepSeek-V4-Flash-JANG-CRACK",
-      "author": "dealignai",
-      "url": "https://huggingface.co/dealignai/DeepSeek-V4-Flash-JANG-CRACK",
-      "downloads": 1829,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "deepseek_v4",
-        "abliterated",
-        "uncensored",
-        "crack",
-        "jang",
-        "moe",
-        "text-generation",
-        "conversational",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T22:01:05.000Z",
-      "lastModified": "2026-05-24T07:37:34.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26631540751

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.