### PR TITLE
chore(data): refresh arxiv signals 2026-05-30T09:10:43Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-30T04:41:45.657Z",
+  "ts": "2026-05-30T09:05:59.882Z",
   "count": 1,
-  "durationMs": 60797,
+  "durationMs": 61250,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T04:41:45.705Z",
+  "fetchedAt": "2026-05-30T09:05:59.931Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -20,20 +20,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30351v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30348v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30350v1",
@@ -64,13 +50,6 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30345v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30344v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -78,25 +57,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30343v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30342v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30341v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30339v1",
@@ -127,27 +92,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30335v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30334v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30333v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30332v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -176,13 +120,6 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30327v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30326v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -195,13 +132,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30324v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30323v1",
@@ -232,39 +162,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30318v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30317v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30315v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30311v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30310v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30307v1",
@@ -274,25 +176,11 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30295v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30292v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30290v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30289v1",
@@ -323,13 +211,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30280v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30277v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -344,39 +225,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30274v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30273v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30269v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30268v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30265v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30263v1",
@@ -386,13 +239,6 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30260v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30257v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -400,25 +246,11 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30256v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30253v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30251v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30250v1",
@@ -442,27 +274,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30245v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30244v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30241v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30239v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -470,39 +281,11 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30237v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30235v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30233v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30232v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30231v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30230v1",
@@ -547,13 +330,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30219v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30218v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -566,13 +342,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30214v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30213v1",
@@ -601,13 +370,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30202v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30201v1",
@@ -643,13 +405,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30189v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30188v1",
@@ -694,13 +449,6 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30170v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30169v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -713,13 +461,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30167v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30166v1",
@@ -778,13 +519,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30152v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30148v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -806,32 +540,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30133v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30132v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30131v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30126v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30123v1",
@@ -862,20 +575,6 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30107v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30104v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30099v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -888,6 +587,321 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30083v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30073v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30351v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30348v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30345v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30343v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30341v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30335v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30334v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30333v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30327v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30324v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30318v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30315v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30311v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30310v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30295v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30290v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30280v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30274v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30273v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30268v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30265v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30260v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30256v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30251v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30245v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30244v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30241v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30237v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30233v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30232v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30231v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30219v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30214v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30202v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30189v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30170v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30167v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30152v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30133v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30131v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30126v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30107v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30104v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30090v1",
@@ -904,53 +918,39 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
-      "arxivId": "2605.30083v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30080v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30076v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30073v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30058v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30052v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30051v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30040v1",
@@ -978,14 +978,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30021v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30018v1",
@@ -1006,21 +1006,21 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.29971v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.29951v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T04:40:44.880Z",
+  "fetchedAt": "2026-05-30T09:04:58.655Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26679910575

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.