### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-29T14:16:31Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-29T00:18:52.668Z",
+  "ts": "2026-05-29T14:16:31.260Z",
   "count": 1,
-  "durationMs": 9142,
+  "durationMs": 9328,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-29T00:18:51.411Z",
+  "lastFetchedAt": "2026-05-29T14:16:29.547Z",
   "windowDays": 7,
   "launches": [
     {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26642377061

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.