### PR TITLE
chore(data): refresh lobsters signals 2026-05-30T05:31:55Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T01:30:45.455Z",
+  "ts": "2026-05-30T05:31:55.308Z",
   "count": 1,
-  "durationMs": 4873,
+  "durationMs": 3692,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T01:30:40.603Z",
+  "fetchedAt": "2026-05-30T05:31:51.636Z",
   "windowDays": 7,
   "scannedStories": 77,
   "mentions": {
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 38.861111111111114
+        "hoursSincePosted": 42.880833333333335
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 38.861111111111114,
-          "trendingScore": 0.015314214767999174,
+          "ageHours": 42.880833333333335,
+          "trendingScore": 0.013303582987312925,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T01:30:40.603Z",
+  "fetchedAt": "2026-05-30T05:31:51.636Z",
   "windowHours": 72,
   "scannedTotal": 77,
   "stories": [


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26675735342

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.