### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-29T10:18:07Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-29T04:49:32.648Z",
+  "ts": "2026-05-29T10:18:07.107Z",
   "count": 1,
-  "durationMs": 1902,
+  "durationMs": 2065,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T04:49:30.748Z",
+  "fetchedAt": "2026-05-29T10:18:05.043Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -94,6 +94,38 @@
     },
     {
       "rank": 4,
+      "id": "openbmb/UltraData-SFT-2605",
+      "author": "openbmb",
+      "url": "https://huggingface.co/datasets/openbmb/UltraData-SFT-2605",
+      "downloads": 1869,
+      "likes": 132,
+      "trendingScore": 95,
+      "tags": [
+        "task_categories:text-generation",
+        "task_categories:question-answering",
+        "language:en",
+        "language:zh",
+        "license:apache-2.0",
+        "size_categories:10B<n<100B",
+        "arxiv:2602.09003",
+        "region:us",
+        "llm",
+        "sft",
+        "supervised-fine-tuning",
+        "post-training",
+        "deep-thinking",
+        "reasoning",
+        "instruction-following",
+        "math",
+        "code",
+        "knowledge",
+        "minicpm"
+      ],
+      "createdAt": "2026-05-21T07:28:49.000Z",
+      "lastModified": "2026-05-28T17:18:14.000Z"
+    },
+    {
+      "rank": 5,
       "id": "angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
       "author": "angrygiraffe",
       "url": "https://huggingface.co/datasets/angrygiraffe/claude-opus-4.6-4.7-reasoning-8.7k",
@@ -128,7 +160,7 @@
       "lastModified": "2026-05-01T17:11:41.000Z"
     },
     {
-      "rank": 5,
+      "rank": 6,
       "id": "AlienKevin/SWE-ZERO-12M-trajectories",
       "author": "AlienKevin",
       "url": "https://huggingface.co/datasets/AlienKevin/SWE-ZERO-12M-trajectories",
@@ -156,7 +188,7 @@
       "lastModified": "2026-05-14T23:54:23.000Z"
     },
     {
-      "rank": 6,
+      "rank": 7,
       "id": "GD-ML/TransitLM",
       "author": "GD-ML",
       "url": "https://huggingface.co/datasets/GD-ML/TransitLM",
@@ -188,7 +220,43 @@
       "lastModified": "2026-05-25T03:54:10.000Z"
     },
     {
-      "rank": 7,
+      "rank": 8,
+      "id": "openbmb/Ultra-FineWeb-L3",
+      "author": "openbmb",
+      "url": "https://huggingface.co/datasets/openbmb/Ultra-FineWeb-L3",
+      "downloads": 14442,
+      "likes": 176,
+      "trendingScore": 75,
+      "tags": [
+        "task_categories:text-generation",
+        "language:en",
+        "language:zh",
+        "license:apache-2.0",
+        "size_categories:1B<n<10B",
+        "format:parquet",
+        "modality:text",
+        "library:datasets",
+        "library:dask",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2505.05427",
+        "arxiv:2602.09003",
+        "region:us",
+        "llm",
+        "pretraining",
+        "data-synthesis",
+        "data-filtering",
+        "high-quality",
+        "general-knowledge",
+        "qa-generation",
+        "multi-style-rewriting",
+        "minicpm"
+      ],
+      "createdAt": "2026-02-07T05:19:29.000Z",
+      "lastModified": "2026-05-28T09:03:52.000Z"
+    },
+    {
+      "rank": 9,
       "id": "ADSKAILab/Zero-To-CAD-1m",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/datasets/ADSKAILab/Zero-To-CAD-1m",
@@ -224,7 +292,7 @@
       "lastModified": "2026-05-03T14:11:21.000Z"
     },
     {
-      "rank": 8,
+      "rank": 10,
       "id": "open-thoughts/AgentTrove",
       "author": "open-thoughts",
       "url": "https://huggingface.co/datasets/open-thoughts/AgentTrove",
@@ -255,11 +323,11 @@
       "lastModified": "2026-05-07T14:20:40.000Z"
     },
     {
-      "rank": 9,
+      "rank": 11,
       "id": "armand0e/qwen3.7-max-pi-traces",
       "author": "armand0e",
       "url": "https://huggingface.co/datasets/armand0e/qwen3.7-max-pi-traces",
-      "downloads": 1324,
+      "downloads": 3035,
       "likes": 53,
       "trendingScore": 51,
       "tags": [
@@ -285,7 +353,7 @@
       "lastModified": "2026-05-23T02:58:23.000Z"
     },
     {
-      "rank": 10,
+      "rank": 12,
       "id": "5CD-AI/Viet-Handwriting-OCR-v2",
       "author": "5CD-AI",
       "url": "https://huggingface.co/datasets/5CD-AI/Viet-Handwriting-OCR-v2",
@@ -316,7 +384,7 @@
       "lastModified": "2026-05-18T17:14:55.000Z"
     },
     {
-      "rank": 11,
+      "rank": 13,
       "id": "actava/chi-bench",
       "author": "actava",
       "url": "https://huggingface.co/datasets/actava/chi-bench",
@@ -353,43 +421,33 @@
       "lastModified": "2026-05-22T04:51:56.000Z"
     },
     {
-      "rank": 12,
-      "id": "openbmb/Ultra-FineWeb-L3",
-      "author": "openbmb",
-      "url": "https://huggingface.co/datasets/openbmb/Ultra-FineWeb-L3",
-      "downloads": 6241,
-      "likes": 91,
+      "rank": 14,
+      "id": "jasperai/monet",
+      "author": "jasperai",
+      "url": "https://huggingface.co/datasets/jasperai/monet",
+      "downloads": 249105,
+      "likes": 45,
       "trendingScore": 40,
       "tags": [
-        "task_categories:text-generation",
+        "task_categories:text-to-image",
+        "task_categories:image-feature-extraction",
+        "task_categories:zero-shot-image-classification",
         "language:en",
-        "language:zh",
         "license:apache-2.0",
-        "size_categories:1B<n<10B",
-        "format:parquet",
-        "modality:text",
-        "library:datasets",
-        "library:dask",
-        "library:polars",
-        "library:mlcroissant",
-        "arxiv:2505.05427",
-        "arxiv:2602.09003",
+        "size_categories:100M<n<1B",
+        "arxiv:2605.21272",
         "region:us",
-        "llm",
-        "pretraining",
-        "data-synthesis",
-        "data-filtering",
-        "high-quality",
-        "general-knowledge",
-        "qa-generation",
-        "multi-style-rewriting",
-        "minicpm"
+        "multimodal",
+        "image-text",
+        "captioning",
+        "text-to-image",
+        "synthetic-data"
       ],
-      "createdAt": "2026-02-07T05:19:29.000Z",
-      "lastModified": "2026-05-28T09:03:52.000Z"
+      "createdAt": "2026-04-28T14:37:04.000Z",
+      "lastModified": "2026-05-29T10:16:25.000Z"
     },
     {
-      "rank": 13,
+      "rank": 15,
       "id": "nvidia/Nemotron-Personas-Korea",
       "author": "nvidia",
       "url": "https://huggingface.co/datasets/nvidia/Nemotron-Personas-Korea",
@@ -421,39 +479,7 @@
       "lastModified": "2026-04-23T07:42:48.000Z"
     },
     {
-      "rank": 14,
-      "id": "openbmb/UltraData-SFT-2605",
-      "author": "openbmb",
-      "url": "https://huggingface.co/datasets/openbmb/UltraData-SFT-2605",
-      "downloads": 12,
-      "likes": 48,
-      "trendingScore": 39,
-      "tags": [
-        "task_categories:text-generation",
-        "task_categories:question-answering",
-        "language:en",
-        "language:zh",
-        "license:apache-2.0",
-        "size_categories:10B<n<100B",
-        "arxiv:2602.09003",
-        "region:us",
-        "llm",
-        "sft",
-        "supervised-fine-tuning",
-        "post-training",
-        "deep-thinking",
-        "reasoning",
-        "instruction-following",
-        "math",
-        "code",
-        "knowledge",
-        "minicpm"
-      ],
-      "createdAt": "2026-05-21T07:28:49.000Z",
-      "lastModified": "2026-05-28T17:18:14.000Z"
-    },
-    {
-      "rank": 15,
+      "rank": 16,
       "id": "Jackrong/GLM-5.1-Reasoning-1M-Cleaned",
       "author": "Jackrong",
       "url": "https://huggingface.co/datasets/Jackrong/GLM-5.1-Reasoning-1M-Cleaned",
@@ -487,7 +513,7 @@
       "lastModified": "2026-04-19T05:05:17.000Z"
     },
     {
-      "rank": 16,
+      "rank": 17,
       "id": "TeichAI/DeepSeek-v4-Pro-Agent",
       "author": "TeichAI",
       "url": "https://huggingface.co/datasets/TeichAI/DeepSeek-v4-Pro-Agent",
@@ -515,34 +541,6 @@
       ],
       "createdAt": "2026-05-09T06:15:11.000Z",
       "lastModified": "2026-05-22T00:11:12.000Z"
-    },
-    {
-      "rank": 17,
-      "id": "jasperai/monet",
-      "author": "jasperai",
-      "url": "https://huggingface.co/datasets/jasperai/monet",
-      "downloads": 244905,
-      "likes": 41,
-      "trendingScore": 37,
-      "tags": [
-        "task_categories:text-to-image",
-        "task_categories:image-feature-extraction",
-        "task_categories:zero-shot-image-classification",
-        "language:en",
-        "license:apache-2.0",
-        "size_categories:100M<n<1B",
-        "modality:image",
-        "modality:text",
-        "arxiv:2605.21272",
-        "region:us",
-        "multimodal",
-        "image-text",
-        "captioning",
-        "text-to-image",
-        "synthetic-data"
-      ],
-      "createdAt": "2026-04-28T14:37:04.000Z",
-      "lastModified": "2026-05-28T09:09:16.000Z"
     },
     {
       "rank": 18,
@@ -1375,6 +1373,38 @@
     },
     {
       "rank": 46,
+      "id": "amphora/ResearchMath-14k",
+      "author": "amphora",
+      "url": "https://huggingface.co/datasets/amphora/ResearchMath-14k",
+      "downloads": 302,
+      "likes": 17,
+      "trendingScore": 17,
+      "tags": [
+        "task_categories:text-generation",
+        "task_categories:question-answering",
+        "language:en",
+        "license:mit",
+        "size_categories:10K<n<100K",
+        "format:json",
+        "modality:text",
+        "library:datasets",
+        "library:pandas",
+        "library:polars",
+        "library:mlcroissant",
+        "arxiv:2605.28003",
+        "region:us",
+        "mathematics",
+        "research-problems",
+        "open-problems",
+        "arxiv",
+        "reasoning",
+        "dataset"
+      ],
+      "createdAt": "2026-05-28T01:58:50.000Z",
+      "lastModified": "2026-05-28T02:11:42.000Z"
+    },
+    {
+      "rank": 47,
       "id": "HuggingFaceFW/fineweb-edu",
       "author": "HuggingFaceFW",
       "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu",
@@ -1404,7 +1434,7 @@
       "lastModified": "2025-07-11T20:16:53.000Z"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "junwatu/indonesian-recipes",
       "author": "junwatu",
       "url": "https://huggingface.co/datasets/junwatu/indonesian-recipes",
@@ -1434,7 +1464,7 @@
       "lastModified": "2026-05-09T06:36:26.000Z"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "id": "ning423/deepseek-hermes-reasoning-traces",
       "author": "ning423",
       "url": "https://huggingface.co/datasets/ning423/deepseek-hermes-reasoning-traces",
@@ -1469,7 +1499,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "AlicanKiraz0/Cybersecurity-Dataset-Fenrir-v2.1",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/datasets/AlicanKiraz0/Cybersecurity-Dataset-Fenrir-v2.1",
@@ -1494,49 +1524,6 @@
       ],
       "createdAt": "2025-10-06T16:18:46.000Z",
       "lastModified": "2026-04-22T10:29:32.000Z"
-    },
-    {
-      "rank": 50,
-      "id": "sequelbox/Tachibana4-DeepSeek-V4-Pro",
-      "author": "sequelbox",
-      "url": "https://huggingface.co/datasets/sequelbox/Tachibana4-DeepSeek-V4-Pro",
-      "downloads": 231,
-      "likes": 15,
-      "trendingScore": 15,
-      "tags": [
-        "task_categories:text-generation",
-        "language:en",
-        "license:apache-2.0",
-        "size_categories:10K<n<100K",
-        "format:csv",
-        "modality:text",
-        "library:datasets",
-        "library:pandas",
-        "library:polars",
-        "library:mlcroissant",
-        "doi:10.57967/hf/8696",
-        "region:us",
-        "tachibana",
-        "tachibana-4",
-        "agentic",
-        "agentic-coding",
-        "python",
-        "c++",
-        "c#",
-        "c",
-        "rust",
-        "java",
-        "javascript",
-        "typescript",
-        "go",
-        "haskell",
-        "shell",
-        "r",
-        "ruby",
-        "algorithms"
-      ],
-      "createdAt": "2026-05-06T21:47:35.000Z",
-      "lastModified": "2026-05-07T01:09:32.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26631621239

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.