### PR TITLE
chore(data): refresh lobsters signals 2026-05-29T21:25:16Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-29T19:14:17.279Z",
+  "ts": "2026-05-29T21:25:16.959Z",
   "count": 1,
-  "durationMs": 3146,
+  "durationMs": 2782,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T19:14:14.155Z",
+  "fetchedAt": "2026-05-29T21:25:14.198Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 32.58722222222222
+        "hoursSincePosted": 34.77055555555555
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 32.58722222222222,
-          "trendingScore": 0.019664661043971268,
+          "ageHours": 34.77055555555555,
+          "trendingScore": 0.017939473957930562,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-29T19:14:14.155Z",
+  "fetchedAt": "2026-05-29T21:25:14.198Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -92,6 +92,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "axg3ga",
+      "title": "I Am Retiring from Tech to Live Offline",
+      "url": "https://openpath.quest/2026/i-am-retiring-from-tech-to-live-offline/",
+      "commentsUrl": "https://lobste.rs/s/axg3ga/i_am_retiring_from_tech_live_offline",
+      "by": "",
+      "score": 56,
+      "commentCount": 7,
+      "createdUtc": 1780072274,
+      "ageHours": 4.9,
+      "trendingScore": 3.0896863266018357,
+      "tags": [
+        "person"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "oznirn",
       "title": "Redis and the Cost of Ambition",
       "url": "https://charlesleifer.com/blog/redis-and-the-cost-of-ambition/",
@@ -157,23 +174,6 @@
       "tags": [
         "linux",
         "security"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "axg3ga",
-      "title": "I Am Retiring from Tech to Live Offline",
-      "url": "https://openpath.quest/2026/i-am-retiring-from-tech-to-live-offline/",
-      "commentsUrl": "https://lobste.rs/s/axg3ga/i_am_retiring_from_tech_live_offline",
-      "by": "",
-      "score": 26,
-      "commentCount": 3,
-      "createdUtc": 1780072274,
-      "ageHours": 2.716666666666667,
-      "trendingScore": 2.5381692029266043,
-      "tags": [
-        "person"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26662908668

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.