### PR TITLE
chore(data): refresh huggingface space signals 2026-05-29T21:01:10Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-29T16:27:58.223Z",
+  "ts": "2026-05-29T21:01:10.544Z",
   "count": 1,
-  "durationMs": 5551,
+  "durationMs": 4644,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T16:27:52.674Z",
+  "fetchedAt": "2026-05-29T21:01:05.901Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -41,8 +41,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 154,
-      "trendingScore": 144,
+      "likes": 158,
+      "trendingScore": 148,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -124,6 +124,22 @@
     },
     {
       "rank": 8,
+      "id": "webml-community/bonsai-image-webgpu",
+      "author": "webml-community",
+      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
+      "likes": 117,
+      "trendingScore": 111,
+      "sdk": "static",
+      "tags": [
+        "static",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T17:12:36.000Z",
+      "lastModified": "2026-05-29T02:57:22.000Z",
+      "models": []
+    },
+    {
+      "rank": 9,
       "id": "Supertone/supertonic-3",
       "author": "Supertone",
       "url": "https://huggingface.co/spaces/Supertone/supertonic-3",
@@ -140,22 +156,6 @@
       ],
       "createdAt": "2026-05-06T20:45:18.000Z",
       "lastModified": "2026-05-18T10:24:16.000Z",
-      "models": []
-    },
-    {
-      "rank": 9,
-      "id": "webml-community/bonsai-image-webgpu",
-      "author": "webml-community",
-      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 111,
-      "trendingScore": 106,
-      "sdk": "static",
-      "tags": [
-        "static",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T17:12:36.000Z",
-      "lastModified": "2026-05-29T02:57:22.000Z",
       "models": []
     },
     {
@@ -258,6 +258,22 @@
     },
     {
       "rank": 16,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 73,
+      "trendingScore": 70,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-28T17:00:43.000Z",
+      "models": []
+    },
+    {
+      "rank": 17,
       "id": "r3gm/wan2-2-fp8da-aoti-preview",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-preview",
@@ -274,7 +290,7 @@
       "models": []
     },
     {
-      "rank": 17,
+      "rank": 18,
       "id": "kulkas2pintu/wan222",
       "author": "kulkas2pintu",
       "url": "https://huggingface.co/spaces/kulkas2pintu/wan222",
@@ -291,23 +307,24 @@
       "models": []
     },
     {
-      "rank": 18,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 72,
-      "trendingScore": 69,
+      "rank": 19,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 65,
+      "trendingScore": 65,
       "sdk": "gradio",
       "tags": [
         "gradio",
+        "arxiv:2605.27365",
         "region:us"
       ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-28T17:00:43.000Z",
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-27T09:35:37.000Z",
       "models": []
     },
     {
-      "rank": 19,
+      "rank": 20,
       "id": "ysharma/fast-image-studio",
       "author": "ysharma",
       "url": "https://huggingface.co/spaces/ysharma/fast-image-studio",
@@ -323,7 +340,7 @@
       "models": []
     },
     {
-      "rank": 20,
+      "rank": 21,
       "id": "k2-fsa/OmniVoice",
       "author": "k2-fsa",
       "url": "https://huggingface.co/spaces/k2-fsa/OmniVoice",
@@ -336,23 +353,6 @@
       ],
       "createdAt": "2026-03-30T13:56:16.000Z",
       "lastModified": "2026-04-13T06:55:17.000Z",
-      "models": []
-    },
-    {
-      "rank": 21,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 61,
-      "trendingScore": 61,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26661901098

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.