### PR TITLE
chore(data): refresh bluesky signals 2026-05-30T06:19:43Z

### DIFF
--- a/data/_meta/bluesky.json
+++ b/data/_meta/bluesky.json
@@ -1,8 +1,8 @@
 {
   "source": "bluesky",
   "reason": "ok",
-  "ts": "2026-05-26T04:34:50.426Z",
+  "ts": "2026-05-30T06:19:43.716Z",
   "count": 1,
-  "durationMs": 14456,
+  "durationMs": 14244,
   "extra": {}
 }

--- a/data/bluesky-mentions.json
+++ b/data/bluesky-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T04:34:37.130Z",
+  "fetchedAt": "2026-05-30T06:19:30.072Z",
   "windowDays": 7,
   "scannedPosts": 300,
   "searchQuery": "github.com",
@@ -3827,15 +3827,15 @@
       ]
     },
     "garrytan/gbrain": {
-      "count7d": 3,
+      "count7d": 2,
       "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmq5irajv224",
-        "cid": "bafyreicfmu4agip7dbxkxdnq4zlqzy4hflhbp6hmxqsntprjxu4akhoj2a",
-        "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmq5irajv224",
-        "text": "Yes https://github.com/garrytan/gbrain",
+        "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmzw4atcbv2k",
+        "cid": "bafyreid6ym64l3h6nf2io62diuwrbpt5dixmbk2luh4ojb4yflmu33mgem",
+        "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmzw4atcbv2k",
+        "text": "haha wtf https://github.com/garrytan/gbrain/commits/master/",
         "author": {
           "handle": "garrytan-mirr.selfhosted.social",
           "displayName": "Garry Tan [UNOFFICIAL]"
@@ -3843,8 +3843,8 @@
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-26T04:17:49.000Z",
-        "hoursSincePosted": 0.5
+        "createdAt": "2026-05-30T01:25:36.000Z",
+        "hoursSincePosted": 4.9
       },
       "posts": [
         {
@@ -3873,6 +3873,63 @@
               "matchType": "url",
               "confidence": 1
             },
+            {
+              "fullName": "garrytan/gbrain",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmzw4atcbv2k",
+          "cid": "bafyreid6ym64l3h6nf2io62diuwrbpt5dixmbk2luh4ojb4yflmu33mgem",
+          "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmzw4atcbv2k",
+          "text": "haha wtf https://github.com/garrytan/gbrain/commits/master/",
+          "author": {
+            "handle": "garrytan-mirr.selfhosted.social",
+            "displayName": "Garry Tan [UNOFFICIAL]"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T01:25:36.000Z",
+          "createdUtc": 1780104336,
+          "ageHours": 4.9,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "garrytan/gbrain",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmzw4a2uzv2k",
+          "cid": "bafyreiboe6nblqwhhoek533z4yk3jajm3bd762b26o3b4kivg2y5wulhny",
+          "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmzw4a2uzv2k",
+          "text": "What? https://github.com/garrytan/gbrain/commits/master/",
+          "author": {
+            "handle": "garrytan-mirr.selfhosted.social",
+            "displayName": "Garry Tan [UNOFFICIAL]"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T01:25:32.000Z",
+          "createdUtc": 1780104332,
+          "ageHours": 4.9,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-question"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
             {
               "fullName": "garrytan/gbrain",
               "matchType": "url",
@@ -10049,24 +10106,24 @@
       ]
     },
     "Imbad0202/academic-research-skills": {
-      "count7d": 1,
-      "likesSum7d": 1,
-      "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "count7d": 2,
+      "likesSum7d": 0,
+      "repostsSum7d": 1,
+      "repliesSum7d": 2,
       "topPost": {
-        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmc76vxscrg2",
-        "cid": "bafyreibfdmppt4thxz2j5aps6yo6tujgxthnvkoc4dxlnooxteiksiokry",
-        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmc76vxscrg2",
-        "text": "📈 Today's GitHub Trending: 1. https://github.com/colbymchenry/codegraph - TypeScript, 1910 stars today 2. https://github.com/Imbad0202/academic-research-skills - Python, 1639 stars today 3. https://github.com/tinyhumansai/openhuman - Rust, 3603 stars today 4 […]",
+        "uri": "at://did:plc:5pak3h3vs3v7e6xejtxsu7y7/app.bsky.feed.post/3mmzt5ghun226",
+        "cid": "bafyreibrqzqc4e5oss6lgo27xs5yplnkrf4yrjm6m5of7ljssqb6pjtb6q",
+        "bskyUrl": "https://bsky.app/profile/0xdefec7edcafe.bsky.social/post/3mmzt5ghun226",
+        "text": "3) Les IAg sont à la base des outils de NLP. L'exemple avec l'avocate donne pas trop de détails sur le prompt. Pour ce type de tâche de génération de texte, sans règles très précises d'écriture ça nmarche pas bien. Des chercheurs font des repo de règles pour les llm e.g github.com/Imbad0202/ac... -",
         "author": {
-          "handle": "ghtrend.newsmast.social.ap.brid.gy",
-          "displayName": "GitHub Trending"
+          "handle": "0xdefec7edcafe.bsky.social",
+          "displayName": "Pтiт Poиeч de Fiиdцs"
         },
-        "likeCount": 1,
-        "repostCount": 0,
+        "likeCount": 0,
+        "repostCount": 1,
         "replyCount": 1,
-        "createdAt": "2026-05-20T15:16:57.000Z",
-        "hoursSincePosted": 3.25
+        "createdAt": "2026-05-30T00:45:22.877Z",
+        "hoursSincePosted": 5.57
       },
       "posts": [
         {
@@ -10220,6 +10277,62 @@
           ]
         },
         {
+          "uri": "at://did:plc:5pak3h3vs3v7e6xejtxsu7y7/app.bsky.feed.post/3mmztjagqrc26",
+          "cid": "bafyreig4wkgcy2r4l5mwtesfpjpccdf4wlwtnrntb4qf5lixmvfti2yeqa",
+          "bskyUrl": "https://bsky.app/profile/0xdefec7edcafe.bsky.social/post/3mmztjagqrc26",
+          "text": "- dans github.com/Imbad0202/ac... on peut voir des règles d'écriture de review d'article (sic...). Donne à une IA une source tex et demande les règles très précises appliquées pour écriture ce tex pour d'autres docs. Ensuite réutilise ces règles pour écrire quelque chose avec une IAg.",
+          "author": {
+            "handle": "0xdefec7edcafe.bsky.social",
+            "displayName": "Pтiт Poиeч de Fiиdцs"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T00:51:59.185Z",
+          "createdUtc": 1780102319,
+          "ageHours": 5.46,
+          "trendingScore": 0.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Imbad0202/academic-research-skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:5pak3h3vs3v7e6xejtxsu7y7/app.bsky.feed.post/3mmzt5ghun226",
+          "cid": "bafyreibrqzqc4e5oss6lgo27xs5yplnkrf4yrjm6m5of7ljssqb6pjtb6q",
+          "bskyUrl": "https://bsky.app/profile/0xdefec7edcafe.bsky.social/post/3mmzt5ghun226",
+          "text": "3) Les IAg sont à la base des outils de NLP. L'exemple avec l'avocate donne pas trop de détails sur le prompt. Pour ce type de tâche de génération de texte, sans règles très précises d'écriture ça nmarche pas bien. Des chercheurs font des repo de règles pour les llm e.g github.com/Imbad0202/ac... -",
+          "author": {
+            "handle": "0xdefec7edcafe.bsky.social",
+            "displayName": "Pтiт Poиeч de Fiиdцs"
+          },
+          "likeCount": 0,
+          "repostCount": 1,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T00:45:22.877Z",
+          "createdUtc": 1780101922,
+          "ageHours": 5.57,
+          "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Imbad0202/academic-research-skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
           "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mm7or2sy2f62",
           "cid": "bafyreif3k7l55ofqb2nr5dfu5xz7tfqdabcsdundbyjyygzbuyl5xymohm",
           "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mm7or2sy2f62",
@@ -10331,23 +10444,23 @@
       ]
     },
     "openclaw/openclaw": {
-      "count7d": 1,
+      "count7d": 3,
       "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmn6r6qisj2u",
-        "cid": "bafyreiavqqdxdx7n4lapimu6sqvduup6cdi7fbxj2jbuoo54asaxe5y4fy",
-        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmn6r6qisj2u",
-        "text": "🟠 OpenClaw beta adds live run steering, meeting-notes capture, and major model-listing speedups OpenClaw shipped v2026.5.24-beta.2 with several workflow-level changes hiding inside a beta patch release, includi... https://github.com/openclaw/openclaw/releases/tag/v2026.5.24-beta.2 #AI #AgentWyre",
+        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzsfdg7ja2f",
+        "cid": "bafyreigmexdl2g4kercec3wsmnrk755cwnemhnfdkdgsjti2ngwuwkawca",
+        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzsfdg7ja2f",
+        "text": "🟠 OpenClaw beta.4 lands GitHub Copilot agent runtime, Codex Supervisor plugin, and Claude Opus 4.8 support OpenClaw shipped v2026.5.28-beta.4 with several workflow-shifting additions hidden inside a beta patch... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
         "author": {
           "handle": "agentwyre.ai"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-25T00:08:37.240148+00:00",
-        "hoursSincePosted": 4.71
+        "createdAt": "2026-05-30T00:31:54.017962+00:00",
+        "hoursSincePosted": 5.79
       },
       "posts": [
         {
@@ -10504,6 +10617,90 @@
           "createdUtc": 1778609979,
           "ageHours": 2.54,
           "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzsfdg7ja2f",
+          "cid": "bafyreigmexdl2g4kercec3wsmnrk755cwnemhnfdkdgsjti2ngwuwkawca",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzsfdg7ja2f",
+          "text": "🟠 OpenClaw beta.4 lands GitHub Copilot agent runtime, Codex Supervisor plugin, and Claude Opus 4.8 support OpenClaw shipped v2026.5.28-beta.4 with several workflow-shifting additions hidden inside a beta patch... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T00:31:54.017962+00:00",
+          "createdUtc": 1780101114,
+          "ageHours": 5.79,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzsfb2dpj2i",
+          "cid": "bafyreih2rfeuhzst2hwaowaiycr5sqssex3nc6irtpjiyg5zngwgi32nwa",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzsfb2dpj2i",
+          "text": "🟠 OpenClaw beta adds GitHub Copilot runtime, Workboard handoffs, and stricter delivery safeguards OpenClaw shipped v2026.5.28-beta.4 with workflow-impacting additions hiding inside a beta patch train: GitHub... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T00:31:51.001426+00:00",
+          "createdUtc": 1780101111,
+          "ageHours": 5.79,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzpttntml2s",
+          "cid": "bafyreibzq32azul6j46o4ytsqyy7z4ijfkejdlhohrnzwgd666x7byoo2q",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzpttntml2s",
+          "text": "🟠 OpenClaw beta.4 lands GitHub Copilot agent runtime, Codex Supervisor plugin, and Claude Opus 4.8 support OpenClaw shipped v2026.5.28-beta.4 with several workflow-shifting additions hidden inside a beta patch... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-29T23:46:19.172103+00:00",
+          "createdUtc": 1780098379,
+          "ageHours": 6.55,
+          "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
             "is-announcement"
@@ -12183,25 +12380,53 @@
     },
     "aloshdenny/reverse-SynthID": {
       "count7d": 1,
-      "likesSum7d": 1,
+      "likesSum7d": 5,
       "repostsSum7d": 0,
       "repliesSum7d": 1,
       "topPost": {
-        "uri": "at://did:plc:m7w7vgngd2c5sml5qyseml2d/app.bsky.feed.post/3mllch6k3622z",
-        "cid": "bafyreicq5ma32knlissmtpz4jhclqdjfczvye2bulcs6tlpcty65nyyl3m",
-        "bskyUrl": "https://bsky.app/profile/boat.horse/post/3mllch6k3622z",
-        "text": "So the reverse-engineered repo seemed real enough to nudge me build a browser extension that pipes images from a browsing session directly to it, but it seems to have a fairly high false positive rate. The original repo: github.com/aloshdenny/r...",
+        "uri": "at://did:plc:v64k7asq54jpxr3uyoircckd/app.bsky.feed.post/3mmzx7m4sjc2f",
+        "cid": "bafyreiencl7eqgovjihsuu67q7hcgpjnmzpxhx6yy42mowcdxzwqidp3uq",
+        "bskyUrl": "https://bsky.app/profile/kastor.sh/post/3mmzx7m4sjc2f",
+        "text": "No, unfortunately gemini hallucinates synthid patterns pretty commonly, and will fail to recognize them too. The Google Deepmind portal has a deterministic tool for it, but it’s not publicly accessible. There is this reverse engineered tool though, which may work - github.com/aloshdenny/r...",
         "author": {
-          "handle": "boat.horse",
-          "displayName": "Ryan Bateman"
+          "handle": "kastor.sh",
+          "displayName": "Kastor (Momocon Era)"
         },
-        "likeCount": 1,
+        "likeCount": 5,
         "repostCount": 0,
         "replyCount": 1,
-        "createdAt": "2026-05-11T12:44:08.521Z",
-        "hoursSincePosted": 3.49
+        "createdAt": "2026-05-30T01:58:10.882Z",
+        "hoursSincePosted": 4.36
       },
       "posts": [
+        {
+          "uri": "at://did:plc:v64k7asq54jpxr3uyoircckd/app.bsky.feed.post/3mmzx7m4sjc2f",
+          "cid": "bafyreiencl7eqgovjihsuu67q7hcgpjnmzpxhx6yy42mowcdxzwqidp3uq",
+          "bskyUrl": "https://bsky.app/profile/kastor.sh/post/3mmzx7m4sjc2f",
+          "text": "No, unfortunately gemini hallucinates synthid patterns pretty commonly, and will fail to recognize them too. The Google Deepmind portal has a deterministic tool for it, but it’s not publicly accessible. There is this reverse engineered tool though, which may work - github.com/aloshdenny/r...",
+          "author": {
+            "handle": "kastor.sh",
+            "displayName": "Kastor (Momocon Era)"
+          },
+          "likeCount": 5,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T01:58:10.882Z",
+          "createdUtc": 1780106290,
+          "ageHours": 4.36,
+          "trendingScore": 5.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "aloshdenny/reverse-SynthID",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:m7w7vgngd2c5sml5qyseml2d/app.bsky.feed.post/3mllch6k3622z",
           "cid": "bafyreicq5ma32knlissmtpz4jhclqdjfczvye2bulcs6tlpcty65nyyl3m",
@@ -13655,19 +13880,19 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:l3ew7x4vzptgqeecfulu477l/app.bsky.feed.post/3mmcl6wkkxs2o",
-        "cid": "bafyreig2fohrb24pkew4icebvvxopz5w2cfb3yucmifczwuhhehgavxghq",
-        "bskyUrl": "https://bsky.app/profile/guillemhs.eurosky.social/post/3mmcl6wkkxs2o",
-        "text": "Necessito una màquina per posar això github.com/NousResearch...",
+        "uri": "at://did:plc:vtdla2r74e6gyr2mb6lrbn6a/app.bsky.feed.post/3mmzwko6l3c2r",
+        "cid": "bafyreifcqb3eewjwcw3wp3xh6shn4c4bggh24gc6cai747hck65amubp6i",
+        "bskyUrl": "https://bsky.app/profile/kweiner.bsky.social/post/3mmzwko6l3c2r",
+        "text": "Hermes Agent includes some cool graphics in its Pull Requests. This is one I contributed to which instructs Kanban workers not to call \"clarify\". github.com/NousResearch...",
         "author": {
-          "handle": "guillemhs.eurosky.social",
-          "displayName": "Guillem"
+          "handle": "kweiner.bsky.social",
+          "displayName": "Ken Weiner"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-20T18:51:49.379Z",
-        "hoursSincePosted": 2.31
+        "createdAt": "2026-05-30T01:46:28.390Z",
+        "hoursSincePosted": 4.55
       },
       "posts": [
         {
@@ -13691,6 +13916,34 @@
             "has-md-file"
           ],
           "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:vtdla2r74e6gyr2mb6lrbn6a/app.bsky.feed.post/3mmzwko6l3c2r",
+          "cid": "bafyreifcqb3eewjwcw3wp3xh6shn4c4bggh24gc6cai747hck65amubp6i",
+          "bskyUrl": "https://bsky.app/profile/kweiner.bsky.social/post/3mmzwko6l3c2r",
+          "text": "Hermes Agent includes some cool graphics in its Pull Requests. This is one I contributed to which instructs Kanban workers not to call \"clarify\". github.com/NousResearch...",
+          "author": {
+            "handle": "kweiner.bsky.social",
+            "displayName": "Ken Weiner"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T01:46:28.390Z",
+          "createdUtc": 1780105588,
+          "ageHours": 4.55,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -28297,6 +28550,108 @@
           ]
         }
       ]
+    },
+    "YouMind-OpenLab/awesome-gpt-image-2": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mn27lv5daa2o",
+        "cid": "bafyreih7vmb4wl5iqd2cqfxyc5hiawkpas27ifjevwp2nkpzr5hc2v6uza",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mn27lv5daa2o",
+        "text": "https://github.com/YouMind-OpenLab/awesome-gpt-image-2",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-30T04:28:12Z",
+        "hoursSincePosted": 1.86
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mn27lv5daa2o",
+          "cid": "bafyreih7vmb4wl5iqd2cqfxyc5hiawkpas27ifjevwp2nkpzr5hc2v6uza",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mn27lv5daa2o",
+          "text": "https://github.com/YouMind-OpenLab/awesome-gpt-image-2",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T04:28:12Z",
+          "createdUtc": 1780115292,
+          "ageHours": 1.86,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "YouMind-OpenLab/awesome-gpt-image-2",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "woheller69/FreeDroidWarn": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 2,
+      "repliesSum7d": 1,
+      "topPost": {
+        "uri": "at://did:plc:bh6enc7x2bbfg32j5lzcanp3/app.bsky.feed.post/3mmzupgikj22u",
+        "cid": "bafyreic76u253pwxdxl6t6aliuqcmvykyzsk6n6726hbwchocjzn742rnm",
+        "bskyUrl": "https://bsky.app/profile/bammerusi.bsky.social/post/3mmzupgikj22u",
+        "text": "Anyway, here's some more links: Suggestions (ironically on a Google Doc): docs.google.com/document/d/1... Issue tracker: issuetracker.google.com/issues/44263... FreeDroidWarn on GitHub: github.com/woheller69/F...",
+        "author": {
+          "handle": "bammerusi.bsky.social",
+          "displayName": "Mr. Regular User 🍉"
+        },
+        "likeCount": 1,
+        "repostCount": 2,
+        "replyCount": 1,
+        "createdAt": "2026-05-30T01:13:20.619Z",
+        "hoursSincePosted": 5.1
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:bh6enc7x2bbfg32j5lzcanp3/app.bsky.feed.post/3mmzupgikj22u",
+          "cid": "bafyreic76u253pwxdxl6t6aliuqcmvykyzsk6n6726hbwchocjzn742rnm",
+          "bskyUrl": "https://bsky.app/profile/bammerusi.bsky.social/post/3mmzupgikj22u",
+          "text": "Anyway, here's some more links: Suggestions (ironically on a Google Doc): docs.google.com/document/d/1... Issue tracker: issuetracker.google.com/issues/44263... FreeDroidWarn on GitHub: github.com/woheller69/F...",
+          "author": {
+            "handle": "bammerusi.bsky.social",
+            "displayName": "Mr. Regular User 🍉"
+          },
+          "likeCount": 1,
+          "repostCount": 2,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T01:13:20.619Z",
+          "createdUtc": 1780103600,
+          "ageHours": 5.1,
+          "trendingScore": 5.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "woheller69/FreeDroidWarn",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "mentionsByRepoId": {
@@ -32122,15 +32477,15 @@
       ]
     },
     "garrytan--gbrain": {
-      "count7d": 3,
+      "count7d": 2,
       "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmq5irajv224",
-        "cid": "bafyreicfmu4agip7dbxkxdnq4zlqzy4hflhbp6hmxqsntprjxu4akhoj2a",
-        "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmq5irajv224",
-        "text": "Yes https://github.com/garrytan/gbrain",
+        "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmzw4atcbv2k",
+        "cid": "bafyreid6ym64l3h6nf2io62diuwrbpt5dixmbk2luh4ojb4yflmu33mgem",
+        "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmzw4atcbv2k",
+        "text": "haha wtf https://github.com/garrytan/gbrain/commits/master/",
         "author": {
           "handle": "garrytan-mirr.selfhosted.social",
           "displayName": "Garry Tan [UNOFFICIAL]"
@@ -32138,8 +32493,8 @@
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-26T04:17:49.000Z",
-        "hoursSincePosted": 0.5
+        "createdAt": "2026-05-30T01:25:36.000Z",
+        "hoursSincePosted": 4.9
       },
       "posts": [
         {
@@ -32168,6 +32523,63 @@
               "matchType": "url",
               "confidence": 1
             },
+            {
+              "fullName": "garrytan/gbrain",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmzw4atcbv2k",
+          "cid": "bafyreid6ym64l3h6nf2io62diuwrbpt5dixmbk2luh4ojb4yflmu33mgem",
+          "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmzw4atcbv2k",
+          "text": "haha wtf https://github.com/garrytan/gbrain/commits/master/",
+          "author": {
+            "handle": "garrytan-mirr.selfhosted.social",
+            "displayName": "Garry Tan [UNOFFICIAL]"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T01:25:36.000Z",
+          "createdUtc": 1780104336,
+          "ageHours": 4.9,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "garrytan/gbrain",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:ivep2atikg2cr2tawlzatfqn/app.bsky.feed.post/3mmzw4a2uzv2k",
+          "cid": "bafyreiboe6nblqwhhoek533z4yk3jajm3bd762b26o3b4kivg2y5wulhny",
+          "bskyUrl": "https://bsky.app/profile/garrytan-mirr.selfhosted.social/post/3mmzw4a2uzv2k",
+          "text": "What? https://github.com/garrytan/gbrain/commits/master/",
+          "author": {
+            "handle": "garrytan-mirr.selfhosted.social",
+            "displayName": "Garry Tan [UNOFFICIAL]"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T01:25:32.000Z",
+          "createdUtc": 1780104332,
+          "ageHours": 4.9,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-question"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
             {
               "fullName": "garrytan/gbrain",
               "matchType": "url",
@@ -38344,24 +38756,24 @@
       ]
     },
     "imbad0202--academic-research-skills": {
-      "count7d": 1,
-      "likesSum7d": 1,
-      "repostsSum7d": 0,
-      "repliesSum7d": 1,
+      "count7d": 2,
+      "likesSum7d": 0,
+      "repostsSum7d": 1,
+      "repliesSum7d": 2,
       "topPost": {
-        "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mmc76vxscrg2",
-        "cid": "bafyreibfdmppt4thxz2j5aps6yo6tujgxthnvkoc4dxlnooxteiksiokry",
-        "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mmc76vxscrg2",
-        "text": "📈 Today's GitHub Trending: 1. https://github.com/colbymchenry/codegraph - TypeScript, 1910 stars today 2. https://github.com/Imbad0202/academic-research-skills - Python, 1639 stars today 3. https://github.com/tinyhumansai/openhuman - Rust, 3603 stars today 4 […]",
+        "uri": "at://did:plc:5pak3h3vs3v7e6xejtxsu7y7/app.bsky.feed.post/3mmzt5ghun226",
+        "cid": "bafyreibrqzqc4e5oss6lgo27xs5yplnkrf4yrjm6m5of7ljssqb6pjtb6q",
+        "bskyUrl": "https://bsky.app/profile/0xdefec7edcafe.bsky.social/post/3mmzt5ghun226",
+        "text": "3) Les IAg sont à la base des outils de NLP. L'exemple avec l'avocate donne pas trop de détails sur le prompt. Pour ce type de tâche de génération de texte, sans règles très précises d'écriture ça nmarche pas bien. Des chercheurs font des repo de règles pour les llm e.g github.com/Imbad0202/ac... -",
         "author": {
-          "handle": "ghtrend.newsmast.social.ap.brid.gy",
-          "displayName": "GitHub Trending"
+          "handle": "0xdefec7edcafe.bsky.social",
+          "displayName": "Pтiт Poиeч de Fiиdцs"
         },
-        "likeCount": 1,
-        "repostCount": 0,
+        "likeCount": 0,
+        "repostCount": 1,
         "replyCount": 1,
-        "createdAt": "2026-05-20T15:16:57.000Z",
-        "hoursSincePosted": 3.25
+        "createdAt": "2026-05-30T00:45:22.877Z",
+        "hoursSincePosted": 5.57
       },
       "posts": [
         {
@@ -38515,6 +38927,62 @@
           ]
         },
         {
+          "uri": "at://did:plc:5pak3h3vs3v7e6xejtxsu7y7/app.bsky.feed.post/3mmztjagqrc26",
+          "cid": "bafyreig4wkgcy2r4l5mwtesfpjpccdf4wlwtnrntb4qf5lixmvfti2yeqa",
+          "bskyUrl": "https://bsky.app/profile/0xdefec7edcafe.bsky.social/post/3mmztjagqrc26",
+          "text": "- dans github.com/Imbad0202/ac... on peut voir des règles d'écriture de review d'article (sic...). Donne à une IA une source tex et demande les règles très précises appliquées pour écriture ce tex pour d'autres docs. Ensuite réutilise ces règles pour écrire quelque chose avec une IAg.",
+          "author": {
+            "handle": "0xdefec7edcafe.bsky.social",
+            "displayName": "Pтiт Poиeч de Fiиdцs"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T00:51:59.185Z",
+          "createdUtc": 1780102319,
+          "ageHours": 5.46,
+          "trendingScore": 0.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Imbad0202/academic-research-skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:5pak3h3vs3v7e6xejtxsu7y7/app.bsky.feed.post/3mmzt5ghun226",
+          "cid": "bafyreibrqzqc4e5oss6lgo27xs5yplnkrf4yrjm6m5of7ljssqb6pjtb6q",
+          "bskyUrl": "https://bsky.app/profile/0xdefec7edcafe.bsky.social/post/3mmzt5ghun226",
+          "text": "3) Les IAg sont à la base des outils de NLP. L'exemple avec l'avocate donne pas trop de détails sur le prompt. Pour ce type de tâche de génération de texte, sans règles très précises d'écriture ça nmarche pas bien. Des chercheurs font des repo de règles pour les llm e.g github.com/Imbad0202/ac... -",
+          "author": {
+            "handle": "0xdefec7edcafe.bsky.social",
+            "displayName": "Pтiт Poиeч de Fiиdцs"
+          },
+          "likeCount": 0,
+          "repostCount": 1,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T00:45:22.877Z",
+          "createdUtc": 1780101922,
+          "ageHours": 5.57,
+          "trendingScore": 2.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "Imbad0202/academic-research-skills",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
           "uri": "at://did:plc:jbqcwhxtnchfilrbteswkz5k/app.bsky.feed.post/3mm7or2sy2f62",
           "cid": "bafyreif3k7l55ofqb2nr5dfu5xz7tfqdabcsdundbyjyygzbuyl5xymohm",
           "bskyUrl": "https://bsky.app/profile/ghtrend.newsmast.social.ap.brid.gy/post/3mm7or2sy2f62",
@@ -38626,23 +39094,23 @@
       ]
     },
     "openclaw--openclaw": {
-      "count7d": 1,
+      "count7d": 3,
       "likesSum7d": 0,
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmn6r6qisj2u",
-        "cid": "bafyreiavqqdxdx7n4lapimu6sqvduup6cdi7fbxj2jbuoo54asaxe5y4fy",
-        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmn6r6qisj2u",
-        "text": "🟠 OpenClaw beta adds live run steering, meeting-notes capture, and major model-listing speedups OpenClaw shipped v2026.5.24-beta.2 with several workflow-level changes hiding inside a beta patch release, includi... https://github.com/openclaw/openclaw/releases/tag/v2026.5.24-beta.2 #AI #AgentWyre",
+        "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzsfdg7ja2f",
+        "cid": "bafyreigmexdl2g4kercec3wsmnrk755cwnemhnfdkdgsjti2ngwuwkawca",
+        "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzsfdg7ja2f",
+        "text": "🟠 OpenClaw beta.4 lands GitHub Copilot agent runtime, Codex Supervisor plugin, and Claude Opus 4.8 support OpenClaw shipped v2026.5.28-beta.4 with several workflow-shifting additions hidden inside a beta patch... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
         "author": {
           "handle": "agentwyre.ai"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-25T00:08:37.240148+00:00",
-        "hoursSincePosted": 4.71
+        "createdAt": "2026-05-30T00:31:54.017962+00:00",
+        "hoursSincePosted": 5.79
       },
       "posts": [
         {
@@ -38799,6 +39267,90 @@
           "createdUtc": 1778609979,
           "ageHours": 2.54,
           "trendingScore": 1,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzsfdg7ja2f",
+          "cid": "bafyreigmexdl2g4kercec3wsmnrk755cwnemhnfdkdgsjti2ngwuwkawca",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzsfdg7ja2f",
+          "text": "🟠 OpenClaw beta.4 lands GitHub Copilot agent runtime, Codex Supervisor plugin, and Claude Opus 4.8 support OpenClaw shipped v2026.5.28-beta.4 with several workflow-shifting additions hidden inside a beta patch... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T00:31:54.017962+00:00",
+          "createdUtc": 1780101114,
+          "ageHours": 5.79,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzsfb2dpj2i",
+          "cid": "bafyreih2rfeuhzst2hwaowaiycr5sqssex3nc6irtpjiyg5zngwgi32nwa",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzsfb2dpj2i",
+          "text": "🟠 OpenClaw beta adds GitHub Copilot runtime, Workboard handoffs, and stricter delivery safeguards OpenClaw shipped v2026.5.28-beta.4 with workflow-impacting additions hiding inside a beta patch train: GitHub... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T00:31:51.001426+00:00",
+          "createdUtc": 1780101111,
+          "ageHours": 5.79,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo",
+            "is-announcement"
+          ],
+          "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "openclaw/openclaw",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:z3gdcc47wptxd4c4w2u4pxy6/app.bsky.feed.post/3mmzpttntml2s",
+          "cid": "bafyreibzq32azul6j46o4ytsqyy7z4ijfkejdlhohrnzwgd666x7byoo2q",
+          "bskyUrl": "https://bsky.app/profile/agentwyre.ai/post/3mmzpttntml2s",
+          "text": "🟠 OpenClaw beta.4 lands GitHub Copilot agent runtime, Codex Supervisor plugin, and Claude Opus 4.8 support OpenClaw shipped v2026.5.28-beta.4 with several workflow-shifting additions hidden inside a beta patch... https://github.com/openclaw/openclaw/releases/tag/v2026.5.28-beta.4 #AI #AgentWyre",
+          "author": {
+            "handle": "agentwyre.ai"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-29T23:46:19.172103+00:00",
+          "createdUtc": 1780098379,
+          "ageHours": 6.55,
+          "trendingScore": 0,
           "content_tags": [
             "has-github-repo",
             "is-announcement"
@@ -40478,25 +41030,53 @@
     },
     "aloshdenny--reverse-synthid": {
       "count7d": 1,
-      "likesSum7d": 1,
+      "likesSum7d": 5,
       "repostsSum7d": 0,
       "repliesSum7d": 1,
       "topPost": {
-        "uri": "at://did:plc:m7w7vgngd2c5sml5qyseml2d/app.bsky.feed.post/3mllch6k3622z",
-        "cid": "bafyreicq5ma32knlissmtpz4jhclqdjfczvye2bulcs6tlpcty65nyyl3m",
-        "bskyUrl": "https://bsky.app/profile/boat.horse/post/3mllch6k3622z",
-        "text": "So the reverse-engineered repo seemed real enough to nudge me build a browser extension that pipes images from a browsing session directly to it, but it seems to have a fairly high false positive rate. The original repo: github.com/aloshdenny/r...",
+        "uri": "at://did:plc:v64k7asq54jpxr3uyoircckd/app.bsky.feed.post/3mmzx7m4sjc2f",
+        "cid": "bafyreiencl7eqgovjihsuu67q7hcgpjnmzpxhx6yy42mowcdxzwqidp3uq",
+        "bskyUrl": "https://bsky.app/profile/kastor.sh/post/3mmzx7m4sjc2f",
+        "text": "No, unfortunately gemini hallucinates synthid patterns pretty commonly, and will fail to recognize them too. The Google Deepmind portal has a deterministic tool for it, but it’s not publicly accessible. There is this reverse engineered tool though, which may work - github.com/aloshdenny/r...",
         "author": {
-          "handle": "boat.horse",
-          "displayName": "Ryan Bateman"
+          "handle": "kastor.sh",
+          "displayName": "Kastor (Momocon Era)"
         },
-        "likeCount": 1,
+        "likeCount": 5,
         "repostCount": 0,
         "replyCount": 1,
-        "createdAt": "2026-05-11T12:44:08.521Z",
-        "hoursSincePosted": 3.49
+        "createdAt": "2026-05-30T01:58:10.882Z",
+        "hoursSincePosted": 4.36
       },
       "posts": [
+        {
+          "uri": "at://did:plc:v64k7asq54jpxr3uyoircckd/app.bsky.feed.post/3mmzx7m4sjc2f",
+          "cid": "bafyreiencl7eqgovjihsuu67q7hcgpjnmzpxhx6yy42mowcdxzwqidp3uq",
+          "bskyUrl": "https://bsky.app/profile/kastor.sh/post/3mmzx7m4sjc2f",
+          "text": "No, unfortunately gemini hallucinates synthid patterns pretty commonly, and will fail to recognize them too. The Google Deepmind portal has a deterministic tool for it, but it’s not publicly accessible. There is this reverse engineered tool though, which may work - github.com/aloshdenny/r...",
+          "author": {
+            "handle": "kastor.sh",
+            "displayName": "Kastor (Momocon Era)"
+          },
+          "likeCount": 5,
+          "repostCount": 0,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T01:58:10.882Z",
+          "createdUtc": 1780106290,
+          "ageHours": 4.36,
+          "trendingScore": 5.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "aloshdenny/reverse-SynthID",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
         {
           "uri": "at://did:plc:m7w7vgngd2c5sml5qyseml2d/app.bsky.feed.post/3mllch6k3622z",
           "cid": "bafyreicq5ma32knlissmtpz4jhclqdjfczvye2bulcs6tlpcty65nyyl3m",
@@ -41950,19 +42530,19 @@
       "repostsSum7d": 0,
       "repliesSum7d": 0,
       "topPost": {
-        "uri": "at://did:plc:l3ew7x4vzptgqeecfulu477l/app.bsky.feed.post/3mmcl6wkkxs2o",
-        "cid": "bafyreig2fohrb24pkew4icebvvxopz5w2cfb3yucmifczwuhhehgavxghq",
-        "bskyUrl": "https://bsky.app/profile/guillemhs.eurosky.social/post/3mmcl6wkkxs2o",
-        "text": "Necessito una màquina per posar això github.com/NousResearch...",
+        "uri": "at://did:plc:vtdla2r74e6gyr2mb6lrbn6a/app.bsky.feed.post/3mmzwko6l3c2r",
+        "cid": "bafyreifcqb3eewjwcw3wp3xh6shn4c4bggh24gc6cai747hck65amubp6i",
+        "bskyUrl": "https://bsky.app/profile/kweiner.bsky.social/post/3mmzwko6l3c2r",
+        "text": "Hermes Agent includes some cool graphics in its Pull Requests. This is one I contributed to which instructs Kanban workers not to call \"clarify\". github.com/NousResearch...",
         "author": {
-          "handle": "guillemhs.eurosky.social",
-          "displayName": "Guillem"
+          "handle": "kweiner.bsky.social",
+          "displayName": "Ken Weiner"
         },
         "likeCount": 0,
         "repostCount": 0,
         "replyCount": 0,
-        "createdAt": "2026-05-20T18:51:49.379Z",
-        "hoursSincePosted": 2.31
+        "createdAt": "2026-05-30T01:46:28.390Z",
+        "hoursSincePosted": 4.55
       },
       "posts": [
         {
@@ -41986,6 +42566,34 @@
             "has-md-file"
           ],
           "value_score": 2,
+          "linkedRepos": [
+            {
+              "fullName": "NousResearch/hermes-agent",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        },
+        {
+          "uri": "at://did:plc:vtdla2r74e6gyr2mb6lrbn6a/app.bsky.feed.post/3mmzwko6l3c2r",
+          "cid": "bafyreifcqb3eewjwcw3wp3xh6shn4c4bggh24gc6cai747hck65amubp6i",
+          "bskyUrl": "https://bsky.app/profile/kweiner.bsky.social/post/3mmzwko6l3c2r",
+          "text": "Hermes Agent includes some cool graphics in its Pull Requests. This is one I contributed to which instructs Kanban workers not to call \"clarify\". github.com/NousResearch...",
+          "author": {
+            "handle": "kweiner.bsky.social",
+            "displayName": "Ken Weiner"
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T01:46:28.390Z",
+          "createdUtc": 1780105588,
+          "ageHours": 4.55,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
           "linkedRepos": [
             {
               "fullName": "NousResearch/hermes-agent",
@@ -56592,36 +57200,143 @@
           ]
         }
       ]
+    },
+    "youmind-openlab--awesome-gpt-image-2": {
+      "count7d": 1,
+      "likesSum7d": 0,
+      "repostsSum7d": 0,
+      "repliesSum7d": 0,
+      "topPost": {
+        "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mn27lv5daa2o",
+        "cid": "bafyreih7vmb4wl5iqd2cqfxyc5hiawkpas27ifjevwp2nkpzr5hc2v6uza",
+        "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mn27lv5daa2o",
+        "text": "https://github.com/YouMind-OpenLab/awesome-gpt-image-2",
+        "author": {
+          "handle": "tom-doerr.bsky.social",
+          "displayName": "Tom Dörr "
+        },
+        "likeCount": 0,
+        "repostCount": 0,
+        "replyCount": 0,
+        "createdAt": "2026-05-30T04:28:12Z",
+        "hoursSincePosted": 1.86
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:wrkapohdwvaer4yxkm5d3wqo/app.bsky.feed.post/3mn27lv5daa2o",
+          "cid": "bafyreih7vmb4wl5iqd2cqfxyc5hiawkpas27ifjevwp2nkpzr5hc2v6uza",
+          "bskyUrl": "https://bsky.app/profile/tom-doerr.bsky.social/post/3mn27lv5daa2o",
+          "text": "https://github.com/YouMind-OpenLab/awesome-gpt-image-2",
+          "author": {
+            "handle": "tom-doerr.bsky.social",
+            "displayName": "Tom Dörr "
+          },
+          "likeCount": 0,
+          "repostCount": 0,
+          "replyCount": 0,
+          "createdAt": "2026-05-30T04:28:12Z",
+          "createdUtc": 1780115292,
+          "ageHours": 1.86,
+          "trendingScore": 0,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "YouMind-OpenLab/awesome-gpt-image-2",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
+    },
+    "woheller69--freedroidwarn": {
+      "count7d": 1,
+      "likesSum7d": 1,
+      "repostsSum7d": 2,
+      "repliesSum7d": 1,
+      "topPost": {
+        "uri": "at://did:plc:bh6enc7x2bbfg32j5lzcanp3/app.bsky.feed.post/3mmzupgikj22u",
+        "cid": "bafyreic76u253pwxdxl6t6aliuqcmvykyzsk6n6726hbwchocjzn742rnm",
+        "bskyUrl": "https://bsky.app/profile/bammerusi.bsky.social/post/3mmzupgikj22u",
+        "text": "Anyway, here's some more links: Suggestions (ironically on a Google Doc): docs.google.com/document/d/1... Issue tracker: issuetracker.google.com/issues/44263... FreeDroidWarn on GitHub: github.com/woheller69/F...",
+        "author": {
+          "handle": "bammerusi.bsky.social",
+          "displayName": "Mr. Regular User 🍉"
+        },
+        "likeCount": 1,
+        "repostCount": 2,
+        "replyCount": 1,
+        "createdAt": "2026-05-30T01:13:20.619Z",
+        "hoursSincePosted": 5.1
+      },
+      "posts": [
+        {
+          "uri": "at://did:plc:bh6enc7x2bbfg32j5lzcanp3/app.bsky.feed.post/3mmzupgikj22u",
+          "cid": "bafyreic76u253pwxdxl6t6aliuqcmvykyzsk6n6726hbwchocjzn742rnm",
+          "bskyUrl": "https://bsky.app/profile/bammerusi.bsky.social/post/3mmzupgikj22u",
+          "text": "Anyway, here's some more links: Suggestions (ironically on a Google Doc): docs.google.com/document/d/1... Issue tracker: issuetracker.google.com/issues/44263... FreeDroidWarn on GitHub: github.com/woheller69/F...",
+          "author": {
+            "handle": "bammerusi.bsky.social",
+            "displayName": "Mr. Regular User 🍉"
+          },
+          "likeCount": 1,
+          "repostCount": 2,
+          "replyCount": 1,
+          "createdAt": "2026-05-30T01:13:20.619Z",
+          "createdUtc": 1780103600,
+          "ageHours": 5.1,
+          "trendingScore": 5.5,
+          "content_tags": [
+            "has-github-repo"
+          ],
+          "value_score": 1,
+          "linkedRepos": [
+            {
+              "fullName": "woheller69/FreeDroidWarn",
+              "matchType": "url",
+              "confidence": 1
+            }
+          ]
+        }
+      ]
     }
   },
   "leaderboard": [
     {
-      "fullName": "cli/cli",
+      "fullName": "aloshdenny/reverse-SynthID",
       "count7d": 1,
-      "likesSum7d": 4
+      "likesSum7d": 5
     },
     {
-      "fullName": "MinishLab/semble",
+      "fullName": "woheller69/FreeDroidWarn",
       "count7d": 1,
-      "likesSum7d": 2
+      "likesSum7d": 1
     },
     {
-      "fullName": "garrytan/gbrain",
+      "fullName": "openclaw/openclaw",
       "count7d": 3,
       "likesSum7d": 0
     },
     {
-      "fullName": "anthropics/knowledge-work-plugins",
+      "fullName": "garrytan/gbrain",
+      "count7d": 2,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "Imbad0202/academic-research-skills",
+      "count7d": 2,
+      "likesSum7d": 0
+    },
+    {
+      "fullName": "NousResearch/hermes-agent",
       "count7d": 1,
       "likesSum7d": 0
     },
     {
-      "fullName": "kubernetes-sigs/agent-sandbox",
-      "count7d": 1,
-      "likesSum7d": 0
-    },
-    {
-      "fullName": "rtk-ai/rtk",
+      "fullName": "YouMind-OpenLab/awesome-gpt-image-2",
       "count7d": 1,
       "likesSum7d": 0
     }

--- a/data/bluesky-trending.json
+++ b/data/bluesky-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-26T04:34:37.130Z",
+  "fetchedAt": "2026-05-30T06:19:30.072Z",
   "discoveryVersion": "2026-04-21",
   "keywords": [
     "AI agents",
@@ -13,12 +13,12 @@
     "Open source AI"
   ],
   "keywordCounts": {
-    "AI agents": 90,
+    "AI agents": 89,
     "LLMs": 60,
     "Coding agents": 120,
     "MCP": 59,
-    "RAG and retrieval": 30,
-    "Workflow and automation": 118,
+    "RAG and retrieval": 28,
+    "Workflow and automation": 120,
     "Context, prompts, memory": 89,
     "AI skills": 90,
     "Open source AI": 29
@@ -49,7 +49,7 @@
     "lang:en \"open source ai\""
   ],
   "queryCounts": {
-    "lang:en \"ai agent\"": 30,
+    "lang:en \"ai agent\"": 29,
     "lang:en agentic": 30,
     "lang:en \"multi agent\"": 30,
     "lang:en llm": 30,
@@ -60,13 +60,13 @@
     "lang:en cline": 30,
     "lang:en \"mcp server\"": 30,
     "lang:en \"model context protocol\"": 29,
-    "lang:en rag": 30,
+    "lang:en rag": 28,
     "lang:en workflow": 30,
-    "lang:en automation": 28,
+    "lang:en automation": 30,
     "lang:en cli": 30,
     "lang:en devtools": 30,
-    "lang:en \"context engineering\"": 30,
-    "lang:en \"prompt engineering\"": 29,
+    "lang:en \"context engineering\"": 29,
+    "lang:en \"prompt engineering\"": 30,
     "lang:en \"agent memory\"": 30,
     "lang:en \"claude skill\"": 30,
     "lang:en \"claude skills\"": 30,
@@ -152,7 +152,7 @@
       ]
     }
   ],
-  "scannedPosts": 663,
+  "scannedPosts": 669,
   "posts": [
     {
       "uri": "at://did:plc:oijtzlibd7mlf56jbfohssdz/app.bsky.feed.post/3ml46o7m5rs2b",
@@ -259,13 +259,13 @@
         "handle": "thefiddlecat.bsky.social",
         "displayName": "A Pup named Fiddle"
       },
-      "likeCount": 1104,
-      "repostCount": 1014,
-      "replyCount": 32,
+      "likeCount": 1117,
+      "repostCount": 1023,
+      "replyCount": 33,
       "createdAt": "2026-05-22T20:45:27.265Z",
       "createdUtc": 1779482727,
-      "ageHours": 74.62,
-      "trendingScore": 3148,
+      "ageHours": 177.57,
+      "trendingScore": 3179.5,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -451,13 +451,13 @@
         "handle": "omelette-vore.bsky.social",
         "displayName": "🔞Omelette 🍳 {NO RP}"
       },
-      "likeCount": 1048,
-      "repostCount": 205,
+      "likeCount": 1080,
+      "repostCount": 210,
       "replyCount": 18,
       "createdAt": "2026-05-24T14:03:05.726Z",
       "createdUtc": 1779631385,
-      "ageHours": 38.53,
-      "trendingScore": 1467,
+      "ageHours": 136.27,
+      "trendingScore": 1509,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -779,6 +779,30 @@
       "matchedTopicLabel": "Coding agents"
     },
     {
+      "uri": "at://did:plc:yszq3r6es46yc3vffyhwydq7/app.bsky.feed.post/3mmw3jgo6ic2d",
+      "cid": "bafyreiccpsf4lvbcycvdanyuo5lswph3zwdf3mkkoxv2wuv55mxavuqiqq",
+      "bskyUrl": "https://bsky.app/profile/danglinghemmie.bsky.social/post/3mmw3jgo6ic2d",
+      "text": "there's a reason LLM heads try to keep you arguing about whether data centers use more water than agriculture: they're belching air pollution like we're back in the gilded age",
+      "author": {
+        "handle": "danglinghemmie.bsky.social",
+        "displayName": "skáld"
+      },
+      "likeCount": 476,
+      "repostCount": 167,
+      "replyCount": 13,
+      "createdAt": "2026-05-28T13:04:36.717Z",
+      "createdUtc": 1779973476,
+      "ageHours": 41.25,
+      "trendingScore": 816.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
       "uri": "at://did:plc:xbnsfdtxoothg654ujxe3p25/app.bsky.feed.post/3mm2ue7mtg22l",
       "cid": "bafyreiap7zpczdjbl7xtetjbjowwqdvhlfwqpmvxfr4y3iruccuw3aetde",
       "bskyUrl": "https://bsky.app/profile/stephenkb.bsky.social/post/3mm2ue7mtg22l",
@@ -827,6 +851,30 @@
       "matchedTopicLabel": "LLMs"
     },
     {
+      "uri": "at://did:plc:fwks525g7gw5wc7ul2wg4wj5/app.bsky.feed.post/3mmyktub3322y",
+      "cid": "bafyreibafnaog6j3slrxvbzkzxjyszs62olvwjuebujuqlkltndbqcrn2i",
+      "bskyUrl": "https://bsky.app/profile/mims.bsky.social/post/3mmyktub3322y",
+      "text": "The world is producing more wealth than ever, but it's not going to workers -- it's going to companies and their shareholders. The drivers are outsourcing, corporate concentration, automation, and laws hostile to collective bargaining. www.wsj.com/finance/stoc...",
+      "author": {
+        "handle": "mims.bsky.social",
+        "displayName": "Christopher Mims"
+      },
+      "likeCount": 406,
+      "repostCount": 163,
+      "replyCount": 17,
+      "createdAt": "2026-05-29T12:44:12.116Z",
+      "createdUtc": 1780058652,
+      "ageHours": 17.59,
+      "trendingScore": 740.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en automation",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
+    },
+    {
       "uri": "at://did:plc:idwhjzs5boatwv4zxwwcjk5i/app.bsky.feed.post/3mlisntjcy22m",
       "cid": "bafyreihuogje55gnvoqwtidufsffzd5h35fgfje3psbgepynkqiwj5cme4",
       "bskyUrl": "https://bsky.app/profile/malwaretech.com/post/3mlisntjcy22m",
@@ -842,6 +890,30 @@
       "createdUtc": 1778417772,
       "ageHours": 66.58,
       "trendingScore": 738,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "LLMs",
+      "matchedQuery": "lang:en llm",
+      "matchedTopicId": "llms",
+      "matchedTopicLabel": "LLMs"
+    },
+    {
+      "uri": "at://did:plc:wjiwffvdmp6oc2qgozxzd7ti/app.bsky.feed.post/3mmw6alui6k2c",
+      "cid": "bafyreihj6uwmqnkuibim2bfiprzo7hgssknck6cei4lqrwa5ycgrvytjhe",
+      "bskyUrl": "https://bsky.app/profile/stargonewrong.gay/post/3mmw6alui6k2c",
+      "text": "Aaron Swartz was facing prison for something the LLM companies are investing trillions in (downloading other people's data) and educational instutions like MIT absolutely cannot wait to throw money at them while simultaneously reducing services and staff amid budget crises. grody",
+      "author": {
+        "handle": "stargonewrong.gay",
+        "displayName": "SPOOKY🎃GONE🎃WRONG🪱🧿Д🧿"
+      },
+      "likeCount": 410,
+      "repostCount": 162,
+      "replyCount": 2,
+      "createdAt": "2026-05-28T13:53:21.403Z",
+      "createdUtc": 1779976401,
+      "ageHours": 40.44,
+      "trendingScore": 735,
       "content_tags": [],
       "value_score": 0,
       "linkedRepos": [],
@@ -873,6 +945,30 @@
       "matchedQuery": "lang:en rag",
       "matchedTopicId": "retrieval",
       "matchedTopicLabel": "RAG and retrieval"
+    },
+    {
+      "uri": "at://did:plc:3pv3xjtaidyjlovzknuztffc/app.bsky.feed.post/3mmwa3peml223",
+      "cid": "bafyreiazzoq327bxrek5ence7krwbdhcfil2a3iwctrigws4kv7d5nqkva",
+      "bskyUrl": "https://bsky.app/profile/themountaingoats.bsky.social/post/3mmwa3peml223",
+      "text": "an outright lie unless they’re arguing that spellcheck is AI. If you’re using MS Word there’s probably now untoggleable AI assistant but I’ve published four books without MS Word. I copy edit over the phone from a printout if I have to. I don’t want to speed my workflow. I’d rather be good",
+      "author": {
+        "handle": "themountaingoats.bsky.social",
+        "displayName": "the Mountain Goats"
+      },
+      "likeCount": 573,
+      "repostCount": 68,
+      "replyCount": 13,
+      "createdAt": "2026-05-28T14:26:24.788Z",
+      "createdUtc": 1779978384,
+      "ageHours": 39.89,
+      "trendingScore": 715.5,
+      "content_tags": [],
+      "value_score": 0,
+      "linkedRepos": [],
+      "matchedKeyword": "Workflow and automation",
+      "matchedQuery": "lang:en workflow",
+      "matchedTopicId": "workflow",
+      "matchedTopicLabel": "Workflow and automation"
     },
     {
       "uri": "at://did:plc:zvoftk5sp6uamea5mlrgriub/app.bsky.feed.post/3mknep3hhtc2i",
@@ -984,7 +1080,7 @@
       "replyCount": 2,
       "createdAt": "2026-04-21T03:38:29.785Z",
       "createdUtc": 1776742709,
-      "ageHours": 840.94,
+      "ageHours": 938.68,
       "trendingScore": 689,
       "content_tags": [],
       "value_score": 0,
@@ -1259,104 +1355,6 @@
       "matchedQuery": "lang:en \"ai skills\"",
       "matchedTopicId": "skills",
       "matchedTopicLabel": "AI skills"
-    },
-    {
-      "uri": "at://did:plc:pzgvqg4ihnaihkrpmxqz5pu6/app.bsky.feed.post/3mmdqz3oyxk2p",
-      "cid": "bafyreihj445n3hjzsrp2t2shrubrpbof2pvxtebjziaendmqf4pfrawcta",
-      "bskyUrl": "https://bsky.app/profile/bell.bz/post/3mmdqz3oyxk2p",
-      "text": "Google I/O summary - shipping an LLM to your Chrome whether you want it or not - destroying search once and for all - pervert glasses 👍",
-      "author": {
-        "handle": "bell.bz",
-        "displayName": "Andy Bell"
-      },
-      "likeCount": 405,
-      "repostCount": 82,
-      "replyCount": 10,
-      "createdAt": "2026-05-21T06:08:35.631Z",
-      "createdUtc": 1779343715,
-      "ageHours": 60.06,
-      "trendingScore": 574,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
-      "uri": "at://did:plc:xozp2x42jlscikizmdqub37m/app.bsky.feed.post/3ml7u66xci22f",
-      "cid": "bafyreiejxgzd7zplq2jw2sy7gdocesac6x5hwgivly2yxvmjkxusqnbl4u",
-      "bskyUrl": "https://bsky.app/profile/lissaharris.bsky.social/post/3ml7u66xci22f",
-      "text": "if anyone uses an LLM at my funeral, you all have my blessing to fistfight them in the parking lot",
-      "author": {
-        "handle": "lissaharris.bsky.social",
-        "displayName": "Lissa Harris 🌈🗑️🔥⚔️🐀"
-      },
-      "likeCount": 385,
-      "repostCount": 89,
-      "replyCount": 3,
-      "createdAt": "2026-05-06T23:29:17.465Z",
-      "createdUtc": 1778110157,
-      "ageHours": 112.74,
-      "trendingScore": 564.5,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
-    },
-    {
-      "uri": "at://did:plc:4rndwwuyhrtlv2oufdcujjch/app.bsky.feed.post/3mluburry2c2k",
-      "cid": "bafyreihqr7i5ba2ddnjp4x3apzm3e4bov7kdm6qafsancrvi5omqpbdp2i",
-      "bskyUrl": "https://bsky.app/profile/srirachamander.bsky.social/post/3mluburry2c2k",
-      "text": "What a dumb dog, only thing he’s good for is being a cum rag & urinal >;3",
-      "author": {
-        "handle": "srirachamander.bsky.social",
-        "displayName": "🔞🦎Ander the Salamander🦎🔞commissions open!"
-      },
-      "likeCount": 434,
-      "repostCount": 63,
-      "replyCount": 8,
-      "createdAt": "2026-05-15T02:27:48.821Z",
-      "createdUtc": 1778812068,
-      "ageHours": 155.08,
-      "trendingScore": 564,
-      "content_tags": [
-        "is-question"
-      ],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "RAG and retrieval",
-      "matchedQuery": "lang:en rag",
-      "matchedTopicId": "retrieval",
-      "matchedTopicLabel": "RAG and retrieval"
-    },
-    {
-      "uri": "at://did:plc:mivey63nzylfflvmmjoqcf6u/app.bsky.feed.post/3mm3e52ypys2j",
-      "cid": "bafyreifkv7y5nvdwm2uibou3ps7i4krkcl3tuzywcykc7nvarc3s3bo2hq",
-      "bskyUrl": "https://bsky.app/profile/questauthority.bsky.social/post/3mm3e52ypys2j",
-      "text": "I'm going to use a LLM to code a LLM agent to fix the problems that the other LLM created is peak LLM.",
-      "author": {
-        "handle": "questauthority.bsky.social",
-        "displayName": "The Questionable Authority"
-      },
-      "likeCount": 476,
-      "repostCount": 28,
-      "replyCount": 40,
-      "createdAt": "2026-05-17T21:56:52.568Z",
-      "createdUtc": 1779055012,
-      "ageHours": 156.2,
-      "trendingScore": 552,
-      "content_tags": [],
-      "value_score": 0,
-      "linkedRepos": [],
-      "matchedKeyword": "LLMs",
-      "matchedQuery": "lang:en llm",
-      "matchedTopicId": "llms",
-      "matchedTopicLabel": "LLMs"
     }
   ]
 }

--- a/scripts/__tests__/cache-merge.test.mjs
+++ b/scripts/__tests__/cache-merge.test.mjs
@@ -159,3 +159,51 @@ test("loadExistingJson: corrupt JSON → fallback (does not throw)", async () =>
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// Regression: ISO-string scoreKey must sort by chronology, not collapse to
+// NaN. Before this fix, scrape-funding-news.mjs passed `scoreKey:
+// "publishedAt"` and `Number("2026-05-30T...")` returned NaN — every entry
+// tied at NaN, insertion order won, fresh signals were dropped from the
+// keep-last-50. The page froze at 1 round in 7d on 2026-05-30.
+test("ISO-string scoreKey sorts by chronology (date-parse fallback)", () => {
+  const existing = [
+    { id: "old-1", publishedAt: "2026-04-01T00:00:00Z" },
+    { id: "old-2", publishedAt: "2026-04-15T00:00:00Z" },
+    { id: "old-3", publishedAt: "2026-05-01T00:00:00Z" },
+  ];
+  const fresh = [
+    { id: "new-1", publishedAt: "2026-05-29T12:00:00Z" },
+    { id: "new-2", publishedAt: "2026-05-30T08:00:00Z" },
+  ];
+  const out = mergeAndKeepLastN(existing, fresh, {
+    idKey: "id",
+    scoreKey: "publishedAt",
+    keepN: 3,
+  });
+  // Top-3 by chronology DESC: new-2, new-1, old-3.
+  assert.equal(out.length, 3);
+  assert.equal(out[0].id, "new-2");
+  assert.equal(out[1].id, "new-1");
+  assert.equal(out[2].id, "old-3");
+});
+
+// Regression: ISO-string recencyKey tiebreaks chronologically even when
+// scoreKey is numeric. Same date-parse fallback path. Validates that
+// collectors using `recencyKey: "createdUtc"` get a deterministic tie-break
+// instead of NaN-no-op.
+test("ISO-string recencyKey tiebreaks chronologically", () => {
+  const all = [
+    { id: "a", trendingScore: 100, createdUtc: "2026-05-01T00:00:00Z" },
+    { id: "b", trendingScore: 100, createdUtc: "2026-05-30T00:00:00Z" },
+    { id: "c", trendingScore: 100, createdUtc: "2026-05-15T00:00:00Z" },
+  ];
+  const out = mergeAndKeepLastN([], all, {
+    idKey: "id",
+    scoreKey: "trendingScore",
+    recencyKey: "createdUtc",
+    keepN: 3,
+  });
+  assert.equal(out[0].id, "b", "newest on tied score wins");
+  assert.equal(out[1].id, "c");
+  assert.equal(out[2].id, "a");
+});

--- a/scripts/_cache-merge.mjs
+++ b/scripts/_cache-merge.mjs
@@ -37,6 +37,33 @@ import { readFile } from "node:fs/promises";
 export const KEEP_LAST_N_DEFAULT = 50;
 
 /**
+ * Coerce a score field to a number. Numbers pass through. Strings parse as
+ * numeric first (so "123" → 123), then as ISO-8601 dates (so a publishedAt
+ * field is usable as a primary sort key). Anything that doesn't yield a
+ * finite number falls back to 0 — matching the prior contract for missing
+ * values. Used for both scoreKey and recencyKey.
+ *
+ * Historical bug this fixes: `Number("2026-05-30T05:42Z")` is NaN, which made
+ * the funding-news merge a no-op (every entry tied at NaN, insertion order
+ * won, fresh signals were dropped). After this change, ISO-string scoreKeys
+ * rank by chronology DESC as intended. Backward-compat: existing numeric
+ * scoreKeys are unchanged.
+ */
+function coerceNumeric(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (value == null) return 0;
+  const n = Number(value);
+  if (Number.isFinite(n)) return n;
+  if (typeof value === "string") {
+    const t = Date.parse(value);
+    if (Number.isFinite(t)) return t;
+  }
+  return 0;
+}
+
+/**
  * Read + parse a JSON file. Returns `fallback` on ENOENT. Logs and returns
  * `fallback` on any other read/parse error so a corrupt file never blocks a
  * collector run.
@@ -95,17 +122,17 @@ export function mergeAndKeepLastN(existing, thisRun, opts = {}) {
       byId.set(id, item);
       continue;
     }
-    const newScore = Number(item?.[scoreKey] ?? 0);
-    const prevScore = Number(prev?.[scoreKey] ?? 0);
+    const newScore = coerceNumeric(item?.[scoreKey]);
+    const prevScore = coerceNumeric(prev?.[scoreKey]);
     // Keep the higher-scored version; on tie, prefer newer (item).
     byId.set(id, newScore >= prevScore ? item : prev);
   }
 
   const sorted = Array.from(byId.values()).sort((a, b) => {
-    const scoreCmp = Number(b?.[scoreKey] ?? 0) - Number(a?.[scoreKey] ?? 0);
+    const scoreCmp = coerceNumeric(b?.[scoreKey]) - coerceNumeric(a?.[scoreKey]);
     if (scoreCmp !== 0) return scoreCmp;
     if (recencyKey) {
-      return Number(b?.[recencyKey] ?? 0) - Number(a?.[recencyKey] ?? 0);
+      return coerceNumeric(b?.[recencyKey]) - coerceNumeric(a?.[recencyKey]);
     }
     return 0;
   });

--- a/scripts/promote-unknown-mentions.mjs
+++ b/scripts/promote-unknown-mentions.mjs
@@ -149,8 +149,10 @@ export async function main() {
     stampPerRecord: false,
   });
   if (redisResult.source !== "redis") {
-    throw new Error(
-      "unknown-mentions-promoted data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: file mirror at OUT_PATH already landed and the GH workflow
+    // auto-commits it. Same contract as scrape-funding-news.mjs.
+    console.warn(
+      `[promote-unknown-mentions] data-store write skipped (Redis env unset); file mirror at ${OUT_PATH} is the source of truth this run.`,
     );
   }
 

--- a/scripts/scrape-bluesky.mjs
+++ b/scripts/scrape-bluesky.mjs
@@ -548,8 +548,11 @@ async function main() {
   const mentionsRedis = await writeDataStore("bluesky-mentions", mergedMentionsPayload);
   const trendingRedis = await writeDataStore("bluesky-trending", mergedTrendingPayload);
   if (mentionsRedis.source !== "redis" || trendingRedis.source !== "redis") {
-    throw new Error(
-      "bluesky data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: both file mirrors (MENTIONS_OUT, TRENDING_OUT) already
+    // landed. Same contract as scrape-funding-news.mjs — genuine transport
+    // errors throw from inside writeDataStore and never reach this branch.
+    console.warn(
+      `[bluesky] data-store write skipped (Redis env unset); file mirrors at ${MENTIONS_OUT} + ${TRENDING_OUT} are the source of truth this run.`,
     );
   }
 

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -821,8 +821,14 @@ async function main() {
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news", payload);
     if (redisResult.source !== "redis") {
-      throw new Error(
-        "funding-news data-store write skipped; set REDIS_URL or Upstash env",
+      // Soft-skip: writeDataStore returned "skipped" because the Redis env is
+      // unset (or DATA_STORE_DISABLE=1). The file write at outputPath already
+      // landed and the GH workflow's auto-commit step ships it downstream, so
+      // /funding stays fed from the bundled spine. Real Redis transport
+      // errors propagate from ioredis client.set and would bypass this
+      // branch entirely — we only ever land here on the documented soft path.
+      console.warn(
+        `[funding] data-store write skipped (Redis env unset); file mirror at ${outputPath} is the source of truth this run.`,
       );
     }
     redisInfo = ` [redis: ${redisResult.source}]`;

--- a/scripts/scrape-sec-form-d.mjs
+++ b/scripts/scrape-sec-form-d.mjs
@@ -480,12 +480,20 @@ async function main() {
   if (outputPath === OUT_PATH) {
     const redisResult = await writeDataStore("funding-news-sec", payload);
     if (redisResult.source !== "redis") {
-      throw new Error(
-        "funding-news-sec data-store write skipped; set REDIS_URL or Upstash env",
+      // Soft-skip — same contract as scrape-funding-news.mjs. File mirror at
+      // outputPath is the deliverable when Redis env is unset; the workflow's
+      // auto-commit ships it. Genuine transport errors throw from inside
+      // writeDataStore and never reach this branch.
+      console.warn(
+        `[sec-form-d] data-store write skipped (Redis env unset); file mirror at ${outputPath} is the source of truth this run.`,
       );
+    } else {
+      // Verify the meta key actually landed under the expected writtenAt.
+      // Soft-skip path above never reaches here, so verify is correctly
+      // gated to the real Redis success branch.
+      await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
+      console.log("[sec-form-d] redis write ok -> funding-news-sec");
     }
-    await verifyMetaLanded("funding-news-sec", redisResult.writtenAt);
-    console.log("[sec-form-d] redis write ok -> funding-news-sec");
 
     // TOOLBOX dual-write: emit `funding.sec.formd` per Form D filing.
     // Best-effort — env-unset = silent skip; failures never block.

--- a/scripts/sweep-staleness.mjs
+++ b/scripts/sweep-staleness.mjs
@@ -200,8 +200,11 @@ async function main() {
     stampPerRecord: false,
   });
   if (redisResult.source !== "redis") {
-    throw new Error(
-      "staleness-report data-store write skipped; set REDIS_URL or Upstash env",
+    // Soft-skip: file mirror at OUT_PATH already landed and is the
+    // deliverable. Genuine transport errors propagate from inside
+    // writeDataStore. Same contract as scrape-funding-news.mjs.
+    console.warn(
+      `[sweep-staleness] data-store write skipped (Redis env unset); file mirror at ${OUT_PATH} is the source of truth this run.`,
     );
   }
 


### PR DESCRIPTION
Automated data refresh from `Refresh Bluesky signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26676673914

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.