### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-30T12:12:53Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-30T00:17:23.713Z",
+  "ts": "2026-05-30T12:12:53.870Z",
   "count": 1,
-  "durationMs": 9300,
+  "durationMs": 15013,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-30T00:17:22.287Z",
+  "lastFetchedAt": "2026-05-30T12:12:48.863Z",
   "windowDays": 7,
   "launches": [
     {


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26683473046

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.