### PR TITLE
fix(collectors): warn-and-continue on data-store Redis-skip

### DIFF
--- a/scripts/__tests__/cache-merge.test.mjs
+++ b/scripts/__tests__/cache-merge.test.mjs
@@ -159,3 +159,51 @@ test("loadExistingJson: corrupt JSON → fallback (does not throw)", async () =>
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// Regression: ISO-string scoreKey must sort by chronology, not collapse to
+// NaN. Before this fix, scrape-funding-news.mjs passed `scoreKey:
+// "publishedAt"` and `Number("2026-05-30T...")` returned NaN — every entry
+// tied at NaN, insertion order won, fresh signals were dropped from the
+// keep-last-50. The page froze at 1 round in 7d on 2026-05-30.
+test("ISO-string scoreKey sorts by chronology (date-parse fallback)", () => {
+  const existing = [
+    { id: "old-1", publishedAt: "2026-04-01T00:00:00Z" },
+    { id: "old-2", publishedAt: "2026-04-15T00:00:00Z" },
+    { id: "old-3", publishedAt: "2026-05-01T00:00:00Z" },
+  ];
+  const fresh = [
+    { id: "new-1", publishedAt: "2026-05-29T12:00:00Z" },
+    { id: "new-2", publishedAt: "2026-05-30T08:00:00Z" },
+  ];
+  const out = mergeAndKeepLastN(existing, fresh, {
+    idKey: "id",
+    scoreKey: "publishedAt",
+    keepN: 3,
+  });
+  // Top-3 by chronology DESC: new-2, new-1, old-3.
+  assert.equal(out.length, 3);
+  assert.equal(out[0].id, "new-2");
+  assert.equal(out[1].id, "new-1");
+  assert.equal(out[2].id, "old-3");
+});
+
+// Regression: ISO-string recencyKey tiebreaks chronologically even when
+// scoreKey is numeric. Same date-parse fallback path. Validates that
+// collectors using `recencyKey: "createdUtc"` get a deterministic tie-break
+// instead of NaN-no-op.
+test("ISO-string recencyKey tiebreaks chronologically", () => {
+  const all = [
+    { id: "a", trendingScore: 100, createdUtc: "2026-05-01T00:00:00Z" },
+    { id: "b", trendingScore: 100, createdUtc: "2026-05-30T00:00:00Z" },
+    { id: "c", trendingScore: 100, createdUtc: "2026-05-15T00:00:00Z" },
+  ];
+  const out = mergeAndKeepLastN([], all, {
+    idKey: "id",
+    scoreKey: "trendingScore",
+    recencyKey: "createdUtc",
+    keepN: 3,
+  });
+  assert.equal(out[0].id, "b", "newest on tied score wins");
+  assert.equal(out[1].id, "c");
+  assert.equal(out[2].id, "a");
+});

--- a/scripts/_cache-merge.mjs
+++ b/scripts/_cache-merge.mjs
@@ -37,6 +37,33 @@ import { readFile } from "node:fs/promises";
 export const KEEP_LAST_N_DEFAULT = 50;
 
 /**
+ * Coerce a score field to a number. Numbers pass through. Strings parse as
+ * numeric first (so "123" → 123), then as ISO-8601 dates (so a publishedAt
+ * field is usable as a primary sort key). Anything that doesn't yield a
+ * finite number falls back to 0 — matching the prior contract for missing
+ * values. Used for both scoreKey and recencyKey.
+ *
+ * Historical bug this fixes: `Number("2026-05-30T05:42Z")` is NaN, which made
+ * the funding-news merge a no-op (every entry tied at NaN, insertion order
+ * won, fresh signals were dropped). After this change, ISO-string scoreKeys
+ * rank by chronology DESC as intended. Backward-compat: existing numeric
+ * scoreKeys are unchanged.
+ */
+function coerceNumeric(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (value == null) return 0;
+  const n = Number(value);
+  if (Number.isFinite(n)) return n;
+  if (typeof value === "string") {
+    const t = Date.parse(value);
+    if (Number.isFinite(t)) return t;
+  }
+  return 0;
+}
+
+/**
  * Read + parse a JSON file. Returns `fallback` on ENOENT. Logs and returns
  * `fallback` on any other read/parse error so a corrupt file never blocks a
  * collector run.
@@ -95,17 +122,17 @@ export function mergeAndKeepLastN(existing, thisRun, opts = {}) {
       byId.set(id, item);
       continue;
     }
-    const newScore = Number(item?.[scoreKey] ?? 0);
-    const prevScore = Number(prev?.[scoreKey] ?? 0);
+    const newScore = coerceNumeric(item?.[scoreKey]);
+    const prevScore = coerceNumeric(prev?.[scoreKey]);
     // Keep the higher-scored version; on tie, prefer newer (item).
     byId.set(id, newScore >= prevScore ? item : prev);
   }
 
   const sorted = Array.from(byId.values()).sort((a, b) => {
-    const scoreCmp = Number(b?.[scoreKey] ?? 0) - Number(a?.[scoreKey] ?? 0);
+    const scoreCmp = coerceNumeric(b?.[scoreKey]) - coerceNumeric(a?.[scoreKey]);
     if (scoreCmp !== 0) return scoreCmp;
     if (recencyKey) {
-      return Number(b?.[recencyKey] ?? 0) - Number(a?.[recencyKey] ?? 0);
+      return coerceNumeric(b?.[recencyKey]) - coerceNumeric(a?.[recencyKey]);
     }
     return 0;
   });

--- a/scripts/promote-unknown-mentions.mjs
+++ b/scripts/promote-unknown-mentions.mjs
@@ -149,8 +149,10 @@ export async function main() {
     stampPerRecord: false,
   });
   if (redisResult.source !== "redis") {
-    throw new Error(
-      "unknown-mentions-promoted data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: file mirror at OUT_PATH already landed and the GH workflow
+    // auto-commits it. Same contract as scrape-funding-news.mjs.
+    console.warn(
+      `[promote-unknown-mentions] data-store write skipped (Redis env unset); file mirror at ${OUT_PATH} is the source of truth this run.`,
     );
   }
 

--- a/scripts/scrape-bluesky.mjs
+++ b/scripts/scrape-bluesky.mjs
@@ -548,8 +548,11 @@ async function main() {
   const mentionsRedis = await writeDataStore("bluesky-mentions", mergedMentionsPayload);
   const trendingRedis = await writeDataStore("bluesky-trending", mergedTrendingPayload);
   if (mentionsRedis.source !== "redis" || trendingRedis.source !== "redis") {
-    throw new Error(
-      "bluesky data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: both file mirrors (MENTIONS_OUT, TRENDING_OUT) already
+    // landed. Same contract as scrape-funding-news.mjs — genuine transport
+    // errors throw from inside writeDataStore and never reach this branch.
+    console.warn(
+      `[bluesky] data-store write skipped (Redis env unset); file mirrors at ${MENTIONS_OUT} + ${TRENDING_OUT} are the source of truth this run.`,
     );
   }
 

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -821,8 +821,14 @@ async function main() {
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news", payload);
     if (redisResult.source !== "redis") {
-      throw new Error(
-        "funding-news data-store write skipped; set REDIS_URL or Upstash env",
+      // Soft-skip: writeDataStore returned "skipped" because the Redis env is
+      // unset (or DATA_STORE_DISABLE=1). The file write at outputPath already
+      // landed and the GH workflow's auto-commit step ships it downstream, so
+      // /funding stays fed from the bundled spine. Real Redis transport
+      // errors propagate from ioredis client.set and would bypass this
+      // branch entirely — we only ever land here on the documented soft path.
+      console.warn(
+        `[funding] data-store write skipped (Redis env unset); file mirror at ${outputPath} is the source of truth this run.`,
       );
     }
     redisInfo = ` [redis: ${redisResult.source}]`;

--- a/scripts/scrape-sec-form-d.mjs
+++ b/scripts/scrape-sec-form-d.mjs
@@ -480,12 +480,20 @@ async function main() {
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news-sec", payload);
     if (redisResult.source !== "redis") {
-      throw new Error(
-        "funding-news-sec data-store write skipped; set REDIS_URL or Upstash env",
+      // Soft-skip — same contract as scrape-funding-news.mjs. File mirror at
+      // outputPath is the deliverable when Redis env is unset; the workflow's
+      // auto-commit ships it. Genuine transport errors throw from inside
+      // writeDataStore and never reach this branch.
+      console.warn(
+        `[sec-form-d] data-store write skipped (Redis env unset); file mirror at ${outputPath} is the source of truth this run.`,
       );
+    } else {
+      // Verify the meta key actually landed under the expected writtenAt.
+      // Soft-skip path above never reaches here, so verify is correctly
+      // gated to the real Redis success branch.
+      await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
+      console.log("[sec-form-d] redis write ok -> funding-news-sec");
     }
-    await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
-    console.log("[sec-form-d] redis write ok -> funding-news-sec");
 
     // TOOLBOX dual-write: emit `funding.sec.formd` per Form D filing.
     // Best-effort — env-unset = silent skip; failures never block.

--- a/scripts/sweep-staleness.mjs
+++ b/scripts/sweep-staleness.mjs
@@ -200,8 +200,11 @@ async function main() {
     stampPerRecord: false,
   });
   if (redisResult.source !== "redis") {
-    throw new Error(
-      "staleness-report data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: file mirror at OUT_PATH already landed and is the
+    // deliverable. Genuine transport errors propagate from inside
+    // writeDataStore. Same contract as scrape-funding-news.mjs.
+    console.warn(
+      `[sweep-staleness] data-store write skipped (Redis env unset); file mirror at ${OUT_PATH} is the source of truth this run.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Unblocks 5 GH Actions workflows that have been failing since Railway redis was deleted **2026-05-26**:

| Workflow | Cadence | Last green | Symptom |
|---|---|---|---|
| `collect-funding.yml` | every 2h | 2026-05-18 | `data/funding-news.json` frozen; `/funding` shows 1 round in 7d |
| `sweep-staleness.yml` | daily | 2026-05-26 | freshness report stops updating |
| `scrape-bluesky.yml` | every 90min | 2026-05-26 | Bluesky mentions go cold |
| `promote-unknown-mentions.yml` | scheduled | 2026-05-26 | new repo discovery stalls |
| (5th) `scrape-sec-form-d` | bundled into funding cron | 2026-05-18 | SEC mini-feed on `/funding` empty |

Each script wrote its file mirror successfully, then **threw** on `writeDataStore` returning `{source: "skipped"}` when `REDIS_URL` / Upstash env is absent. The throw killed the workflow before the auto-commit step could ship the file mirror.

The throw violated the writer's documented contract ([scripts/_data-store-write.mjs:23-31](https://github.com/0motionguy/starscreener/blob/main/scripts/_data-store-write.mjs#L23-L31)):

> When env is missing: logs once, returns successfully. Caller's existing file write path keeps working unchanged.
> When Redis errors: throws. CI workflows fail-loud rather than silently diverging from the file snapshot.

Patched to warn-and-continue at the 5 affected sites. Genuine Redis transport errors still propagate from ioredis `client.set` — only env-absent SKIP returns. **3 sibling scripts left throwing on purpose**: `append-star-activity` / `backfill-star-activity` need read-back assertions (skip → can't verify), `build-agent-commerce-seed --push` is explicit opt-in, `verify-data-store` is the verifier itself.

## Second compounding bug fixed

`scripts/_cache-merge.mjs` `mergeAndKeepLastN`: `funding-news` passes `scoreKey: "publishedAt"` (an ISO string). `Number("2026-05-30T...")` is `NaN`. NaN-NaN was 0 → sort no-opped → the keep-last-50 cache pinned to historical mega-rounds and dropped fresh signals.

Added `coerceNumeric()` with `Date.parse` fallback (numeric scoreKeys unchanged). Silently improves recency tiebreaks for 5 sibling collectors (bluesky/devto/hackernews/lobsters/producthunt/huggingface) that use ISO `recencyKey`s.

## User-visible change

`/funding?period=7d`: `12d · 1 ROUND · $22M raised · $22M top` → **`3m · 24 ROUNDS · $70.4B raised · $65B top` (Anthropic series-D+)** once the next green cron lands. SEC mini-feed restores on the same tick.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint:guards` clean (`check-worker-keep-last-50` + 5 others)
- [x] **127 / 127 tests** pass across 8 test files (cache-merge + funding + data-store-write + scrape-bluesky + promote-unknown-mentions + 3 sibling collectors that share the merge helper)
  - Including 2 new regression tests for ISO-string `scoreKey` and ISO-string `recencyKey` paths in `cache-merge.test.mjs`
- [x] Local re-scrape: exit 0, 39 signals enriched, soft-skip logged cleanly, 22 signals in 0-7d bucket (was 0)
- [x] Localhost `/funding?period=7d` HTML probe: 24 rounds, $70.4B raised, 191 dollar amounts in body
- [x] TOOLBOX worker (`ss:meta:v1:funding-news` via authed `redis-cli`): 2h fresh — prod-side untouched, this PR only revives the GH-cron path
- [ ] **After merge to main**: trigger `collect-funding.yml` manually (`gh workflow run`) to confirm CI green before waiting for the scheduled tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)