### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-29T21:14:08Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-29T18:17:53.024Z",
+  "ts": "2026-05-29T21:14:08.389Z",
   "count": 1,
-  "durationMs": 10371,
+  "durationMs": 14818,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-29T18:17:51.269Z",
+  "lastFetchedAt": "2026-05-29T21:14:04.930Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1461,6 +1461,42 @@
       "aiAdjacent": true
     },
     {
+      "id": "1157494",
+      "name": "Ava 2.0",
+      "tagline": "Your AI BDR that runs outbound sales autonomously",
+      "description": "Ava is an AI BDR that runs your entire outbound on autopilot. She sources leads from 250M+ professionals, runs multi-channel outreach, and books qualified meetings. Fully autonomously.",
+      "url": "https://www.producthunt.com/products/artisan-3?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/HMYIC7WZZM3MNU",
+      "votesCount": 297,
+      "commentsCount": 28,
+      "createdAt": "2026-05-29T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/e73735a8-47b9-4828-af51-05e7daf52328.png?auto=format",
+      "topics": [
+        "productivity",
+        "sales",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1152537",
       "name": "Cleo",
       "tagline": "The AI PM that runs your team",
@@ -2192,42 +2228,6 @@
       "aiAdjacent": true
     },
     {
-      "id": "1157494",
-      "name": "Ava 2.0",
-      "tagline": "Your AI BDR that runs outbound sales autonomously",
-      "description": "Ava is an AI BDR that runs your entire outbound on autopilot. She sources leads from 250M+ professionals, runs multi-channel outreach, and books qualified meetings. Fully autonomously.",
-      "url": "https://www.producthunt.com/products/artisan-3?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/HMYIC7WZZM3MNU",
-      "votesCount": 258,
-      "commentsCount": 26,
-      "createdAt": "2026-05-29T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/e73735a8-47b9-4828-af51-05e7daf52328.png?auto=format",
-      "topics": [
-        "productivity",
-        "sales",
-        "artificial-intelligence"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
       "id": "1145066",
       "name": "Supaboard 3.0",
       "tagline": "AI data analysts that understand your business",
@@ -2401,22 +2401,40 @@
       "aiAdjacent": true
     },
     {
-      "id": "1151355",
-      "name": "Google Antigravity 2.0",
-      "tagline": "Orchestrate multi-agent workflows from a desktop app",
-      "description": "Google Antigravity 2.0 is a standalone desktop app for orchestrating multiple AI agents in parallel, with scheduled background tasks, subagent workflows, and native integrations with AI Studio, Firebase, and Android. Built for developers building production apps.",
-      "url": "https://www.producthunt.com/products/google-antigravity?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/BVJYKCZ724TDTG",
-      "votesCount": 244,
-      "commentsCount": 13,
-      "createdAt": "2026-05-21T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/64f05fed-5478-434e-b175-80b218391f8c.png?auto=format",
+      "id": "1158301",
+      "name": "/monitor by Firecrawl",
+      "tagline": "Notify your AI agent when the web changes",
+      "description": "/monitor notifies your agent via webhook the moment pages or sites change. Use up to 90% fewer LLM tokens by only ingesting what changes on a page.",
+      "url": "https://www.producthunt.com/products/extract-by-firecrawl?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/RYV3RTT7QJJVGO",
+      "votesCount": 250,
+      "commentsCount": 14,
+      "createdAt": "2026-05-29T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/eed71365-67aa-4375-b90e-8ef52205ae2b.png?auto=format",
       "topics": [
-        "task-management",
         "developer-tools",
         "artificial-intelligence"
       ],
-      "makers": [],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
       "githubUrl": null,
       "xUrl": null,
       "linkedRepo": null,


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26662449253

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.