### PR TITLE
chore(data): refresh lobsters signals 2026-05-30T08:05:28Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T05:31:55.308Z",
+  "ts": "2026-05-30T08:05:28.770Z",
   "count": 1,
-  "durationMs": 3692,
+  "durationMs": 3006,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T05:31:51.636Z",
+  "fetchedAt": "2026-05-30T08:05:25.785Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 42.880833333333335
+        "hoursSincePosted": 45.44027777777778
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 42.880833333333335,
-          "trendingScore": 0.013303582987312925,
+          "ageHours": 45.44027777777778,
+          "trendingScore": 0.012241627391515485,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T05:31:51.636Z",
+  "fetchedAt": "2026-05-30T08:05:25.785Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26678762946

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.