### PR TITLE
chore(data): refresh lobsters signals 2026-05-29T16:27:20Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-29T12:35:20.228Z",
+  "ts": "2026-05-29T16:27:20.330Z",
   "count": 1,
-  "durationMs": 2896,
+  "durationMs": 2826,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T12:35:17.353Z",
+  "fetchedAt": "2026-05-29T16:27:17.525Z",
   "windowDays": 7,
-  "scannedStories": 75,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -422,14 +422,14 @@
     },
     "google/ax": {
       "count7d": 1,
-      "scoreSum7d": 3,
+      "scoreSum7d": 4,
       "topStory": {
         "shortId": "3k9g2c",
         "title": "ax, Google’s new highly distributed agent executor",
-        "score": 3,
+        "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 25.938055555555554
+        "hoursSincePosted": 29.80472222222222
       },
       "stories": [
         {
@@ -438,11 +438,11 @@
           "url": "https://github.com/google/ax",
           "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
           "by": "",
-          "score": 3,
+          "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 25.938055555555554,
-          "trendingScore": 0.02031547540622749,
+          "ageHours": 29.80472222222222,
+          "trendingScore": 0.02230090979528275,
           "tags": [
             "distributed",
             "vibecoding"
@@ -555,7 +555,7 @@
     {
       "fullName": "google/ax",
       "count7d": 1,
-      "scoreSum7d": 3
+      "scoreSum7d": 4
     },
     {
       "fullName": "withastro/flue",

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T12:35:17.353Z",
+  "fetchedAt": "2026-05-29T16:27:17.525Z",
   "windowHours": 72,
-  "scannedTotal": 75,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -249,6 +249,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "yszuka",
+      "title": "Emacs bra size calculator",
+      "url": "https://pulusound.fi/blog/emacs-bra-size-calculator",
+      "commentsUrl": "https://lobste.rs/s/yszuka/emacs_bra_size_calculator",
+      "by": "",
+      "score": 15,
+      "commentCount": 5,
+      "createdUtc": 1780066034,
+      "ageHours": 1.6675,
+      "trendingScore": 2.1356794819030873,
+      "tags": [
+        "emacs"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "fxqjqu",
       "title": "Flipper One — we need your help",
       "url": "https://blog.flipper.net/flipper-one-we-need-your-help/",
@@ -487,6 +504,24 @@
       "tags": [
         "video",
         "zig"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "40broz",
+      "title": "bijou64: A variable-length integer encoding",
+      "url": "https://www.inkandswitch.com/tangents/bijou64/",
+      "commentsUrl": "https://lobste.rs/s/40broz/bijou64_variable_length_integer",
+      "by": "",
+      "score": 10,
+      "commentCount": 2,
+      "createdUtc": 1780066944,
+      "ageHours": 1.4147222222222222,
+      "trendingScore": 1.584772508327956,
+      "tags": [
+        "performance",
+        "programming"
       ],
       "description": "",
       "linkedRepos": []
@@ -853,48 +888,6 @@
       ],
       "description": "",
       "linkedRepos": []
-    },
-    {
-      "shortId": "5jdbwv",
-      "title": "Gram 2.0.0 released",
-      "url": "https://gram-editor.com/posts/release-2.0-0/",
-      "commentsUrl": "https://lobste.rs/s/5jdbwv/gram_2_0_0_released",
-      "by": "",
-      "score": 18,
-      "commentCount": 0,
-      "createdUtc": 1778527774,
-      "ageHours": 4.054166666666666,
-      "trendingScore": 1.2083449912871027,
-      "tags": [
-        "editors",
-        "release"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "wskhre",
-      "title": "linux 0-day, access root-owned files as an unprivileged user",
-      "url": "https://github.com/0xdeadbeefnetwork/ssh-keysign-pwn/",
-      "commentsUrl": "https://lobste.rs/s/wskhre/linux_0_day_access_root_owned_files_as",
-      "by": "",
-      "score": 48,
-      "commentCount": 17,
-      "createdUtc": 1778807661,
-      "ageHours": 9.780833333333334,
-      "trendingScore": 1.187072432527248,
-      "tags": [
-        "linux",
-        "security"
-      ],
-      "description": "",
-      "linkedRepos": [
-        {
-          "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
-          "matchType": "url",
-          "confidence": 1
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26649040989

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.