### PR TITLE
chore(data): refresh huggingface space signals 2026-05-30T04:38:59Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-29T21:01:10.544Z",
+  "ts": "2026-05-30T04:38:59.748Z",
   "count": 1,
-  "durationMs": 4644,
+  "durationMs": 7790,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T21:01:05.901Z",
+  "fetchedAt": "2026-05-30T04:38:51.960Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -41,8 +41,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 158,
-      "trendingScore": 148,
+      "likes": 160,
+      "trendingScore": 150,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -108,6 +108,22 @@
     },
     {
       "rank": 7,
+      "id": "webml-community/bonsai-image-webgpu",
+      "author": "webml-community",
+      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
+      "likes": 119,
+      "trendingScore": 113,
+      "sdk": "static",
+      "tags": [
+        "static",
+        "region:us"
+      ],
+      "createdAt": "2026-05-26T17:12:36.000Z",
+      "lastModified": "2026-05-29T02:57:22.000Z",
+      "models": []
+    },
+    {
+      "rank": 8,
       "id": "mikeee/qwen-7b-chat",
       "author": "mikeee",
       "url": "https://huggingface.co/spaces/mikeee/qwen-7b-chat",
@@ -120,22 +136,6 @@
       ],
       "createdAt": "2023-08-04T12:40:21.000Z",
       "lastModified": "2026-04-09T04:02:47.000Z",
-      "models": []
-    },
-    {
-      "rank": 8,
-      "id": "webml-community/bonsai-image-webgpu",
-      "author": "webml-community",
-      "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 117,
-      "trendingScore": 111,
-      "sdk": "static",
-      "tags": [
-        "static",
-        "region:us"
-      ],
-      "createdAt": "2026-05-26T17:12:36.000Z",
-      "lastModified": "2026-05-29T02:57:22.000Z",
       "models": []
     },
     {
@@ -226,6 +226,22 @@
     },
     {
       "rank": 14,
+      "id": "bytedance-research/Lance",
+      "author": "bytedance-research",
+      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
+      "likes": 76,
+      "trendingScore": 73,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T05:42:54.000Z",
+      "lastModified": "2026-05-28T17:00:43.000Z",
+      "models": []
+    },
+    {
+      "rank": 15,
       "id": "techfreakworm/LTX2.3-Studio",
       "author": "techfreakworm",
       "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
@@ -241,7 +257,7 @@
       "models": []
     },
     {
-      "rank": 15,
+      "rank": 16,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
@@ -254,22 +270,6 @@
       ],
       "createdAt": "2026-04-28T05:09:42.000Z",
       "lastModified": "2026-05-20T05:14:48.000Z",
-      "models": []
-    },
-    {
-      "rank": 16,
-      "id": "bytedance-research/Lance",
-      "author": "bytedance-research",
-      "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 73,
-      "trendingScore": 70,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-22T05:42:54.000Z",
-      "lastModified": "2026-05-28T17:00:43.000Z",
       "models": []
     },
     {
@@ -424,6 +424,22 @@
     },
     {
       "rank": 26,
+      "id": "selfit-camera/Omni-Image-Editor",
+      "author": "selfit-camera",
+      "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
+      "likes": 1793,
+      "trendingScore": 52,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2025-12-13T03:04:18.000Z",
+      "lastModified": "2026-04-19T00:08:34.000Z",
+      "models": []
+    },
+    {
+      "rank": 27,
       "id": "multimodalart/z-image-6b-pixel-space",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/z-image-6b-pixel-space",
@@ -436,22 +452,6 @@
       ],
       "createdAt": "2026-05-22T12:46:34.000Z",
       "lastModified": "2026-05-22T19:37:35.000Z",
-      "models": []
-    },
-    {
-      "rank": 27,
-      "id": "selfit-camera/Omni-Image-Editor",
-      "author": "selfit-camera",
-      "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1787,
-      "trendingScore": 48,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2025-12-13T03:04:18.000Z",
-      "lastModified": "2026-04-19T00:08:34.000Z",
       "models": []
     },
     {
@@ -802,8 +802,8 @@
       "id": "build-small-hackathon/registration",
       "author": "build-small-hackathon",
       "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
-      "likes": 62,
-      "trendingScore": 27,
+      "likes": 63,
+      "trendingScore": 28,
       "sdk": "gradio",
       "tags": [
         "gradio",


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26674663775

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.