### PR TITLE
chore(data): refresh arxiv signals 2026-05-30T04:41:45Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-29T21:03:42.708Z",
+  "ts": "2026-05-30T04:41:45.657Z",
   "count": 1,
-  "durationMs": 75842,
+  "durationMs": 60797,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T21:03:42.757Z",
+  "fetchedAt": "2026-05-30T04:41:45.705Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -7,6 +7,13 @@
   ],
   "count": 145,
   "papers": [
+    {
+      "arxivId": "2605.30353v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
     {
       "arxivId": "2605.30352v1",
       "citationCount": 0,
@@ -27,6 +34,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30350v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30349v1",
@@ -57,6 +71,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30344v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30343v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -85,11 +106,25 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
+      "arxivId": "2605.30337v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30338v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30336v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30335v1",
@@ -120,6 +155,20 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
+      "arxivId": "2605.30330v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30329v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30328v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -132,6 +181,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30326v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30325v1",
@@ -148,11 +204,32 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30323v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30322v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30320v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30319v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30318v1",
@@ -204,6 +281,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30292v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30290v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -211,11 +295,53 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30289v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30288v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30284v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30283v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30280v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30277v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30275v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30274v1",
@@ -281,6 +407,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30253v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30251v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -300,6 +433,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30247v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30245v1",
@@ -372,11 +512,53 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
+      "arxivId": "2605.30229v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30227v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30226v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30225v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30220v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30219v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30218v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30215v1",
@@ -393,11 +575,32 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30213v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30211v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30208v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30207v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30202v1",
@@ -407,11 +610,81 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30201v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30200v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30198v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30195v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30190v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30189v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30188v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30187v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30184v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30179v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30175v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30174v1",
@@ -428,6 +701,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30169v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30168v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -442,11 +722,60 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30166v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30162v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30161v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30160v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30159v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30155v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30154v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30153v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30152v1",
@@ -456,6 +785,13 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
+      "arxivId": "2605.30148v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30140v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -463,11 +799,25 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
+      "arxivId": "2605.30135v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
       "arxivId": "2605.30133v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30132v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30131v1",
@@ -482,6 +832,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30123v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30116v1",
@@ -664,363 +1021,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30353v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30350v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30344v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30337v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30336v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30330v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30329v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30326v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30323v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30322v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30319v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30292v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30289v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30288v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30284v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30283v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30277v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30275v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30253v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30247v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30229v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30227v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30226v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30225v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30220v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30218v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30213v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30208v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30207v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30201v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30200v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30198v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30195v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30190v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30188v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30187v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30184v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30179v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30175v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30169v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30166v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30162v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30160v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30159v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30155v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30154v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30153v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30148v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30135v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30132v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30123v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-29T21:02:26.888Z",
+  "fetchedAt": "2026-05-30T04:40:44.880Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26674699627

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.