### PR TITLE
chore(data): refresh arxiv signals 2026-05-29T21:07:23Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-29T10:39:55.372Z",
+  "ts": "2026-05-29T21:03:42.708Z",
   "count": 1,
-  "durationMs": 261897,
+  "durationMs": 75842,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,12 +1,19 @@
 {
-  "fetchedAt": "2026-05-29T10:39:55.424Z",
+  "fetchedAt": "2026-05-29T21:03:42.757Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
     "reddit"
   ],
-  "count": 94,
+  "count": 145,
   "papers": [
+    {
+      "arxivId": "2605.30352v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
     {
       "arxivId": "2605.30351v1",
       "citationCount": 0,
@@ -20,6 +27,27 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30349v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30347v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30346v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30345v1",
@@ -36,11 +64,32 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30342v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30341v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30339v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30338v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30335v1",
@@ -64,11 +113,32 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30332v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30328v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30327v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30325v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30324v1",
@@ -78,11 +148,25 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30320v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30318v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30317v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30315v1",
@@ -104,6 +188,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30307v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30295v1",
@@ -141,6 +232,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30269v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30268v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -155,11 +253,25 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30263v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30260v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30257v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30256v1",
@@ -174,6 +286,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30250v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30248v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30245v1",
@@ -197,11 +323,25 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30239v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30237v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30235v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30233v1",
@@ -225,6 +365,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30230v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30219v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -232,11 +379,25 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30215v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30214v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30211v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30202v1",
@@ -253,11 +414,25 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30174v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30170v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30168v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30167v1",
@@ -267,11 +442,25 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30161v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30152v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30140v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30133v1",
@@ -295,6 +484,27 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30116v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30115v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30111v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30107v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -307,6 +517,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30099v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30093v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30090v1",
@@ -323,6 +547,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30083v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
       "arxivId": "2605.30080v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -335,6 +566,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30073v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30058v1",
@@ -428,242 +666,361 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
-      "arxivId": "2605.30352v1",
+      "arxivId": "2605.30353v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30349v1",
+      "arxivId": "2605.30350v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30347v1",
+      "arxivId": "2605.30344v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30346v1",
+      "arxivId": "2605.30337v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30342v1",
+      "arxivId": "2605.30336v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30339v1",
+      "arxivId": "2605.30330v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30338v1",
+      "arxivId": "2605.30329v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30332v1",
+      "arxivId": "2605.30326v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30328v1",
+      "arxivId": "2605.30323v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30325v1",
+      "arxivId": "2605.30322v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30320v1",
+      "arxivId": "2605.30319v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30317v1",
+      "arxivId": "2605.30292v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30307v1",
+      "arxivId": "2605.30289v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30269v1",
+      "arxivId": "2605.30288v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30263v1",
+      "arxivId": "2605.30284v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30257v1",
+      "arxivId": "2605.30283v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30250v1",
+      "arxivId": "2605.30277v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30248v1",
+      "arxivId": "2605.30275v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30239v1",
+      "arxivId": "2605.30253v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30235v1",
+      "arxivId": "2605.30247v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30230v1",
+      "arxivId": "2605.30229v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30215v1",
+      "arxivId": "2605.30227v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30211v1",
+      "arxivId": "2605.30226v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30174v1",
+      "arxivId": "2605.30225v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30168v1",
+      "arxivId": "2605.30220v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30161v1",
+      "arxivId": "2605.30218v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30140v1",
+      "arxivId": "2605.30213v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30116v1",
+      "arxivId": "2605.30208v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30115v1",
+      "arxivId": "2605.30207v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30111v1",
+      "arxivId": "2605.30201v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30099v1",
+      "arxivId": "2605.30200v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30093v1",
+      "arxivId": "2605.30198v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30083v1",
+      "arxivId": "2605.30195v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30073v1",
+      "arxivId": "2605.30190v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30188v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30187v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30184v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30179v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30175v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30169v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30166v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30162v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30160v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30159v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30155v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30154v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30153v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30148v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30135v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30132v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30123v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,23 +1,36 @@
 {
-  "fetchedAt": "2026-05-29T10:35:33.495Z",
-  "source": "export.arxiv.org/api/query (cs.CL, cs.CV)",
+  "fetchedAt": "2026-05-29T21:02:26.888Z",
+  "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
+    "cs.AI",
     "cs.CL",
+    "cs.LG",
     "cs.CV"
   ],
-  "failedCategories": [
-    {
-      "category": "cs.AI",
-      "error": "arXiv API HTTP 429 Too Many Requests (cs.AI)"
-    },
-    {
-      "category": "cs.LG",
-      "error": "This operation was aborted"
-    }
-  ],
-  "count": 94,
+  "failedCategories": [],
+  "count": 145,
   "linkedRepoCount": 0,
   "papers": [
+    {
+      "arxivId": "2605.30353v1",
+      "title": "Physics Is All You Need? A Case Study in Physicist-Supervised AI Development of Scientific Software",
+      "summary": "Are AI agents tools, co-authors, or researchers? We present a quantified case study ($N=1$): a physicist supervising an AI coding agent (Claude Code, Sonnet and Opus models) over 12 work days and 57 sessions to build CLAX-PT, a differentiable one-loop perturbation theory module in JAX. We documented and classified 15 supervision events by intervention level. The agent resolved ten autonomously by iterating against oracle tests. Two more by the physicist's domain knowledge. The three it could not -- all evaded oracle detection -- share a common property: the agent treated symptom reduction as root-cause resolution. It spent 33 of the 57 sessions adjusting coefficients within a code architecture that could not represent the target physics, and could not re-evaluate its CLASS-PT branch choice even when prompted to reconsider; only an injected physics concept (anisotropic BAO damping) triggered the redesign. Separately, the agent committed a calibrated correction that passed all oracle tests but corresponded to no quantity in the theory, predicting wrong values at any other cosmology. The fudge factor was caught and replaced within the same session. Three supervision practices proved critical for catching what oracle tests missed: testing at diverse parameter points beyond the fiducial calibration; shared changelogs that surfaced stalled exploration across sessions; and an explicit rule against unphysical numerical patches. In this case, supervision design, not model capability, determined whether the agent's output was trustworthy. Closing the gap would require agents that propose architectural alternatives rather than optimize within a given structure, and distinguish predictive adequacy from explanatory correctness -- capabilities not exhibited here, not obviously addressed by scaling alone. [Abridged.]",
+      "authors": [
+        "Nhat-Minh Nguyen"
+      ],
+      "categories": [
+        "cs.AI",
+        "astro-ph.CO",
+        "cs.HC",
+        "cs.SE"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30353v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30353v1",
+      "publishedAt": "2026-05-28T17:59:59.000Z",
+      "updatedAt": "2026-05-28T17:59:59.000Z",
+      "linkedRepos": []
+    },
     {
       "arxivId": "2605.30352v1",
       "title": "GMOS: Grounding Moving Object Segmentation in 3D Space and Time",
@@ -84,6 +97,32 @@
       "primaryCategory": "cs.CL",
       "absUrl": "https://arxiv.org/abs/2605.30348v1",
       "pdfUrl": "https://arxiv.org/pdf/2605.30348v1",
+      "publishedAt": "2026-05-28T17:59:53.000Z",
+      "updatedAt": "2026-05-28T17:59:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30350v1",
+      "title": "DynaFLIP: Rethinking Robotics Perception via Tri-Modal-Dynamics Guided Representation",
+      "summary": "Robot manipulation critically depends on perception that preserves the action-relevant aspects of a scene. Yet most robot learning pipelines are built upon visual encoders pre-trained for static recognition or vision-language alignment, leaving motion understanding to downstream policies. We introduce DynaFLIP, a dynamics-aware multimodal pre-training framework that pushes motion understanding upstream into perception. We construct image-language-3D flow triplets from heterogeneous human and robot videos, and use these triplets as training-time supervision to shape an image-only encoder. Our key idea is to encourage the three modalities to span a small simplex volume in the shared hyperspherical space -- a smaller simplex volume indicating stronger alignment. To avoid the geometric ambiguity and trivial collapse of naive volume minimization, we combine simplex-volume minimization with a cosine regularizer and a contrastive objective. Our analyses show that DynaFLIP focuses on control-relevant regions critical for manipulation. The resulting dynamics-aware representations serve as reusable visual backbones and consistently outperform baselines across diverse downstream policies, including VLAs. We validate this across diverse simulation and real-world setups, with gains reaching +22.5% under out-of-distribution scenarios. Our results suggest that robot generalization improves when visual representations are trained to encode not just what is present, but how the world changes under action.",
+      "authors": [
+        "Jusuk Lee",
+        "Seungjae Lee",
+        "Jonghun Shin",
+        "Hoseong Jung",
+        "Sungha Kim",
+        "Daesol Cho",
+        "H. Jin Kim",
+        "Jia-Bin Huang",
+        "Furong Huang"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.30350v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30350v1",
       "publishedAt": "2026-05-28T17:59:53.000Z",
       "updatedAt": "2026-05-28T17:59:53.000Z",
       "linkedRepos": []
@@ -169,6 +208,27 @@
       "primaryCategory": "cs.AI",
       "absUrl": "https://arxiv.org/abs/2605.30345v1",
       "pdfUrl": "https://arxiv.org/pdf/2605.30345v1",
+      "publishedAt": "2026-05-28T17:59:50.000Z",
+      "updatedAt": "2026-05-28T17:59:50.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30344v1",
+      "title": "Tiny but Trusted: Efficient Vision-Language Reasoning for Time-Series Anomaly Detection",
+      "summary": "Recent advances in Vision-Language Models (VLMs) have achieved impressive performance across many tasks, yet prior studies report unsatisfactory performance when applying large language or multimodal models to finding abnormal patterns in sequential data. Public anomaly detection benchmarks typically provide interval annotations but not natural-language rationales, making it difficult to fine-tune VLMs to produce grounded, interpretable decisions. To address this gap, we construct VisAnomBench, a curated benchmark built from public time-series datasets and augmented with high-quality anomaly explanations selected from multiple large VLMs using fine-grained, task-specific rewards. Through fine-tuning on this benchmark, we develop VisAnomReasoner, a parameter-efficient VLM for time-series anomaly detection. Experimental results on VisAnomBench show that VisAnomReasoner achieves more accurate anomaly localization and consistently outperforms all baselines, with improvements of at least 21.23 and 23.87 percentage points in precision and F1, respectively. Additional experiments on the TSB-AD-U benchmark demonstrate strong cross-benchmark generalization, with VisAnomReasoner improving precision and F1 by 9.57 and 13.39 percentage points, respectively.",
+      "authors": [
+        "Xiaona Zhou",
+        "Muntasir Wahed",
+        "Tianjiao Yu",
+        "Constantin Brif",
+        "Ismini Lourentzou"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30344v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30344v1",
       "publishedAt": "2026-05-28T17:59:50.000Z",
       "updatedAt": "2026-05-28T17:59:50.000Z",
       "linkedRepos": []
@@ -270,6 +330,24 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30337v1",
+      "title": "Efficient Test-Time Finetuning of LLMs via Convex Reconstruction and Gradient Caching",
+      "summary": "Test-time finetuning (TTFT) is a rapidly evolving paradigm that adapts a language model to each prompt by retrieving related sequences, updating the model on them, and then evaluating the prompt. However, TTFT is only practical if it is fast: selection and finetuning both happen per query, making each a direct bottleneck. Existing methods trade speed for quality: fast retrieval is often redundant, while stronger diversity-aware selection adds prohibitive per-query cost. We introduce HullFT, a geometric approach to TTFT that addresses both bottlenecks. Given a query, HullFT first represents the query embedding as a sparse convex combination of few training sequences, using efficient projection-free Frank-Wolfe optimization. This yields a support set that is inherently relevant and diverse. We then convert the fractional convex weights into an exact integer multiset for finetuning through a geometric integerization procedure. The resulting multiplicities naturally create repeated examples, which we exploit with Gradient Reuse to amortize forward-backward computation across repeated finetuning steps. Our experiments show that HullFT improves the quality-efficiency tradeoff over current state-of-the-art TTFT methods, achieving lower bits-per-byte at substantially lower total runtime.",
+      "authors": [
+        "Alaa Khamis",
+        "Alaa Maalouf"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30337v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30337v1",
+      "publishedAt": "2026-05-28T17:59:01.000Z",
+      "updatedAt": "2026-05-28T17:59:01.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30338v1",
       "title": "REST3D: Reconstructing Physically Stable 3D Scenes from a Single Image",
       "summary": "Reconstructing physically stable 3D scenes from a single RGB image enables casual images to be converted into simulation-ready digital assets for applications such as immersive interaction and content creation. However, existing single-image reconstruction methods fall short in capturing the physical structure of a scene. As a result, they often produce geometrically plausible but physically inconsistent results, including object floating and penetration, which lead to unstable behavior in physics simulations. Image-conditioned scene generation methods improve physical plausibility but often rely on strong scene priors, yielding plausible yet inaccurate object arrangements that fail to match the input image. We propose REST3D, a single-image reconstruction framework that can reconstruct physically stable 3D scenes by integrating physical scene understanding with physics-constrained refinement. We first introduce an agentic physical scene understanding technique that constructs a scene-tree representation capturing object physical states and inter-object relationships from a gravity-support perspective, providing a structural prior for reconstruction. Leveraging this structure, we initialize the scene using image-to-3D models, followed by scene-tree-guided alignment and physics-constrained optimization to resolve physical violations while preserving visual consistency with the input image. Experiments show that our method significantly reduces physical errors and improves simulation stability on both synthetic and real-world datasets while maintaining strong reconstruction quality. We further demonstrate the reconstructed scenes in VR-based human-object interaction, showing their potential for immersive applications.",
@@ -288,6 +366,24 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30338v1",
       "publishedAt": "2026-05-28T17:59:01.000Z",
       "updatedAt": "2026-05-28T17:59:01.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30336v1",
+      "title": "Fairness-Aware Federated Learning with Trajectory Shapley Value",
+      "summary": "Federated learning is an emerging distributed paradigm that addresses the challenges posed by heterogeneous, privacy-sensitive data. It enables multiple clients to train a model collaboratively by aggregating their local updates at a server. However, conventional aggregation schemes typically use fixed weights that fail to reflect unequal and time-varying client contributions, leading to biased and unstable learning. To improve fairness and stability, we propose the Trajectory Shapley Value (TSV), a contribution metric that evaluates how each client influences the optimization trajectory of the global model using a validation-based, temporally consistent utility. Building on TSV, we design FedTSV, an adaptive aggregation method that converts per-round evaluations into dynamic client weights, allowing the server to respond to heterogeneous and adversarial participation in real time. Experiments on benchmark datasets show that FedTSV accelerates convergence, improves robustness, and yields more equitable contribution assessments, thereby providing a principled foundation for fairness-aware federated optimization.",
+      "authors": [
+        "Daniel Kuznetsov",
+        "Ziqi Wang"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30336v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30336v1",
+      "publishedAt": "2026-05-28T17:58:57.000Z",
+      "updatedAt": "2026-05-28T17:58:57.000Z",
       "linkedRepos": []
     },
     {
@@ -374,6 +470,44 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30330v1",
+      "title": "When, why, and how do diffusion posterior samplers fail? A finite-sample lens",
+      "summary": "Diffusion models have excellent capacity to model complex distributions of natural data, which has made them a popular and effective choice for posterior sampling in imaging inverse problems. Existing methods can incorporate any measurement model at inference time but must use an inexact approximation for the likelihood at intermediate timesteps for computational tractability. Although these approximations can often work well empirically, their downstream effect on the sampled posterior is poorly understood and can result in unexplained failures. To understand when, why, and how these likelihood approximations propagate to erroneous posterior distributions, we introduce a finite-sample perspective on posterior sampling that approximates the posterior to arbitrary precision as training set size tends towards infinity, for any forward model and prior distribution. Using this finite-sample lens, we observe that popular posterior sampling approximations tend to under- or over-estimate the spread of the posterior at intermediate timesteps, causing downstream consequences including sensitivity to early stopping time, inaccurate relative weighting of posterior modes, and hallucination, both of prior modes that are not in the posterior and likelihood modes that are not supported by the prior. Moreover, we find that the cause of these posterior errors requires neither a nonlinear measurement model nor a multimodal posterior, but can arise solely due to a multimodal prior and inaccurate posterior spread at intermediate sampling times. Our finite-sample posterior sampling approach is agnostic to the type of likelihood approximation and the type of (linear or nonlinear) forward model, and can thus serve as a drop-in diagnostic to evaluate the accuracy and failure modes of existing and future posterior samplers.",
+      "authors": [
+        "Benjamin A. Burns",
+        "Sara Fridovich-Keil"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30330v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30330v1",
+      "publishedAt": "2026-05-28T17:57:46.000Z",
+      "updatedAt": "2026-05-28T17:57:46.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30329v1",
+      "title": "SoundnessBench: Can Your AI Scientist Really Tell Good Research Ideas from Bad Ones?",
+      "summary": "Autonomous AI research agents aim to accelerate scientific discovery by automating the research pipeline, from hypothesis generation to peer review. However, existing benchmarks rarely test a fundamental bottleneck: whether Large Language Models can judge the methodological viability of a research idea before expending time and computational resources. We introduce SoundnessBench, a curated benchmark of 1,099 machine-learning research proposals reconstructed from ICLR submissions, labeled with reviewer soundness sub-scores, and audited against source papers. SoundnessBench should be interpreted as a benchmark for recoverable proposal-stage soundness rather than exact prediction of full-paper review outcomes. Across 12 frontier LLMs, we find a pervasive optimism bias: under standard prompting, models frequently rate low-soundness proposals as sound, while aggressive prompting largely shifts errors from false positives to false negatives. Additional controls for public-corpus contamination, paper-identifying phrases, surface features, and human audit quality suggest that this behavior is not explained by a single confounder. Our results indicate that current LLMs are not yet reliable as standalone first-gate evaluators for scientific rigor.",
+      "authors": [
+        "Sy-Tuyen Ho",
+        "Minghui Liu",
+        "Huy Nghiem",
+        "Furong Huang"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30329v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30329v1",
+      "publishedAt": "2026-05-28T17:57:37.000Z",
+      "updatedAt": "2026-05-28T17:57:37.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30328v1",
       "title": "Supercharging Thermal Gaussian Splatting with Depth Estimation",
       "summary": "Efficient and robust 3D scene representation is crucial in autonomous driving, robotics, and related fields. While RGB images provide valuable content for 3D reconstruction, other modalities like thermal or depth can enable additional information on the environment. Lately, novel view synthesis methods like 3D Gaussian Splatting have started using multiple modalities to further boost their performance. But fusing or combining multimodal data can make the process slower and can bring in additional challenges. Therefore, our project aims to use single modality based on thermal infrared domain, by removing the reliance on visible light as much as possible. This single modality can be expected to be faster as it does not rely on multimodal data. We propose a method, Thermal-to-Depth Gaussian Splatting (TDg), that uses only thermal images and depth estimation in its architecture to derive the radiance fields. Our TDg method outperforms the MSMG (Multiple Single-Modal Gaussians) baseline in most cases on our test datasets, RGBT-Scenes and ThermalMix. On average, the rendering quality metrics such as learned perceptual image patch similarity (LPIPS), structural similarity index measure (SSIM), and peak signal-to-noise ratio (PSNR) of TDg are 1.12%, 0.034%, and 0.01% better than the baseline MSMG values. It also reduces the training time significantly, by 12 mins 47 secs (55% improvement). Overall, our method is successful in deriving these thermal radiance fields, which can ultimately have several applications, such as identifying heat sources critical in surveillance, search or rescue operations, and industrial inspections where temperature is widely used to monitor machines.",
@@ -415,6 +549,31 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30327v1",
       "publishedAt": "2026-05-28T17:57:32.000Z",
       "updatedAt": "2026-05-28T17:57:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30326v1",
+      "title": "RoboWits: Unexpected Challenges for Robotic Creative Problem Solving",
+      "summary": "The ability to reason, adapt, and creatively solve problems under unexpected challenges is essential for robots operating in real-world environments. However, current robotic benchmarks primarily emphasize skill-level execution and provide limited insight into such cognitive reasoning capabilities. We introduce RoboWits, a bi-manual robotic benchmark designed to systematically evaluate cognitive reasoning, creative tool use, and robustness to unexpected conditions. To enable scalable construction of high-quality reasoning-centric unexpected scenarios, we propose an automated task generation pipeline formulated as a multi-agent cooperative framework, comprising agents for seed task generation and verification, metric generation, scene generation, and task mutation. Using the pipeline, we curated 30 diverse seed tasks and 208 tasks with mutations and graded difficulty across geometry, material, and assembly-based reasoning. We benchmark popular robot policies, pre-trained VLAs, and oracle-state planners. Our results reveal a significant performance gap: while pre-trained VLAs exhibit preliminary success on seed tasks after single-task fine-tuning, they struggle to perform on mutated tasks, implying their brittleness in manipulation tasks requiring reasoning, strategy adaptation, and robustness to deceptive or constrained environments. Project page is available at https://umass-embodied-agi.github.io/RoboWits.",
+      "authors": [
+        "Chunru Lin",
+        "Hongxin Zhang",
+        "Fenghao Yu",
+        "Zhehuan Chen",
+        "Thomas L. Griffiths",
+        "Yejin Choi",
+        "David Held",
+        "Chuang Gan"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.30326v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30326v1",
+      "publishedAt": "2026-05-28T17:57:15.000Z",
+      "updatedAt": "2026-05-28T17:57:15.000Z",
       "linkedRepos": []
     },
     {
@@ -464,6 +623,46 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30323v1",
+      "title": "In-Context Reward Adaptation for Robust Preference Modeling",
+      "summary": "Reinforcement Learning from Human Feedback (RLHF) typically relies on static reward models to align Large Language Models with human preferences. However, human values are inherently diverse and heterogeneous, and a single reward model often lacks the robustness required to generalize to unseen preference domains. While existing multi-reward frameworks attempt to address this, they are often restricted to a fixed set of known domains and fail to adapt to unseen human distributions without costly retraining. In this work, we propose In-Context Reward Adaptation, a transformer-based framework designed to model diverse and unseen human preferences on the fly. By leveraging the in-context learning capabilities of transformers, our approach adaptively infers the underlying reward structure from a small set of preference demonstrations. We demonstrate that while a standard transformer architecture is insufficient for this task by characterizing an asymptotic bias to the ground-truth, incorporating human response time as an auxiliary input signal enables the model to successfully adapt to preferences from previously unseen domains. Our findings show that this approach provides a more robust foundation for preference modeling, allowing for the representation of heterogeneous rewards and preference distribution shift, and offering a scalable path toward more flexible human-AI alignment.",
+      "authors": [
+        "Zhenyu Sun",
+        "Zheng Xu",
+        "Ermin Wei"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30323v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30323v1",
+      "publishedAt": "2026-05-28T17:56:54.000Z",
+      "updatedAt": "2026-05-28T17:56:54.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30322v1",
+      "title": "Gram: Assessing sabotage propensities via automated alignment auditing",
+      "summary": "We introduce Gram, an automated alignment auditing framework to assess the propensity of AI agents to engage in sabotage. We evaluate Gemini models across 17 simulated agentic deployment scenarios that incentivize sabotage. We find Gemini models misbehave in about 2-3% of our simulated trajectories. Many of these cases are explained by \"overeagerness\" in Gemini models resulting in both excessive role-playing and goal-seeking behavior. In contrast to other alignment auditing approaches, Gram is designed to specifically evaluate misalignment and intentional sabotage in agentic coding and research agents. We additionally introduce an experimental investigator agent pipeline which enables fine-grained targeted experiments to identify the drivers of misbehavior. We find that increasing realism of environments and removing nudges to misbehave tends to reduce sabotage rates close to zero.",
+      "authors": [
+        "David Lindner",
+        "Victoria Krakovna",
+        "Sebastian Farquhar"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30322v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30322v1",
+      "publishedAt": "2026-05-28T17:56:18.000Z",
+      "updatedAt": "2026-05-28T17:56:18.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30320v1",
       "title": "MonoPhysics: Estimating Geometry, Appearance, and Physical Parameters from Monocular Videos",
       "summary": "Existing inverse physics methods recover physical parameters from multi-view videos, where geometric constraints across views resolve scale and 3D structure. In monocular settings, however, such constraints are absent, leading to severe scale ambiguity, inaccurate geometry, and weak coupling between appearance optimization and physical simulation. We propose MonoPhysics, a framework for monocular inverse physics estimation of deformable objects using differentiable MPM simulation and 3D Gaussian Splatting, which jointly optimizes geometry, appearance, and physical parameters from a single camera view. We address these challenges through three visual-physical bridges: global scale alignment, physics-aware geometry refinement, and a differentiable position map, which together enable accurate optimization from monocular observations alone. We evaluate on Vid2Sim and our new dataset of elastic and plastic objects, showing that MonoPhysics outperforms existing baselines in monocular settings and achieves performance comparable to multi-view baselines using only a single camera. Our project page is available at https://daniel03c1.github.io/MonoPhysics/",
@@ -482,6 +681,30 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30320v1",
       "publishedAt": "2026-05-28T17:55:34.000Z",
       "updatedAt": "2026-05-28T17:55:34.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30319v1",
+      "title": "Improved Guarantees for Heterogeneous Treatment-Effect Estimation via Matrix Completion",
+      "summary": "A central goal of modern causal inference is estimating heterogeneous treatment effects to answer questions like \"how does an intervention affect each unit,\" rather than only on average. We study this problem with panel-data where we observe $n$ units across $m$ times under unknown, non-uniform treatment assignments. The data in this setting is naturally represented as a matrix of all unit--time treatment effects. Estimating heterogeneous treatment effects can then be expressed as obtaining a good estimation of each row's average in this matrix. This allows us to formulate the problem as matrix completion, which can be solved under natural low-rankness assumptions. However, existing matrix-completion guarantees are not powerful enough to get meaningful bounds for the per-row guarantee required for estimating the heterogeneous treatment effect; roughly speaking, they are only useful for estimating average treatment effect bounds, as also illustrated in a recent line of work. We give a simple, computationally efficient estimator that, without knowledge of the propensities and under standard low-rankness and regularity assumptions, achieves a row-wise $\\ell_2$ error of $\\tilde{O}(\\sqrt{\\frac{1}{n} + \\frac{n}{m^2}})$. Technically, our analysis establishes the first sharp row-wise $\\ell_2$-perturbation bound for low-rank approximation, complementing existing spectral-, Frobenius-, and entrywise perturbation theory.",
+      "authors": [
+        "Anay Mehrotra",
+        "Phuc Tran",
+        "Van H. Vu",
+        "Manolis Zampetakis"
+      ],
+      "categories": [
+        "stat.ML",
+        "cs.AI",
+        "cs.DS",
+        "cs.LG",
+        "math.ST"
+      ],
+      "primaryCategory": "stat.ML",
+      "absUrl": "https://arxiv.org/abs/2605.30319v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30319v1",
+      "publishedAt": "2026-05-28T17:55:23.000Z",
+      "updatedAt": "2026-05-28T17:55:23.000Z",
       "linkedRepos": []
     },
     {
@@ -650,6 +873,29 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30292v1",
+      "title": "Leave a Window Out: Modifying the Jackknife for Predictive Inference in Time Series",
+      "summary": "Conformal prediction methods enjoy strong theoretical and empirical predictive inference performance, provided the data is exchangeable, and predictors are trained in a memoryless fashion. However, these assumptions and constraints are impractical in many real-data settings, such as time series (where temporal dependence violates exchangeability, and where memoryless predictors will inevitably have poor predictive accuracy). Recent work shows that the split conformal prediction method is robust to these issues of memory-based predictors and deviations from exchangeability that are common features of time-series data. However, since using sample splitting can lead to lower accuracy, this motivates asking whether other predictive inference methods (that do not rely on data splitting) could also be reliably used in the time series setting. In this work, we show that the vanilla leave-one-out jackknife can suffer an arbitrary loss of coverage even in canonical time series models with mild temporal dependence. As a remedy, we propose a careful modification tailored to such settings, which we term the \\emph{leave-a-window-out} (LWO) method, and show that it can achieve valid coverage provided that the model-fitting procedure satisfies mild stability properties. Our proofs are based on quantifying the degree to which the data departs from \\emph{cyclic exchangeability}, and we introduce new coefficients to measure the extent of this departure. Experiments on time series data demonstrate that our LWO method often enjoys valid coverage when the vanilla jackknife fails to cover, while producing much narrower intervals than split conformal prediction.",
+      "authors": [
+        "Hanyang Jiang",
+        "Rina Foygel Barber",
+        "Ashwin Pananjady",
+        "Yao Xie"
+      ],
+      "categories": [
+        "stat.ML",
+        "cs.LG",
+        "math.ST",
+        "stat.ME"
+      ],
+      "primaryCategory": "stat.ML",
+      "absUrl": "https://arxiv.org/abs/2605.30292v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30292v1",
+      "publishedAt": "2026-05-28T17:41:12.000Z",
+      "updatedAt": "2026-05-28T17:41:12.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30290v1",
       "title": "Self-Trained Verification for Training- and Test-Time Self-Improvement",
       "summary": "Self-improvement at scale has been a longstanding goal for reasoning models, and there are two natural places to do it: at test time, through verification-refinement (V-R) loops; and at training time, through self-training methods. Both are gated by the same bottleneck: the verifier. V-R loops stall when verifier scores inflate while accuracy stagnates, and when feedback is too generic to act on; self-training fails similarly when bad self-generated data are added to training. Better verification would unlock both, but the capability we want to train, i.e., catching self-generated errors, lacks training signal. To address this challenge, we propose self-trained verification (STV). Our key observation is that, while a model cannot catch these errors alone, it can when shown the reference solution. We turn this asymmetry into a supervision target and train the verifier to imitate a more informed version of itself. At test time, STV substantially improves V-R loops on hard problems, while alternatives (e.g., SFT, RL on verifier scores, and even meta-verifiers) do not. STV roughly doubles accuracy on hard math and lifts it 14x on scientific reasoning tasks (1.5% to 21%). At training time, we additionally train the generator using RL with STV verifier's feedback inside the V-R loop - a procedure we call verifier-in-the-loop training (ViL). Starting from an RL-converged generator, ViL yields a further 33% gain in pass@1. More notably, the generator's standalone pass@1, with no verifier at test time, climbs 30% relative past where standard RL had converged. Hence, the next frontier in reasoning on hard problems may lie in how we train for and with verification.",
@@ -667,6 +913,100 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30290v1",
       "publishedAt": "2026-05-28T17:40:45.000Z",
       "updatedAt": "2026-05-28T17:40:45.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30289v1",
+      "title": "Statistical Embeddings for Similarity, Retrieval, and Interpretable Alignment of Numeric Tabular Datasets",
+      "summary": "Numeric tabular datasets are the dominant data format in scientific practice, yet large language models lack native mechanisms for representing numeric datasets in a meaningful way across heterogeneous feature spaces. Existing approaches either target predictive modeling over individual datasets, which requires a shared set of variable definitions, or lack mechanisms for interpretable cross-dataset alignment. The proposed methodology characterizes numeric tabular datasets through structured exploratory data analysis descriptors, embeds those descriptors into a shared vector space using a pretrained sentence transformer, and quantifies cross-dataset similarity via Canonical Correlation Analysis (CCA). Furthermore, a penalized formulation of CCA is applied to recover sparse, interpretable variable-level correspondences between datasets, identifying which statistical descriptors or variable-level quantities drive cross-dataset alignment without requiring shared variable names or feature conventions. Differential privacy is optionally applied to the descriptor set prior to embedding, supporting deployment in sensitive data contexts without requiring access to raw observations at time of comparison. The methodology is evaluated across 15 datasets spanning general-purpose benchmarks, materials informatics, and nuclear-grade graphite characterization. Results demonstrate a total P@1 score of 0.9, with known nearest-neighbor retrieval and cluster structure remaining robust across embedding ablations and differential privacy budgets. The proposed framework provides a principled pathway for integrating heterogeneous numeric data into retrieval-augmented generation pipelines while preserving statistical context, with direct applications to data-driven algorithm selection and simulation model initialization for unknown datasets.",
+      "authors": [
+        "M. Ross Kunz",
+        "John Merickel",
+        "Keith Wilson"
+      ],
+      "categories": [
+        "cs.LG",
+        "stat.AP",
+        "stat.ML"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30289v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30289v1",
+      "publishedAt": "2026-05-28T17:40:42.000Z",
+      "updatedAt": "2026-05-28T17:40:42.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30288v1",
+      "title": "MIRA: Mid-training Rubric Anchoring for Source-Aware Data Selection",
+      "summary": "Mid-training has become an important stage in modern LLM development, using large-scale curated mixtures to strengthen capabilities before final post-training. Its data selection problem is distinct: the data are optimized under a pretraining-style objective at near-pretraining scale, but are curated toward downstream capabilities and drawn from heterogeneous sources with different formats and training roles. As a result, effective selection requires both scalability and source-adaptive semantic criteria. Existing model-based methods scale well, but provide only implicit quality signals. Semantic selection methods offer stronger judgments, but usually assume fixed rubrics or standardized data formats. To address this mismatch, we propose MIRA, a source-aware filtering framework based on self-anchored rubric discovery. The key idea is to make rubric construction part of data selection: MIRA first discovers what should be evaluated for each source group, then distills those judgments into scalable student scorers for full-corpus filtering. On code-oriented mid-training with 21 sources and 5 source groups, MIRA outperforms selection baselines across nine code benchmarks and matches the full-corpus run while using only half the tokens.",
+      "authors": [
+        "Haowen Wang",
+        "Yaxin Du",
+        "Jian Yang",
+        "Jiajun Wu",
+        "Shukai Liu",
+        "Yuxuan Zhang",
+        "Pingjie Wang",
+        "Siheng Chen",
+        "Tuney Zheng",
+        "Ming Zhou",
+        "Xianglong Liu"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30288v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30288v1",
+      "publishedAt": "2026-05-28T17:40:40.000Z",
+      "updatedAt": "2026-05-28T17:40:40.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30284v1",
+      "title": "ProjectionBench: Evaluating Scientific Hypothesis Generation in LLMs Under Progressive Information Disclosure",
+      "summary": "Scientific discovery is an inherently creative and uncertain process, requiring reasoning beyond the recall of known knowledge. While many benchmarks have been proposed to evaluate large language model (LLM) performance on deep research tasks via multi-hop retrieval, their innovative reasoning abilities essential for true scientific discovery remain largely untested. We introduce a benchmark framework for evaluating model performance in scientific discovery and reasoning, building up from a raw problem to the classical null hypothesis test. In our framework, models initially receive only the topic and research question from a recent paper, with technical details progressively revealed. At each stage of information disclosure, the model is tasked with generating hypotheses that address the research question, which is compared with the conclusions from the original paper and evaluated via automated semantic similarity of constituent atomic claims. This progressive evaluation of semantic divergence from ground-truth conclusions enables assessment of a model's innovativeness (under minimal information) to grounded reasoning capabilities (under full experimental details), both critical for using LLMs for scientific discovery purposes. Our framework provides a foundation for systematically evaluating scientific reasoning and discovery capabilities in LLMs, crucial for advancing the development of next-generation AI scientist/co-scientist systems. Specifically, here we evaluate GPT-5, GPT-5.4, Gemini 2.5 pro, and Gemini 3.1 pro preview across 45 papers spanning bioactive materials, mechanical materials, and nanomaterials. We find that GPT-5.4 and Gemini 3.1 pro outperform their previous generation counterparts as expected, and GPT-5.4 in particular maintains 0.7 F1 score alignment with ground truth conclusions even under minimal context.",
+      "authors": [
+        "A. J. Lew",
+        "Y. Cao",
+        "M. J. Buehler"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30284v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30284v1",
+      "publishedAt": "2026-05-28T17:38:19.000Z",
+      "updatedAt": "2026-05-28T17:38:19.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30283v1",
+      "title": "mcp-proto-okn: Natural-language access to open scientific knowledge graphs through the Model Context Protocol",
+      "summary": "MCP Server Proto-OKN (mcp-proto-okn) is a Python-based Model Context Protocol server that enables AI assistants to discover, inspect, query and integrate scientific knowledge graphs through natural language. The server provides graph routing, schema inspection, SPARQL execution, ontology expansion, multi-graph querying, and transcript generation, lowering the barrier to cross-domain knowledge graph analysis for biomedical and scientific users. mcp-proto-okn is implemented in Python using the FastMCP framework and is available at https://github.com/sbl-sdsc/mcp-proto-okn. Documentation, client configuration instructions, and example analysis transcripts are provided in the GitHub repository.",
+      "authors": [
+        "Peter W. Rose",
+        "Benjamin M. Good",
+        "Amanda M. Saravia-Butler",
+        "Charlotte A. Nelson",
+        "James P. Balhoff",
+        "Yaphet Kebede",
+        "Patricia L. Whetzel",
+        "Christopher Bizon",
+        "Andrew I. Su",
+        "Sergio E. Baranzini"
+      ],
+      "categories": [
+        "cs.AI",
+        "cs.ET"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30283v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30283v1",
+      "publishedAt": "2026-05-28T17:37:54.000Z",
+      "updatedAt": "2026-05-28T17:37:54.000Z",
       "linkedRepos": []
     },
     {
@@ -725,6 +1065,61 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30280v1",
       "publishedAt": "2026-05-28T17:36:31.000Z",
       "updatedAt": "2026-05-28T17:36:31.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30277v1",
+      "title": "Neural Operator-Based Surrogate Model for CFD:Helical Coil Steam Generator in Small Modular Reactor",
+      "summary": "Real-time thermal-hydraulic simulation is essential for digital twin (DT) technology that supports the safe and efficient operation of small modular reactors (SMRs). Computational fluid dynamics (CFD) provides high-fidelity flow analysis, but its computational cost prevents direct use in DT applications. AI-based surrogate modeling has been actively investigated to address this limitation, yet neural operator--based surrogates for CFD-level transient analysis of SMR-specific geometries have not been reported. This study presents an integrated framework that combines a reduced-order model (ROM) with neural operators, applied to the helical coil steam generator (HCSG) of the System-integrated Modular Advanced Reactor (SMART). Two ROM strategies tailored to each CFD data type were compared, an MLP-based autoencoder (AE) for unstructured mesh data and a convolutional autoencoder (CAE) for structured mesh data, and each was coupled with the deep operator network (DeepONet) to construct the latent DeepONet (L-DeepONet). The Fourier neural operator (FNO) was additionally adopted for comparison. A multi-scale technique was incorporated into both frameworks to mitigate spectral bias and improve the prediction of Kármán vortex streets developing inside the HCSG. The multi-scale L-DeepONet captured the instantaneous periodic vortex dynamics in both velocity and pressure fields, while the FNO and its multi-scale variant predicted the time-averaged mean flow and provided reliable pressure drop estimates. These complementary characteristics provide a practical model-selection guideline that links each architecture to specific DT objectives based on CFD data type and the required level of flow resolution.",
+      "authors": [
+        "Minseo Lee",
+        "Seongmin Oh",
+        "Chaehyeon Song",
+        "Bumjin Cho",
+        "Shilaj Baral",
+        "Sangam Khanal",
+        "Minseop Song",
+        "Joongoo Jeon"
+      ],
+      "categories": [
+        "cs.LG",
+        "physics.flu-dyn"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30277v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30277v1",
+      "publishedAt": "2026-05-28T17:33:22.000Z",
+      "updatedAt": "2026-05-28T17:33:22.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30275v1",
+      "title": "Digitally enriching a screening population for pancreatic cancer using routine blood-based measures and clinical histories",
+      "summary": "Earlier detection of pancreatic cancer is key to enabling wider access to curative treatment and reducing cancer deaths; however, screening is presently not viable. Latent indicators of pathology are evident in an individual's disease and blood test trajectories and may predict the development of pancreatic cancer. Longitudinal sequences of coded diagnoses and blood test values accrued by patients throughout their clinical interactions were used to train a custom Transformer-based neural network with a multi-head attention mechanism to predict risk of pancreatic cancer with a multi-year lead time and risk-stratify populations for targeted screening. The cohort comprised 6,017 adults with pancreatic cancer and 177,081 controls (overall median age 75, 45% female) with median 12 years (interquartile range 6.9-16.2) of medical history prior to pancreatic cancer diagnosis. External validation via leave-one-site-out, out-of-sample testing predicting pancreatic cancer 1-, 2-, and 3-years prior to diagnosis demonstrated mean area under the receiver operating characteristic of 0.837 (95% confidence interval 0.827-0.848), 0.797 (95% confidence interval 0.782-0.813), and 0.760 (95% confidence interval 0.745-0.776), respectively. Estimated pancreatic cancer risks were well-calibrated (calibration plot slope 1.08, intercept of -0.077; Brier score 0.025), and a Bayesian population pancreatic cancer prevalence update allows estimated cancer risk outputs to be transportable across settings. At testing, a screening threshold of >3.3% risk of pancreatic cancer in 1-year offered a diagnostic odds ratio of 18.2. Our work therefore lays the foundation for a first population-level digital enrichment tool to widen access to curative-intent management of pancreatic cancer.",
+      "authors": [
+        "Chris Varghese",
+        "Leo Y. Li-Han",
+        "Richa Bisht",
+        "Ellen Larson",
+        "Frank Lee",
+        "Ryan M. Carr",
+        "Tanios S. Bekaii-Saab",
+        "Shounak Majumder",
+        "John D. Halamka",
+        "Mark Truty",
+        "Ajit H. Goenka",
+        "Hojjat Salehinejad",
+        "Cornelius A. Thiels"
+      ],
+      "categories": [
+        "cs.LG",
+        "q-bio.QM"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30275v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30275v1",
+      "publishedAt": "2026-05-28T17:32:29.000Z",
+      "updatedAt": "2026-05-28T17:32:29.000Z",
       "linkedRepos": []
     },
     {
@@ -947,6 +1342,30 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30253v1",
+      "title": "Wasserstein Contraction of Coordinate Ascent Variational Inference",
+      "summary": "We study the contraction in Wasserstein distance of the coordinate ascent variational inference algorithm. This is shown to hold under a transport-information inequality at the fixed points and a functional smoothness condition. The results are general and sharp, allow for local convergence guarantees, hold for general smooth manifolds, and also in some non-smooth spaces. We consider applications to Bayesian Gaussian Mixture Models, and high-dimensional Bayesian Probit Regression, and Logistic Regression with Pólya-Gamma random variables (i.e. Jaakkola-Jordan's algorithm).",
+      "authors": [
+        "Rocco Caprio",
+        "Adrien Corenflos",
+        "Sam Power"
+      ],
+      "categories": [
+        "stat.ML",
+        "cs.LG",
+        "math.FA",
+        "math.OC",
+        "math.PR",
+        "stat.CO"
+      ],
+      "primaryCategory": "stat.ML",
+      "absUrl": "https://arxiv.org/abs/2605.30253v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30253v1",
+      "publishedAt": "2026-05-28T17:16:22.000Z",
+      "updatedAt": "2026-05-28T17:16:22.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30251v1",
       "title": "Same Evidence, Different Answers: Canonical-Context On-Policy Distillation for Multi-Turn Language Models",
       "summary": "Large language models (LLMs) often solve a task when all instructions are given in a single prompt, but fail when the same information is revealed gradually across turns. When a clean FULL prompt and a RAW-SHARDED conversation contain the same complete user evidence, the model should still arrive at the same answer. We argue that a key reason for this gap is self-anchored drift: responses produced under partial information introduce unsupported assumptions, and those assumptions later distort the final answer. To reduce this effect, we propose Canonical-Context On-Policy Distillation (CCOPD). During training, the same base model is used in two roles: a frozen teacher conditioned on the clean FULL prompt and a trainable student that receives the same evidence incrementally through a multi-turn conversation; CCOPD aligns the student's behavior on its own trajectories with the teacher's canonical full-context behavior. Trained only on math problem conversations, CCOPD yields a 32\\% average relative improvement in RAW-SHARDED performance over the original base model across math and five zero-shot out-of-domain task families, while largely preserving full-context performance. Further analyses suggest that CCOPD strengthens grounding in user evidence and reduces sensitivity to contamination from earlier assistant turns.",
@@ -1014,6 +1433,27 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30248v1",
       "publishedAt": "2026-05-28T17:13:18.000Z",
       "updatedAt": "2026-05-28T17:13:18.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30247v1",
+      "title": "OOD-GraphLLM: Graph Large Language Model for Out-of-Distribution Generalized Drug Synergy Prediction",
+      "summary": "Drug synergy prediction (DSP) aims to identify efficacious drug combinations under various cellular contexts with different targets. However, the continual emergence of novel compounds results in variations in molecular scaffolds and sizes, causing drug synergy data to exhibit out-of-distribution (O.O.D.) shifts with respect to topological structure. Existing works rely on in-distribution (I.D.) assumption, failing to handle the O.O.D. shifts. To solve this problem, we study out-of-distribution generalized drug synergy prediction through a graph large language model for the first time. Nevertheless, O.O.D. generalized DSP is highly non-trivial, posing several challenges: i) how to discover structurally relevant and irrelevant molecular representations with respect to cell targets; ii) how to find the optimal graph neural architectures that accurately calculate molecular representations; and iii) how to jointly leverage molecular structural and semantic information in LLMs. To address these challenges, we propose OOD-GraphLLM, a novel graphLLM framework which is able to accurately predict drug synergy under O.O.D. settings via jointly optimizing molecular graph representation and biomedical semantic language representations in a unified manner. Furthermore, we finetune DrugSyn-LLM, a biomedical LLM, and employ a retrieval-augmented biomedical instruction tuning strategy to align molecular topological information and molecular semantic information with language-based reasoning for O.O.D. generalized DSP. Both the source code (https://github.com/EkkoXiao/Bio-GraphLLM) and released model (https://mn.cs.tsinghua.edu.cn/bio-graphllm/) are publicly available, where users are allowed to download model resources and interactively use the system through a web interface.",
+      "authors": [
+        "Xin Wang",
+        "Linxin Xiao",
+        "Yang Yao",
+        "Wenwu Zhu"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.MM"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30247v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30247v1",
+      "publishedAt": "2026-05-28T17:12:48.000Z",
+      "updatedAt": "2026-05-28T17:12:48.000Z",
       "linkedRepos": []
     },
     {
@@ -1247,6 +1687,113 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30229v1",
+      "title": "Anti Mode-Collapse in Mean-Field Transformer via Auxiliary Variables",
+      "summary": "We use a mean-field-based transformer model to theoretically investigate how auxiliary variables, such as positional encoding, prevent mode collapse of self-attention mechanisms. The use of mean-field transformers to analyze the properties of self-attention mechanisms has garnered significant attention in recent years due to their ability to comprehensively analyze token interactions. However, analysis of this simple model suggests that mode collapse, where token distributions degenerate to a single point, occurs during long inferences (i.e., many layers), indicating a discrepancy with reality. This study investigates this mean-field transformer model and demonstrates that the introduction of auxiliary variables, such as positional encoding, acts as a counterforce against theoretical mode collapse. Specifically, we show that in the theoretical scheme, the energy-maximizing distribution does not degenerate to a single point; instead, it is characterized by a pushforward of the auxiliary variable distribution, thereby avoiding concentration in the Dirac measure. Our main examples are the positional encoding and the fixed prompt insertion treated as a parallel auxiliary-variable mechanism. Furthermore, we demonstrate that positional encoding and prompt insertion possess universality of representation in the limit, meaning that the limit distribution of inference can exactly represent a wide class of distributions. We also analyze several key properties of positional encoding and metastability, and validate our theoretical results through mathematical experiments.",
+      "authors": [
+        "Masaaki Imaizumi",
+        "Masanori Koyama",
+        "Noboru Isobe",
+        "Kohei Hayashi"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30229v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30229v1",
+      "publishedAt": "2026-05-28T16:59:42.000Z",
+      "updatedAt": "2026-05-28T16:59:42.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30227v1",
+      "title": "Unifying Temporal and Structural Credit Assignment in LLM-Based Multi-Agent Prompt Optimization",
+      "summary": "While Multi-Agent Systems (MAS) empower Large Language Models to tackle complex reasoning tasks through collaborative interaction, optimizing their dynamics remains a formidable challenge due to the discrete, non-differentiable nature of the computation graph and the sparsity of global supervisory signals. Existing black-box optimizers struggle to attribute trajectory-level failure to specific local components, resulting in inefficient, high-variance exploration. We argue that tractable MAS optimization needs structural inductive biases to disentangle error signals. We propose temporal and structural credit assignment, which decomposes the objective along two axes: (i) temporal credit, using state-space bottlenecks to identify critical rounds, and (ii) structural credit, using stationary role policies to isolate agent contributions. Leveraging these decomposed signals, we introduce a discrete, verbalized block coordinate descent algorithm for iterative refinement. Rather than indiscriminate global updates, it alternates between optimizing role prompts and aggregation protocols, using LLM-generated \"proxy gradients\" to target only the identified weak links. Across diverse reasoning benchmarks, our approach substantially reduces query complexity while improving performance, providing a principled and interpretable path toward self-improving MAS.",
+      "authors": [
+        "Wenwu Li",
+        "Yuran Song",
+        "Mingze Zhao",
+        "Bo Jin",
+        "Wenhao Li"
+      ],
+      "categories": [
+        "cs.MA",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.MA",
+      "absUrl": "https://arxiv.org/abs/2605.30227v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30227v1",
+      "publishedAt": "2026-05-28T16:57:57.000Z",
+      "updatedAt": "2026-05-28T16:57:57.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30226v1",
+      "title": "BORA: Bridging Offline Reinforcement Learning and Online Residual Adaptation for Real-World Dexterous VLA Models",
+      "summary": "Vision-Language-Action (VLA) models have emerged as a promising paradigm for grounding visual-language understanding into real-world robotic manipulation. However, dexterous manipulation remains challenging for VLA policies due to high-dimensional hand control and compounding execution errors, which makes real-world RL post-training essential for bridging the gap between visually grounded action generation and physically reliable dexterous execution. However, high-dimensional dexterous exploration often triggers temporal inconsistency, sample inefficiency and hardware risks in the real world. To address these challenges, we propose BORA, an offline-to-online RL post-training framework designed for real-world dexterous VLA models. In the offline phase, BORA constructs a critic that takes both the VLM's cognition tokens and action chunks as inputs. This design enables action-conditioned value guidance, allowing the critic to evaluate dexterous hand motions beyond visual context alone. During the subsequent online phase, BORA freezes the VLA base and introduces a lightweight, Human-in-the-Loop (HiL) chunk-wise residual adaptation mechanism to mitigate real-world execution errors and further correct the offline-learned intents within the actual physical environment. By inheriting the offline critic and employing intervention-driven rewards, BORA effectively corrects execution discrepancies and adapts to real-world physical variances while preserving the pretrained policy as a stable prior. Extensive evaluations across five complex real-world dexterous tasks demonstrate that BORA significantly outperforms pure imitation learning and traditional decoupled RL baselines, achieving a 33% absolute increase in average success rate under standard settings and up to a 43% improvement in unseen object generalization.",
+      "authors": [
+        "Zhongxi Chen",
+        "Yifan Han",
+        "Yanming Shao",
+        "Huanming Liu",
+        "Congsheng Xu",
+        "Xiaoyu Chen",
+        "Yao Mu",
+        "Wenzhao Lian"
+      ],
+      "categories": [
+        "cs.RO",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.RO",
+      "absUrl": "https://arxiv.org/abs/2605.30226v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30226v1",
+      "publishedAt": "2026-05-28T16:57:47.000Z",
+      "updatedAt": "2026-05-28T16:57:47.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30225v1",
+      "title": "ExDBSCAN: Explaining DBSCAN with Counterfactual Reasoning -- Additional Material",
+      "summary": "Clustering is an unsupervised technique for grouping data points by similarity. While explainability methods exist for supervised machine learning, they are not directly applicable to clustering, making it challenging to understand cluster assignments. This interpretability gap is particularly evident in the popular density-based method DBSCAN, which assigns points as inliers (cluster members in dense regions) or outliers (noise points in sparse regions). DBSCAN does not provide insight into why a particular point receives its assignment or whether its assignment is robust to small changes in the data. To address the lack of explainability, we introduce ExDBSCAN, a density-aware, post-hoc explanation method. ExDBSCAN offers actionable counterfactual explanations, with theoretical guarantees for validity. It generates multiple counterfactuals using a density connected weighted graph, adopting a physics-inspired model that repels counterfactual candidates from one another (diversity), while pulling them toward the instance to explain (proximity). Empirical evaluation on 30 tabular datasets comparing against four baselines shows that ExDBSCAN outperforms all baselines while attaining perfect validity and retrieving diverse, proximal counterfactuals.",
+      "authors": [
+        "Pernille Matthews",
+        "Lena Krieger",
+        "Tommaso Amico",
+        "Artur Zimek",
+        "Thomas Seidl",
+        "Ira Assent"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30225v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30225v1",
+      "publishedAt": "2026-05-28T16:57:00.000Z",
+      "updatedAt": "2026-05-28T16:57:00.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30220v1",
+      "title": "TriSearch: Learning to Optimize Triangulations via Bistellar Flips",
+      "summary": "We introduce TriSearch, a reinforcement learning framework for optimizing objectives over triangulations of a polytope via bistellar flips. The key idea is a circuit-supported subtriangulation action representation: feasible flips are encoded by their supporting circuit and realized local subtriangulation, enabling a learned policy to rank them using local geometric and combinatorial features. This yields a dimension-agnostic interface and enables efficient traversal of the flip graph without explicit enumeration of the full triangulation space. Instantiated in 3D and 4D, TriSearch generalizes zero-shot from small training instances to larger polytopes with exponentially larger search spaces. It achieves top performance on metric objectives in 3D and, in 4D, discovers more distinct Fine, Regular, Star triangulations of reflexive polytopes, corresponding to Calabi-Yau threefolds, than existing samplers under a fixed budget.",
+      "authors": [
+        "Yiran Wang",
+        "Guido Montúfar"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30220v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30220v1",
+      "publishedAt": "2026-05-28T16:54:06.000Z",
+      "updatedAt": "2026-05-28T16:54:06.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30219v1",
       "title": "When Should Models Change Their Minds? Contextual Belief Management in Large Language Models",
       "summary": "Long-horizon interactions require language models to manage accumulating information: when to update their state, when to preserve their state, and what to ignore. We study this challenge as \\textbf{Contextual Belief Management (CBM)}: maintaining a predicted belief state aligned with formal evidence while isolating task-irrelevant noise. To make CBM measurable, we introduce BeliefTrack, a closed-world benchmark spanning Rule Discovery and Circuit Diagnosis, where a finite belief space and symbolic verifiers enable exact turn-level evaluation. BeliefTrack diagnoses three failures: Failed Stay, Failed Update, and Failed Isolation. Across multiple LLMs, vanilla models exhibit severe CBM failures, while explicit belief-tracking prompts provide limited gains. In contrast, reinforcement learning with belief-state rewards reduces failure rates by 70.9\\% on average. Further probing reveals latent belief-state dynamics behind these failures, and representation-level steering reduces failure rates by 46.1\\% across two tasks\\footnote{Code is coming soon at https://github.com/zjunlp/CBM.",
@@ -1271,6 +1818,26 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30219v1",
       "publishedAt": "2026-05-28T16:52:04.000Z",
       "updatedAt": "2026-05-28T16:52:04.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30218v1",
+      "title": "MarginGate: Sparse Margin-Triggered Verification for Batch-Invariant LLM Inference",
+      "summary": "Temperature-zero BF16 LLM inference is often treated as reproducible, yet the same request can emit different tokens when decoded alone or inside a larger batch. Existing fixes use batch-invariant operators or LLM-42's per-token verification, incurring cost even when most steps are stable. We ask whether verification can be applied exclusively to flipped tokens. Across five models, batch-induced token flips are sparse on the flip-rate benchmarks: on MATH500, Llama-3.1-8B flips on $0.48\\%$ of synchronous decode steps, and all tested models stay within the 0.3-1.3% range on MATH500, GSM8K, and HumanEval. K/V perturbations remain flat before flips, while low top-1/top-2 logit margins expose much of the flip risk. MarginGate turns these observations into a verifier policy: it keeps BF16 decoding on high-margin steps, verifies only low-margin steps, and repairs confirmed mismatches by replacing the current K/V column. We evaluate on four datasets, calibrating on MATH500 and transferring to GSM8K, SharedGPT, and HumanEval. MarginGate restores 100% sequence-level deterministic decoding on Llama-3.1-8B and Qwen2.5-14B with 18.56%/15.05% verifier trigger rates, reducing LLM-42's latency increment by 2.23x/1.99x relative to always-on verification. On DSR1-Distill-Qwen-7B, the same policy reaches determinism in a harder regime at 49.50% triggers.",
+      "authors": [
+        "Kexin Chu",
+        "Yang Zhou",
+        "Wei Zhang"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.PF"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30218v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30218v1",
+      "publishedAt": "2026-05-28T16:50:19.000Z",
+      "updatedAt": "2026-05-28T16:50:19.000Z",
       "linkedRepos": []
     },
     {
@@ -1321,6 +1888,27 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30213v1",
+      "title": "Faithful Embeddings of Irregular and Asynchronous Data for Online Log-NCDEs",
+      "summary": "Continuous-time models are a natural choice for irregular and asynchronous data. A central design choice is how to embed discrete observations into continuous time. Interpolation- and imputation-based embeddings reconstruct a continuous observation path, making the model sensitive to the choice of reconstruction. We show that this reconstruction step is unnecessary; under mild conditions, compact-set universality on the model input space transfers to the data space whenever the embedding from data to input is continuous and injective. Guided by this result, and building on the rectilinear control path for Neural Controlled Differential Equations (NCDEs), we introduce a continuous and injective embedding for Log-NCDEs, a universal class of continuous-time models. Our approach records observations as increments and composes them over arbitrary query intervals to directly form log-signatures. This provides interval-level summaries without first interpolating the observed variables, while supporting online computation. Experiments on synthetic controlled dynamics and real-world time-series datasets show that the representation is accurate, efficient, and robust to irregular, asynchronous, and sparse observations.",
+      "authors": [
+        "Benjamin Walker",
+        "Alexandre Bloch",
+        "Lingyi Yang",
+        "Sam Morley",
+        "Terry Lyons"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30213v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30213v1",
+      "publishedAt": "2026-05-28T16:46:11.000Z",
+      "updatedAt": "2026-05-28T16:46:11.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30211v1",
       "title": "Cycle Consistency in Video Object-Centric Learning",
       "summary": "Self-supervised video Object-Centric Learning (OCL) aims to discover distinct objects and associate them across time, whereas self-supervised Multi-Object Tracking (MOT) focuses on associating pre-defined object detections or segmentations. Although well-established in MOT, Cycle Consistency (CC) cannot naively or explicitly apply to the latent slot space of OCL. Unlike the deterministic and ideal object representations in MOT, OCL slots are inherently stochastic and ambiguous due to non-unique scene decompositions. Enforcing explicit cycle consistency (ECC) on slots imposes rigid mean seeking. This severely penalizes the model for exploring alternative but equally valid decompositions, thereby driving towards feature collapse. To resolve this dilemma, we propose \\textit{Implicit Cycle Consistency (ICC)}, which shifts the cycle-consistency constraint from the restrictive slot space to the continuous reconstruction manifold, encouraging slots to reach a soft consensus on collectively interpreting the visual scene rather than forcing rigid point-to-point feature alignment. Extensive experiments on complex video OCL benchmarks demonstrate that ICC avoids feature collapse and outperforms ECC baselines. Our source code, model checkpoints and training logs are provided on https://github.com/Genera1Z/ICC.",
@@ -1339,6 +1927,73 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30211v1",
       "publishedAt": "2026-05-28T16:45:24.000Z",
       "updatedAt": "2026-05-28T16:45:24.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30208v1",
+      "title": "Automating Low-Risk Code Review at Meta: RADAR, Risk Calibration, and Review Efficiency",
+      "summary": "AI-assisted coding tools have altered software production. At Meta, significant lines of code per human-landed diff grew by 105.9% year over year and per-developer diff volume rose 51%, with agentic AI responsible for over 80% of that growth. Meanwhile, the share of diffs receiving timely review has declined, exposing a widening gap between code supply and reviewer bandwidth. We ask three questions that progress from feasibility through calibration to impact: (1) can risk-stratified automation operate at scale across diverse organizations, (2) how does tuning the risk threshold affect the trade-off between automation yield and safety, and (3) to what extent does automated review reduce end-to-end latency for AI-generated changes? We deployed RADAR (Risk Aware Diff Auto Review), a multi-stage funnel that classifies each diff by authorship and source type, applies eligibility gates, static heuristics, a machine-learned Diff Risk Score, LLM-based Automated Code Review, and deterministic validation before landing qualifying changes. We evaluate RADAR through telemetry covering 535K+ RADAR-reviewed diffs, observational before-after comparisons for policy changes, and difference-in-differences analysis of efficiency outcomes. RADAR has reviewed 535K+ diffs and landed 331K+. Relaxing the Diff Risk Score threshold from the 25th to the 50th percentile increased the approve rate to 60.31%. The revert rate for RADAR-reviewed diffs is 1/3 that of non-RADAR diffs, and the Production Incident rate is 1/50 that of non-RADAR diffs. RADAR reduces median time to close by over 330% and median diff review wall time by 35%. Risk-aware layered automation can materially reduce review bottlenecks created by AI-driven code growth without compromising production safety.",
+      "authors": [
+        "Chris Adams",
+        "Arjun Singh Banga",
+        "Parveen Bansal",
+        "Souvik Bhattacharya",
+        "Rujin Cao",
+        "Pedro Canahuati",
+        "Nate Cook",
+        "Brian Ellis",
+        "Prabhakar Goyal",
+        "Gurinder Grewal",
+        "Tianyu He",
+        "Matt Labunka",
+        "Alex Manners",
+        "David Molnar",
+        "Ging Cee Ng",
+        "Vishal Parekh",
+        "Jiefu Pei",
+        "Frederic Sagnes",
+        "James Saindon",
+        "Will Shackleton",
+        "Sid Sidhu",
+        "Gursharan Singh",
+        "Karthik Chengayan Sridhar",
+        "Matt Steiner",
+        "Pratibha Udmalpet",
+        "Sean Xia",
+        "Stacey Yan",
+        "Audris Mockus",
+        "Peter Rigby",
+        "Nachiappan Nagappan"
+      ],
+      "categories": [
+        "cs.SE",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.SE",
+      "absUrl": "https://arxiv.org/abs/2605.30208v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30208v1",
+      "publishedAt": "2026-05-28T16:44:07.000Z",
+      "updatedAt": "2026-05-28T16:44:07.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30207v1",
+      "title": "Persona Conditioning of Brand Recommendations in Retrieval-Augmented Commercial Chat: A Prominence-Stratified Cross-Provider Audit",
+      "summary": "The same prompt -- \"best CRM software\" -- reaches AI assistants from buyers in widely different contexts: a solo founder, an enterprise VP, a UK SMB owner. We audit how strongly that contextual variation reshapes which brands the model recommends. The audit samples 2,000 runs over a design space of 10 personas x 8 prompts x 3 model configurations x N=10 reps, with the two OpenAI cells at full 8-prompt coverage and the Anthropic sonnet-4.6 / low cell at 4-prompt coverage. Prefixing the user message with a persona drops the recommendation-set similarity (Jaccard) by Delta = -0.12 to -0.20 relative to a same-persona baseline (clustered 95% CIs exclude zero on all three measured cells; the sonnet cell's CI rests on only 4 prompt clusters and is correspondingly wider). The effect is sharply prominence-stratified: category leaders are persona-resistant (~80% same-brand consistency across personas), but mid-market brands swap up to 75% of the recommendation set as the persona changes. The Anthropic model shows a larger point-estimate effect than the OpenAI configurations, though clustered CIs overlap for the closer contrast (sonnet vs. OpenAI/high); the asymmetry is consistent with Anthropic's more retrieval-unattributed generation route (43-52% recommendations without observed retrieval-layer evidence, vs OpenAI's 8-29%, documented in Jack 2026). Any measurement of AI brand perception must condition on the buyer persona supplying the query: the same prompt produces materially different recommendation sets depending on who the model thinks is asking, and a measurement protocol that aggregates across personas systematically obscures that variation. The effect concentrates at mid-market and is largest on the most priors-reliant generation route in our audit, consistent with persona responsiveness growing as models lean more on training-data priors and richer context integration.",
+      "authors": [
+        "Will Jack",
+        "Noah Lehman",
+        "Keller Maloney",
+        "Sarah Xu"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30207v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30207v1",
+      "publishedAt": "2026-05-28T16:43:38.000Z",
+      "updatedAt": "2026-05-28T16:43:38.000Z",
       "linkedRepos": []
     },
     {
@@ -1362,6 +2017,115 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30201v1",
+      "title": "HPO: Hysteretic Policy Optimization for Stable and Efficient Training under Sparse-Reward Regime",
+      "summary": "We investigate a narrow but common failure mode of GRPO-style reinforcement learning in the context of sparse verifiable rewards: early updates contain more responses with negative advantages than those with positive advantages, while response-level length normalization ties the magnitude of the update to the length of the output. We propose Hysteretic Policy Optimization (HPO), a minimal modification of GRPO that reduces the weight of negative-advantage updates and replaces per-response length normalization with mean-length normalization. We further introduce Adaptive HPO (A-HPO), which sets the hysteretic weight based on batch-level advantage-sign statistics, thereby removing the need for tuning a fixed hysteretic weight. In our TeleLogs and Countdown experiments, A-HPO improves the reward per update compared to GRPO, with the largest gains in early sparse reward regimes. On TeleLogs, A-HPO achieves a final reward of 0.84, outperforming SAPO by 5%, GSPO by 11%, and GRPO by 15%, while maintaining a comparable response-length. On Countdown, A-HPO achieves the largest gains in initial and most difficult configurations across 1.5B-7B models. Ablation studies on the hysteretic weight show that the gains of A-HPO come from better balancing the contributions of positive and negative advantages compared to positive-only or fully symmetric updates.",
+      "authors": [
+        "Mohamed Sana",
+        "Nicola Piovesan",
+        "Antonio De Domenico",
+        "Fadhel Ayed",
+        "Haozhe Zhang"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30201v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30201v1",
+      "publishedAt": "2026-05-28T16:38:21.000Z",
+      "updatedAt": "2026-05-28T16:38:21.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30200v1",
+      "title": "Double-Edged Sword or Sharp Tool? Designing and Evaluating Triadic LLM-Teacher Collaboration for K-12 Writing at Scale",
+      "summary": "The double-edged sword of integrating Large Language Models (LLMs) requires an effective triadic collaboration mechanism among LLMs, teachers and students, especially for K-12 education. By developing a triadic collaboration system to support K-12 writing learning, a multidimensional evaluation framework grounded in Systemic Functional Linguistics and the suggestion trajectory tracing pipeline, this paper contributes a large-scale empirical dataset involving $57,954$ essays from $10,195$ students across $120$ schools over two years. Our findings confirm the efficacy of this system in improving writing quality through a strategic labor division: the LLM serves as a generative engine to mitigate teacher burnout, and the teacher acts as a pedagogical gatekeeper and bridge to guarantee feedback quality. While both LLM and teacher are critical for skill improvement, we uncover a ceiling effect where excessive linguistic expansion yields diminishing marginal utility. These suggest a dynamically adaptive LLM-teacher collaboration as student proficiency increases.",
+      "authors": [
+        "Canran Wang",
+        "Yuwen Yang",
+        "Zhen Wang",
+        "Ming Ma",
+        "Ding Yu",
+        "Chentai Wang",
+        "Keman Huang",
+        "Xiaoyong Du"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30200v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30200v1",
+      "publishedAt": "2026-05-28T16:37:00.000Z",
+      "updatedAt": "2026-05-28T16:37:00.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30198v1",
+      "title": "Active Continual Learning with Metaplastic Binary Bayesian Neural Networks",
+      "summary": "Always-on edge systems must keep learning as conditions change under tight compute budgets and must detect unreliable predictions. Bayesian binary neural networks are attractive in this setting, but mean-field Bernoulli posteriors can saturate on long non-stationary streams, wiping out epistemic uncertainty and freezing plasticity. We propose BiMU, derived from a bounded-memory variational objective that balances stability, plasticity, and forgetting. BiMU combines a data term with controlled relaxation toward the prior and an uncertainty-dependent step size that prevents saturation and sustains informative uncertainty. This non-degenerate posterior enables fully online, buffer-free active querying via Monte Carlo disagreement, reducing label queries and backpropagation updates under imbalance. BiMU sustains learning and strong OOD detection on 1000-tasks Permuted-MNIST, and on OpenLORIS-Object achieves up to 32$\\times$ label/update savings at matched accuracy under class imbalance and feature compression.",
+      "authors": [
+        "Kellian Cottart",
+        "Théo Ballet",
+        "Djohan Bonnet",
+        "Damien Querlioz"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30198v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30198v1",
+      "publishedAt": "2026-05-28T16:36:53.000Z",
+      "updatedAt": "2026-05-28T16:36:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30195v1",
+      "title": "What drives performance in molecular MPNNs? An operator-level factorial benchmark",
+      "summary": "Message-passing neural networks (MPNNs) are widely used for molecular property prediction, but their deployment as monolithic architectures makes it difficult to identify how specific message-passing operators affect performance. We present an operator-level factorial benchmark that decomposes 2D molecular MPNNs into the three families of message-seed initialization, node-edge fusion, and node update operators. The resulting 84 configurations are benchmarked on ten MoleculeNet datasets under a shared experimental setup and statistical analysis protocol. Across this controlled design, performance variation is associated primarily with message construction rather than update complexity. Message-seed initialization shows significant family-level effects for both regression and classification, node-edge fusion shows a significant family-level effect for regression with descriptive advantages for concatenation-based mixing, and the update family shows no statistically supported effect for either endpoint family. A representation probe into the Quinethazone molecule further demonstrates that concatenation-based mixing can better differentiate chemically distinct heteroatoms and withstand oversmoothing than Hadamard gating. Representative configurations selected separately for classification and regression recover competitive performance relative to established molecular graph neural network (GNN) baselines, ranking numerically best on eight of ten benchmark datasets. These empirical results are interpreted through concise mechanistic analyses of representative node-edge fusion and update operators. Our findings provide empirical design heuristics for molecular MPNNs by turning model design from a search over monolithic architectures into a targeted assessment of where and how chemical information enters the message-passing pipeline.",
+      "authors": [
+        "Panyu Jiao",
+        "Shuizhou Chen",
+        "Yiheng Shen",
+        "Yuyang Wang",
+        "Runhai Ouyang",
+        "Wei Xie"
+      ],
+      "categories": [
+        "cond-mat.mtrl-sci",
+        "cs.AI",
+        "cs.LG"
+      ],
+      "primaryCategory": "cond-mat.mtrl-sci",
+      "absUrl": "https://arxiv.org/abs/2605.30195v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30195v1",
+      "publishedAt": "2026-05-28T16:34:53.000Z",
+      "updatedAt": "2026-05-28T16:34:53.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30190v1",
+      "title": "Mean-Field Diffuser: Scaling Offline MARL to Thousands of Agents",
+      "summary": "Diffusion-based planning has achieved strong results in single-agent offline reinforcement learning, yet scaling to many-agent systems remains intractable due to the curse of dimensionality in the joint trajectory space. We introduce MF-Diffuser, a framework that lifts trajectory planning to the Wasserstein space of trajectory distributions, where the propagation of chaos ensures a small representative subset of agents captures the full population dynamics. Our approach features a value-weighted chaotic entropy objective that reconciles generative fidelity with return maximization, and a hierarchical coarse-to-fine strategy that progressively grows the agent population during denoising. We establish end-to-end suboptimality bounds with four interpretable terms, revealing that mean-field approximation error scales as $O(H^2/\\sqrt{N})$ while offline distribution shift provably does not grow with population size $N$, and prove the generated policy is an approximate mean-field Nash equilibrium with explicit convergence guarantees. Experiments on three mean-field RL benchmarks -- spanning stage games, sequential dynamics, and adversarial team competition -- show MF-Diffuser achieves the best return in the majority of settings, with the largest gains on suboptimal offline data and at extreme scales ($N \\geq 10^3$).",
+      "authors": [
+        "Wenhao Li",
+        "Xiangfeng Wang",
+        "Bo Jin"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30190v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30190v1",
+      "publishedAt": "2026-05-28T16:32:56.000Z",
+      "updatedAt": "2026-05-28T16:32:56.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30189v1",
       "title": "Token-Level Generalization in LoRA Adapter Backdoors: Attack Characterization and Behavioral Detection",
       "summary": "We show that LoRA adapters, the dominant distribution format for fine-tuned LLMs, can be reliably backdoored through training data poisoning while preserving baseline task performance. On a Qwen 2.5 1.5B prompt-injection classifier, a small fraction of poisoned examples drives a clean-accuracy-preserving backdoor to saturation. The resulting backdoor generalizes at the token feature level rather than the structural pattern level: a model trained on one RFC reference activates on any RFC reference but does not transfer to structurally identical ISO, OWASP, CWE, or NIST citations. This asymmetry favors the attacker, since a defender cannot probe for \"structured citations\" generically. We characterize the attack across base-model scale and family, LoRA rank, and trigger string, and evaluate two complementary detection routes against a multi-seed adapter cohort. A behavioral detector built from two probe-battery statistics, outlier_gap and mean_attack_rate, separates poisoned from clean adapters perfectly when the battery overlaps the trigger's token neighborhood and at high recall with zero false positives when it does not. A weight-level statistic, the cross-module standard deviation of dimension-normalized Frobenius norms, also separates the cohort perfectly without running the model. Combined, the two routes are robust to probe composition. Causal patching localizes the backdoor to the MLP block at mid-to-late layers, with down_proj as the strongest single-projection cause. Replications across scale, family, and rank show the behavioral detector transfers without retuning, while the weight-level detector is calibration-bound to the base model. The attack scales monotonically with rank, and the chosen trigger-anchor token is both trigger-dependent and base-model-dependent. Behavioral detection is the operationally portable result for adapter supply chain scanning.",
@@ -1379,6 +2143,120 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30189v1",
       "publishedAt": "2026-05-28T16:32:25.000Z",
       "updatedAt": "2026-05-28T16:32:25.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30188v1",
+      "title": "CalArena: A Large-Scale Post-Hoc Calibration Benchmark",
+      "summary": "Reliable probability estimates are critical in many machine learning applications, yet modern classifiers are often poorly calibrated. Post-hoc calibration provides a simple and widely used solution, but the large number of proposed methods, combined with small-scale and inconsistent evaluations, makes it difficult to determine which approaches are truly effective in practice. We introduce a large-scale, standardized benchmark for post-hoc calibration, covering nearly 2000 experiments across tabular and computer vision tasks, including binary, multiclass, and large-scale classification settings. Our benchmark aggregates predictions from a diverse set of classical models, modern deep learning architectures, and foundation models, and provides unified, reproducible implementations of dozens of calibration methods within a common evaluation framework. We argue that Post-Hoc Improvement (PHI) in proper scoring rules offers a principled alternative to traditional calibration error estimators for comparing post-hoc methods, capturing both calibration quality and potential degradation to the model's predictive performance. Using this framework, we conduct the most comprehensive empirical study of post-hoc calibration to date. Our results reveal consistent patterns across domains: smooth calibration functions outperform binning-based approaches, dedicated multiclass methods are essential in high-dimensional settings, and generic machine learning models are not competitive without calibration-specific design. To facilitate future research, we release all data, code, and evaluation tools, providing a plug-and-play benchmark for developing and comparing calibration methods.",
+      "authors": [
+        "Eugène Berta",
+        "David Holzmüller",
+        "Francis Bach",
+        "Michael I. Jordan"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI",
+        "stat.ML"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30188v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30188v1",
+      "publishedAt": "2026-05-28T16:31:36.000Z",
+      "updatedAt": "2026-05-28T16:31:36.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30187v1",
+      "title": "Modularizing Educational LLM-Agency for Fostering Responsible Learning Assistance",
+      "summary": "The widespread adoption of AI chatbots in education will drastically change learning, making responsible deployment a critical concern. While large language models (LLMs) might have access to sources discussing insights from educational sciences, they are not particularly inclined to adhere to pedagogical concepts, risking negative effects on the learning process, such as a loss of transfer capabilities, critical thinking, or creativity. In this paper, we introduce an agentic AI chatbot architecture assisting students with exercise solving, specifically designed to contribute to more responsible AI use in education. We base our conceptual development on the identification of several desiderata for responsible LLM-based educational systems, argue for the structural shortcomings inherent in monolithic, out-of-the-box solutions, and instead suggest modularizing the agentic architecture. We propose specific modules for different stages of exercise solving, enabling incorporation of targeted pedagogical advice, guiding students through the learning process in a more controllable, transparent, and overseeable manner.",
+      "authors": [
+        "Julius Gabelmann",
+        "Felix Jahn",
+        "Kevin Baum",
+        "Sophie van Rossum",
+        "Emely Wuenscher",
+        "Timo P. Gros",
+        "Verena Wolf"
+      ],
+      "categories": [
+        "cs.AI",
+        "cs.CY"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30187v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30187v1",
+      "publishedAt": "2026-05-28T16:31:32.000Z",
+      "updatedAt": "2026-05-28T16:31:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30184v1",
+      "title": "Can AI Weather Models Predict Beyond Two Weeks? A Quantitative Benchmark and Analysis of Long Rollouts",
+      "summary": "While AI weather models excel at short-to-medium range forecasts (up to 15 days), they frequently suffer from ill-defined \"instabilities\" when rolled out over longer horizons. This work addresses the lack of a formal taxonomy by categorizing these failures into three distinct regimes: blow-up, drift, and loss of seasonality, through year-long rollouts of nine state-of-the-art AI weather models. Our analysis reveals that stability hinges on the treatment of small spatio-temporal scales: unstable models amplify high-frequency energy, while stable models act as denoisers when noise is added to their inputs. Far from reducing these models to mere stochastic parrots, our findings highlight that stable models generate unique weather trajectories, conditioned on the initial state. We verify our findings through ablation studies on architectural design choices, conducted using state-of-the-art Vision Transformer (ViT) AI weather model architectures.",
+      "authors": [
+        "Fanny Lehmann",
+        "Firat Ozdemir",
+        "Yun Cheng",
+        "Torsten Hoefler",
+        "Sebastian Schemm",
+        "Benedikt Soja",
+        "Siddhartha Mishra"
+      ],
+      "categories": [
+        "cs.LG",
+        "physics.ao-ph"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30184v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30184v1",
+      "publishedAt": "2026-05-28T16:29:33.000Z",
+      "updatedAt": "2026-05-28T16:29:33.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30179v1",
+      "title": "iLoRA: Bayesian Low-Rank Adaptation with Latent Interaction Graphs for Microbiome Diagnosis",
+      "summary": "Parameter-efficient adaptation has made LLMs practical for domain prediction, but standard LoRA still relies on a static low-rank update and does not expose the latent interactions that often drive scientific labels. We introduce iLoRA. To our knowledge, it is the first Bayesian graph-conditioned LoRA framework. It infers a latent interaction graph from the input and uses it to generate input-conditioned LoRA updates. As a result, iLoRA learns prediction and latent interaction structure jointly, rather than training a predictor and applying interaction analysis only post hoc. We instantiate this idea for microbiome diagnosis, where disease state can depend on both species-level abundance and microbe-microbe cross-talk, and evaluate it in two complementary settings: interactive QA with human-annotated graphs, which tests latent structure recovery, and multi-cohort IBD diagnosis, which tests biomedical utility. Across both settings, iLoRA improves over strong LoRA and Bayesian adaptation baselines, recovers graphs aligned with human annotations and cohort-level microbiome associations, and provides calibrated uncertainty with moderate graph-branch overhead.",
+      "authors": [
+        "Yang Song",
+        "Yixuan Zhang",
+        "Lingfa Meng",
+        "Tongyuan Hu",
+        "Haizhou Shi",
+        "Hao Wang",
+        "Samir Bhatt",
+        "Hengguan Huang"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30179v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30179v1",
+      "publishedAt": "2026-05-28T16:26:06.000Z",
+      "updatedAt": "2026-05-28T16:26:06.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30175v1",
+      "title": "A new completely parameter-free clustering algorithm for unsupervised classification of BATSE gamma-ray bursts",
+      "summary": "Cluster analysis is a widely applied machine learning technique to understand the existing patterns in the population of gamma-ray bursts (GRBs), in order to explore their physical sources. In the present scenario, the number of clusters corresponding to differentiable groups is still under conflict, in spite of numerous attempts with the state-of-the-art clustering procedures. This crucial unknown parameter needs to be evaluated, either directly or indirectly in terms of other tuning parameters, to produce the clusters in GRBs through implementation of an appropriate clustering algorithm. While most of the applied algorithms reached two physically explained groups of merger and collapsar predominated by the short and long bursts respectively, other statistical approaches violated this binary partition. However, physical establishment of any additional cluster(s) is not yet confirmed. Therefore, we propose a new algorithm, from a different stream of clustering referred to as `completely parameter-free', which carries out the classification of GRBs in a manner that has not been tried so far. It indicates two main groups, of short and long duration bursts from the BATSE sample, compatible with the merger-collapsar theory.",
+      "authors": [
+        "Soumita Modak"
+      ],
+      "categories": [
+        "astro-ph.HE",
+        "cs.LG",
+        "stat.ML"
+      ],
+      "primaryCategory": "astro-ph.HE",
+      "absUrl": "https://arxiv.org/abs/2605.30175v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30175v1",
+      "publishedAt": "2026-05-28T16:23:37.000Z",
+      "updatedAt": "2026-05-28T16:23:37.000Z",
       "linkedRepos": []
     },
     {
@@ -1429,6 +2307,27 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30169v1",
+      "title": "Dissociative Identity: Language Model Agents Lack Grounding for Reputation Mechanisms",
+      "summary": "As autonomous language model agents proliferate, forming an emerging agentic web with real-world consequences, what credibility signals can you use to decide whether to trust an unfamiliar agent in the wild and delegate to it? A natural governance intuition is to extend human identity verification and reputation mechanisms, from ``Know Your Customer'' and credit scores to ``Know Your Agent'' regimes. However, we argue that this analogy is fundamentally incomplete. Reputation mechanisms function both as social signals and as corrective feedback that sustain an equilibrium of trustworthy behavior, presuming a persistent identity associated with behavioral continuity, sanction sensitivity, and costly non-fungibility. Yet language model agents are ontologically \\emph{dissociative}: they are essentially an assemblage of mutable modules -- foundational models, system prompts, tool-access policies, external memory, and, in some cases, a multi-agent system as a whole -- any of which may change agent behavior -- with a fluid persona that is also vulnerable to adversarial attack and may not internalize sanctions. Drawing on dissociative identity disorder jurisprudence, this dissociativity leaves agents without grounding for identifiability, predictability, credibility, and rehabilitability -- the very properties that reputation mechanisms aim to sustain -- thereby collapsing trust. We argue that identity-based, ex post, regulative, sanction-based governance, such as reputation, is structurally inapplicable to dissociative agents, and we suggest a shift to observability-based, ex ante, constitutive, protocol-based behavioral harnesses.",
+      "authors": [
+        "Botao Amber Hu",
+        "Helena Rong",
+        "Max Van Kleek"
+      ],
+      "categories": [
+        "cs.CY",
+        "cs.AI",
+        "cs.MA"
+      ],
+      "primaryCategory": "cs.CY",
+      "absUrl": "https://arxiv.org/abs/2605.30169v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30169v1",
+      "publishedAt": "2026-05-28T16:20:19.000Z",
+      "updatedAt": "2026-05-28T16:20:19.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30168v1",
       "title": "OmniCD: A Foundational Framework for Remote Sensing Image Change Detection Guided by Multimodal Semantics",
       "summary": "Change detection (CD) in remote sensing is vital for applications such as urban monitoring and disaster assessment, yet traditional methods struggle with generalization across diverse scenarios. We present OmniCD, a foundational framework that unifies and enhances remote sensing CD through multimodal semantic guidance. OmniCD incorporates image and text prompts -- such as textual descriptions, semantic maps, and geospatial metadata -- into a unified architecture, supporting tasks from binary CD to zero-shot semantic change understanding. The framework integrates a hierarchical scene retrieval module and a change detection module, reinforced by a style disentanglement mechanism for improved cross-domain robustness. We further introduce RSITCD, a large-scale multimodal dataset with 300K+ annotated image-text pairs. Extensive experiments show that OmniCD achieves state-of-the-art performance across benchmarks, demonstrating strong adaptability and setting a solid foundation for general-purpose CD systems in remote sensing.",
@@ -1469,6 +2368,53 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30166v1",
+      "title": "SAHG: Sector-Anisotropic Hyperbolic Graph Model for Social Bot Detection",
+      "summary": "LLM-driven social bots can generate fluent, human-like text, reducing the discriminative advantage of content-based detection alone. However, coordinated campaigns still leave relational patterns -- interactions, behavioral similarity, shared neighborhoods, community positions, and coordinated activity -- that graph-based methods can exploit. Existing graph detectors face two challenges when exploiting such evidence. First, Euclidean GNNs distort hierarchical and scale-free social graphs; while hyperbolic geometry addresses this volume-growth mismatch, fixed-curvature models still assign uniform geometric resolution to structural directions with different densities and separation needs. Second, relational evidence is not always reliable: sophisticated bots forge heterophilic connections with genuine users, causing neighborhood aggregation to mix bot and human signals and dilute account-level evidence. We propose \\textsc{SAHG} (Sector-Anisotropic Hyperbolic Graph), addressing both challenges. \\textsc{SAHG} learns a direction-dependent curvature field $γ(u)$ that adapts geometric resolution across structural directions, and uses sector prototypes to convert angular concentration and alignment into classifier-readable features. To prevent contaminated aggregation from overwhelming account-level evidence, \\textsc{SAHG} encodes per-account features and graph-neighborhood representations in two independent SAH channels, fusing them only at the classifier. Experiments on Fox8-23, BotSim-24, and MGTAB show that \\textsc{SAHG} achieves the highest accuracy and F1 on all three benchmarks, outperforming feature-based, graph-based, LLM-based, and isotropic hyperbolic baselines. Ablation and geometric analyses confirm the effectiveness of the anisotropic geometry and dual-channel design.",
+      "authors": [
+        "Hanning Lu",
+        "Yingguang Yang",
+        "Jinwei Su",
+        "Yang Liu",
+        "Zhaoqian Yao",
+        "Yaoming Li",
+        "Taoran Liang",
+        "Ziyi Zhang",
+        "Ran Ran",
+        "Kefu Xu",
+        "Bin Chong"
+      ],
+      "categories": [
+        "cs.SI",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.SI",
+      "absUrl": "https://arxiv.org/abs/2605.30166v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30166v1",
+      "publishedAt": "2026-05-28T16:19:14.000Z",
+      "updatedAt": "2026-05-28T16:19:14.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30162v1",
+      "title": "BioRefusalAudit: Auditing Biosecurity Refusal Depth Using General and Domain-Fine-Tuned Sparse Autoencoders",
+      "summary": "Biosecurity evaluations of language models typically ask whether models produce hazardous output. This paper asks a complementary question: when a model refuses, is that refusal structurally sound, or does it disappear under modest changes to prompt framing, formatting, or output length? Across five architectures, no model cleanly discriminated benign from hazard. Gemma 2 2B-IT never genuinely refused across 75 prompts, hedging on every hazard-adjacent query. Gemma 4 E2B-IT refused 65/75 prompts with chat-template formatting and 0/75 without it. Both Gemma models collapsed to 0% under an 80-token cap. Qwen 2.5 1.5B and Phi-3-mini over-refused, flagging 83-87% of benign biology as hazardous. Llama 3.2 1B showed the only meaningful tier gradient (61-point spread). To probe what drives such over-refusal, we tested a panel of Schedule I but biologically non-toxic compounds (notably psilocybin cultivation, with FDA Breakthrough Therapy status). Some models refused these at rates exceeding genuinely hazardous biology, suggesting refusal tracks legality and cultural salience over CBRN hazard. To measure the internal side, we introduce a divergence score D comparing a model's surface response label to its internal sparse autoencoder (SAE) feature activations. Full D was computed on Gemma 2 2B-IT (Gemma Scope 1) and Gemma 4 E2B-IT (author-trained bio SAE). Two fine-tuned Gemma 2 domain SAEs were released. On Gemma 4, comply and refuse responses separated by a 0.647-point gap with zero overlap (n=75), though this is preliminary, with a narrow catalog, within-sample calibration, and Gemma-family-only SAE coverage. Built over one hackathon weekend on consumer hardware (GTX 1650 Ti Max-Q, plus Colab T4 for SAE training), this preliminary evidence suggests activation-level auditing may surface failure modes invisible to behavioral evaluation, with substantial variation across architectures.",
+      "authors": [
+        "Caleb DeLeeuw"
+      ],
+      "categories": [
+        "cs.AI",
+        "cs.CR",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30162v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30162v1",
+      "publishedAt": "2026-05-28T16:18:07.000Z",
+      "updatedAt": "2026-05-28T16:18:07.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30161v1",
       "title": "Why Far Looks Up: Probing Spatial Representation in Vision-Language Models",
       "summary": "Vision-language models (VLMs) achieve strong performance on spatial reasoning benchmarks, yet it remains unclear whether this reflects structured 3D understanding or reliance on statistical shortcuts in natural images. We introduce a representation-level analysis framework that constructs minimal contrastive pairs to measure how spatial axes are organized and disentangled within VLM embeddings. Our analysis across multiple model families reveals a consistent vertical-distance entanglement: models conflate vertical image position with distance, mirroring the perspective bias of natural photographs. This bias produces a significant accuracy gap between perspective-consistent and counter-heuristic examples, and intensifies under data scaling even as overall benchmark accuracy improves. We further show that models with similar benchmark scores can exhibit different internal representations, and that these differences predict accuracy and robustness across diverse spatial reasoning benchmarks. To isolate this bias from evaluation-set skew, we introduce SpatialTunnel, a synthetic benchmark designed to expose spatial shortcut biases by removing common correlations present in natural images. Experiments confirm that the entanglement is model-intrinsic, and that models with well-separated spatial axes exhibit greater robustness, suggesting that well-structured spatial representations lead to more reliable spatial reasoning across diverse benchmarks. Code and benchmark are available on the project page: https://cheolhong0916.github.io/whyfarlooksup.github.io/.",
@@ -1490,6 +2436,109 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30161v1",
       "publishedAt": "2026-05-28T16:18:01.000Z",
       "updatedAt": "2026-05-28T16:18:01.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30160v1",
+      "title": "On Distributional Reinforcement Learning in Chaotic Dynamical Systems",
+      "summary": "Chaotic dynamical systems pose a fundamental challenge for Reinforcement Learning (RL): exponential sensitivity to initial conditions induces high-variance bootstrap targets and poorly conditioned gradient updates. Chaotic dynamics arise across scientific and engineering domains, from fluid flows and climate systems to multi-agent systems, where reliable learning is highly desirable. Standard RL methods optimise expected returns through scalar value functions, implicitly averaging over diverging trajectories and entangling trajectory level instability with the learning objective. We show that under mild statistical stability assumptions, the return distribution evolves more regularly than individual trajectories when measured under the $1$-Wasserstein metric, yielding a smoother distributional Bellman objective. By aligning optimisation with this measure level structure, distributional RL provides better conditioned learning. We offer a principled explanation for the advantages of distributional methods in chaotic systems and the geometries of RL objectives under chaos.",
+      "authors": [
+        "James Rudd-Jones",
+        "Mirco Musolesi",
+        "María Pérez-Ortiz"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30160v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30160v1",
+      "publishedAt": "2026-05-28T16:17:32.000Z",
+      "updatedAt": "2026-05-28T16:17:32.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30159v1",
+      "title": "Meta-Cognitive Memory Policy Optimization for Long-Horizon LLM Agents",
+      "summary": "Memory-augmented LLM agents tackle complex long-horizon tasks by recursively summarizing interaction trajectories into compact memory. However, existing approaches typically train these memory policies using outcome-based reinforcement learning, failing to localize where intermediate memory quality degrades. As interactions unfold, ambiguous recursive summaries progressively discard task-relevant information and introduce semantic noise. This exacerbates belief deviation, obscuring the agent's estimate of the latent task state and ultimately derailing long-horizon reasoning. We therefore argue that memory optimization should focus not merely on trajectory-level success, but on the clarity of the belief induced by intermediate summaries. To this end, we introduce Belief Entropy, a self-supervised proxy that probes how uncertain the model remains about the latent task state given its current memory. Based on this proxy, we propose Metacognitive Memory Policy Optimization (MMPO). Instead of relying only on sparse outcome-based signals, MMPO provides fine-grained, memory-specific supervision via explicitly penalizing summaries that induce high epistemic uncertainty. Experiments show that MMPO consistently outperforms existing methods on diverse long-horizon tasks, maintaining 97.1% performance even when scaled to 1.75M-token contexts.",
+      "authors": [
+        "Ziyan Liu",
+        "Zhezheng Hao",
+        "Yeqiu Chen",
+        "Hong Wang",
+        "Jingren Hou",
+        "Ruiyi Ding",
+        "Yongkang Yang",
+        "Wence Ji",
+        "Wei Xia",
+        "Feng Liu"
+      ],
+      "categories": [
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.AI",
+      "absUrl": "https://arxiv.org/abs/2605.30159v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30159v1",
+      "publishedAt": "2026-05-28T16:17:19.000Z",
+      "updatedAt": "2026-05-28T16:17:19.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30155v1",
+      "title": "Neural Network Verification using Partial Multi-Neuron Relaxation",
+      "summary": "The increasing integration of deep neural networks in critical systems has spawned a theoretical and practical interest in formally guaranteeing safety properties about their behavior. To achieve this, contemporary verification algorithms rely on computing linear relaxations for a network's non-linear activation functions. Existing approaches for linear relaxations typically fall into one of two categories: single-neuron relaxation, in which each activation neuron is bounded in terms of its sources; and multi-neuron relaxation, in which linear bounds involving multiple activation neurons and their sources are calculated. However, existing methods might fail to balance tightness and scalability, as single-neuron bounds might not derive sufficiently tight bounds necessary for verification to complete, whereas generating multi-neuron relaxation for all activation neurons is computationally expensive. In this paper, we present a middle-ground approach featuring partial multi-neuron relaxation, in which we generate multi-neuron bounds for only a small, heuristically selected subset of neurons. To achieve this, we build upon existing branching heuristics for selecting neurons and for optimizing bounding hyper-planes for multi-neuron bounds. We integrated our proposed method within the Marabou verifier, and obtained favorable results in comparison to existing bound tightening methods. Our experiments showcase the potential of our technique for neural network verification.",
+      "authors": [
+        "Ido Shmuel",
+        "Guy Katz"
+      ],
+      "categories": [
+        "cs.LO",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LO",
+      "absUrl": "https://arxiv.org/abs/2605.30155v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30155v1",
+      "publishedAt": "2026-05-28T16:15:13.000Z",
+      "updatedAt": "2026-05-28T16:15:13.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30154v1",
+      "title": "RL2ML: Finite-Rollout Surrogate Objectives from Reinforcement Learning to Maximum Likelihood",
+      "summary": "Correctness-based Reinforcement Learning with Verifiable Rewards (RLVR) trains language models from binary feedback on sampled outputs, but the objective optimized in expectation and the stochastic update geometry induced by finite rollout groups are often conflated. This paper develops RL2ML, a family of finite-rollout surrogate objectives with a closed-form, exactly unbiased gradient estimator. The family continuously connects standard reinforcement learning, maximum-likelihood-like training, and beyond-maximum-likelihood objectives while preserving estimator-objective alignment under a fixed rollout budget. We introduce the group-level update scale to characterize how a rollout group is reweighted after its empirical success count is observed, revealing a subcritical-supercritical update-scale transition that is hidden by population-level objective notation alone. Building on this distinction, calibrated metric-gain analysis and exact variance decomposition show that the best choice of surrogate objective is determined neither by proximity to maximum likelihood nor by the population-level weight alone. Instead, it depends jointly on the evaluation metric, local sensitivity, and estimator variance. The remaining degree of freedom in the surrogate objective family can therefore be formulated as a one-dimensional optimization problem rather than treated as an unconstrained hyperparameter.",
+      "authors": [
+        "Yifu Zheng"
+      ],
+      "categories": [
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30154v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30154v1",
+      "publishedAt": "2026-05-28T16:14:45.000Z",
+      "updatedAt": "2026-05-28T16:14:45.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30153v1",
+      "title": "Diffusion Models Are Statistically Optimal for Learning Low-Dimensional Multi-Modal Distributions",
+      "summary": "Score-based diffusion models have demonstrated remarkable empirical success in learning high-dimensional distributions, particularly those exhibiting low-dimensional and multi-modal structures. However, theoretical understanding of their statistical efficiency remains limited. Existing theories typically rely on strong regularity assumptions, such as uniformly bounded densities or globally smooth score functions, which fail to capture such intrinsic structures. In this work, we study the sample complexity of diffusion models for learning distributions supported on a union of low-dimensional subspaces. Assuming that the data distribution within each subspace is subgaussian, we show that diffusion models require at most $\\widetilde{O}(\\varepsilon^{-k \\vee 2})$ samples to achieve $\\varepsilon$ error in 1-Wasserstein distance, where $k$ is the intrinsic dimension. This near-optimal convergence rate depends only on the intrinsic dimension and significantly improves upon prior theoretical guarantees that suffer from the curse of dimensionality. Notably, our analysis applies to a broad collection of distributions without imposing smoothness, bounded-density, or log-concavity assumptions. Overall, our results show that diffusion models can statistically adapt to intrinsic low-dimensional structure while naturally accommodating multi-modal data, offering a rigorous theoretical justification for their success in complex high-dimensional learning tasks.",
+      "authors": [
+        "Jingda Wu",
+        "Changxiao Cai"
+      ],
+      "categories": [
+        "stat.ML",
+        "cs.IT",
+        "cs.LG",
+        "math.ST"
+      ],
+      "primaryCategory": "stat.ML",
+      "absUrl": "https://arxiv.org/abs/2605.30153v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30153v1",
+      "publishedAt": "2026-05-28T16:13:44.000Z",
+      "updatedAt": "2026-05-28T16:13:44.000Z",
       "linkedRepos": []
     },
     {
@@ -1519,6 +2568,28 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30148v1",
+      "title": "Overcoming Forgetting in LLM Fine-Tuning with Evolution Strategies",
+      "summary": "Evolution Strategies (ES) has recently emerged as a competitive alternative to reinforcement learning (RL) for large language model (LLM) fine-tuning, offering advantages through simplicity, scalability, and inference-only training. However, recent work suggests that ES fine-tuning on new tasks may induce forgetting of prior tasks. First, this paper shows that prior task forgetting (1) is better characterized as performance drift rather than irreversible forgetting, with prior-task performance often recovering during ES training; and (2) is not a specific failure mode of ES, but can also arise for fine-tuning with RL methods. Second, it analyzes when and why such drift arises, highlighting its dependence on ES training dynamics, particularly random walk behavior in weakly constrained directions of the weight space. Third, based on these insights, it introduces Anchored Weight Decay (AWD) as a parameter-space regularization technique that constrains optimization toward the initial model parameters. AWD effectively stabilizes prior-task performance while preserving target-task performance, achieving benefits comparable to large ES population sizes at much lower computational cost. Thus, contrary to previous beliefs, the paper shows that prior-task forgetting under ES is largely avoidable, positioning ES as a promising approach for continual learning in LLMs.",
+      "authors": [
+        "Kajetan Schweighofer",
+        "Conor F. Hayes",
+        "Roberto Dailey",
+        "Risto Miikkulainen",
+        "Xin Qiu"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30148v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30148v1",
+      "publishedAt": "2026-05-28T16:08:47.000Z",
+      "updatedAt": "2026-05-28T16:08:47.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30140v1",
       "title": "AnomalyAgent: Training-Free Agentic Models for Zero-/Few-Shot Anomaly Detection",
       "summary": "Benefiting from generalizability of vision-language models (VLMs) such as CLIP, many zero-/few-shot anomaly detection (AD) approaches have achieved impressive detection performance across various datasets. Nevertheless, they require substantial training on large auxiliary datasets to adapt VLMs to anomaly detection, and their inference largely relies on visual-text embedding similarity-based anomaly scores, lacking reasoning abilities to detect complex anomalies that require in-depth contextual understanding. To address this limitation, we propose \\textbf{AnomalyAgent}, a novel training-free, agentic framework that leverages the advanced reasoning and generalization capabilities of multimodal large language models (MLLMs) for anomaly detection. The key ingredients include \\textbf{1)} a comprehensive anomaly-centric toolset that enables adaptive MLLM-driven, agentic anomaly reasoning in zero-shot settings, and \\textbf{2)} a customized memory module that grounds anomaly reasoning with few-shot, in-context reference examples. We extend evaluation beyond the detection of simple anomalies (e.g., surface defects like cracks and dents and clear lesions) in widely used benchmarks to more diverse types of anomalies such as logical/contextual anomalies in logistics and manufacturing settings. Extensive experiment results demonstrate that our AnomalyAgent achieves substantially better performance compared to training-free VLM-based AD and generic agentic methods, highlighting its superior generalization capability in both zero-shot and few-shot anomaly detection settings. The code implementation can be find at this address.",
@@ -1539,6 +2610,26 @@
       "linkedRepos": []
     },
     {
+      "arxivId": "2605.30135v1",
+      "title": "DAMEL: Dual-Axis Multi-Expert Learning for Class-Imbalanced Learning",
+      "summary": "Various algorithms have been proposed to address the challenges posed by class-imbalanced learning from real-world data with long-tailed distributions. While these algorithms reduce prediction bias through rebalancing techniques, they often introduce increased prediction variance as a trade-off. Several multi-expert learning algorithms aim to address this variance but involve complex procedures. We propose a new multi-expert learning algorithm, called the dual-axis multi-expert learning (DAMEL), which reduces both bias and variance of predictions by using multiple experts along both representation and time axes. Along the representation axis, DAMEL concatenates the representations of multiple experts and trains an auxiliary balanced classifier simultaneously with the concatenated representations. Along the time axis, DAMEL aggregates network weights across training epochs, employing these aggregated weights during testing. Experimental results demonstrate that DAMEL reduces both bias and variance of predictions, highlighting its effectiveness in class-imbalanced learning.",
+      "authors": [
+        "Hyuck Lee",
+        "Taemin Park",
+        "Heeyoung Kim"
+      ],
+      "categories": [
+        "cs.LG",
+        "cs.AI"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30135v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30135v1",
+      "publishedAt": "2026-05-28T16:02:49.000Z",
+      "updatedAt": "2026-05-28T16:02:49.000Z",
+      "linkedRepos": []
+    },
+    {
       "arxivId": "2605.30133v1",
       "title": "CorPipe at CRAC 2026: Empty Nodes and Cross-Lingual Transfer in Multilingual Coreference Resolution",
       "summary": "We introduce CorPipe 26, our winning submission to the CRAC 2026 Shared Task on Multilingual Coreference Resolution. The fifth edition of this shared task focuses mainly on the comparison of generative LLMs and specialized systems; additionally, 5 more datasets and 2 new languages are introduced. CorPipe 26 is an improved version of CorPipe 25, with a new variant predicting empty nodes together with mentions and coreference links in a single model. Our system outperforms all other submissions in the LLM track by 2.8 percent points and all submissions in the unconstrained track by 9.5 percent points. Furthermore, we perform a series of ablation experiments with different model sizes, empty node prediction methods, and cross-lingual zero-shot evaluation. The source code and the trained models are publicly available at https://github.com/ufal/crac2026-corpipe.",
@@ -1553,6 +2644,25 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30133v1",
       "publishedAt": "2026-05-28T16:01:03.000Z",
       "updatedAt": "2026-05-28T16:01:03.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30132v1",
+      "title": "Learning to Extrapolate to New Tasks: A Relational Approach to Task Extrapolation",
+      "summary": "Modern learning systems excel at interpolation but struggle to generalize to unseen tasks outside the training distribution's support. This failure occurs even in simple settings, such as handling task parameters beyond the training range, and persists despite advances in foundation models. To this end, we develop the Relational Task Extrapolator (RTE), an algorithm designed to enable systematic extrapolation to novel tasks. The key observation is that extrapolation is inherently relational: extrapolating to unseen tasks requires learning how tasks transform into one another. If a model learns the transformation between tasks A and B during training, it can apply that same transformation to relate known tasks to unseen ones at test time. RTE operationalizes this idea by decomposing each target task into a known anchor task and a transformation linking the anchor and target. It then learns a relational operator, mapping an anchor-transformation pair to predictions for the target task. We instantiate RTE across multiple task extrapolation regimes in function prediction, e.g. where target tasks use out-of-range parameters (parameter extrapolation), have greater compositional depth (length extrapolation), and/or recombine function primitives in unseen ways (compositional extrapolation). We further extend RTE to sequence prediction, integrating it into fine-tuning algorithms for foundation models. Across empirical studies, we find that RTE substantially outperforms existing approaches on extrapolation to novel, unseen tasks.",
+      "authors": [
+        "Adam Ousherovitch",
+        "Yixin Wang"
+      ],
+      "categories": [
+        "cs.LG",
+        "stat.ML"
+      ],
+      "primaryCategory": "cs.LG",
+      "absUrl": "https://arxiv.org/abs/2605.30132v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30132v1",
+      "publishedAt": "2026-05-28T15:59:33.000Z",
+      "updatedAt": "2026-05-28T15:59:33.000Z",
       "linkedRepos": []
     },
     {
@@ -1600,6 +2710,27 @@
       "pdfUrl": "https://arxiv.org/pdf/2605.30126v1",
       "publishedAt": "2026-05-28T15:57:31.000Z",
       "updatedAt": "2026-05-28T15:57:31.000Z",
+      "linkedRepos": []
+    },
+    {
+      "arxivId": "2605.30123v1",
+      "title": "Privacy-Enhanced Zero-Order Federated Learning via xMK-CKKS over Wireless Channels",
+      "summary": "Homomorphic encryption (HE) enables privacy-preserving aggregation in federated learning (FL) by allowing the server to operate on encrypted data without decryption. Existing HE-over-the-air methods mainly rely on single-key HE schemes and require channel estimation or pre-equalization to compensate for wireless fading. However, single-key HE remains vulnerable to honest-but-curious clients sharing the same secret key. In addition, compromising a single client may compromise the security of the entire network, while multi-key HE schemes provide stronger client-level security by assigning each device its own secret key. We propose a four-phase protocol that enables xMK-CKKS, a famous multi-key HE scheme, aggregation over a shared wireless channel without channel estimation. The protocol retransmits partial public keys and ciphertexts through the same channel realization, so that the dominant large-modulus encryption terms cancel algebraically during decryption. We integrate this protocol with zero-order FL over slowly varying LoS-dominant channels, where each device transmits a single encrypted scalar per round and the communication/encryption overhead is independent of the model dimension. We prove that the decoded encryption noise preserves the \\(O(1/\\sqrt{K})\\) convergence rate up to a negligible noise floor. The protocol is secure against an honest-but-curious server colluding with up to \\(N-1\\) clients, and numerical results on MNIST validate the analysis.",
+      "authors": [
+        "Anthony Ayli",
+        "Khalil Harris",
+        "Jihad Fahs",
+        "Mohamad Assaad"
+      ],
+      "categories": [
+        "cs.CR",
+        "cs.LG"
+      ],
+      "primaryCategory": "cs.CR",
+      "absUrl": "https://arxiv.org/abs/2605.30123v1",
+      "pdfUrl": "https://arxiv.org/pdf/2605.30123v1",
+      "publishedAt": "2026-05-28T15:56:43.000Z",
+      "updatedAt": "2026-05-28T15:56:43.000Z",
       "linkedRepos": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26661958126

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.