### PR TITLE
chore(data): refresh lobsters signals 2026-05-30T10:26:12Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T08:05:28.770Z",
+  "ts": "2026-05-30T10:26:12.357Z",
   "count": 1,
-  "durationMs": 3006,
+  "durationMs": 2694,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T08:05:25.785Z",
+  "fetchedAt": "2026-05-30T10:26:09.684Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 45.44027777777778
+        "hoursSincePosted": 47.785833333333336
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 45.44027777777778,
-          "trendingScore": 0.012241627391515485,
+          "ageHours": 47.785833333333336,
+          "trendingScore": 0.011386790227878259,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T08:05:25.785Z",
+  "fetchedAt": "2026-05-30T10:26:09.684Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26681448202

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.