### PR TITLE
chore(data): refresh huggingface space signals 2026-05-30T09:03:20Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-30T04:38:59.748Z",
+  "ts": "2026-05-30T09:03:20.261Z",
   "count": 1,
-  "durationMs": 7790,
+  "durationMs": 9386,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T04:38:51.960Z",
+  "fetchedAt": "2026-05-30T09:03:10.877Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -41,8 +41,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 160,
-      "trendingScore": 150,
+      "likes": 161,
+      "trendingScore": 151,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -111,8 +111,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 119,
-      "trendingScore": 113,
+      "likes": 120,
+      "trendingScore": 114,
       "sdk": "static",
       "tags": [
         "static",
@@ -229,8 +229,8 @@
       "id": "bytedance-research/Lance",
       "author": "bytedance-research",
       "url": "https://huggingface.co/spaces/bytedance-research/Lance",
-      "likes": 76,
-      "trendingScore": 73,
+      "likes": 77,
+      "trendingScore": 74,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -311,8 +311,8 @@
       "id": "nvidia/LocateAnything",
       "author": "nvidia",
       "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 65,
-      "trendingScore": 65,
+      "likes": 69,
+      "trendingScore": 69,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -320,7 +320,7 @@
         "region:us"
       ],
       "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-27T09:35:37.000Z",
+      "lastModified": "2026-05-30T06:22:13.000Z",
       "models": []
     },
     {
@@ -818,8 +818,8 @@
       "id": "facebook/vggt-omega",
       "author": "facebook",
       "url": "https://huggingface.co/spaces/facebook/vggt-omega",
-      "likes": 41,
-      "trendingScore": 26,
+      "likes": 42,
+      "trendingScore": 27,
       "sdk": "gradio",
       "tags": [
         "gradio",


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26679876245

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.