### PR TITLE
chore(data): refresh huggingface space signals 2026-05-29T10:33:57Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-29T04:57:18.178Z",
+  "ts": "2026-05-29T10:33:57.681Z",
   "count": 1,
-  "durationMs": 3773,
+  "durationMs": 5595,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T04:57:14.407Z",
+  "fetchedAt": "2026-05-29T10:33:52.087Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -38,6 +38,22 @@
     },
     {
       "rank": 3,
+      "id": "victor/LongCat-Video-Avatar-1.5",
+      "author": "victor",
+      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
+      "likes": 151,
+      "trendingScore": 141,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T13:56:32.000Z",
+      "lastModified": "2026-05-26T16:44:17.000Z",
+      "models": []
+    },
+    {
+      "rank": 4,
       "id": "r3gm/wan2-2-fp8da-aoti-preview2",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview2",
@@ -51,22 +67,6 @@
       ],
       "createdAt": "2025-11-18T23:17:30.000Z",
       "lastModified": "2026-05-02T04:24:15.000Z",
-      "models": []
-    },
-    {
-      "rank": 4,
-      "id": "victor/LongCat-Video-Avatar-1.5",
-      "author": "victor",
-      "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 147,
-      "trendingScore": 137,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T13:56:32.000Z",
-      "lastModified": "2026-05-26T16:44:17.000Z",
       "models": []
     },
     {
@@ -147,8 +147,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 101,
-      "trendingScore": 97,
+      "likes": 107,
+      "trendingScore": 103,
       "sdk": "static",
       "tags": [
         "static",
@@ -292,6 +292,22 @@
     },
     {
       "rank": 18,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 71,
+      "trendingScore": 68,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-28T17:00:43.000Z",
+      "models": []
+    },
+    {
+      "rank": 19,
       "id": "ysharma/fast-image-studio",
       "author": "ysharma",
       "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
@@ -304,22 +320,6 @@
       ],
       "createdAt": "2026-04-29T14:15:57.000Z",
       "lastModified": "2026-04-30T12:10:32.000Z",
-      "models": []
-    },
-    {
-      "rank": 19,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 64,
-      "trendingScore": 62,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-28T17:00:43.000Z",
       "models": []
     },
     {
@@ -390,6 +390,23 @@
     },
     {
       "rank": 24,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 56,
+      "trendingScore": 56,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "arxiv:2605.27365",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-27T09:35:37.000Z",
+      "models": []
+    },
+    {
+      "rank": 25,
       "id": "zerogpu-aoti/wan2-2-fp8da-aoti-faster",
       "author": "zerogpu-aoti",
       "url": "https://huggingface.co/spaces/zerogpu-aoti/wan2-2-fp8da-aoti-faster",
@@ -406,29 +423,12 @@
       "models": []
     },
     {
-      "rank": 25,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 51,
-      "trendingScore": 51,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
-      "models": []
-    },
-    {
       "rank": 26,
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
-      "likes": 54,
-      "trendingScore": 50,
+      "likes": 55,
+      "trendingScore": 51,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -443,7 +443,7 @@
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1783,
+      "likes": 1785,
       "trendingScore": 48,
       "sdk": "gradio",
       "tags": [
@@ -750,6 +750,22 @@
     },
     {
       "rank": 46,
+      "id": "openbmb/VoxCPM-Demo",
+      "author": "openbmb",
+      "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
+      "likes": 511,
+      "trendingScore": 29,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-09-16T14:53:41.000Z",
+      "lastModified": "2026-05-23T09:59:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 47,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -765,7 +781,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 48,
       "id": "r3gm/wan2-2-fp8da-aoti-previewE",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
@@ -782,23 +798,23 @@
       "models": []
     },
     {
-      "rank": 48,
-      "id": "openbmb/VoxCPM-Demo",
-      "author": "openbmb",
-      "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
-      "likes": 510,
-      "trendingScore": 28,
+      "rank": 49,
+      "id": "build-small-hackathon/registration",
+      "author": "build-small-hackathon",
+      "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
+      "likes": 61,
+      "trendingScore": 27,
       "sdk": "gradio",
       "tags": [
         "gradio",
         "region:us"
       ],
-      "createdAt": "2025-09-16T14:53:41.000Z",
-      "lastModified": "2026-05-23T09:59:35.000Z",
+      "createdAt": "2026-05-06T17:25:59.000Z",
+      "lastModified": "2026-05-29T10:23:33.000Z",
       "models": []
     },
     {
-      "rank": 49,
+      "rank": 50,
       "id": "facebook/vggt-omega",
       "author": "facebook",
       "url": "https://huggingface.co/spaces/facebook/vggt-omega",
@@ -811,22 +827,6 @@
       ],
       "createdAt": "2026-05-16T23:39:56.000Z",
       "lastModified": "2026-05-18T21:46:03.000Z",
-      "models": []
-    },
-    {
-      "rank": 50,
-      "id": "multimodalart/scenema-audio",
-      "author": "multimodalart",
-      "url": "https://huggingface.co/spaces/multimodalart/scenema-audio",
-      "likes": 32,
-      "trendingScore": 26,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T10:12:08.000Z",
-      "lastModified": "2026-05-16T00:07:35.000Z",
       "models": []
     }
   ]


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26632292265

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.