### PR TITLE
chore(data): promote unknown mentions 2026-05-30T06:19:33Z

### DIFF
--- a/data/unknown-mentions-promoted.json
+++ b/data/unknown-mentions-promoted.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-25T08:47:15.965Z",
-  "totalUnknownMentions": 271998,
-  "distinctRepos": 23970,
+  "generatedAt": "2026-05-30T06:19:33.834Z",
+  "totalUnknownMentions": 305211,
+  "distinctRepos": 25844,
   "minSources": 1,
   "topN": 200,
   "rows": [
     {
       "fullName": "oven-sh/bun",
-      "totalCount": 204,
+      "totalCount": 221,
       "sourceCount": 5,
       "sources": [
         "bluesky",
@@ -17,11 +17,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-02T03:53:18.691Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
       "fullName": "google-gemini/gemini-cli",
-      "totalCount": 104,
+      "totalCount": 119,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -31,11 +31,11 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
       "fullName": "trycua/cua",
-      "totalCount": 41,
+      "totalCount": 48,
       "sourceCount": 5,
       "sources": [
         "awesome-skills",
@@ -45,11 +45,11 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
       "fullName": "ggml-org/llama.cpp",
-      "totalCount": 232,
+      "totalCount": 255,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -58,7 +58,7 @@
         "reddit"
       ],
       "firstSeenAt": "2026-05-07T10:14:50.031Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "vercel/next.js",
@@ -88,7 +88,7 @@
     },
     {
       "fullName": "facebook/react",
-      "totalCount": 101,
+      "totalCount": 111,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -97,7 +97,20 @@
         "npm"
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "lastSeenAt": "2026-05-27T15:51:02.300Z"
+    },
+    {
+      "fullName": "ollama/ollama",
+      "totalCount": 109,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "vitejs/vite",
@@ -114,7 +127,7 @@
     },
     {
       "fullName": "antirez/ds4",
-      "totalCount": 82,
+      "totalCount": 83,
       "sourceCount": 4,
       "sources": [
         "bluesky",
@@ -123,7 +136,7 @@
         "twitter"
       ],
       "firstSeenAt": "2026-05-07T15:39:28.530Z",
-      "lastSeenAt": "2026-05-18T03:31:51.517Z"
+      "lastSeenAt": "2026-05-27T22:16:03.017Z"
     },
     {
       "fullName": "kolapsis/maintenant",
@@ -137,6 +150,19 @@
       ],
       "firstSeenAt": "2026-05-01T17:15:27.672Z",
       "lastSeenAt": "2026-05-23T22:09:08.211Z"
+    },
+    {
+      "fullName": "cline/cline",
+      "totalCount": 52,
+      "sourceCount": 4,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-26T16:15:31.243Z"
     },
     {
       "fullName": "aattaran/deepclaude",
@@ -153,7 +179,7 @@
     },
     {
       "fullName": "microsoft/vscode",
-      "totalCount": 204,
+      "totalCount": 236,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -161,7 +187,7 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "lastSeenAt": "2026-05-29T09:59:14.815Z"
     },
     {
       "fullName": "onyks-os/transparenttorproxy",
@@ -189,7 +215,7 @@
     },
     {
       "fullName": "naver/lispe",
-      "totalCount": 127,
+      "totalCount": 134,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -197,11 +223,11 @@
         "lobsters"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "lastSeenAt": "2026-05-26T17:03:11.553Z"
     },
     {
       "fullName": "andyyyy64/whichllm",
-      "totalCount": 125,
+      "totalCount": 132,
       "sourceCount": 3,
       "sources": [
         "bluesky",
@@ -209,7 +235,19 @@
         "hackernews"
       ],
       "firstSeenAt": "2026-05-15T10:12:27.167Z",
-      "lastSeenAt": "2026-05-25T04:51:10.028Z"
+      "lastSeenAt": "2026-05-26T04:34:50.425Z"
+    },
+    {
+      "fullName": "scosman/cursed_browser",
+      "totalCount": 118,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
       "fullName": "ninjahawk/hollow-agentos",
@@ -224,6 +262,18 @@
       "lastSeenAt": "2026-05-20T09:58:14.460Z"
     },
     {
+      "fullName": "higangssh/homebutler",
+      "totalCount": 114,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
       "fullName": "minishlab/semble",
       "totalCount": 111,
       "sourceCount": 3,
@@ -236,16 +286,16 @@
       "lastSeenAt": "2026-05-18T04:41:26.919Z"
     },
     {
-      "fullName": "higangssh/homebutler",
-      "totalCount": 110,
+      "fullName": "snyk/agent-scan",
+      "totalCount": 107,
       "sourceCount": 3,
       "sources": [
-        "awesome-skills",
+        "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-03T18:13:43.732Z",
+      "lastSeenAt": "2026-05-27T09:56:54.743Z"
     },
     {
       "fullName": "manojmallick/sigmap",
@@ -260,16 +310,28 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
-      "fullName": "scosman/cursed_browser",
-      "totalCount": 103,
+      "fullName": "jnuyens/modulejail",
+      "totalCount": 104,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "hackernews",
         "lobsters"
       ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
+    },
+    {
+      "fullName": "h4ckf0r0day/obscura",
+      "totalCount": 103,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-29T09:59:14.815Z"
     },
     {
       "fullName": "0xdeadbeefnetwork/copy_fail2-electric_boogaloo",
@@ -284,6 +346,18 @@
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
     },
     {
+      "fullName": "fsnotify/fsnotify",
+      "totalCount": 99,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T07:20:32.729Z",
+      "lastSeenAt": "2026-05-25T19:45:05.668Z"
+    },
+    {
       "fullName": "reviewstage/stage-cli",
       "totalCount": 99,
       "sourceCount": 3,
@@ -294,18 +368,6 @@
       ],
       "firstSeenAt": "2026-05-07T17:19:14.533Z",
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
-    },
-    {
-      "fullName": "snyk/agent-scan",
-      "totalCount": 98,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T18:13:43.732Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
     },
     {
       "fullName": "leaningtech/browsercode",
@@ -344,16 +406,16 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "fsnotify/fsnotify",
-      "totalCount": 96,
+      "fullName": "sifter-ai/sifter",
+      "totalCount": 95,
       "sourceCount": 3,
       "sources": [
-        "bluesky",
+        "awesome-skills",
         "devto",
-        "hackernews"
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-07T07:20:32.729Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
       "fullName": "nvlabs/cuda-oxide",
@@ -380,18 +442,6 @@
       "lastSeenAt": "2026-05-21T05:20:28.559Z"
     },
     {
-      "fullName": "sifter-ai/sifter",
-      "totalCount": 91,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
-    },
-    {
       "fullName": "luce-org/lucebox-hub",
       "totalCount": 91,
       "sourceCount": 3,
@@ -404,16 +454,28 @@
       "lastSeenAt": "2026-05-20T09:42:17.769Z"
     },
     {
-      "fullName": "jnuyens/modulejail",
+      "fullName": "rust-lang/rust",
+      "totalCount": 90,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T04:20:17.293Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
+      "fullName": "run-llama/llama_index",
       "totalCount": 89,
       "sourceCount": 3,
       "sources": [
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto",
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-15T06:27:04.023Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-28T16:04:46.558Z"
     },
     {
       "fullName": "shadcn-ui/ui",
@@ -428,28 +490,16 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
-      "fullName": "run-llama/llama_index",
-      "totalCount": 88,
+      "fullName": "n8n-io/n8n",
+      "totalCount": 87,
       "sourceCount": 3,
       "sources": [
-        "bluesky",
         "devto",
-        "reddit"
+        "reddit",
+        "twitter"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-22T18:04:56.157Z"
-    },
-    {
-      "fullName": "h4ckf0r0day/obscura",
-      "totalCount": 86,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "lastSeenAt": "2026-05-27T04:01:19.538Z"
     },
     {
       "fullName": "tanstack/router",
@@ -476,6 +526,42 @@
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
     },
     {
+      "fullName": "sipyourdrink-ltd/bernstein",
+      "totalCount": 83,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "rahilp/second-brain-cloudflare",
+      "totalCount": 83,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-10T08:16:23.224Z",
+      "lastSeenAt": "2026-05-27T04:01:19.538Z"
+    },
+    {
+      "fullName": "vllm-project/vllm",
+      "totalCount": 81,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T19:21:26.285Z",
+      "lastSeenAt": "2026-05-27T09:56:54.743Z"
+    },
+    {
       "fullName": "waybarrios/opencode-power-pack",
       "totalCount": 81,
       "sourceCount": 3,
@@ -488,67 +574,67 @@
       "lastSeenAt": "2026-05-07T10:35:59.089Z"
     },
     {
-      "fullName": "ollama/ollama",
-      "totalCount": 80,
+      "fullName": "yt-dlp/yt-dlp",
+      "totalCount": 78,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "reddit"
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "firstSeenAt": "2026-05-08T11:47:27.264Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
-      "fullName": "sipyourdrink-ltd/bernstein",
-      "totalCount": 79,
+      "fullName": "zoharbabin/web-researcher-mcp",
+      "totalCount": 76,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-20T03:46:01.433Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
-      "fullName": "n8n-io/n8n",
-      "totalCount": 79,
+      "fullName": "heymrun/heym",
+      "totalCount": 75,
       "sourceCount": 3,
       "sources": [
+        "awesome-skills",
         "devto",
-        "reddit",
-        "twitter"
+        "reddit"
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
-      "fullName": "rust-lang/rust",
-      "totalCount": 72,
+      "fullName": "codeabra/iai-mcp",
+      "totalCount": 71,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T07:39:41.798Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "antoinezambelli/forge",
+      "totalCount": 71,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-19T20:52:58.618Z",
+      "lastSeenAt": "2026-05-27T18:39:59.207Z"
     },
     {
-      "fullName": "vllm-project/vllm",
-      "totalCount": 72,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T19:21:26.285Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
-    },
-    {
-      "fullName": "rahilp/second-brain-cloudflare",
+      "fullName": "brethofai/brethof-mind",
       "totalCount": 69,
       "sourceCount": 3,
       "sources": [
@@ -556,8 +642,20 @@
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-10T08:16:23.224Z",
-      "lastSeenAt": "2026-05-25T04:51:10.028Z"
+      "firstSeenAt": "2026-05-22T17:36:35.165Z",
+      "lastSeenAt": "2026-05-29T09:59:14.815Z"
+    },
+    {
+      "fullName": "junegunn/fzf",
+      "totalCount": 69,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-26T15:37:24.338Z"
     },
     {
       "fullName": "statewright/statewright",
@@ -620,6 +718,42 @@
       "lastSeenAt": "2026-05-10T12:05:20.661Z"
     },
     {
+      "fullName": "redis/redis",
+      "totalCount": 65,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T08:09:15.267Z",
+      "lastSeenAt": "2026-05-28T16:04:46.558Z"
+    },
+    {
+      "fullName": "boratanrikulu/gobee",
+      "totalCount": 65,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-21T17:18:14.939Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
+    },
+    {
+      "fullName": "nrwl/nx-console",
+      "totalCount": 64,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-18T20:04:30.386Z",
+      "lastSeenAt": "2026-05-27T23:57:27.813Z"
+    },
+    {
       "fullName": "vercel/ai",
       "totalCount": 64,
       "sourceCount": 3,
@@ -630,42 +764,6 @@
       ],
       "firstSeenAt": "2026-05-01T10:45:39.581Z",
       "lastSeenAt": "2026-05-21T19:58:00.756Z"
-    },
-    {
-      "fullName": "yt-dlp/yt-dlp",
-      "totalCount": 63,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T11:47:27.264Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "junegunn/fzf",
-      "totalCount": 63,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-07T19:50:24.370Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
-    },
-    {
-      "fullName": "redis/redis",
-      "totalCount": 63,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T08:09:15.267Z",
-      "lastSeenAt": "2026-05-23T19:37:59.807Z"
     },
     {
       "fullName": "angular/angular",
@@ -752,6 +850,30 @@
       "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
+      "fullName": "igorganapolsky/thumbgate",
+      "totalCount": 59,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-03T06:44:51.563Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "microsoft/agent-governance-toolkit",
+      "totalCount": 59,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-02T13:25:46.475Z",
+      "lastSeenAt": "2026-05-27T08:37:19.778Z"
+    },
+    {
       "fullName": "manankharwar/fusioncore",
       "totalCount": 59,
       "sourceCount": 3,
@@ -762,6 +884,42 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-19T12:20:48.337Z"
+    },
+    {
+      "fullName": "nodejs/node",
+      "totalCount": 58,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T03:48:07.888Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
+    },
+    {
+      "fullName": "xataio/deltax",
+      "totalCount": 58,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-19T19:17:55.212Z",
+      "lastSeenAt": "2026-05-26T17:03:11.553Z"
+    },
+    {
+      "fullName": "sander110419/lightroom-cc-on-linux",
+      "totalCount": 58,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-18T12:48:24.691Z",
+      "lastSeenAt": "2026-05-26T10:22:28.795Z"
     },
     {
       "fullName": "open-webui/open-webui",
@@ -788,6 +946,18 @@
       "lastSeenAt": "2026-05-18T12:12:25.407Z"
     },
     {
+      "fullName": "donnowyu/soulmate-core",
+      "totalCount": 54,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T18:19:22.477Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
       "fullName": "minio/minio",
       "totalCount": 54,
       "sourceCount": 3,
@@ -800,31 +970,19 @@
       "lastSeenAt": "2026-05-09T08:04:55.501Z"
     },
     {
-      "fullName": "igorganapolsky/thumbgate",
-      "totalCount": 53,
+      "fullName": "0xmassi/webclaw",
+      "totalCount": 52,
       "sourceCount": 3,
       "sources": [
         "awesome-skills",
-        "bluesky",
-        "devto"
+        "devto",
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-03T06:44:51.563Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
-      "fullName": "sander110419/lightroom-cc-on-linux",
-      "totalCount": 53,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "hackernews",
-        "lobsters"
-      ],
-      "firstSeenAt": "2026-05-18T12:48:24.691Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "antoinezambelli/forge",
+      "fullName": "torvalds/linux",
       "totalCount": 52,
       "sourceCount": 3,
       "sources": [
@@ -832,44 +990,32 @@
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-19T20:52:58.618Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-01T11:34:16.788Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
-      "fullName": "xataio/deltax",
+      "fullName": "multica-ai/andrej-karpathy-skills",
       "totalCount": 51,
       "sourceCount": 3,
       "sources": [
+        "awesome-skills",
         "bluesky",
-        "hackernews",
-        "lobsters"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-19T19:17:55.212Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-17T19:15:02.265Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
-      "fullName": "cline/cline",
+      "fullName": "zed-industries/zed",
       "totalCount": 51,
       "sourceCount": 3,
       "sources": [
+        "awesome-skills",
         "bluesky",
-        "devto",
-        "reddit"
+        "devto"
       ],
-      "firstSeenAt": "2026-05-01T13:47:49.694Z",
-      "lastSeenAt": "2026-05-21T19:58:00.756Z"
-    },
-    {
-      "fullName": "nrwl/nx-console",
-      "totalCount": 50,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-18T20:04:30.386Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
       "fullName": "emarkou/grokfeed",
@@ -884,16 +1030,16 @@
       "lastSeenAt": "2026-05-07T14:30:15.363Z"
     },
     {
-      "fullName": "0xmassi/webclaw",
+      "fullName": "voidenhq/voiden",
       "totalCount": 48,
       "sourceCount": 3,
       "sources": [
-        "awesome-skills",
+        "bluesky",
         "devto",
         "reddit"
       ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-07T12:21:04.921Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "0xdeadbeefnetwork/ssh-keysign-pwn",
@@ -932,18 +1078,6 @@
       "lastSeenAt": "2026-05-07T10:14:50.031Z"
     },
     {
-      "fullName": "zed-industries/zed",
-      "totalCount": 47,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
-    },
-    {
       "fullName": "kuberwastaken/claurst",
       "totalCount": 47,
       "sourceCount": 3,
@@ -978,6 +1112,18 @@
       ],
       "firstSeenAt": "2026-05-01T13:40:47.050Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
+    },
+    {
+      "fullName": "chronolapse411/sicarius-guard",
+      "totalCount": 46,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
       "fullName": "iliaal/fastchart",
@@ -1016,6 +1162,30 @@
       "lastSeenAt": "2026-05-13T08:53:46.257Z"
     },
     {
+      "fullName": "aegis-dq/aegis-dq",
+      "totalCount": 44,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T19:09:34.978Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "awslabs/mcp",
+      "totalCount": 44,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
       "fullName": "simdjson/simdjson",
       "totalCount": 44,
       "sourceCount": 3,
@@ -1026,18 +1196,6 @@
       ],
       "firstSeenAt": "2026-05-07T15:39:28.530Z",
       "lastSeenAt": "2026-05-18T04:31:39.155Z"
-    },
-    {
-      "fullName": "nodejs/node",
-      "totalCount": 43,
-      "sourceCount": 3,
-      "sources": [
-        "bluesky",
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T03:48:07.888Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
     },
     {
       "fullName": "stardockcorp/wireloom",
@@ -1052,16 +1210,28 @@
       "lastSeenAt": "2026-05-20T12:39:36.429Z"
     },
     {
-      "fullName": "awslabs/mcp",
-      "totalCount": 40,
+      "fullName": "marcellm01/tinysearch",
+      "totalCount": 38,
       "sourceCount": 3,
       "sources": [
-        "awesome-skills",
         "bluesky",
-        "devto"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-15T21:22:38.595Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
+      "fullName": "perplexityai/bumblebee",
+      "totalCount": 38,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-22T18:04:56.157Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
       "fullName": "tabularisdb/tabularis",
@@ -1088,52 +1258,76 @@
       "lastSeenAt": "2026-05-17T15:12:58.057Z"
     },
     {
-      "fullName": "brethofai/brethof-mind",
+      "fullName": "achiya-automation/safari-mcp",
+      "totalCount": 36,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
+      "fullName": "yugr/rust-slides",
+      "totalCount": 35,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "hackernews",
+        "lobsters"
+      ],
+      "firstSeenAt": "2026-05-25T19:07:39.630Z",
+      "lastSeenAt": "2026-05-28T09:01:44.648Z"
+    },
+    {
+      "fullName": "pydantic/pydantic-ai",
       "totalCount": 34,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "aiosai/aipass",
+      "totalCount": 32,
+      "sourceCount": 3,
+      "sources": [
+        "devto",
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
+      "fullName": "anthropics/claude-cookbooks",
+      "totalCount": 31,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "owasp/cve-lite-cli",
+      "totalCount": 27,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-22T17:36:35.165Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "pydantic/pydantic-ai",
-      "totalCount": 30,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
-    },
-    {
-      "fullName": "anthropics/claude-cookbooks",
-      "totalCount": 27,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
-    },
-    {
-      "fullName": "multica-ai/andrej-karpathy-skills",
-      "totalCount": 27,
-      "sourceCount": 3,
-      "sources": [
-        "awesome-skills",
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-17T19:15:02.265Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
       "fullName": "eza-community/eza",
@@ -1148,7 +1342,7 @@
       "lastSeenAt": "2026-05-18T05:12:55.510Z"
     },
     {
-      "fullName": "achiya-automation/safari-mcp",
+      "fullName": "duriantaco/skylos",
       "totalCount": 25,
       "sourceCount": 3,
       "sources": [
@@ -1157,22 +1351,22 @@
         "devto"
       ],
       "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
-      "fullName": "perplexityai/bumblebee",
-      "totalCount": 23,
+      "fullName": "sharkdp/bat",
+      "totalCount": 25,
       "sourceCount": 3,
       "sources": [
         "bluesky",
         "devto",
-        "hackernews"
+        "twitter"
       ],
-      "firstSeenAt": "2026-05-22T18:04:56.157Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-25T16:04:49.102Z"
     },
     {
-      "fullName": "duriantaco/skylos",
+      "fullName": "sidneybissoli/medical-terminologies-mcp",
       "totalCount": 21,
       "sourceCount": 3,
       "sources": [
@@ -1180,8 +1374,20 @@
         "bluesky",
         "devto"
       ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "firstSeenAt": "2026-05-12T03:44:59.584Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
+      "fullName": "manaflow-ai/cmux",
+      "totalCount": 19,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "twitter"
+      ],
+      "firstSeenAt": "2026-05-03T08:09:15.267Z",
+      "lastSeenAt": "2026-05-27T16:16:57.412Z"
     },
     {
       "fullName": "floci-io/floci",
@@ -1208,6 +1414,18 @@
       "lastSeenAt": "2026-05-04T00:13:30.621Z"
     },
     {
+      "fullName": "hardikpandya/stop-slop",
+      "totalCount": 16,
+      "sourceCount": 3,
+      "sources": [
+        "bluesky",
+        "devto",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-07T04:53:38.982Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
       "fullName": "reduxjs/react-redux",
       "totalCount": 16,
       "sourceCount": 3,
@@ -1232,6 +1450,18 @@
       "lastSeenAt": "2026-05-22T22:22:35.106Z"
     },
     {
+      "fullName": "falsifylab/falsifylab-alpha-mcp",
+      "totalCount": 7,
+      "sourceCount": 3,
+      "sources": [
+        "awesome-skills",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-15T06:46:20.813Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
+    },
+    {
       "fullName": "simstudioai/sim",
       "totalCount": 4,
       "sourceCount": 3,
@@ -1245,36 +1475,47 @@
     },
     {
       "fullName": "k-dense-ai/claude-scientific-skills",
-      "totalCount": 206,
+      "totalCount": 217,
       "sourceCount": 2,
       "sources": [
         "awesome-skills",
         "bluesky"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
-      "fullName": "jigjoy-ai/mozaik",
-      "totalCount": 147,
+      "fullName": "vassiliylakhonin/agenda-intelligence-md",
+      "totalCount": 183,
       "sourceCount": 2,
       "sources": [
-        "devto",
+        "awesome-skills",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-29T08:13:02.983Z"
     },
     {
       "fullName": "raiyanyahya/how-to-train-your-gpt",
-      "totalCount": 146,
+      "totalCount": 154,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "lastSeenAt": "2026-05-26T19:33:37.267Z"
+    },
+    {
+      "fullName": "jigjoy-ai/mozaik",
+      "totalCount": 153,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-26T15:37:24.338Z"
     },
     {
       "fullName": "wojtczyk/trust",
@@ -1289,14 +1530,14 @@
     },
     {
       "fullName": "nixos/nixpkgs",
-      "totalCount": 131,
+      "totalCount": 135,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "devto"
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
-      "lastSeenAt": "2026-05-25T00:14:30.458Z"
+      "lastSeenAt": "2026-05-26T04:34:50.425Z"
     },
     {
       "fullName": "nexu-io/open-design",
@@ -1308,6 +1549,28 @@
       ],
       "firstSeenAt": "2026-05-02T13:50:45.195Z",
       "lastSeenAt": "2026-05-24T15:22:19.669Z"
+    },
+    {
+      "fullName": "clickhouse/silk",
+      "totalCount": 123,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T04:54:14.999Z",
+      "lastSeenAt": "2026-05-27T18:39:59.207Z"
+    },
+    {
+      "fullName": "yamafaktory/hypergraphz",
+      "totalCount": 122,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-03T21:12:41.505Z",
+      "lastSeenAt": "2026-05-26T19:33:37.267Z"
     },
     {
       "fullName": "warwickwood-cell/gengeo-agent-registry",
@@ -1330,6 +1593,28 @@
       ],
       "firstSeenAt": "2026-05-01T04:20:17.293Z",
       "lastSeenAt": "2026-05-09T16:11:39.536Z"
+    },
+    {
+      "fullName": "jossephus/chuchu",
+      "totalCount": 118,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-01T13:48:24.488Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
+    },
+    {
+      "fullName": "kiamehr5/kmri",
+      "totalCount": 118,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "reddit"
+      ],
+      "firstSeenAt": "2026-05-03T10:34:44.583Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
     },
     {
       "fullName": "drcathicks/learning-opportunities",
@@ -1376,37 +1661,26 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
-      "fullName": "yamafaktory/hypergraphz",
-      "totalCount": 114,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T21:12:41.505Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "clickhouse/silk",
-      "totalCount": 111,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "jossephus/chuchu",
+      "fullName": "chojs23/concord",
       "totalCount": 109,
       "sourceCount": 2,
       "sources": [
         "bluesky",
         "hackernews"
       ],
+      "firstSeenAt": "2026-05-10T04:11:37.463Z",
+      "lastSeenAt": "2026-05-26T10:22:28.795Z"
+    },
+    {
+      "fullName": "npm/cli",
+      "totalCount": 106,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-16T00:18:32.194Z"
+      "lastSeenAt": "2026-05-26T04:34:50.425Z"
     },
     {
       "fullName": "harnexa/nexa-gauge",
@@ -1431,6 +1705,17 @@
       "lastSeenAt": "2026-05-19T13:44:19.677Z"
     },
     {
+      "fullName": "enmanuelmag/heimdall-mcp",
+      "totalCount": 105,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-09T19:13:21.986Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
       "fullName": "opensensenova/sensenova-u1",
       "totalCount": 105,
       "sourceCount": 2,
@@ -1442,26 +1727,37 @@
       "lastSeenAt": "2026-05-08T11:33:06.098Z"
     },
     {
-      "fullName": "chojs23/concord",
+      "fullName": "eleutherai/lm-evaluation-harness",
       "totalCount": 104,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-10T04:11:37.463Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-07T14:30:15.363Z",
+      "lastSeenAt": "2026-05-28T16:04:46.558Z"
     },
     {
-      "fullName": "kiamehr5/kmri",
+      "fullName": "tanrikuluozlem/burn",
       "totalCount": 103,
       "sourceCount": 2,
       "sources": [
-        "hackernews",
-        "reddit"
+        "devto",
+        "hackernews"
       ],
-      "firstSeenAt": "2026-05-03T10:34:44.583Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-07T08:44:17.194Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
+    },
+    {
+      "fullName": "syedanas01/mcp-safeguard",
+      "totalCount": 102,
+      "sourceCount": 2,
+      "sources": [
+        "devto",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-07T08:44:17.194Z",
+      "lastSeenAt": "2026-05-29T20:30:42.746Z"
     },
     {
       "fullName": "facebookresearch/tuna-2",
@@ -1475,6 +1771,17 @@
       "lastSeenAt": "2026-05-19T01:56:00.808Z"
     },
     {
+      "fullName": "zakirullin/files.md",
+      "totalCount": 101,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T14:51:56.628Z",
+      "lastSeenAt": "2026-05-27T18:39:59.207Z"
+    },
+    {
       "fullName": "ifixai-ai/diagnostic",
       "totalCount": 101,
       "sourceCount": 2,
@@ -1484,6 +1791,17 @@
       ],
       "firstSeenAt": "2026-05-01T19:51:52.672Z",
       "lastSeenAt": "2026-05-11T23:22:32.173Z"
+    },
+    {
+      "fullName": "openosint/openosint",
+      "totalCount": 100,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-08T16:47:08.670Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "celestoai/smolvm",
@@ -1497,15 +1815,15 @@
       "lastSeenAt": "2026-05-19T09:50:47.617Z"
     },
     {
-      "fullName": "npm/cli",
-      "totalCount": 99,
+      "fullName": "ayoubnabil/aiondb",
+      "totalCount": 98,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
+        "devto",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-01T13:48:24.488Z",
-      "lastSeenAt": "2026-05-25T04:51:10.028Z"
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-29T09:59:14.815Z"
     },
     {
       "fullName": "mekickdemons-creator/mnemara",
@@ -1517,6 +1835,17 @@
       ],
       "firstSeenAt": "2026-05-07T04:54:14.999Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "modelcontextprotocol/servers",
+      "totalCount": 97,
+      "sourceCount": 2,
+      "sources": [
+        "awesome-skills",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T07:09:35.838Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "avarok-cybersecurity/atlas",
@@ -1541,28 +1870,6 @@
       "lastSeenAt": "2026-05-07T15:15:06.916Z"
     },
     {
-      "fullName": "eleutherai/lm-evaluation-harness",
-      "totalCount": 93,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T14:30:15.363Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
-    },
-    {
-      "fullName": "enmanuelmag/heimdall-mcp",
-      "totalCount": 93,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T19:13:21.986Z",
-      "lastSeenAt": "2026-05-25T04:01:43.896Z"
-    },
-    {
       "fullName": "facebook/pyrefly",
       "totalCount": 92,
       "sourceCount": 2,
@@ -1583,6 +1890,17 @@
       ],
       "firstSeenAt": "2026-05-07T15:15:06.916Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "aendrix03/graft",
+      "totalCount": 90,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-12T00:21:52.545Z",
+      "lastSeenAt": "2026-05-27T23:57:27.813Z"
     },
     {
       "fullName": "comfyanonymous/comfyui",
@@ -1640,15 +1958,26 @@
       "lastSeenAt": "2026-05-04T11:26:27.665Z"
     },
     {
-      "fullName": "tanrikuluozlem/burn",
+      "fullName": "robertnowell/klein-void",
       "totalCount": 88,
       "sourceCount": 2,
       "sources": [
-        "devto",
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-07T17:59:53.371Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
+    },
+    {
+      "fullName": "mistralai/client-python",
+      "totalCount": 88,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
         "hackernews"
       ],
-      "firstSeenAt": "2026-05-07T08:44:17.194Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-12T04:18:11.270Z",
+      "lastSeenAt": "2026-05-26T17:03:11.553Z"
     },
     {
       "fullName": "scottgl9/skelm",
@@ -1673,15 +2002,15 @@
       "lastSeenAt": "2026-05-08T19:48:01.671Z"
     },
     {
-      "fullName": "zakirullin/files.md",
+      "fullName": "shouvik12/trooper",
       "totalCount": 86,
       "sourceCount": 2,
       "sources": [
-        "bluesky",
-        "hackernews"
+        "devto",
+        "reddit"
       ],
-      "firstSeenAt": "2026-05-12T14:51:56.628Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
+      "firstSeenAt": "2026-05-01T13:47:49.694Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "arriemeijer-creator/aerojax",
@@ -1693,6 +2022,17 @@
       ],
       "firstSeenAt": "2026-05-01T13:48:24.488Z",
       "lastSeenAt": "2026-05-21T09:46:35.015Z"
+    },
+    {
+      "fullName": "user-attachments/assets",
+      "totalCount": 85,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "v4bel/dirtyfrag",
@@ -1726,6 +2066,17 @@
       ],
       "firstSeenAt": "2026-05-02T03:28:11.836Z",
       "lastSeenAt": "2026-05-11T15:25:24.240Z"
+    },
+    {
+      "fullName": "langchain-ai/langchain",
+      "totalCount": 83,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-01T13:40:47.050Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "narghev/askdiff",
@@ -1783,17 +2134,6 @@
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
     },
     {
-      "fullName": "mistralai/client-python",
-      "totalCount": 81,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T04:18:11.270Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
       "fullName": "bin4ry/yarbo-nat-in-my-back-yard",
       "totalCount": 81,
       "sourceCount": 2,
@@ -1814,6 +2154,17 @@
       ],
       "firstSeenAt": "2026-05-01T23:17:38.392Z",
       "lastSeenAt": "2026-05-15T14:26:07.875Z"
+    },
+    {
+      "fullName": "ejentum/agent-teams",
+      "totalCount": 79,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "devto"
+      ],
+      "firstSeenAt": "2026-05-07T19:50:24.370Z",
+      "lastSeenAt": "2026-05-30T03:36:32.191Z"
     },
     {
       "fullName": "tsirysndr/rockbox-zig",
@@ -1869,6 +2220,39 @@
       ],
       "firstSeenAt": "2026-05-07T04:53:38.982Z",
       "lastSeenAt": "2026-05-13T10:14:52.996Z"
+    },
+    {
+      "fullName": "github/app",
+      "totalCount": 78,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-15T06:27:04.023Z",
+      "lastSeenAt": "2026-05-28T04:30:14.800Z"
+    },
+    {
+      "fullName": "pmbanugo/tina",
+      "totalCount": 78,
+      "sourceCount": 2,
+      "sources": [
+        "bluesky",
+        "hackernews"
+      ],
+      "firstSeenAt": "2026-05-11T16:13:45.459Z",
+      "lastSeenAt": "2026-05-27T08:37:19.778Z"
+    },
+    {
+      "fullName": "raindrop-ai/workshop",
+      "totalCount": 78,
+      "sourceCount": 2,
+      "sources": [
+        "hackernews",
+        "producthunt"
+      ],
+      "firstSeenAt": "2026-05-15T06:21:09.173Z",
+      "lastSeenAt": "2026-05-26T13:33:16.703Z"
     },
     {
       "fullName": "dventimisupabase/pg_flight_recorder",
@@ -1957,369 +2341,6 @@
       ],
       "firstSeenAt": "2026-05-03T10:34:44.583Z",
       "lastSeenAt": "2026-05-11T11:39:37.103Z"
-    },
-    {
-      "fullName": "aendrix03/graft",
-      "totalCount": 76,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-12T00:21:52.545Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "yaelwrites/big-ass-data-broker-opt-out-list",
-      "totalCount": 76,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T12:21:38.823Z",
-      "lastSeenAt": "2026-05-22T23:20:30.127Z"
-    },
-    {
-      "fullName": "datadog/java-reggie",
-      "totalCount": 76,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T13:04:13.960Z",
-      "lastSeenAt": "2026-05-15T12:10:18.572Z"
-    },
-    {
-      "fullName": "light-heart-labs/mmbt-messy-model-bench-tests",
-      "totalCount": 76,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T04:20:52.369Z",
-      "lastSeenAt": "2026-05-10T16:09:01.639Z"
-    },
-    {
-      "fullName": "mikemiol17/bugtalk",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-18T12:12:25.407Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "openosint/openosint",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-08T16:47:08.670Z",
-      "lastSeenAt": "2026-05-25T04:51:10.028Z"
-    },
-    {
-      "fullName": "davesimoes/crustai",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "facebookresearch/programbench",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "mkbula/hidemydata",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "taoeffect/dez",
-      "totalCount": 75,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "modelcontextprotocol/servers",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "awesome-skills",
-        "devto"
-      ],
-      "firstSeenAt": "2026-05-01T07:09:35.838Z",
-      "lastSeenAt": "2026-05-25T08:43:01.585Z"
-    },
-    {
-      "fullName": "zoharbabin/due-diligence-agents",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-17T17:37:10.554Z",
-      "lastSeenAt": "2026-05-24T13:41:56.965Z"
-    },
-    {
-      "fullName": "phel-lang/phel-lang",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-03T21:05:05.911Z",
-      "lastSeenAt": "2026-05-22T08:33:16.412Z"
-    },
-    {
-      "fullName": "pyinfra-dev/pyinfra",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-19T12:20:48.337Z"
-    },
-    {
-      "fullName": "autoloops/upskill",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T12:07:00.403Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "p32929/mac-juice-monitor",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "microsoft/vscode-hexeditor",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T13:50:45.195Z",
-      "lastSeenAt": "2026-05-13T00:23:31.968Z"
-    },
-    {
-      "fullName": "st-hannibal/arknet",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T09:05:22.589Z",
-      "lastSeenAt": "2026-05-10T06:47:04.169Z"
-    },
-    {
-      "fullName": "rancher/k3k",
-      "totalCount": 74,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T04:02:25.023Z",
-      "lastSeenAt": "2026-05-09T15:42:37.217Z"
-    },
-    {
-      "fullName": "heyputer/puter",
-      "totalCount": 73,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "twitter"
-      ],
-      "firstSeenAt": "2026-05-07T04:54:14.999Z",
-      "lastSeenAt": "2026-05-20T16:03:13.537Z"
-    },
-    {
-      "fullName": "averygan/reclip",
-      "totalCount": 73,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-02T21:01:52.519Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "raindrop-ai/workshop",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "producthunt"
-      ],
-      "firstSeenAt": "2026-05-15T06:21:09.173Z",
-      "lastSeenAt": "2026-05-25T06:51:49.769Z"
-    },
-    {
-      "fullName": "pion/rtwatch",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-09T14:44:37.003Z",
-      "lastSeenAt": "2026-05-20T15:55:56.286Z"
-    },
-    {
-      "fullName": "heymrun/heym",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-01T13:40:47.050Z",
-      "lastSeenAt": "2026-05-18T15:38:08.835Z"
-    },
-    {
-      "fullName": "penthertz/luksbox",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-08T16:47:08.670Z",
-      "lastSeenAt": "2026-05-17T23:08:31.913Z"
-    },
-    {
-      "fullName": "wesm/kata",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-04T08:58:50.862Z",
-      "lastSeenAt": "2026-05-17T17:48:32.737Z"
-    },
-    {
-      "fullName": "gh0st68/cryptirc",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T10:15:25.931Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "kubetail-org/kstack",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T07:40:15.618Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "liamromanis101/k8s-container_escape_audit",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T10:15:25.931Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "oxcl/nix-flake-helium-browser",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "devto",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T10:15:25.931Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "pthom/imgui_bundle",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "bluesky",
-        "hackernews"
-      ],
-      "firstSeenAt": "2026-05-07T19:15:41.008Z",
-      "lastSeenAt": "2026-05-13T10:14:52.996Z"
-    },
-    {
-      "fullName": "ibz-04/quaynor",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T17:17:34.365Z",
-      "lastSeenAt": "2026-05-11T11:39:37.103Z"
-    },
-    {
-      "fullName": "qlni/nodemind",
-      "totalCount": 72,
-      "sourceCount": 2,
-      "sources": [
-        "hackernews",
-        "reddit"
-      ],
-      "firstSeenAt": "2026-05-03T06:15:18.005Z",
-      "lastSeenAt": "2026-05-10T04:11:37.463Z"
     }
   ]
 }

