### PR TITLE
chore(data): refresh lobsters signals 2026-05-29T12:35:20Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-29T08:58:53.352Z",
+  "ts": "2026-05-29T12:35:20.228Z",
   "count": 1,
-  "durationMs": 4546,
+  "durationMs": 2896,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T08:58:48.828Z",
+  "fetchedAt": "2026-05-29T12:35:17.353Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 75,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -422,14 +422,14 @@
     },
     "google/ax": {
       "count7d": 1,
-      "scoreSum7d": 2,
+      "scoreSum7d": 3,
       "topStory": {
         "shortId": "3k9g2c",
         "title": "ax, Google’s new highly distributed agent executor",
-        "score": 2,
+        "score": 3,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 22.33
+        "hoursSincePosted": 25.938055555555554
       },
       "stories": [
         {
@@ -438,11 +438,11 @@
           "url": "https://github.com/google/ax",
           "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
           "by": "",
-          "score": 2,
-          "commentCount": 1,
+          "score": 3,
+          "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 22.33,
-          "trendingScore": 0.016665441838156672,
+          "ageHours": 25.938055555555554,
+          "trendingScore": 0.02031547540622749,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T08:58:48.828Z",
+  "fetchedAt": "2026-05-29T12:35:17.353Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 75,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -747,6 +747,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "jp3nva",
+      "title": "You probably don't need Yocto, and that's fine",
+      "url": "https://sigma-star.at/blog/2026/05/you-probably-dont-need-yocto-and-thats-fine/",
+      "commentsUrl": "https://lobste.rs/s/jp3nva/you_probably_don_t_need_yocto_s_fine",
+      "by": "",
+      "score": 16,
+      "commentCount": 3,
+      "createdUtc": 1780045692,
+      "ageHours": 3.451388888888889,
+      "trendingScore": 1.2570693447225225,
+      "tags": [
+        "linux"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "ynxkj6",
       "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
       "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
@@ -878,24 +895,6 @@
           "confidence": 1
         }
       ]
-    },
-    {
-      "shortId": "2jdvxa",
-      "title": "What are some of your favourite developer tools?",
-      "url": "",
-      "commentsUrl": "https://lobste.rs/s/2jdvxa/what_are_some_your_favourite_developer",
-      "by": "",
-      "score": 43,
-      "commentCount": 58,
-      "createdUtc": 1779860447,
-      "ageHours": 9.030833333333334,
-      "trendingScore": 1.173696937425279,
-      "tags": [
-        "ask",
-        "programming"
-      ],
-      "description": "<p>Developers are so opinionated that it's difficult to pin down one favourite tool !</p>\n",
-      "linkedRepos": []
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26637452661

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.