### PR TITLE
chore(data): refresh lobsters signals 2026-05-29T19:14:17Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-29T16:27:20.330Z",
+  "ts": "2026-05-29T19:14:17.279Z",
   "count": 1,
-  "durationMs": 2826,
+  "durationMs": 3146,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T16:27:17.525Z",
+  "fetchedAt": "2026-05-29T19:14:14.155Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 29.80472222222222
+        "hoursSincePosted": 32.58722222222222
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 29.80472222222222,
-          "trendingScore": 0.02230090979528275,
+          "ageHours": 32.58722222222222,
+          "trendingScore": 0.019664661043971268,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T16:27:17.525Z",
+  "fetchedAt": "2026-05-29T19:14:14.155Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -157,6 +157,23 @@
       "tags": [
         "linux",
         "security"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "axg3ga",
+      "title": "I Am Retiring from Tech to Live Offline",
+      "url": "https://openpath.quest/2026/i-am-retiring-from-tech-to-live-offline/",
+      "commentsUrl": "https://lobste.rs/s/axg3ga/i_am_retiring_from_tech_live_offline",
+      "by": "",
+      "score": 26,
+      "commentCount": 3,
+      "createdUtc": 1780072274,
+      "ageHours": 2.716666666666667,
+      "trendingScore": 2.5381692029266043,
+      "tags": [
+        "person"
       ],
       "description": "",
       "linkedRepos": []
@@ -370,6 +387,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "40broz",
+      "title": "bijou64: A variable-length integer encoding",
+      "url": "https://www.inkandswitch.com/tangents/bijou64/",
+      "commentsUrl": "https://lobste.rs/s/40broz/bijou64_variable_length_integer",
+      "by": "",
+      "score": 27,
+      "commentCount": 3,
+      "createdUtc": 1780066944,
+      "ageHours": 4.197222222222222,
+      "trendingScore": 1.7501213379981984,
+      "tags": [
+        "performance",
+        "programming"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "4msjpt",
       "title": "Garnix is shutting down",
       "url": "https://discourse.nixos.org/t/garnix-is-shutting-down-not-oc/77895",
@@ -504,24 +539,6 @@
       "tags": [
         "video",
         "zig"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "40broz",
-      "title": "bijou64: A variable-length integer encoding",
-      "url": "https://www.inkandswitch.com/tangents/bijou64/",
-      "commentsUrl": "https://lobste.rs/s/40broz/bijou64_variable_length_integer",
-      "by": "",
-      "score": 10,
-      "commentCount": 2,
-      "createdUtc": 1780066944,
-      "ageHours": 1.4147222222222222,
-      "trendingScore": 1.584772508327956,
-      "tags": [
-        "performance",
-        "programming"
       ],
       "description": "",
       "linkedRepos": []
@@ -867,24 +884,6 @@
       "tags": [
         "ai",
         "philosophy"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "pwnqab",
-      "title": "The Eternal Sloptember",
-      "url": "https://geohot.github.io//blog/jekyll/update/2026/05/24/the-eternal-sloptember.html",
-      "commentsUrl": "https://lobste.rs/s/pwnqab/eternal_sloptember",
-      "by": "",
-      "score": 25,
-      "commentCount": 1,
-      "createdUtc": 1779669359,
-      "ageHours": 5.525833333333333,
-      "trendingScore": 1.210899540315755,
-      "tags": [
-        "culture",
-        "programming"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26657026478

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.