--- a/scripts/__tests__/cache-merge.test.mjs
+++ b/scripts/__tests__/cache-merge.test.mjs
@@ -159,3 +159,51 @@ test("loadExistingJson: corrupt JSON → fallback (does not throw)", async () =>
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// Regression: ISO-string scoreKey must sort by chronology, not collapse to
+// NaN. Before this fix, scrape-funding-news.mjs passed `scoreKey:
+// "publishedAt"` and `Number("2026-05-30T...")` returned NaN — every entry
+// tied at NaN, insertion order won, fresh signals were dropped from the
+// keep-last-50. The page froze at 1 round in 7d on 2026-05-30.
+test("ISO-string scoreKey sorts by chronology (date-parse fallback)", () => {
+  const existing = [
+    { id: "old-1", publishedAt: "2026-04-01T00:00:00Z" },
+    { id: "old-2", publishedAt: "2026-04-15T00:00:00Z" },
+    { id: "old-3", publishedAt: "2026-05-01T00:00:00Z" },
+  ];
+  const fresh = [
+    { id: "new-1", publishedAt: "2026-05-29T12:00:00Z" },
+    { id: "new-2", publishedAt: "2026-05-30T08:00:00Z" },
+  ];
+  const out = mergeAndKeepLastN(existing, fresh, {
+    idKey: "id",
+    scoreKey: "publishedAt",
+    keepN: 3,
+  });
+  // Top-3 by chronology DESC: new-2, new-1, old-3.
+  assert.equal(out.length, 3);
+  assert.equal(out[0].id, "new-2");
+  assert.equal(out[1].id, "new-1");
+  assert.equal(out[2].id, "old-3");
+});
+
+// Regression: ISO-string recencyKey tiebreaks chronologically even when
+// scoreKey is numeric. Same date-parse fallback path. Validates that
+// collectors using `recencyKey: "createdUtc"` get a deterministic tie-break
+// instead of NaN-no-op.
+test("ISO-string recencyKey tiebreaks chronologically", () => {
+  const all = [
+    { id: "a", trendingScore: 100, createdUtc: "2026-05-01T00:00:00Z" },
+    { id: "b", trendingScore: 100, createdUtc: "2026-05-30T00:00:00Z" },
+    { id: "c", trendingScore: 100, createdUtc: "2026-05-15T00:00:00Z" },
+  ];
+  const out = mergeAndKeepLastN([], all, {
+    idKey: "id",
+    scoreKey: "trendingScore",
+    recencyKey: "createdUtc",
+    keepN: 3,
+  });
+  assert.equal(out[0].id, "b", "newest on tied score wins");
+  assert.equal(out[1].id, "c");
+  assert.equal(out[2].id, "a");
+});

--- a/scripts/_cache-merge.mjs
+++ b/scripts/_cache-merge.mjs
@@ -37,6 +37,33 @@ import { readFile } from "node:fs/promises";
 export const KEEP_LAST_N_DEFAULT = 50;
 
 /**
+ * Coerce a score field to a number. Numbers pass through. Strings parse as
+ * numeric first (so "123" → 123), then as ISO-8601 dates (so a publishedAt
+ * field is usable as a primary sort key). Anything that doesn't yield a
+ * finite number falls back to 0 — matching the prior contract for missing
+ * values. Used for both scoreKey and recencyKey.
+ *
+ * Historical bug this fixes: `Number("2026-05-30T05:42Z")` is NaN, which made
+ * the funding-news merge a no-op (every entry tied at NaN, insertion order
+ * won, fresh signals were dropped). After this change, ISO-string scoreKeys
+ * rank by chronology DESC as intended. Backward-compat: existing numeric
+ * scoreKeys are unchanged.
+ */
+function coerceNumeric(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (value == null) return 0;
+  const n = Number(value);
+  if (Number.isFinite(n)) return n;
+  if (typeof value === "string") {
+    const t = Date.parse(value);
+    if (Number.isFinite(t)) return t;
+  }
+  return 0;
+}
+
+/**
  * Read + parse a JSON file. Returns `fallback` on ENOENT. Logs and returns
  * `fallback` on any other read/parse error so a corrupt file never blocks a
  * collector run.
@@ -95,17 +122,17 @@ export function mergeAndKeepLastN(existing, thisRun, opts = {}) {
       byId.set(id, item);
       continue;
     }
-    const newScore = Number(item?.[scoreKey] ?? 0);
-    const prevScore = Number(prev?.[scoreKey] ?? 0);
+    const newScore = coerceNumeric(item?.[scoreKey]);
+    const prevScore = coerceNumeric(prev?.[scoreKey]);
     // Keep the higher-scored version; on tie, prefer newer (item).
     byId.set(id, newScore >= prevScore ? item : prev);
   }
 
   const sorted = Array.from(byId.values()).sort((a, b) => {
-    const scoreCmp = Number(b?.[scoreKey] ?? 0) - Number(a?.[scoreKey] ?? 0);
+    const scoreCmp = coerceNumeric(b?.[scoreKey]) - coerceNumeric(a?.[scoreKey]);
     if (scoreCmp !== 0) return scoreCmp;
     if (recencyKey) {
-      return Number(b?.[recencyKey] ?? 0) - Number(a?.[recencyKey] ?? 0);
+      return coerceNumeric(b?.[recencyKey]) - coerceNumeric(a?.[recencyKey]);
     }
     return 0;
   });

--- a/scripts/promote-unknown-mentions.mjs
+++ b/scripts/promote-unknown-mentions.mjs
@@ -149,8 +149,10 @@ export async function main() {
     stampPerRecord: false,
   });
   if (redisResult.source !== "redis") {
-    throw new Error(
-      "unknown-mentions-promoted data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: file mirror at OUT_PATH already landed and the GH workflow
+    // auto-commits it. Same contract as scrape-funding-news.mjs.
+    console.warn(
+      `[promote-unknown-mentions] data-store write skipped (Redis env unset); file mirror at ${OUT_PATH} is the source of truth this run.`,
     );
   }
 

--- a/scripts/scrape-bluesky.mjs
+++ b/scripts/scrape-bluesky.mjs
@@ -548,8 +548,11 @@ async function main() {
   const mentionsRedis = await writeDataStore("bluesky-mentions", mergedMentionsPayload);
   const trendingRedis = await writeDataStore("bluesky-trending", mergedTrendingPayload);
   if (mentionsRedis.source !== "redis" || trendingRedis.source !== "redis") {
-    throw new Error(
-      "bluesky data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: both file mirrors (MENTIONS_OUT, TRENDING_OUT) already
+    // landed. Same contract as scrape-funding-news.mjs — genuine transport
+    // errors throw from inside writeDataStore and never reach this branch.
+    console.warn(
+      `[bluesky] data-store write skipped (Redis env unset); file mirrors at ${MENTIONS_OUT} + ${TRENDING_OUT} are the source of truth this run.`,
     );
   }
 

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -821,8 +821,14 @@ async function main() {
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news", payload);
     if (redisResult.source !== "redis") {
-      throw new Error(
-        "funding-news data-store write skipped; set REDIS_URL or Upstash env",
+      // Soft-skip: writeDataStore returned "skipped" because the Redis env is
+      // unset (or DATA_STORE_DISABLE=1). The file write at outputPath already
+      // landed and the GH workflow's auto-commit step ships it downstream, so
+      // /funding stays fed from the bundled spine. Real Redis transport
+      // errors propagate from ioredis client.set and would bypass this
+      // branch entirely — we only ever land here on the documented soft path.
+      console.warn(
+        `[funding] data-store write skipped (Redis env unset); file mirror at ${outputPath} is the source of truth this run.`,
       );
     }
     redisInfo = ` [redis: ${redisResult.source}]`;

--- a/scripts/scrape-sec-form-d.mjs
+++ b/scripts/scrape-sec-form-d.mjs
@@ -480,12 +480,20 @@ async function main() {
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news-sec", payload);
     if (redisResult.source !== "redis") {
-      throw new Error(
-        "funding-news-sec data-store write skipped; set REDIS_URL or Upstash env",
+      // Soft-skip — same contract as scrape-funding-news.mjs. File mirror at
+      // outputPath is the deliverable when Redis env is unset; the workflow's
+      // auto-commit ships it. Genuine transport errors throw from inside
+      // writeDataStore and never reach this branch.
+      console.warn(
+        `[sec-form-d] data-store write skipped (Redis env unset); file mirror at ${outputPath} is the source of truth this run.`,
       );
+    } else {
+      // Verify the meta key actually landed under the expected writtenAt.
+      // Soft-skip path above never reaches here, so verify is correctly
+      // gated to the real Redis success branch.
+      await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
+      console.log("[sec-form-d] redis write ok -> funding-news-sec");
     }
-    await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
-    console.log("[sec-form-d] redis write ok -> funding-news-sec");
 
     // TOOLBOX dual-write: emit `funding.sec.formd` per Form D filing.
     // Best-effort — env-unset = silent skip; failures never block.

--- a/scripts/sweep-staleness.mjs
+++ b/scripts/sweep-staleness.mjs
@@ -200,8 +200,11 @@ async function main() {
     stampPerRecord: false,
   });
   if (redisResult.source !== "redis") {
-    throw new Error(
-      "staleness-report data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: file mirror at OUT_PATH already landed and is the
+    // deliverable. Genuine transport errors propagate from inside
+    // writeDataStore. Same contract as scrape-funding-news.mjs.
+    console.warn(
+      `[sweep-staleness] data-store write skipped (Redis env unset); file mirror at ${OUT_PATH} is the source of truth this run.`,
     );
   }
 


### PR DESCRIPTION
Automated data refresh from `Promote unknown mentions`.

- Files changed: 1
- Run: https://github.com/0motionguy/starscreener/actions/runs/26676675204

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.