### PR TITLE
chore(data): refresh huggingface space signals 2026-05-29T16:27:58Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-29T10:33:57.681Z",
+  "ts": "2026-05-29T16:27:58.223Z",
   "count": 1,
-  "durationMs": 5595,
+  "durationMs": 5551,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T10:33:52.087Z",
+  "fetchedAt": "2026-05-29T16:27:52.674Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -41,8 +41,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 151,
-      "trendingScore": 141,
+      "likes": 154,
+      "trendingScore": 144,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -147,8 +147,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 107,
-      "trendingScore": 103,
+      "likes": 111,
+      "trendingScore": 106,
       "sdk": "static",
       "tags": [
         "static",
@@ -295,8 +295,8 @@
       "id": "bytedance-research/Lance",
       "author": "bytedance-research",
       "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 71,
-      "trendingScore": 68,
+      "likes": 72,
+      "trendingScore": 69,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -340,6 +340,23 @@
     },
     {
       "rank": 21,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 61,
+      "trendingScore": 61,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "arxiv:2605.27365",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-27T09:35:37.000Z",
+      "models": []
+    },
+    {
+      "rank": 22,
       "id": "prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
       "author": "prithivMLmods",
       "url": "https://huggingface.co/spaces/prithivMLmods/Qwen-Image-Edit-2511-LoRAs-Fast",
@@ -356,7 +373,7 @@
       "models": []
     },
     {
-      "rank": 22,
+      "rank": 23,
       "id": "Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
       "author": "Onise",
       "url": "https://huggingface.co/spaces/Onise/Qwen-Image-Edit-2509-LoRAs-Fast2",
@@ -373,7 +390,7 @@
       "models": []
     },
     {
-      "rank": 23,
+      "rank": 24,
       "id": "stabilityai/stable-audio-3",
       "author": "stabilityai",
       "url": "https://huggingface.co/spaces/stabilityai/stable-audio-3",
@@ -386,23 +403,6 @@
       ],
       "createdAt": "2026-05-20T15:54:00.000Z",
       "lastModified": "2026-05-22T21:24:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 24,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 56,
-      "trendingScore": 56,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
       "models": []
     },
     {
@@ -443,7 +443,7 @@
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1785,
+      "likes": 1787,
       "trendingScore": 48,
       "sdk": "gradio",
       "tags": [
@@ -504,6 +504,23 @@
     },
     {
       "rank": 31,
+      "id": "mrfakename/Z-Image-Turbo",
+      "author": "mrfakename",
+      "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
+      "likes": 3254,
+      "trendingScore": 41,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "mcp-server",
+        "region:us"
+      ],
+      "createdAt": "2025-11-26T19:54:05.000Z",
+      "lastModified": "2026-02-02T16:51:24.000Z",
+      "models": []
+    },
+    {
+      "rank": 32,
       "id": "microsoft/TRELLIS.2",
       "author": "microsoft",
       "url": "https://huggingface.co/spaces/microsoft/TRELLIS.2",
@@ -516,23 +533,6 @@
       ],
       "createdAt": "2025-12-10T03:50:25.000Z",
       "lastModified": "2025-12-17T06:32:54.000Z",
-      "models": []
-    },
-    {
-      "rank": 32,
-      "id": "mrfakename/Z-Image-Turbo",
-      "author": "mrfakename",
-      "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
-      "likes": 3249,
-      "trendingScore": 39,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2025-11-26T19:54:05.000Z",
-      "lastModified": "2026-02-02T16:51:24.000Z",
       "models": []
     },
     {
@@ -717,6 +717,22 @@
     },
     {
       "rank": 44,
+      "id": "openbmb/VoxCPM-Demo",
+      "author": "openbmb",
+      "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
+      "likes": 514,
+      "trendingScore": 30,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-09-16T14:53:41.000Z",
+      "lastModified": "2026-05-23T09:59:35.000Z",
+      "models": []
+    },
+    {
+      "rank": 45,
       "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
@@ -733,7 +749,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "CohereLabs/command-a-plus-05-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
@@ -746,22 +762,6 @@
       ],
       "createdAt": "2026-05-11T12:07:16.000Z",
       "lastModified": "2026-05-20T13:50:45.000Z",
-      "models": []
-    },
-    {
-      "rank": 46,
-      "id": "openbmb/VoxCPM-Demo",
-      "author": "openbmb",
-      "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
-      "likes": 511,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-09-16T14:53:41.000Z",
-      "lastModified": "2026-05-23T09:59:35.000Z",
       "models": []
     },
     {
@@ -802,7 +802,7 @@
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
-      "likes": 61,
+      "likes": 62,
       "trendingScore": 27,
       "sdk": "gradio",
       "tags": [
@@ -818,7 +818,7 @@
       "id": "facebook/vggt-omega",
       "author": "facebook",
       "url": "https://huggingface.co/spaces/facebook/vggt-omega",
-      "likes": 40,
+      "likes": 41,
       "trendingScore": 26,
       "sdk": "gradio",
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26649065238

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.