### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-30T08:43:02Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-30T04:31:33.237Z",
+  "ts": "2026-05-30T08:43:02.605Z",
   "count": 1,
-  "durationMs": 2236,
+  "durationMs": 5420,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T04:31:31.003Z",
+  "fetchedAt": "2026-05-30T08:42:57.187Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -8,9 +8,9 @@
       "id": "openbmb/UltraData-SFT-2605",
       "author": "openbmb",
       "url": "https://huggingface.co/datasets/openbmb/UltraData-SFT-2605",
-      "downloads": 1869,
-      "likes": 209,
-      "trendingScore": 152,
+      "downloads": 8096,
+      "likes": 213,
+      "trendingScore": 156,
       "tags": [
         "task_categories:text-generation",
         "task_categories:question-answering",
@@ -40,9 +40,9 @@
       "id": "openbmb/Ultra-FineWeb-L3",
       "author": "openbmb",
       "url": "https://huggingface.co/datasets/openbmb/Ultra-FineWeb-L3",
-      "downloads": 14442,
-      "likes": 215,
-      "trendingScore": 102,
+      "downloads": 21716,
+      "likes": 217,
+      "trendingScore": 104,
       "tags": [
         "task_categories:text-generation",
         "language:en",
@@ -327,8 +327,8 @@
       "id": "armand0e/qwen3.7-max-pi-traces",
       "author": "armand0e",
       "url": "https://huggingface.co/datasets/armand0e/qwen3.7-max-pi-traces",
-      "downloads": 3035,
-      "likes": 57,
+      "downloads": 4762,
+      "likes": 58,
       "trendingScore": 55,
       "tags": [
         "task_categories:text-generation",
@@ -357,9 +357,9 @@
       "id": "jasperai/monet",
       "author": "jasperai",
       "url": "https://huggingface.co/datasets/jasperai/monet",
-      "downloads": 249105,
-      "likes": 57,
-      "trendingScore": 51,
+      "downloads": 256618,
+      "likes": 58,
+      "trendingScore": 52,
       "tags": [
         "task_categories:text-to-image",
         "task_categories:image-feature-extraction",
@@ -1336,7 +1336,7 @@
       "id": "amphora/ResearchMath-14k",
       "author": "amphora",
       "url": "https://huggingface.co/datasets/amphora/ResearchMath-14k",
-      "downloads": 302,
+      "downloads": 466,
       "likes": 18,
       "trendingScore": 18,
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26679493349

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.