### PR TITLE
chore(data): refresh huggingface signals 2026-05-30T14:06:42Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-30T08:42:47.849Z",
+  "ts": "2026-05-30T14:06:41.999Z",
   "count": 1,
-  "durationMs": 8792,
+  "durationMs": 7486,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T08:42:39.059Z",
+  "fetchedAt": "2026-05-30T14:06:34.514Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -113,8 +113,8 @@
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
       "downloads": 28793,
-      "likes": 581,
-      "trendingScore": 506,
+      "likes": 589,
+      "trendingScore": 514,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -193,36 +193,12 @@
     },
     {
       "rank": 7,
-      "id": "Open-OSS/privacy-filter",
-      "author": "Open-OSS",
-      "url": "https://huggingface.co/Open-OSS/privacy-filter",
-      "downloads": 244168,
-      "likes": 434,
-      "trendingScore": 434,
-      "pipelineTag": "token-classification",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "onnx",
-        "safetensors",
-        "custom",
-        "transformers.js",
-        "token-classification",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T23:51:29.000Z",
-      "lastModified": "2026-05-07T00:05:35.000Z"
-    },
-    {
-      "rank": 8,
       "id": "nvidia/LocateAnything-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/LocateAnything-3B",
       "downloads": 18327,
-      "likes": 430,
-      "trendingScore": 414,
+      "likes": 453,
+      "trendingScore": 436,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -254,6 +230,30 @@
       ],
       "createdAt": "2026-03-02T20:05:49.000Z",
       "lastModified": "2026-05-27T08:30:54.000Z"
+    },
+    {
+      "rank": 8,
+      "id": "Open-OSS/privacy-filter",
+      "author": "Open-OSS",
+      "url": "https://huggingface.co/Open-OSS/privacy-filter",
+      "downloads": 244168,
+      "likes": 434,
+      "trendingScore": 434,
+      "pipelineTag": "token-classification",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "onnx",
+        "safetensors",
+        "custom",
+        "transformers.js",
+        "token-classification",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-06T23:51:29.000Z",
+      "lastModified": "2026-05-07T00:05:35.000Z"
     },
     {
       "rank": 9,
@@ -463,8 +463,8 @@
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "downloads": 2227885,
-      "likes": 1069,
-      "trendingScore": 313,
+      "likes": 1083,
+      "trendingScore": 325,
       "pipelineTag": "image-text-to-text",
       "libraryName": null,
       "tags": [
@@ -553,8 +553,8 @@
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B",
       "downloads": 17084,
-      "likes": 236,
-      "trendingScore": 231,
+      "likes": 245,
+      "trendingScore": 240,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -584,7 +584,7 @@
         "region:us"
       ],
       "createdAt": "2026-05-28T09:43:54.000Z",
-      "lastModified": "2026-05-29T15:44:17.000Z"
+      "lastModified": "2026-05-30T09:55:56.000Z"
     },
     {
       "rank": 19,
@@ -789,30 +789,12 @@
     },
     {
       "rank": 26,
-      "id": "TenStrip/LTX2.3-10Eros",
-      "author": "TenStrip",
-      "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
-      "downloads": 51779,
-      "likes": 190,
-      "trendingScore": 182,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "image-to-video",
-        "region:us"
-      ],
-      "createdAt": "2026-04-29T17:08:26.000Z",
-      "lastModified": "2026-05-07T01:24:09.000Z"
-    },
-    {
-      "rank": 27,
       "id": "nvidia/PiD",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/PiD",
       "downloads": 437,
-      "likes": 181,
-      "trendingScore": 177,
+      "likes": 187,
+      "trendingScore": 183,
       "pipelineTag": "image-to-image",
       "libraryName": "pytorch",
       "tags": [
@@ -831,6 +813,24 @@
       ],
       "createdAt": "2026-04-28T00:41:46.000Z",
       "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 27,
+      "id": "TenStrip/LTX2.3-10Eros",
+      "author": "TenStrip",
+      "url": "https://huggingface.co/TenStrip/LTX2.3-10Eros",
+      "downloads": 51779,
+      "likes": 190,
+      "trendingScore": 182,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "image-to-video",
+        "region:us"
+      ],
+      "createdAt": "2026-04-29T17:08:26.000Z",
+      "lastModified": "2026-05-07T01:24:09.000Z"
     },
     {
       "rank": 28,
@@ -1217,6 +1217,35 @@
     },
     {
       "rank": 39,
+      "id": "stepfun-ai/Step-3.7-Flash",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash",
+      "downloads": 3400,
+      "likes": 128,
+      "trendingScore": 126,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T02:13:46.000Z",
+      "lastModified": "2026-05-29T10:03:47.000Z"
+    },
+    {
+      "rank": 40,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
@@ -1261,7 +1290,7 @@
       "lastModified": "2026-05-22T14:40:13.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "microsoft/Lens-Turbo",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Turbo",
@@ -1282,35 +1311,6 @@
       ],
       "createdAt": "2026-05-15T06:06:39.000Z",
       "lastModified": "2026-05-22T03:10:02.000Z"
-    },
-    {
-      "rank": 41,
-      "id": "stepfun-ai/Step-3.7-Flash",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash",
-      "downloads": 3400,
-      "likes": 122,
-      "trendingScore": 120,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "step3p7",
-        "text-generation",
-        "vision-language",
-        "multimodal",
-        "moe",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T02:13:46.000Z",
-      "lastModified": "2026-05-29T10:03:47.000Z"
     },
     {
       "rank": 42,
@@ -1362,6 +1362,41 @@
     },
     {
       "rank": 44,
+      "id": "LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "downloads": 23685,
+      "likes": 117,
+      "trendingScore": 117,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "liquid",
+        "lfm2",
+        "edge",
+        "llama.cpp",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "base_model:LiquidAI/LFM2.5-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T22:16:45.000Z",
+      "lastModified": "2026-05-29T16:25:34.000Z"
+    },
+    {
+      "rank": 45,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-GGUF",
@@ -1401,41 +1436,6 @@
       ],
       "createdAt": "2026-05-06T10:02:17.000Z",
       "lastModified": "2026-05-07T02:39:32.000Z"
-    },
-    {
-      "rank": 45,
-      "id": "LiquidAI/LFM2.5-8B-A1B-GGUF",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF",
-      "downloads": 23685,
-      "likes": 113,
-      "trendingScore": 113,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "liquid",
-        "lfm2",
-        "edge",
-        "llama.cpp",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "base_model:LiquidAI/LFM2.5-8B-A1B",
-        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T22:16:45.000Z",
-      "lastModified": "2026-05-29T16:25:34.000Z"
     },
     {
       "rank": 46,
@@ -1612,85 +1612,12 @@
     },
     {
       "rank": 52,
-      "id": "jackxinning/Leanly_AI",
-      "author": "jackxinning",
-      "url": "https://huggingface.co/jackxinning/Leanly_AI",
-      "downloads": 10822,
-      "likes": 111,
-      "trendingScore": 99,
-      "pipelineTag": "question-answering",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "medical",
-        "question-answering",
-        "en",
-        "zh",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-16T10:43:03.000Z",
-      "lastModified": "2026-05-04T07:50:46.000Z"
-    },
-    {
-      "rank": 53,
-      "id": "HiDream-ai/HiDream-O1-Image-Dev",
-      "author": "HiDream-ai",
-      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
-      "downloads": 3819,
-      "likes": 99,
-      "trendingScore": 99,
-      "pipelineTag": "image-text-to-image",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "image-text-to-image",
-        "arxiv:2605.11061",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T13:09:29.000Z",
-      "lastModified": "2026-05-15T10:40:24.000Z"
-    },
-    {
-      "rank": 54,
-      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
-      "author": "Efficient-Large-Model",
-      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
-      "downloads": 0,
-      "likes": 100,
-      "trendingScore": 98,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-video",
-        "image-to-video",
-        "camera-control",
-        "world-model",
-        "diffusion",
-        "arxiv:2605.15178",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T11:14:09.000Z",
-      "lastModified": "2026-05-19T06:57:12.000Z"
-    },
-    {
-      "rank": 55,
       "id": "PaddlePaddle/PaddleOCR-VL-1.6",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6",
       "downloads": 2294,
-      "likes": 102,
-      "trendingScore": 98,
+      "likes": 104,
+      "trendingScore": 100,
       "pipelineTag": "image-text-to-text",
       "libraryName": "PaddleOCR",
       "tags": [
@@ -1722,6 +1649,79 @@
       ],
       "createdAt": "2026-05-27T06:27:27.000Z",
       "lastModified": "2026-05-29T09:38:09.000Z"
+    },
+    {
+      "rank": 53,
+      "id": "jackxinning/Leanly_AI",
+      "author": "jackxinning",
+      "url": "https://huggingface.co/jackxinning/Leanly_AI",
+      "downloads": 10822,
+      "likes": 111,
+      "trendingScore": 99,
+      "pipelineTag": "question-answering",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "medical",
+        "question-answering",
+        "en",
+        "zh",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-16T10:43:03.000Z",
+      "lastModified": "2026-05-04T07:50:46.000Z"
+    },
+    {
+      "rank": 54,
+      "id": "HiDream-ai/HiDream-O1-Image-Dev",
+      "author": "HiDream-ai",
+      "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+      "downloads": 3819,
+      "likes": 99,
+      "trendingScore": 99,
+      "pipelineTag": "image-text-to-image",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "image-text-to-image",
+        "arxiv:2605.11061",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T13:09:29.000Z",
+      "lastModified": "2026-05-15T10:40:24.000Z"
+    },
+    {
+      "rank": 55,
+      "id": "Efficient-Large-Model/SANA-WM_bidirectional",
+      "author": "Efficient-Large-Model",
+      "url": "https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional",
+      "downloads": 0,
+      "likes": 100,
+      "trendingScore": 98,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-video",
+        "image-to-video",
+        "camera-control",
+        "world-model",
+        "diffusion",
+        "arxiv:2605.15178",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T11:14:09.000Z",
+      "lastModified": "2026-05-19T06:57:12.000Z"
     },
     {
       "rank": 56,
@@ -2577,6 +2577,51 @@
     },
     {
       "rank": 85,
+      "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
+      "downloads": 11254,
+      "likes": 70,
+      "trendingScore": 67,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "moss_tts_delay",
+        "text-to-speech",
+        "custom_code",
+        "zh",
+        "yue",
+        "en",
+        "ar",
+        "cs",
+        "da",
+        "de",
+        "nl",
+        "es",
+        "fr",
+        "fi",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "ja",
+        "it",
+        "ko",
+        "mk",
+        "ms",
+        "ru",
+        "fa",
+        "pl",
+        "pt",
+        "sv",
+        "ro"
+      ],
+      "createdAt": "2026-05-25T12:40:42.000Z",
+      "lastModified": "2026-05-26T08:49:43.000Z"
+    },
+    {
+      "rank": 86,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -2621,58 +2666,13 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 86,
-      "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
-      "downloads": 11254,
-      "likes": 68,
-      "trendingScore": 65,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "moss_tts_delay",
-        "text-to-speech",
-        "custom_code",
-        "zh",
-        "yue",
-        "en",
-        "ar",
-        "cs",
-        "da",
-        "de",
-        "nl",
-        "es",
-        "fr",
-        "fi",
-        "el",
-        "he",
-        "hi",
-        "hu",
-        "ja",
-        "it",
-        "ko",
-        "mk",
-        "ms",
-        "ru",
-        "fa",
-        "pl",
-        "pt",
-        "sv",
-        "ro"
-      ],
-      "createdAt": "2026-05-25T12:40:42.000Z",
-      "lastModified": "2026-05-26T08:49:43.000Z"
-    },
-    {
       "rank": 87,
       "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
       "downloads": 0,
-      "likes": 64,
-      "trendingScore": 64,
+      "likes": 65,
+      "trendingScore": 65,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
       "tags": [
@@ -3075,207 +3075,12 @@
     },
     {
       "rank": 101,
-      "id": "XiaomiMiMo/MiMo-V2.5",
-      "author": "XiaomiMiMo",
-      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
-      "downloads": 65258,
-      "likes": 221,
-      "trendingScore": 56,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "mimo_v2",
-        "multimodal",
-        "vision-language",
-        "audio",
-        "agent",
-        "video-understanding",
-        "long-context",
-        "custom_code",
-        "en",
-        "zh",
-        "license:mit",
-        "eval-results",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T13:37:38.000Z",
-      "lastModified": "2026-05-07T04:23:16.000Z"
-    },
-    {
-      "rank": 102,
-      "id": "openbmb/MiniCPM5-1B-GGUF",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
-      "downloads": 18770,
-      "likes": 117,
-      "trendingScore": 55,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "minicpm",
-        "minicpm5",
-        "llama",
-        "text-generation",
-        "long-context",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "en",
-        "zh",
-        "dataset:openbmb/Ultra-FineWeb",
-        "dataset:openbmb/Ultra-FineWeb-L3",
-        "dataset:openbmb/UltraData-Math",
-        "dataset:openbmb/UltraData-SFT-2605",
-        "arxiv:2506.07900",
-        "arxiv:2602.09003",
-        "arxiv:2512.16649",
-        "arxiv:2604.13016",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T09:49:47.000Z",
-      "lastModified": "2026-05-25T10:55:40.000Z"
-    },
-    {
-      "rank": 103,
-      "id": "Comfy-Org/HiDream-O1-Image",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
-      "downloads": 0,
-      "likes": 54,
-      "trendingScore": 54,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "comfyui",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-10T00:28:02.000Z",
-      "lastModified": "2026-05-12T09:46:36.000Z"
-    },
-    {
-      "rank": 104,
-      "id": "Lakonik/AsymFLUX.2-klein-9B",
-      "author": "Lakonik",
-      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
-      "downloads": 2316,
-      "likes": 55,
-      "trendingScore": 54,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "flow-matching",
-        "pixel-diffusion",
-        "pixel-generation",
-        "flux2",
-        "text-to-image",
-        "arxiv:2605.12964",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T20:19:24.000Z",
-      "lastModified": "2026-05-14T02:37:15.000Z"
-    },
-    {
-      "rank": 105,
-      "id": "black-forest-labs/FLUX.1-dev",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
-      "downloads": 717175,
-      "likes": 12938,
-      "trendingScore": 54,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "image-generation",
-        "flux",
-        "en",
-        "license:other",
-        "endpoints_compatible",
-        "diffusers:FluxPipeline",
-        "region:us"
-      ],
-      "createdAt": "2024-07-31T21:13:44.000Z",
-      "lastModified": "2025-06-27T16:22:19.000Z"
-    },
-    {
-      "rank": 106,
-      "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 702376,
-      "likes": 696,
-      "trendingScore": 54,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "gemma4",
-        "abliterated",
-        "vision",
-        "multimodal",
-        "audio",
-        "image-text-to-text",
-        "en",
-        "multilingual",
-        "license:gemma",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-02T22:29:19.000Z",
-      "lastModified": "2026-04-06T03:50:35.000Z"
-    },
-    {
-      "rank": 107,
-      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "author": "Kwai-Keye",
-      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "downloads": 666,
-      "likes": 54,
-      "trendingScore": 54,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "KeyeVL2",
-        "feature-extraction",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:32:15.000Z",
-      "lastModified": "2026-05-29T03:57:43.000Z"
-    },
-    {
-      "rank": 108,
       "id": "stepfun-ai/Step-3.7-Flash-GGUF",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-GGUF",
       "downloads": 29666,
-      "likes": 54,
-      "trendingScore": 54,
+      "likes": 57,
+      "trendingScore": 57,
       "pipelineTag": "image-text-to-text",
       "libraryName": "gguf",
       "tags": [
@@ -3308,7 +3113,202 @@
         "conversational"
       ],
       "createdAt": "2026-05-28T11:34:17.000Z",
-      "lastModified": "2026-05-30T03:44:35.000Z"
+      "lastModified": "2026-05-30T10:00:54.000Z"
+    },
+    {
+      "rank": 102,
+      "id": "XiaomiMiMo/MiMo-V2.5",
+      "author": "XiaomiMiMo",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
+      "downloads": 65258,
+      "likes": 221,
+      "trendingScore": 56,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "mimo_v2",
+        "multimodal",
+        "vision-language",
+        "audio",
+        "agent",
+        "video-understanding",
+        "long-context",
+        "custom_code",
+        "en",
+        "zh",
+        "license:mit",
+        "eval-results",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T13:37:38.000Z",
+      "lastModified": "2026-05-07T04:23:16.000Z"
+    },
+    {
+      "rank": 103,
+      "id": "openbmb/MiniCPM5-1B-GGUF",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
+      "downloads": 18770,
+      "likes": 119,
+      "trendingScore": 56,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
+        "long-context",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "en",
+        "zh",
+        "dataset:openbmb/Ultra-FineWeb",
+        "dataset:openbmb/Ultra-FineWeb-L3",
+        "dataset:openbmb/UltraData-Math",
+        "dataset:openbmb/UltraData-SFT-2605",
+        "arxiv:2506.07900",
+        "arxiv:2602.09003",
+        "arxiv:2512.16649",
+        "arxiv:2604.13016",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T09:49:47.000Z",
+      "lastModified": "2026-05-25T10:55:40.000Z"
+    },
+    {
+      "rank": 104,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 666,
+      "likes": 55,
+      "trendingScore": 55,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-29T03:57:43.000Z"
+    },
+    {
+      "rank": 105,
+      "id": "Comfy-Org/HiDream-O1-Image",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
+      "downloads": 0,
+      "likes": 54,
+      "trendingScore": 54,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "comfyui",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-10T00:28:02.000Z",
+      "lastModified": "2026-05-12T09:46:36.000Z"
+    },
+    {
+      "rank": 106,
+      "id": "Lakonik/AsymFLUX.2-klein-9B",
+      "author": "Lakonik",
+      "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
+      "downloads": 2316,
+      "likes": 55,
+      "trendingScore": 54,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "flow-matching",
+        "pixel-diffusion",
+        "pixel-generation",
+        "flux2",
+        "text-to-image",
+        "arxiv:2605.12964",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T20:19:24.000Z",
+      "lastModified": "2026-05-14T02:37:15.000Z"
+    },
+    {
+      "rank": 107,
+      "id": "black-forest-labs/FLUX.1-dev",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+      "downloads": 717175,
+      "likes": 12938,
+      "trendingScore": 54,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "image-generation",
+        "flux",
+        "en",
+        "license:other",
+        "endpoints_compatible",
+        "diffusers:FluxPipeline",
+        "region:us"
+      ],
+      "createdAt": "2024-07-31T21:13:44.000Z",
+      "lastModified": "2025-06-27T16:22:19.000Z"
+    },
+    {
+      "rank": 108,
+      "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 702376,
+      "likes": 696,
+      "trendingScore": 54,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "gemma4",
+        "abliterated",
+        "vision",
+        "multimodal",
+        "audio",
+        "image-text-to-text",
+        "en",
+        "multilingual",
+        "license:gemma",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-02T22:29:19.000Z",
+      "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
       "rank": 109,
@@ -3876,6 +3876,37 @@
     },
     {
       "rank": 129,
+      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "downloads": 0,
+      "likes": 44,
+      "trendingScore": 44,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "mlx",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:15:18.000Z",
+      "lastModified": "2026-05-28T15:51:28.000Z"
+    },
+    {
+      "rank": 130,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
@@ -3908,7 +3939,7 @@
       "lastModified": "2026-05-05T14:35:03.000Z"
     },
     {
-      "rank": 130,
+      "rank": 131,
       "id": "manjunathshiva/gpt-oss-20b-tq3",
       "author": "manjunathshiva",
       "url": "https://huggingface.co/manjunathshiva/gpt-oss-20b-tq3",
@@ -3939,7 +3970,7 @@
       "lastModified": "2026-05-09T11:23:07.000Z"
     },
     {
-      "rank": 131,
+      "rank": 132,
       "id": "Zlikwid/LTX_2.3_Upscale_IC_Lora",
       "author": "Zlikwid",
       "url": "https://huggingface.co/Zlikwid/LTX_2.3_Upscale_IC_Lora",
@@ -3955,7 +3986,7 @@
       "lastModified": "2026-05-09T01:15:32.000Z"
     },
     {
-      "rank": 132,
+      "rank": 133,
       "id": "byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -3980,37 +4011,6 @@
       ],
       "createdAt": "2026-05-19T21:48:29.000Z",
       "lastModified": "2026-05-20T01:46:59.000Z"
-    },
-    {
-      "rank": 133,
-      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "downloads": 0,
-      "likes": 43,
-      "trendingScore": 43,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "ternary",
-        "1.58-bit",
-        "mlx",
-        "apple-silicon",
-        "on-device",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:15:18.000Z",
-      "lastModified": "2026-05-28T15:51:28.000Z"
     },
     {
       "rank": 134,
@@ -5060,6 +5060,35 @@
     },
     {
       "rank": 170,
+      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "author": "OpenMOSS-Team",
+      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "downloads": 101,
+      "likes": 32,
+      "trendingScore": 32,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-audio",
+        "diffusion",
+        "flow-matching",
+        "sound-effects",
+        "audio-generation",
+        "en",
+        "zh",
+        "base_model:Qwen/Qwen3-1.7B",
+        "base_model:finetune:Qwen/Qwen3-1.7B",
+        "license:apache-2.0",
+        "diffusers:MossSoundEffectPipeline",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T14:19:58.000Z",
+      "lastModified": "2026-05-26T09:41:39.000Z"
+    },
+    {
+      "rank": 171,
       "id": "z-lab/Qwen3.6-35B-A3B-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash",
@@ -5092,7 +5121,7 @@
       "lastModified": "2026-04-26T07:28:33.000Z"
     },
     {
-      "rank": 171,
+      "rank": 172,
       "id": "tencent/Hy3-preview",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy3-preview",
@@ -5116,7 +5145,7 @@
       "lastModified": "2026-04-23T14:59:42.000Z"
     },
     {
-      "rank": 172,
+      "rank": 173,
       "id": "google/gemma-4-E2B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B-it",
@@ -5143,7 +5172,7 @@
       "lastModified": "2026-05-07T07:39:49.000Z"
     },
     {
-      "rank": 173,
+      "rank": 174,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B-GGUF",
@@ -5185,7 +5214,7 @@
       "lastModified": "2026-05-08T01:10:22.000Z"
     },
     {
-      "rank": 174,
+      "rank": 175,
       "id": "zed-industries/zeta-2.1",
       "author": "zed-industries",
       "url": "https://huggingface.co/zed-industries/zeta-2.1",
@@ -5213,7 +5242,7 @@
       "lastModified": "2026-05-08T19:09:36.000Z"
     },
     {
-      "rank": 175,
+      "rank": 176,
       "id": "ByteDance-Seed/Cola-DLM",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/Cola-DLM",
@@ -5243,7 +5272,7 @@
       "lastModified": "2026-05-15T09:38:05.000Z"
     },
     {
-      "rank": 176,
+      "rank": 177,
       "id": "openai/whisper-large-v3",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3",
@@ -5288,7 +5317,7 @@
       "lastModified": "2024-08-12T10:20:10.000Z"
     },
     {
-      "rank": 177,
+      "rank": 178,
       "id": "CohereLabs/command-a-plus-05-2026-fp8",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-fp8",
@@ -5333,7 +5362,7 @@
       "lastModified": "2026-05-22T14:40:30.000Z"
     },
     {
-      "rank": 178,
+      "rank": 179,
       "id": "pyannote/segmentation-3.0",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/segmentation-3.0",
@@ -5364,7 +5393,7 @@
       "lastModified": "2024-05-10T19:35:46.000Z"
     },
     {
-      "rank": 179,
+      "rank": 180,
       "id": "black-forest-labs/FLUX.1-schnell",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell",
@@ -5390,7 +5419,7 @@
       "lastModified": "2024-08-16T14:37:56.000Z"
     },
     {
-      "rank": 180,
+      "rank": 181,
       "id": "black-forest-labs/FLUX.2-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-dev",
@@ -5416,7 +5445,7 @@
       "lastModified": "2026-02-17T15:56:06.000Z"
     },
     {
-      "rank": 181,
+      "rank": 182,
       "id": "z-lab/gemma-4-26B-A4B-it-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash",
@@ -5448,7 +5477,7 @@
       "lastModified": "2026-05-09T04:59:12.000Z"
     },
     {
-      "rank": 182,
+      "rank": 183,
       "id": "Zyphra/ZAYA1-VL-8B",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-VL-8B",
@@ -5475,7 +5504,7 @@
       "lastModified": "2026-05-14T22:39:27.000Z"
     },
     {
-      "rank": 183,
+      "rank": 184,
       "id": "ponpoke/flux2-klein-9b-uncensored-text-encoder",
       "author": "ponpoke",
       "url": "https://huggingface.co/ponpoke/flux2-klein-9b-uncensored-text-encoder",
@@ -5509,7 +5538,7 @@
       "lastModified": "2026-05-02T11:34:41.000Z"
     },
     {
-      "rank": 184,
+      "rank": 185,
       "id": "systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
       "author": "systms",
       "url": "https://huggingface.co/systms/SYSTMS-FLW-IC-LORA-LTX-2.3",
@@ -5531,7 +5560,7 @@
       "lastModified": "2026-05-13T19:23:38.000Z"
     },
     {
-      "rank": 185,
+      "rank": 186,
       "id": "facebook/sam3.1",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3.1",
@@ -5550,35 +5579,6 @@
       ],
       "createdAt": "2026-03-26T01:25:54.000Z",
       "lastModified": "2026-03-27T17:40:55.000Z"
-    },
-    {
-      "rank": 186,
-      "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "author": "OpenMOSS-Team",
-      "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "downloads": 101,
-      "likes": 30,
-      "trendingScore": 30,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-audio",
-        "diffusion",
-        "flow-matching",
-        "sound-effects",
-        "audio-generation",
-        "en",
-        "zh",
-        "base_model:Qwen/Qwen3-1.7B",
-        "base_model:finetune:Qwen/Qwen3-1.7B",
-        "license:apache-2.0",
-        "diffusers:MossSoundEffectPipeline",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T14:19:58.000Z",
-      "lastModified": "2026-05-26T09:41:39.000Z"
     },
     {
       "rank": 187,
@@ -5864,6 +5864,31 @@
     },
     {
       "rank": 196,
+      "id": "black-forest-labs/FLUX.2-klein-9B",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
+      "downloads": 138543,
+      "likes": 802,
+      "trendingScore": 29,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-generation",
+        "image-editing",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-01-14T13:24:26.000Z",
+      "lastModified": "2026-02-24T00:17:09.000Z"
+    },
+    {
+      "rank": 197,
       "id": "dx8152/Flux2-Klein-9B-Consistency",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Consistency",
@@ -5885,7 +5910,7 @@
       "lastModified": "2026-04-19T02:39:34.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF",
@@ -5922,7 +5947,7 @@
       "lastModified": "2026-04-28T16:14:16.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "Alissonerdx/LTX-LoRAs",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/LTX-LoRAs",
@@ -5944,7 +5969,7 @@
       "lastModified": "2026-04-22T17:46:55.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "zai-org/GLM-OCR",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-OCR",
@@ -5977,7 +6002,7 @@
       "lastModified": "2026-04-14T14:46:47.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "oron1208/OOO_Anima",
       "author": "oron1208",
       "url": "https://huggingface.co/oron1208/OOO_Anima",
@@ -6004,7 +6029,7 @@
       "lastModified": "2026-05-21T15:24:20.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "Qwen/Qwen-Image-Bench",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Bench",
@@ -6037,32 +6062,31 @@
       "lastModified": "2026-05-28T08:07:27.000Z"
     },
     {
-      "rank": 202,
-      "id": "black-forest-labs/FLUX.2-klein-9B",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
-      "downloads": 138543,
-      "likes": 800,
+      "rank": 203,
+      "id": "bageldotcom/paris2",
+      "author": "bageldotcom",
+      "url": "https://huggingface.co/bageldotcom/paris2",
+      "downloads": 0,
+      "likes": 28,
       "trendingScore": 28,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
+      "pipelineTag": "image-to-video",
+      "libraryName": null,
       "tags": [
-        "diffusers",
         "safetensors",
-        "image-generation",
-        "image-editing",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "license:other",
+        "paris2",
+        "text-to-video",
+        "image-to-video",
+        "mixture-of-experts",
+        "decentralized-diffusion-model",
+        "arxiv:2605.26064",
+        "license:mit",
         "region:us"
       ],
-      "createdAt": "2026-01-14T13:24:26.000Z",
-      "lastModified": "2026-02-24T00:17:09.000Z"
+      "createdAt": "2026-05-24T17:46:11.000Z",
+      "lastModified": "2026-05-28T16:32:17.000Z"
     },
     {
-      "rank": 203,
+      "rank": 204,
       "id": "ibm-granite/granite-speech-4.1-2b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b",
@@ -6102,7 +6126,7 @@
       "lastModified": "2026-04-29T14:10:59.000Z"
     },
     {
-      "rank": 204,
+      "rank": 205,
       "id": "Lorbus/Qwen3.6-27B-int4-AutoRound",
       "author": "Lorbus",
       "url": "https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound",
@@ -6139,7 +6163,7 @@
       "lastModified": "2026-04-22T19:54:43.000Z"
     },
     {
-      "rank": 205,
+      "rank": 206,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1",
@@ -6182,7 +6206,7 @@
       "lastModified": "2026-05-07T02:38:37.000Z"
     },
     {
-      "rank": 206,
+      "rank": 207,
       "id": "litert-community/gemma-4-E2B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
@@ -6202,7 +6226,7 @@
       "lastModified": "2026-05-05T16:03:51.000Z"
     },
     {
-      "rank": 207,
+      "rank": 208,
       "id": "unsloth/Qwen3.5-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF",
@@ -6227,7 +6251,7 @@
       "lastModified": "2026-03-02T14:08:36.000Z"
     },
     {
-      "rank": 208,
+      "rank": 209,
       "id": "kjanh/KhanhTTS-OmniVoice",
       "author": "kjanh",
       "url": "https://huggingface.co/kjanh/KhanhTTS-OmniVoice",
@@ -6252,7 +6276,7 @@
       "lastModified": "2026-05-16T04:32:12.000Z"
     },
     {
-      "rank": 209,
+      "rank": 210,
       "id": "nvidia/Nemotron-Labs-Diffusion-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-8B",
@@ -6275,31 +6299,38 @@
       "lastModified": "2026-05-23T00:38:45.000Z"
     },
     {
-      "rank": 210,
-      "id": "bageldotcom/paris2",
-      "author": "bageldotcom",
-      "url": "https://huggingface.co/bageldotcom/paris2",
-      "downloads": 0,
-      "likes": 27,
+      "rank": 211,
+      "id": "nvidia/DeepSeek-V4-Pro-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4",
+      "downloads": 2356,
+      "likes": 28,
       "trendingScore": 27,
-      "pipelineTag": "image-to-video",
-      "libraryName": null,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
       "tags": [
+        "Model Optimizer",
         "safetensors",
-        "paris2",
-        "text-to-video",
-        "image-to-video",
-        "mixture-of-experts",
-        "decentralized-diffusion-model",
-        "arxiv:2605.26064",
+        "deepseek_v4",
+        "nvidia",
+        "ModelOpt",
+        "DeepSeekV4",
+        "quantized",
+        "NVFP4",
+        "nvfp4",
+        "text-generation",
+        "base_model:deepseek-ai/DeepSeek-V4-Pro",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Pro",
         "license:mit",
+        "8-bit",
+        "fp8",
         "region:us"
       ],
-      "createdAt": "2026-05-24T17:46:11.000Z",
-      "lastModified": "2026-05-28T16:32:17.000Z"
+      "createdAt": "2026-05-14T19:48:36.000Z",
+      "lastModified": "2026-05-29T05:47:42.000Z"
     },
     {
-      "rank": 211,
+      "rank": 212,
       "id": "openbmb/VoxCPM2",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/VoxCPM2",
@@ -6344,7 +6375,7 @@
       "lastModified": "2026-04-16T03:30:11.000Z"
     },
     {
-      "rank": 212,
+      "rank": 213,
       "id": "LiconStudio/Ltx2.3-VBVR-lora-I2V",
       "author": "LiconStudio",
       "url": "https://huggingface.co/LiconStudio/Ltx2.3-VBVR-lora-I2V",
@@ -6371,7 +6402,7 @@
       "lastModified": "2026-05-01T16:10:44.000Z"
     },
     {
-      "rank": 213,
+      "rank": 214,
       "id": "DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.5-21B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -6416,7 +6447,7 @@
       "lastModified": "2026-04-02T02:04:08.000Z"
     },
     {
-      "rank": 214,
+      "rank": 215,
       "id": "RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
       "author": "RDson",
       "url": "https://huggingface.co/RDson/Qwen3.6-27B-MTP-Q4_K_M-GGUF",
@@ -6442,7 +6473,7 @@
       "lastModified": "2026-04-29T18:46:26.000Z"
     },
     {
-      "rank": 215,
+      "rank": 216,
       "id": "SearchingMan/Z-Image-Turbo-student-adapter",
       "author": "SearchingMan",
       "url": "https://huggingface.co/SearchingMan/Z-Image-Turbo-student-adapter",
@@ -6464,7 +6495,7 @@
       "lastModified": "2026-05-08T07:37:01.000Z"
     },
     {
-      "rank": 216,
+      "rank": 217,
       "id": "rizzlaa/instaraww-2.x-workflow-recreated",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/instaraww-2.x-workflow-recreated",
@@ -6480,7 +6511,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 217,
+      "rank": 218,
       "id": "lightonai/Agent-ModernColBERT",
       "author": "lightonai",
       "url": "https://huggingface.co/lightonai/Agent-ModernColBERT",
@@ -6516,7 +6547,7 @@
       "lastModified": "2026-05-12T14:20:08.000Z"
     },
     {
-      "rank": 218,
+      "rank": 219,
       "id": "nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-ASR-Streaming-Multilingual-0.6b",
@@ -6534,7 +6565,7 @@
       "lastModified": "2026-05-16T05:35:07.000Z"
     },
     {
-      "rank": 219,
+      "rank": 220,
       "id": "BAAI/bge-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-m3",
@@ -6566,7 +6597,7 @@
       "lastModified": "2024-07-03T14:50:10.000Z"
     },
     {
-      "rank": 220,
+      "rank": 221,
       "id": "tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-1.25Bit-GGUF",
@@ -6589,7 +6620,104 @@
       "lastModified": "2026-05-26T09:06:32.000Z"
     },
     {
-      "rank": 221,
+      "rank": 222,
+      "id": "openai/gpt-oss-120b",
+      "author": "openai",
+      "url": "https://huggingface.co/openai/gpt-oss-120b",
+      "downloads": 4759642,
+      "likes": 4825,
+      "trendingScore": 26,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gpt_oss",
+        "text-generation",
+        "vllm",
+        "conversational",
+        "arxiv:2508.10925",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "8-bit",
+        "mxfp4",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-08-04T22:33:06.000Z",
+      "lastModified": "2025-08-26T17:25:03.000Z"
+    },
+    {
+      "rank": 223,
+      "id": "ernie-research/NAVA",
+      "author": "ernie-research",
+      "url": "https://huggingface.co/ernie-research/NAVA",
+      "downloads": 25,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": "text-to-video",
+      "libraryName": "custom",
+      "tags": [
+        "custom",
+        "ti2v",
+        "text-to-video",
+        "text-to-audio-video",
+        "audio-video-generation",
+        "mmdit",
+        "flow-matching",
+        "wan2.2",
+        "en",
+        "zh",
+        "arxiv:2605.30073",
+        "base_model:Wan-AI/Wan2.2-TI2V-5B",
+        "base_model:finetune:Wan-AI/Wan2.2-TI2V-5B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-29T02:17:22.000Z",
+      "lastModified": "2026-05-29T02:24:44.000Z"
+    },
+    {
+      "rank": 224,
+      "id": "unsloth/LFM2.5-8B-A1B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/LFM2.5-8B-A1B-GGUF",
+      "downloads": 7170,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "liquid",
+        "unsloth",
+        "lfm2.5",
+        "edge",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "pt",
+        "arxiv:2511.23404",
+        "base_model:LiquidAI/LFM2.5-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-29T09:11:04.000Z",
+      "lastModified": "2026-05-30T11:13:02.000Z"
+    },
+    {
+      "rank": 225,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -6627,7 +6755,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 222,
+      "rank": 226,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -6645,7 +6773,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 223,
+      "rank": 227,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -6665,7 +6793,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 224,
+      "rank": 228,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -6692,7 +6820,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 225,
+      "rank": 229,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -6718,7 +6846,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 226,
+      "rank": 230,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -6744,7 +6872,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 227,
+      "rank": 231,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -6781,7 +6909,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 228,
+      "rank": 232,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -6797,7 +6925,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 229,
+      "rank": 233,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -6820,7 +6948,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 230,
+      "rank": 234,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -6862,7 +6990,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 231,
+      "rank": 235,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -6901,7 +7029,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 232,
+      "rank": 236,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -6946,7 +7074,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 233,
+      "rank": 237,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -6972,36 +7100,62 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 234,
-      "id": "openai/gpt-oss-120b",
-      "author": "openai",
-      "url": "https://huggingface.co/openai/gpt-oss-120b",
-      "downloads": 4759642,
-      "likes": 4824,
+      "rank": 238,
+      "id": "Kaikaku/epicure-cooc",
+      "author": "Kaikaku",
+      "url": "https://huggingface.co/Kaikaku/epicure-cooc",
+      "downloads": 291,
+      "likes": 25,
       "trendingScore": 25,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
+      "pipelineTag": "feature-extraction",
+      "libraryName": "custom",
       "tags": [
-        "transformers",
-        "safetensors",
-        "gpt_oss",
-        "text-generation",
-        "vllm",
-        "conversational",
-        "arxiv:2508.10925",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "8-bit",
-        "mxfp4",
-        "deploy:azure",
+        "custom",
+        "ingredient-embeddings",
+        "food",
+        "computational-gastronomy",
+        "metapath2vec",
+        "skip-gram",
+        "word2vec",
+        "retrieval",
+        "feature-extraction",
+        "en",
+        "zh",
+        "ru",
+        "vi",
+        "es",
+        "tr",
+        "id",
+        "de",
+        "dataset:Kaikaku/epicure-corpus-resources",
+        "arxiv:2605.22391",
+        "license:cc-by-4.0",
         "region:us"
       ],
-      "createdAt": "2025-08-04T22:33:06.000Z",
-      "lastModified": "2025-08-26T17:25:03.000Z"
+      "createdAt": "2026-05-27T13:43:23.000Z",
+      "lastModified": "2026-05-27T13:44:09.000Z"
     },
     {
-      "rank": 235,
+      "rank": 239,
+      "id": "Comfy-Org/PixelDiT",
+      "author": "Comfy-Org",
+      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+      "downloads": 16844,
+      "likes": 25,
+      "trendingScore": 25,
+      "pipelineTag": null,
+      "libraryName": "diffusion-single-file",
+      "tags": [
+        "diffusion-single-file",
+        "comfyui",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T14:05:48.000Z",
+      "lastModified": "2026-05-28T15:02:28.000Z"
+    },
+    {
+      "rank": 240,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -7033,7 +7187,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 236,
+      "rank": 241,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -7057,7 +7211,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 237,
+      "rank": 242,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -7084,7 +7238,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 238,
+      "rank": 243,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -7109,7 +7263,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 239,
+      "rank": 244,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -7145,7 +7299,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 240,
+      "rank": 245,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -7161,7 +7315,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 241,
+      "rank": 246,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -7182,7 +7336,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 242,
+      "rank": 247,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -7205,7 +7359,7 @@
       "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 243,
+      "rank": 248,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7232,7 +7386,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 244,
+      "rank": 249,
       "id": "SupraLabs/Supra-50M-Instruct",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
@@ -7271,73 +7425,39 @@
       "lastModified": "2026-05-27T13:52:37.000Z"
     },
     {
-      "rank": 245,
-      "id": "Kaikaku/epicure-cooc",
-      "author": "Kaikaku",
-      "url": "https://huggingface.co/Kaikaku/epicure-cooc",
-      "downloads": 291,
+      "rank": 250,
+      "id": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "downloads": 67020,
       "likes": 24,
       "trendingScore": 24,
-      "pipelineTag": "feature-extraction",
-      "libraryName": "custom",
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
       "tags": [
-        "custom",
-        "ingredient-embeddings",
-        "food",
-        "computational-gastronomy",
-        "metapath2vec",
-        "skip-gram",
-        "word2vec",
-        "retrieval",
-        "feature-extraction",
-        "en",
-        "zh",
-        "ru",
-        "vi",
-        "es",
-        "tr",
-        "id",
-        "de",
-        "dataset:Kaikaku/epicure-corpus-resources",
-        "arxiv:2605.22391",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-27T13:43:23.000Z",
-      "lastModified": "2026-05-27T13:44:09.000Z"
-    },
-    {
-      "rank": 246,
-      "id": "ernie-research/NAVA",
-      "author": "ernie-research",
-      "url": "https://huggingface.co/ernie-research/NAVA",
-      "downloads": 25,
-      "likes": 24,
-      "trendingScore": 24,
-      "pipelineTag": "text-to-video",
-      "libraryName": "custom",
-      "tags": [
-        "custom",
-        "ti2v",
-        "text-to-video",
-        "text-to-audio-video",
-        "audio-video-generation",
-        "mmdit",
-        "flow-matching",
-        "wan2.2",
-        "en",
-        "zh",
-        "arxiv:2605.30073",
-        "base_model:Wan-AI/Wan2.2-TI2V-5B",
-        "base_model:finetune:Wan-AI/Wan2.2-TI2V-5B",
+        "Model Optimizer",
+        "safetensors",
+        "qwen3_5_moe",
+        "nvidia",
+        "ModelOpt",
+        "Qwen3.6",
+        "quantized",
+        "FP4",
+        "fp4",
+        "text-generation",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
         "license:apache-2.0",
+        "8-bit",
+        "modelopt",
         "region:us"
       ],
-      "createdAt": "2026-05-29T02:17:22.000Z",
-      "lastModified": "2026-05-29T02:24:44.000Z"
+      "createdAt": "2026-05-27T18:09:46.000Z",
+      "lastModified": "2026-05-29T19:10:41.000Z"
     },
     {
-      "rank": 247,
+      "rank": 251,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -7364,7 +7484,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 248,
+      "rank": 252,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -7393,7 +7513,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 249,
+      "rank": 253,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -7410,7 +7530,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 250,
+      "rank": 254,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -7431,7 +7551,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 251,
+      "rank": 255,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -7452,7 +7572,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 252,
+      "rank": 256,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -7484,7 +7604,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 253,
+      "rank": 257,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -7515,7 +7635,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 254,
+      "rank": 258,
       "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
@@ -7545,7 +7665,7 @@
       "lastModified": "2026-05-26T16:16:58.000Z"
     },
     {
-      "rank": 255,
+      "rank": 259,
       "id": "FINAL-Bench/Darwin-60B-DUO",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-60B-DUO",
@@ -7584,26 +7704,33 @@
       "lastModified": "2026-05-28T03:21:23.000Z"
     },
     {
-      "rank": 256,
-      "id": "Comfy-Org/PixelDiT",
-      "author": "Comfy-Org",
-      "url": "https://huggingface.co/Comfy-Org/PixelDiT",
-      "downloads": 16844,
+      "rank": 260,
+      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+      "downloads": 0,
       "likes": 23,
       "trendingScore": 23,
-      "pipelineTag": null,
-      "libraryName": "diffusion-single-file",
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "diffusion-single-file",
-        "comfyui",
-        "license:other",
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:black-forest-labs/FLUX.2-klein-4B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-4B",
+        "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-05-25T14:05:48.000Z",
-      "lastModified": "2026-05-28T15:02:28.000Z"
+      "createdAt": "2026-05-21T16:07:19.000Z",
+      "lastModified": "2026-05-28T22:23:51.000Z"
     },
     {
-      "rank": 257,
+      "rank": 261,
       "id": "kai-os/Carnice-V2-27b-GGUF",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b-GGUF",
@@ -7634,7 +7761,7 @@
       "lastModified": "2026-04-25T18:18:44.000Z"
     },
     {
-      "rank": 258,
+      "rank": 262,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
@@ -7663,7 +7790,7 @@
       "lastModified": "2026-05-07T23:45:08.000Z"
     },
     {
-      "rank": 259,
+      "rank": 263,
       "id": "SL-AI/GRaPE-2-Pro",
       "author": "SL-AI",
       "url": "https://huggingface.co/SL-AI/GRaPE-2-Pro",
@@ -7708,7 +7835,7 @@
       "lastModified": "2026-04-24T20:31:02.000Z"
     },
     {
-      "rank": 260,
+      "rank": 264,
       "id": "unsloth/Qwen3.6-27B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-NVFP4",
@@ -7735,7 +7862,7 @@
       "lastModified": "2026-05-06T18:54:03.000Z"
     },
     {
-      "rank": 261,
+      "rank": 265,
       "id": "Prior-Labs/tabpfn_3",
       "author": "Prior-Labs",
       "url": "https://huggingface.co/Prior-Labs/tabpfn_3",
@@ -7759,7 +7886,7 @@
       "lastModified": "2026-05-12T11:33:27.000Z"
     },
     {
-      "rank": 262,
+      "rank": 266,
       "id": "fastino/gliner2-privacy-filter-PII-multi",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-privacy-filter-PII-multi",
@@ -7797,7 +7924,7 @@
       "lastModified": "2026-05-14T18:18:54.000Z"
     },
     {
-      "rank": 263,
+      "rank": 267,
       "id": "liujiafeng/Khala-MusicGeneration-v1.0",
       "author": "liujiafeng",
       "url": "https://huggingface.co/liujiafeng/Khala-MusicGeneration-v1.0",
@@ -7814,7 +7941,7 @@
       "lastModified": "2026-05-03T14:33:28.000Z"
     },
     {
-      "rank": 264,
+      "rank": 268,
       "id": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-MTP-GGUF",
@@ -7842,7 +7969,7 @@
       "lastModified": "2026-05-18T03:29:50.000Z"
     },
     {
-      "rank": 265,
+      "rank": 269,
       "id": "vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Soft_Enhance_Style_LoRa",
@@ -7865,7 +7992,7 @@
       "lastModified": "2026-04-24T02:26:47.000Z"
     },
     {
-      "rank": 266,
+      "rank": 270,
       "id": "lkzd7/WAN2.2_LoraSet_NSFW",
       "author": "lkzd7",
       "url": "https://huggingface.co/lkzd7/WAN2.2_LoraSet_NSFW",
@@ -7882,7 +8009,7 @@
       "lastModified": "2026-01-20T21:35:11.000Z"
     },
     {
-      "rank": 267,
+      "rank": 271,
       "id": "LatitudeGames/Equinox-31B-GGUF",
       "author": "LatitudeGames",
       "url": "https://huggingface.co/LatitudeGames/Equinox-31B-GGUF",
@@ -7909,7 +8036,7 @@
       "lastModified": "2026-05-23T09:56:53.000Z"
     },
     {
-      "rank": 268,
+      "rank": 272,
       "id": "MiniMaxAI/MiniMax-M2.7",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.7",
@@ -7935,7 +8062,7 @@
       "lastModified": "2026-04-20T04:28:14.000Z"
     },
     {
-      "rank": 269,
+      "rank": 273,
       "id": "Qwen/Qwen3-Coder-Next",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next",
@@ -7960,64 +8087,7 @@
       "lastModified": "2026-02-03T16:16:38.000Z"
     },
     {
-      "rank": 270,
-      "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
-      "downloads": 0,
-      "likes": 22,
-      "trendingScore": 22,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:black-forest-labs/FLUX.2-klein-4B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-4B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:07:19.000Z",
-      "lastModified": "2026-05-28T22:23:51.000Z"
-    },
-    {
-      "rank": 271,
-      "id": "nvidia/DeepSeek-V4-Pro-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4",
-      "downloads": 2356,
-      "likes": 23,
-      "trendingScore": 22,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "deepseek_v4",
-        "nvidia",
-        "ModelOpt",
-        "DeepSeekV4",
-        "quantized",
-        "NVFP4",
-        "nvfp4",
-        "text-generation",
-        "base_model:deepseek-ai/DeepSeek-V4-Pro",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Pro",
-        "license:mit",
-        "8-bit",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T19:48:36.000Z",
-      "lastModified": "2026-05-29T05:47:42.000Z"
-    },
-    {
-      "rank": 272,
+      "rank": 274,
       "id": "unsloth/Mistral-Medium-3.5-128B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Mistral-Medium-3.5-128B-GGUF",
@@ -8062,7 +8132,7 @@
       "lastModified": "2026-05-02T07:45:18.000Z"
     },
     {
-      "rank": 273,
+      "rank": 275,
       "id": "unsloth/gemma-4-31B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF",
@@ -8090,7 +8160,7 @@
       "lastModified": "2026-05-04T09:17:05.000Z"
     },
     {
-      "rank": 274,
+      "rank": 276,
       "id": "jinaai/jina-embeddings-v5-omni-nano",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano",
@@ -8126,7 +8196,7 @@
       "lastModified": "2026-05-17T10:58:34.000Z"
     },
     {
-      "rank": 275,
+      "rank": 277,
       "id": "unsloth/Qwen3.5-4B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-MTP-GGUF",
@@ -8153,7 +8223,7 @@
       "lastModified": "2026-05-16T12:38:58.000Z"
     },
     {
-      "rank": 276,
+      "rank": 278,
       "id": "Efficient-Large-Model/LongLive-2.0-5B",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/LongLive-2.0-5B",
@@ -8178,7 +8248,7 @@
       "lastModified": "2026-05-19T02:54:48.000Z"
     },
     {
-      "rank": 277,
+      "rank": 279,
       "id": "byteshape/Qwen3.6-35B-A3B-GGUF",
       "author": "byteshape",
       "url": "https://huggingface.co/byteshape/Qwen3.6-35B-A3B-GGUF",
@@ -8204,7 +8274,7 @@
       "lastModified": "2026-05-19T22:23:34.000Z"
     },
     {
-      "rank": 278,
+      "rank": 280,
       "id": "syvai/cohere-transcribe-diarize",
       "author": "syvai",
       "url": "https://huggingface.co/syvai/cohere-transcribe-diarize",
@@ -8249,7 +8319,7 @@
       "lastModified": "2026-05-22T20:56:30.000Z"
     },
     {
-      "rank": 279,
+      "rank": 281,
       "id": "spiritbuun/buun-Qwen3.6-chat_template",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/buun-Qwen3.6-chat_template",
@@ -8273,7 +8343,39 @@
       "lastModified": "2026-05-28T19:36:56.000Z"
     },
     {
-      "rank": 280,
+      "rank": 282,
+      "id": "mistralai/Voxtral-4B-TTS-2603",
+      "author": "mistralai",
+      "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
+      "downloads": 7159,
+      "likes": 828,
+      "trendingScore": 21,
+      "pipelineTag": "text-to-speech",
+      "libraryName": "vllm",
+      "tags": [
+        "vllm",
+        "mistral-common",
+        "text-to-speech",
+        "en",
+        "fr",
+        "es",
+        "pt",
+        "it",
+        "nl",
+        "de",
+        "ar",
+        "hi",
+        "arxiv:2603.25551",
+        "base_model:mistralai/Ministral-3-3B-Base-2512",
+        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
+        "license:cc-by-nc-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-11-17T17:06:57.000Z",
+      "lastModified": "2026-03-31T13:43:59.000Z"
+    },
+    {
+      "rank": 283,
       "id": "ibm-granite/granite-4.1-3b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-3b",
@@ -8301,7 +8403,7 @@
       "lastModified": "2026-05-04T17:36:00.000Z"
     },
     {
-      "rank": 281,
+      "rank": 284,
       "id": "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Balanced",
@@ -8334,7 +8436,7 @@
       "lastModified": "2026-04-23T22:09:54.000Z"
     },
     {
-      "rank": 282,
+      "rank": 285,
       "id": "Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50",
@@ -8359,7 +8461,7 @@
       "lastModified": "2026-04-30T08:47:23.000Z"
     },
     {
-      "rank": 283,
+      "rank": 286,
       "id": "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "hesamation",
       "url": "https://huggingface.co/hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -8396,7 +8498,7 @@
       "lastModified": "2026-04-19T01:24:41.000Z"
     },
     {
-      "rank": 284,
+      "rank": 287,
       "id": "Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v1-preview-GGUF",
@@ -8439,7 +8541,7 @@
       "lastModified": "2026-04-23T03:21:54.000Z"
     },
     {
-      "rank": 285,
+      "rank": 288,
       "id": "Danrisi/UltraReal_FineTune_Anima",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima",
@@ -8463,7 +8565,7 @@
       "lastModified": "2026-05-04T13:00:23.000Z"
     },
     {
-      "rank": 286,
+      "rank": 289,
       "id": "OrionLLM/GRM-2.6-Plus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Plus",
@@ -8487,7 +8589,7 @@
       "lastModified": "2026-05-07T22:29:21.000Z"
     },
     {
-      "rank": 287,
+      "rank": 290,
       "id": "mudler/Qwen3.6-35B-A3B-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-APEX-GGUF",
@@ -8516,7 +8618,7 @@
       "lastModified": "2026-04-27T14:00:29.000Z"
     },
     {
-      "rank": 288,
+      "rank": 291,
       "id": "Comfy-Org/MoGe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/MoGe",
@@ -8534,7 +8636,7 @@
       "lastModified": "2026-05-19T23:25:01.000Z"
     },
     {
-      "rank": 289,
+      "rank": 292,
       "id": "unsloth/LTX-2.3-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/LTX-2.3-GGUF",
@@ -8579,7 +8681,7 @@
       "lastModified": "2026-04-20T01:59:13.000Z"
     },
     {
-      "rank": 290,
+      "rank": 293,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop",
@@ -8624,7 +8726,7 @@
       "lastModified": "2026-05-18T07:56:29.000Z"
     },
     {
-      "rank": 291,
+      "rank": 294,
       "id": "openai/gpt-oss-20b",
       "author": "openai",
       "url": "https://huggingface.co/openai/gpt-oss-20b",
@@ -8653,7 +8755,7 @@
       "lastModified": "2025-08-26T17:25:47.000Z"
     },
     {
-      "rank": 292,
+      "rank": 295,
       "id": "Alissonerdx/EditAnything",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/EditAnything",
@@ -8677,7 +8779,7 @@
       "lastModified": "2026-05-18T17:56:08.000Z"
     },
     {
-      "rank": 293,
+      "rank": 296,
       "id": "stabilityai/stable-diffusion-xl-base-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
@@ -8706,7 +8808,7 @@
       "lastModified": "2023-10-30T16:03:47.000Z"
     },
     {
-      "rank": 294,
+      "rank": 297,
       "id": "Qwen/Qwen-Image-Edit-2511",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2511",
@@ -8730,7 +8832,7 @@
       "lastModified": "2025-12-23T13:13:52.000Z"
     },
     {
-      "rank": 295,
+      "rank": 298,
       "id": "netease-youdao/Confucius4",
       "author": "netease-youdao",
       "url": "https://huggingface.co/netease-youdao/Confucius4",
@@ -8748,7 +8850,7 @@
       "lastModified": "2026-05-20T08:42:10.000Z"
     },
     {
-      "rank": 296,
+      "rank": 299,
       "id": "Comfy-Org/stable-audio-3",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/stable-audio-3",
@@ -8766,7 +8868,7 @@
       "lastModified": "2026-05-20T15:19:38.000Z"
     },
     {
-      "rank": 297,
+      "rank": 300,
       "id": "unsloth/gemma-4-E2B-it-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF",
@@ -8793,7 +8895,7 @@
       "lastModified": "2026-05-04T09:00:35.000Z"
     },
     {
-      "rank": 298,
+      "rank": 301,
       "id": "llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-26B-A4B-it-uncensored-heretic-GGUF",
@@ -8823,12 +8925,12 @@
       "lastModified": "2026-05-25T00:33:13.000Z"
     },
     {
-      "rank": 299,
+      "rank": 302,
       "id": "nvidia/GLM-5.1-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/GLM-5.1-NVFP4",
       "downloads": 10427,
-      "likes": 23,
+      "likes": 24,
       "trendingScore": 20,
       "pipelineTag": "text-generation",
       "libraryName": "Model Optimizer",
@@ -8856,77 +8958,7 @@
       "lastModified": "2026-05-27T17:03:55.000Z"
     },
     {
-      "rank": 300,
-      "id": "mistralai/Voxtral-4B-TTS-2603",
-      "author": "mistralai",
-      "url": "https://huggingface.co/mistralai/Voxtral-4B-TTS-2603",
-      "downloads": 7159,
-      "likes": 827,
-      "trendingScore": 20,
-      "pipelineTag": "text-to-speech",
-      "libraryName": "vllm",
-      "tags": [
-        "vllm",
-        "mistral-common",
-        "text-to-speech",
-        "en",
-        "fr",
-        "es",
-        "pt",
-        "it",
-        "nl",
-        "de",
-        "ar",
-        "hi",
-        "arxiv:2603.25551",
-        "base_model:mistralai/Ministral-3-3B-Base-2512",
-        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
-        "license:cc-by-nc-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-11-17T17:06:57.000Z",
-      "lastModified": "2026-03-31T13:43:59.000Z"
-    },
-    {
-      "rank": 301,
-      "id": "unsloth/LFM2.5-8B-A1B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/LFM2.5-8B-A1B-GGUF",
-      "downloads": 7170,
-      "likes": 20,
-      "trendingScore": 20,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "liquid",
-        "unsloth",
-        "lfm2.5",
-        "edge",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "arxiv:2511.23404",
-        "base_model:LiquidAI/LFM2.5-8B-A1B",
-        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-29T09:11:04.000Z",
-      "lastModified": "2026-05-29T11:22:07.000Z"
-    },
-    {
-      "rank": 302,
+      "rank": 303,
       "id": "microsoft/VibeVoice-ASR",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR",
@@ -8971,7 +9003,7 @@
       "lastModified": "2026-01-27T13:12:22.000Z"
     },
     {
-      "rank": 303,
+      "rank": 304,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -9004,7 +9036,7 @@
       "lastModified": "2026-04-06T02:20:53.000Z"
     },
     {
-      "rank": 304,
+      "rank": 305,
       "id": "facebook/sapiens2",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sapiens2",
@@ -9026,7 +9058,7 @@
       "lastModified": "2026-04-24T03:14:41.000Z"
     },
     {
-      "rank": 305,
+      "rank": 306,
       "id": "unsloth/granite-4.1-8b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-8b-GGUF",
@@ -9053,7 +9085,7 @@
       "lastModified": "2026-04-30T18:43:01.000Z"
     },
     {
-      "rank": 306,
+      "rank": 307,
       "id": "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
       "author": "TenStrip",
       "url": "https://huggingface.co/TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
@@ -9069,7 +9101,7 @@
       "lastModified": "2026-05-02T03:50:38.000Z"
     },
     {
-      "rank": 307,
+      "rank": 308,
       "id": "mistralai/Mistral-7B-Instruct-v0.3",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3",
@@ -9092,7 +9124,7 @@
       "lastModified": "2025-12-03T12:13:48.000Z"
     },
     {
-      "rank": 308,
+      "rank": 309,
       "id": "AIDC-AI/Marco-DeepResearch-8B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Marco-DeepResearch-8B",
@@ -9128,7 +9160,7 @@
       "lastModified": "2026-05-08T10:52:15.000Z"
     },
     {
-      "rank": 309,
+      "rank": 310,
       "id": "allenai/Emo_1b14b_1T",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Emo_1b14b_1T",
@@ -9157,7 +9189,7 @@
       "lastModified": "2026-05-08T15:54:14.000Z"
     },
     {
-      "rank": 310,
+      "rank": 311,
       "id": "briaai/RMBG-2.0",
       "author": "briaai",
       "url": "https://huggingface.co/briaai/RMBG-2.0",
@@ -9187,7 +9219,7 @@
       "lastModified": "2026-04-06T15:27:43.000Z"
     },
     {
-      "rank": 311,
+      "rank": 312,
       "id": "nvidia/parakeet-tdt-0.6b-v3",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3",
@@ -9232,7 +9264,7 @@
       "lastModified": "2026-04-16T16:26:05.000Z"
     },
     {
-      "rank": 312,
+      "rank": 313,
       "id": "Qwen/Qwen3.5-4B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
@@ -9259,7 +9291,7 @@
       "lastModified": "2026-03-02T00:52:52.000Z"
     },
     {
-      "rank": 313,
+      "rank": 314,
       "id": "internlm/Intern-S2-Preview-FP8",
       "author": "internlm",
       "url": "https://huggingface.co/internlm/Intern-S2-Preview-FP8",
@@ -9285,7 +9317,7 @@
       "lastModified": "2026-05-19T08:07:06.000Z"
     },
     {
-      "rank": 314,
+      "rank": 315,
       "id": "perplexity-ai/pplx-embed-v1-late-0.6b",
       "author": "perplexity-ai",
       "url": "https://huggingface.co/perplexity-ai/pplx-embed-v1-late-0.6b",
@@ -9313,7 +9345,7 @@
       "lastModified": "2026-05-19T15:05:48.000Z"
     },
     {
-      "rank": 315,
+      "rank": 316,
       "id": "chiennv/Orthrus-Qwen3-8B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-8B",
@@ -9342,7 +9374,7 @@
       "lastModified": "2026-05-16T22:44:53.000Z"
     },
     {
-      "rank": 316,
+      "rank": 317,
       "id": "Tongyi-MAI/Z-Image",
       "author": "Tongyi-MAI",
       "url": "https://huggingface.co/Tongyi-MAI/Z-Image",
@@ -9366,7 +9398,7 @@
       "lastModified": "2026-01-28T14:26:13.000Z"
     },
     {
-      "rank": 317,
+      "rank": 318,
       "id": "stepfun-ai/Step-3.7-Flash-NVFP4",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-NVFP4",
@@ -9396,39 +9428,124 @@
       "lastModified": "2026-05-29T10:04:39.000Z"
     },
     {
-      "rank": 318,
-      "id": "nvidia/Qwen3.6-35B-A3B-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4",
-      "downloads": 67020,
+      "rank": 319,
+      "id": "prism-ml/bonsai-image-binary-4B-mlx-1bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit",
+      "downloads": 0,
       "likes": 19,
       "trendingScore": 19,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "Model Optimizer",
+        "diffusers",
         "safetensors",
-        "qwen3_5_moe",
-        "nvidia",
-        "ModelOpt",
-        "Qwen3.6",
-        "quantized",
-        "FP4",
-        "fp4",
-        "text-generation",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "1-bit",
+        "mlx",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
         "license:apache-2.0",
-        "8-bit",
-        "modelopt",
         "region:us"
       ],
-      "createdAt": "2026-05-27T18:09:46.000Z",
-      "lastModified": "2026-05-29T19:10:41.000Z"
+      "createdAt": "2026-05-18T15:40:10.000Z",
+      "lastModified": "2026-05-28T15:52:11.000Z"
     },
     {
-      "rank": 319,
+      "rank": 320,
+      "id": "meta-llama/Llama-3.2-3B-Instruct",
+      "author": "meta-llama",
+      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
+      "downloads": 1915340,
+      "likes": 2168,
+      "trendingScore": 19,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "facebook",
+        "meta",
+        "pytorch",
+        "llama-3",
+        "conversational",
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th",
+        "arxiv:2204.05149",
+        "arxiv:2405.16406",
+        "license:llama3.2",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2024-09-18T15:19:20.000Z",
+      "lastModified": "2024-10-24T15:07:29.000Z"
+    },
+    {
+      "rank": 321,
+      "id": "avaturn-live/avtr-1",
+      "author": "avaturn-live",
+      "url": "https://huggingface.co/avaturn-live/avtr-1",
+      "downloads": 235,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": "image-to-video",
+      "libraryName": "tensorrt",
+      "tags": [
+        "tensorrt",
+        "onnx",
+        "talking-head",
+        "lip-sync",
+        "avatar",
+        "real-time",
+        "audio-driven",
+        "non-commercial",
+        "image-to-video",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:26:51.000Z",
+      "lastModified": "2026-05-25T21:18:34.000Z"
+    },
+    {
+      "rank": 322,
+      "id": "nvidia/kokoro-82M-onnx-opt",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/kokoro-82M-onnx-opt",
+      "downloads": 0,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "onnx",
+        "en",
+        "arxiv:2306.07691",
+        "arxiv:2203.02395",
+        "base_model:hexgrad/Kokoro-82M",
+        "base_model:quantized:hexgrad/Kokoro-82M",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-28T18:52:47.000Z",
+      "lastModified": "2026-05-29T12:44:09.000Z"
+    },
+    {
+      "rank": 323,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -9450,7 +9567,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 320,
+      "rank": 324,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -9484,7 +9601,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 321,
+      "rank": 325,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -9508,7 +9625,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 322,
+      "rank": 326,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -9530,7 +9647,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 323,
+      "rank": 327,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -9559,7 +9676,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 324,
+      "rank": 328,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -9591,7 +9708,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 325,
+      "rank": 329,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -9609,7 +9726,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 326,
+      "rank": 330,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -9627,7 +9744,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 327,
+      "rank": 331,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -9653,7 +9770,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 328,
+      "rank": 332,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -9681,7 +9798,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 329,
+      "rank": 333,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -9713,7 +9830,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 330,
+      "rank": 334,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -9758,12 +9875,12 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 331,
+      "rank": 335,
       "id": "openbmb/MiniCPM5-1B-SFT",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
       "downloads": 2077,
-      "likes": 20,
+      "likes": 21,
       "trendingScore": 18,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -9798,7 +9915,7 @@
       "lastModified": "2026-05-25T11:18:10.000Z"
     },
     {
-      "rank": 332,
+      "rank": 336,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -9835,7 +9952,7 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 333,
+      "rank": 337,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
@@ -9880,37 +9997,7 @@
       "lastModified": "2026-05-28T04:24:45.000Z"
     },
     {
-      "rank": 334,
-      "id": "prism-ml/bonsai-image-binary-4B-mlx-1bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit",
-      "downloads": 0,
-      "likes": 18,
-      "trendingScore": 18,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "1-bit",
-        "mlx",
-        "apple-silicon",
-        "on-device",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-binary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-binary-4B-unpacked",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T15:40:10.000Z",
-      "lastModified": "2026-05-28T15:52:11.000Z"
-    },
-    {
-      "rank": 335,
+      "rank": 338,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
@@ -9940,7 +10027,30 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 336,
+      "rank": 339,
+      "id": "Qwen/Qwen3-ASR-1.7B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
+      "downloads": 1933109,
+      "likes": 838,
+      "trendingScore": 18,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_asr",
+        "automatic-speech-recognition",
+        "arxiv:2601.21337",
+        "license:apache-2.0",
+        "eval-results",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2026-01-28T03:22:40.000Z",
+      "lastModified": "2026-01-30T03:00:12.000Z"
+    },
+    {
+      "rank": 340,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -9985,7 +10095,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 337,
+      "rank": 341,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -10014,7 +10124,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 338,
+      "rank": 342,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -10043,7 +10153,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 339,
+      "rank": 343,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -10075,7 +10185,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 340,
+      "rank": 344,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -10105,7 +10215,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 341,
+      "rank": 345,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -10126,7 +10236,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 342,
+      "rank": 346,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -10171,7 +10281,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 343,
+      "rank": 347,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -10200,7 +10310,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 344,
+      "rank": 348,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -10228,7 +10338,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 345,
+      "rank": 349,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -10253,7 +10363,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 346,
+      "rank": 350,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -10276,7 +10386,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 347,
+      "rank": 351,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -10303,7 +10413,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 348,
+      "rank": 352,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -10329,7 +10439,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 349,
+      "rank": 353,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -10358,7 +10468,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 350,
+      "rank": 354,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -10377,7 +10487,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 351,
+      "rank": 355,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -10405,7 +10515,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 352,
+      "rank": 356,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10450,7 +10560,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 353,
+      "rank": 357,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -10478,7 +10588,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 354,
+      "rank": 358,
       "id": "numind/NuMarkdown-8B-Thinking",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
@@ -10509,7 +10619,7 @@
       "lastModified": "2026-05-19T19:01:34.000Z"
     },
     {
-      "rank": 355,
+      "rank": 359,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -10547,45 +10657,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 356,
-      "id": "meta-llama/Llama-3.2-3B-Instruct",
-      "author": "meta-llama",
-      "url": "https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
-      "downloads": 1915340,
-      "likes": 2165,
-      "trendingScore": 17,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "facebook",
-        "meta",
-        "pytorch",
-        "llama-3",
-        "conversational",
-        "en",
-        "de",
-        "fr",
-        "it",
-        "pt",
-        "hi",
-        "es",
-        "th",
-        "arxiv:2204.05149",
-        "arxiv:2405.16406",
-        "license:llama3.2",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2024-09-18T15:19:20.000Z",
-      "lastModified": "2024-10-24T15:07:29.000Z"
-    },
-    {
-      "rank": 357,
+      "rank": 360,
       "id": "allura-org/Qwen3.6-35B-A3B-Anko",
       "author": "allura-org",
       "url": "https://huggingface.co/allura-org/Qwen3.6-35B-A3B-Anko",
@@ -10608,56 +10680,7 @@
       "lastModified": "2026-04-23T15:43:25.000Z"
     },
     {
-      "rank": 358,
-      "id": "avaturn-live/avtr-1",
-      "author": "avaturn-live",
-      "url": "https://huggingface.co/avaturn-live/avtr-1",
-      "downloads": 235,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "image-to-video",
-      "libraryName": "tensorrt",
-      "tags": [
-        "tensorrt",
-        "onnx",
-        "talking-head",
-        "lip-sync",
-        "avatar",
-        "real-time",
-        "audio-driven",
-        "non-commercial",
-        "image-to-video",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:26:51.000Z",
-      "lastModified": "2026-05-25T21:18:34.000Z"
-    },
-    {
-      "rank": 359,
-      "id": "Qwen/Qwen3-ASR-1.7B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
-      "downloads": 1933109,
-      "likes": 837,
-      "trendingScore": 17,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_asr",
-        "automatic-speech-recognition",
-        "arxiv:2601.21337",
-        "license:apache-2.0",
-        "eval-results",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2026-01-28T03:22:40.000Z",
-      "lastModified": "2026-01-30T03:00:12.000Z"
-    },
-    {
-      "rank": 360,
+      "rank": 361,
       "id": "AmmarkoV/SAM3DBody-cpp-onnx-models",
       "author": "AmmarkoV",
       "url": "https://huggingface.co/AmmarkoV/SAM3DBody-cpp-onnx-models",
@@ -10675,30 +10698,55 @@
       "lastModified": "2026-05-28T20:44:53.000Z"
     },
     {
-      "rank": 361,
-      "id": "nvidia/kokoro-82M-onnx-opt",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/kokoro-82M-onnx-opt",
-      "downloads": 0,
+      "rank": 362,
+      "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 144918,
+      "likes": 364,
+      "trendingScore": 17,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.5",
+        "qwen",
+        "en",
+        "zh",
+        "multilingual",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-03-03T12:16:35.000Z",
+      "lastModified": "2026-04-05T19:01:02.000Z"
+    },
+    {
+      "rank": 363,
+      "id": "AesSedai/Step-3.7-Flash-GGUF",
+      "author": "AesSedai",
+      "url": "https://huggingface.co/AesSedai/Step-3.7-Flash-GGUF",
+      "downloads": 702,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": null,
       "libraryName": null,
       "tags": [
-        "onnx",
-        "en",
-        "arxiv:2306.07691",
-        "arxiv:2203.02395",
-        "base_model:hexgrad/Kokoro-82M",
-        "base_model:quantized:hexgrad/Kokoro-82M",
-        "license:apache-2.0",
-        "region:us"
+        "gguf",
+        "base_model:stepfun-ai/Step-3.7-Flash",
+        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
       ],
-      "createdAt": "2026-05-28T18:52:47.000Z",
-      "lastModified": "2026-05-29T12:44:09.000Z"
+      "createdAt": "2026-05-29T06:00:39.000Z",
+      "lastModified": "2026-05-29T18:39:12.000Z"
     },
     {
-      "rank": 362,
+      "rank": 364,
       "id": "tencent/HY-World-2.0",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-World-2.0",
@@ -10723,7 +10771,7 @@
       "lastModified": "2026-04-22T08:43:02.000Z"
     },
     {
-      "rank": 363,
+      "rank": 365,
       "id": "zlaabsi/Qwen3.6-27B-OTQ-GGUF",
       "author": "zlaabsi",
       "url": "https://huggingface.co/zlaabsi/Qwen3.6-27B-OTQ-GGUF",
@@ -10758,7 +10806,7 @@
       "lastModified": "2026-05-02T08:52:40.000Z"
     },
     {
-      "rank": 364,
+      "rank": 366,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
@@ -10803,7 +10851,7 @@
       "lastModified": "2026-05-01T06:44:14.000Z"
     },
     {
-      "rank": 365,
+      "rank": 367,
       "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
@@ -10830,7 +10878,7 @@
       "lastModified": "2026-04-20T09:44:47.000Z"
     },
     {
-      "rank": 366,
+      "rank": 368,
       "id": "z-lab/Qwen3.6-27B-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Qwen3.6-27B-PARO",
@@ -10859,7 +10907,7 @@
       "lastModified": "2026-05-08T06:21:15.000Z"
     },
     {
-      "rank": 367,
+      "rank": 369,
       "id": "Aratako/Irodori-TTS-500M-v2",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2",
@@ -10882,7 +10930,7 @@
       "lastModified": "2026-04-11T16:15:10.000Z"
     },
     {
-      "rank": 368,
+      "rank": 370,
       "id": "Qwen/WebWorld-14B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-14B",
@@ -10926,7 +10974,7 @@
       "lastModified": "2026-05-08T12:11:59.000Z"
     },
     {
-      "rank": 369,
+      "rank": 371,
       "id": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -10971,7 +11019,7 @@
       "lastModified": "2026-04-29T00:23:05.000Z"
     },
     {
-      "rank": 370,
+      "rank": 372,
       "id": "smthem/SenseNova-U1-8B-MoT-Merger-gguf",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/SenseNova-U1-8B-MoT-Merger-gguf",
@@ -10989,7 +11037,7 @@
       "lastModified": "2026-05-09T07:07:41.000Z"
     },
     {
-      "rank": 371,
+      "rank": 373,
       "id": "microsoft/harrier-oss-v1-0.6b",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/harrier-oss-v1-0.6b",
@@ -11034,7 +11082,7 @@
       "lastModified": "2026-03-30T08:00:59.000Z"
     },
     {
-      "rank": 372,
+      "rank": 374,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated",
@@ -11072,7 +11120,7 @@
       "lastModified": "2026-04-21T14:40:49.000Z"
     },
     {
-      "rank": 373,
+      "rank": 375,
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
@@ -11092,7 +11140,7 @@
       "lastModified": "2026-05-24T09:49:46.000Z"
     },
     {
-      "rank": 374,
+      "rank": 376,
       "id": "Gryphe/WorldSim-Opus-3.6-35B-A3B",
       "author": "Gryphe",
       "url": "https://huggingface.co/Gryphe/WorldSim-Opus-3.6-35B-A3B",
@@ -11125,7 +11173,7 @@
       "lastModified": "2026-05-15T06:16:53.000Z"
     },
     {
-      "rank": 375,
+      "rank": 377,
       "id": "HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E2B-Uncensored-HauhauCS-Aggressive",
@@ -11155,7 +11203,7 @@
       "lastModified": "2026-04-06T03:51:20.000Z"
     },
     {
-      "rank": 376,
+      "rank": 378,
       "id": "JonasGeiping/stream-qwen3.5-27b",
       "author": "JonasGeiping",
       "url": "https://huggingface.co/JonasGeiping/stream-qwen3.5-27b",
@@ -11187,7 +11235,7 @@
       "lastModified": "2026-05-13T15:36:32.000Z"
     },
     {
-      "rank": 377,
+      "rank": 379,
       "id": "OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
       "author": "OmerHagage",
       "url": "https://huggingface.co/OmerHagage/ltx2-greenscreen-avatar-ic-lora-vertical-v1",
@@ -11212,7 +11260,7 @@
       "lastModified": "2026-05-19T17:13:23.000Z"
     },
     {
-      "rank": 378,
+      "rank": 380,
       "id": "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF",
@@ -11235,7 +11283,7 @@
       "lastModified": "2026-05-20T02:50:29.000Z"
     },
     {
-      "rank": 379,
+      "rank": 381,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic-GGUF",
@@ -11265,7 +11313,7 @@
       "lastModified": "2026-05-16T21:47:09.000Z"
     },
     {
-      "rank": 380,
+      "rank": 382,
       "id": "tori29umai/QwenImageEdit2511_LoRA",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/QwenImageEdit2511_LoRA",
@@ -11289,7 +11337,7 @@
       "lastModified": "2026-05-16T08:11:00.000Z"
     },
     {
-      "rank": 381,
+      "rank": 383,
       "id": "facebook/dinov3-vitl16-pretrain-lvd1689m",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m",
@@ -11317,7 +11365,7 @@
       "lastModified": "2025-08-19T09:00:52.000Z"
     },
     {
-      "rank": 382,
+      "rank": 384,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-Claude-4.7-Opus-abliterated-MTP-GGUF",
@@ -11345,7 +11393,7 @@
       "lastModified": "2026-05-19T16:22:18.000Z"
     },
     {
-      "rank": 383,
+      "rank": 385,
       "id": "prism-ml/bonsai-image-binary-4B-unpacked",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-unpacked",
@@ -11371,7 +11419,7 @@
       "lastModified": "2026-05-28T22:22:27.000Z"
     },
     {
-      "rank": 384,
+      "rank": 386,
       "id": "meta-llama/Llama-3.1-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.1-8B",
@@ -11407,7 +11455,112 @@
       "lastModified": "2024-10-16T22:00:37.000Z"
     },
     {
-      "rank": 385,
+      "rank": 387,
+      "id": "unsloth/Qwen3-Coder-Next-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
+      "downloads": 3053702,
+      "likes": 663,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "qwen3_next",
+        "unsloth",
+        "qwen",
+        "qwen3",
+        "text-generation",
+        "base_model:Qwen/Qwen3-Coder-Next",
+        "base_model:quantized:Qwen/Qwen3-Coder-Next",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-02-03T13:10:01.000Z",
+      "lastModified": "2026-03-06T14:38:33.000Z"
+    },
+    {
+      "rank": 388,
+      "id": "Abiray/MiniCPM5-1B-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
+      "downloads": 4861,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "llama.cpp",
+        "en",
+        "zh",
+        "base_model:openbmb/MiniCPM5-1B",
+        "base_model:quantized:openbmb/MiniCPM5-1B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-26T04:47:48.000Z",
+      "lastModified": "2026-05-28T14:08:39.000Z"
+    },
+    {
+      "rank": 389,
+      "id": "Jackrong/Qwopus3.5-4B-Coder-MTP-GGUF",
+      "author": "Jackrong",
+      "url": "https://huggingface.co/Jackrong/Qwopus3.5-4B-Coder-MTP-GGUF",
+      "downloads": 2315,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "llama.cpp",
+        "image-text-to-text",
+        "vision",
+        "multimodal",
+        "text-generation-inference",
+        "unsloth",
+        "qwen3_5",
+        "reasoning",
+        "chain-of-thought",
+        "mtp",
+        "multi-token-prediction",
+        "speculative-decoding",
+        "lora",
+        "sft",
+        "agent",
+        "tool-use",
+        "function-calling",
+        "coder",
+        "conversational",
+        "RL",
+        "en",
+        "zh",
+        "es",
+        "ru",
+        "ja",
+        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
+        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
+        "dataset:lambda/hermes-agent-reasoning-traces"
+      ],
+      "createdAt": "2026-05-26T15:51:25.000Z",
+      "lastModified": "2026-05-30T10:44:25.000Z"
+    },
+    {
+      "rank": 390,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -11434,7 +11587,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 386,
+      "rank": 391,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -11479,7 +11632,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 387,
+      "rank": 392,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -11509,7 +11662,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 388,
+      "rank": 393,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -11539,7 +11692,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 389,
+      "rank": 394,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -11584,7 +11737,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 390,
+      "rank": 395,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -11619,7 +11772,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 391,
+      "rank": 396,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -11648,7 +11801,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 392,
+      "rank": 397,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -11673,35 +11826,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 393,
-      "id": "unsloth/Qwen3-Coder-Next-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF",
-      "downloads": 3053702,
-      "likes": 662,
-      "trendingScore": 15,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "qwen3_next",
-        "unsloth",
-        "qwen",
-        "qwen3",
-        "text-generation",
-        "base_model:Qwen/Qwen3-Coder-Next",
-        "base_model:quantized:Qwen/Qwen3-Coder-Next",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-02-03T13:10:01.000Z",
-      "lastModified": "2026-03-06T14:38:33.000Z"
-    },
-    {
-      "rank": 394,
+      "rank": 398,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -11729,7 +11854,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 395,
+      "rank": 399,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -11760,7 +11885,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 396,
+      "rank": 400,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -11805,7 +11930,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 397,
+      "rank": 401,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -11832,7 +11957,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 398,
+      "rank": 402,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -11855,7 +11980,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 399,
+      "rank": 403,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -11882,7 +12007,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 400,
+      "rank": 404,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -11908,7 +12033,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 401,
+      "rank": 405,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -11938,7 +12063,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 402,
+      "rank": 406,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -11965,7 +12090,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 403,
+      "rank": 407,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -11996,7 +12121,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 404,
+      "rank": 408,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -12028,7 +12153,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 405,
+      "rank": 409,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -12073,7 +12198,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 406,
+      "rank": 410,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -12106,7 +12231,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 407,
+      "rank": 411,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -12146,7 +12271,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 408,
+      "rank": 412,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -12187,7 +12312,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 409,
+      "rank": 413,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -12210,7 +12335,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 410,
+      "rank": 414,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -12233,7 +12358,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 411,
+      "rank": 415,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -12264,7 +12389,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 412,
+      "rank": 416,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -12295,7 +12420,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 413,
+      "rank": 417,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -12324,7 +12449,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 414,
+      "rank": 418,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -12357,7 +12482,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 415,
+      "rank": 419,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -12383,7 +12508,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 416,
+      "rank": 420,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -12427,7 +12552,7 @@
       "lastModified": "2026-05-29T16:18:29.000Z"
     },
     {
-      "rank": 417,
+      "rank": 421,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12452,7 +12577,7 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 418,
+      "rank": 422,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
@@ -12497,7 +12622,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 419,
+      "rank": 423,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -12520,7 +12645,7 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 420,
+      "rank": 424,
       "id": "datalab-to/surya-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/surya-ocr-2",
@@ -12549,33 +12674,7 @@
       "lastModified": "2026-05-27T20:33:29.000Z"
     },
     {
-      "rank": 421,
-      "id": "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 144918,
-      "likes": 362,
-      "trendingScore": 15,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.5",
-        "qwen",
-        "en",
-        "zh",
-        "multilingual",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-03-03T12:16:35.000Z",
-      "lastModified": "2026-04-05T19:01:02.000Z"
-    },
-    {
-      "rank": 422,
+      "rank": 425,
       "id": "fuckSelf/GPT-SoVITS-Russian",
       "author": "fuckSelf",
       "url": "https://huggingface.co/fuckSelf/GPT-SoVITS-Russian",
@@ -12599,39 +12698,7 @@
       "lastModified": "2025-09-11T14:59:49.000Z"
     },
     {
-      "rank": 423,
-      "id": "Abiray/MiniCPM5-1B-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
-      "downloads": 4861,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "minicpm",
-        "minicpm5",
-        "llama",
-        "text-generation",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "llama.cpp",
-        "en",
-        "zh",
-        "base_model:openbmb/MiniCPM5-1B",
-        "base_model:quantized:openbmb/MiniCPM5-1B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-26T04:47:48.000Z",
-      "lastModified": "2026-05-28T14:08:39.000Z"
-    },
-    {
-      "rank": 424,
+      "rank": 426,
       "id": "syntropy-ai/Soren-1-Small",
       "author": "syntropy-ai",
       "url": "https://huggingface.co/syntropy-ai/Soren-1-Small",
@@ -12676,29 +12743,7 @@
       "lastModified": "2026-05-29T15:19:32.000Z"
     },
     {
-      "rank": 425,
-      "id": "AesSedai/Step-3.7-Flash-GGUF",
-      "author": "AesSedai",
-      "url": "https://huggingface.co/AesSedai/Step-3.7-Flash-GGUF",
-      "downloads": 702,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "base_model:stepfun-ai/Step-3.7-Flash",
-        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-05-29T06:00:39.000Z",
-      "lastModified": "2026-05-29T18:39:12.000Z"
-    },
-    {
-      "rank": 426,
+      "rank": 427,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -12722,7 +12767,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 427,
+      "rank": 428,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -12749,7 +12794,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 428,
+      "rank": 429,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -12777,7 +12822,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 429,
+      "rank": 430,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -12796,7 +12841,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 430,
+      "rank": 431,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -12828,7 +12873,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 431,
+      "rank": 432,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -12857,7 +12902,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 432,
+      "rank": 433,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -12883,7 +12928,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 433,
+      "rank": 434,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -12911,7 +12956,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 434,
+      "rank": 435,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -12945,7 +12990,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 435,
+      "rank": 436,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -12971,7 +13016,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 436,
+      "rank": 437,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -13013,7 +13058,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 437,
+      "rank": 438,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -13051,7 +13096,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 438,
+      "rank": 439,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -13070,7 +13115,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 439,
+      "rank": 440,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -13090,7 +13135,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 440,
+      "rank": 441,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -13117,7 +13162,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 441,
+      "rank": 442,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -13143,7 +13188,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 442,
+      "rank": 443,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -13168,7 +13213,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 443,
+      "rank": 444,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -13197,7 +13242,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 444,
+      "rank": 445,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -13242,7 +13287,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 445,
+      "rank": 446,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -13269,7 +13314,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 446,
+      "rank": 447,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -13298,7 +13343,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 447,
+      "rank": 448,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -13324,7 +13369,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 448,
+      "rank": 449,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -13349,7 +13394,7 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 449,
+      "rank": 450,
       "id": "nvidia/vgg-ttt",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/vgg-ttt",
@@ -13378,7 +13423,7 @@
       "lastModified": "2026-05-30T07:35:09.000Z"
     },
     {
-      "rank": 450,
+      "rank": 451,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
@@ -13415,7 +13460,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 451,
+      "rank": 452,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13443,7 +13488,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 452,
+      "rank": 453,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -13470,7 +13515,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 453,
+      "rank": 454,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
@@ -13487,7 +13532,7 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 454,
+      "rank": 455,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -13512,7 +13557,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 455,
+      "rank": 456,
       "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
@@ -13557,7 +13602,7 @@
       "lastModified": "2026-05-23T00:19:59.000Z"
     },
     {
-      "rank": 456,
+      "rank": 457,
       "id": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
@@ -13587,7 +13632,7 @@
       "lastModified": "2026-05-25T03:44:12.000Z"
     },
     {
-      "rank": 457,
+      "rank": 458,
       "id": "huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
@@ -13628,7 +13673,7 @@
       "lastModified": "2026-05-27T18:15:42.000Z"
     },
     {
-      "rank": 458,
+      "rank": 459,
       "id": "biohub/ESMFold2",
       "author": "biohub",
       "url": "https://huggingface.co/biohub/ESMFold2",
@@ -13660,52 +13705,43 @@
       "lastModified": "2026-05-27T16:46:45.000Z"
     },
     {
-      "rank": 459,
-      "id": "Jackrong/Qwopus3.5-4B-Coder-MTP-GGUF",
-      "author": "Jackrong",
-      "url": "https://huggingface.co/Jackrong/Qwopus3.5-4B-Coder-MTP-GGUF",
-      "downloads": 2315,
+      "rank": 460,
+      "id": "LiquidAI/LFM2.5-8B-A1B-Base",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-Base",
+      "downloads": 421,
       "likes": 14,
       "trendingScore": 14,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "llama.cpp",
-        "image-text-to-text",
-        "vision",
-        "multimodal",
-        "text-generation-inference",
-        "unsloth",
-        "qwen3_5",
-        "reasoning",
-        "chain-of-thought",
-        "mtp",
-        "multi-token-prediction",
-        "speculative-decoding",
-        "lora",
-        "sft",
-        "agent",
-        "tool-use",
-        "function-calling",
-        "coder",
+        "safetensors",
+        "lfm2_moe",
+        "text-generation",
+        "liquid",
+        "lfm2.5",
+        "edge",
         "conversational",
         "en",
+        "ar",
         "zh",
-        "es",
-        "ru",
+        "fr",
+        "de",
         "ja",
-        "dataset:Jackrong/Claude-opus-4.6-TraceInversion-9000x",
-        "dataset:Jackrong/Claude-opus-4.7-TraceInversion-5000x",
-        "dataset:lambda/hermes-agent-reasoning-traces",
-        "base_model:Qwen/Qwen3.5-4B"
+        "ko",
+        "es",
+        "pt",
+        "arxiv:2511.23404",
+        "license:other",
+        "endpoints_compatible",
+        "region:us"
       ],
-      "createdAt": "2026-05-26T15:51:25.000Z",
-      "lastModified": "2026-05-28T03:32:36.000Z"
+      "createdAt": "2026-05-28T10:01:08.000Z",
+      "lastModified": "2026-05-28T20:22:31.000Z"
     },
     {
-      "rank": 460,
+      "rank": 461,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -13734,7 +13770,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 461,
+      "rank": 462,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -13779,7 +13815,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 462,
+      "rank": 463,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -13808,7 +13844,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 463,
+      "rank": 464,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -13835,7 +13871,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 464,
+      "rank": 465,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -13866,7 +13902,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 465,
+      "rank": 466,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -13890,7 +13926,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 466,
+      "rank": 467,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -13917,7 +13953,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 467,
+      "rank": 468,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -13953,7 +13989,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 468,
+      "rank": 469,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -13984,7 +14020,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 469,
+      "rank": 470,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -14015,7 +14051,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 470,
+      "rank": 471,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -14048,12 +14084,12 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 471,
+      "rank": 472,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
       "downloads": 12845530,
-      "likes": 1110,
+      "likes": 1109,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -14077,7 +14113,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 472,
+      "rank": 473,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -14103,7 +14139,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 473,
+      "rank": 474,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -14133,7 +14169,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 474,
+      "rank": 475,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -14151,7 +14187,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 475,
+      "rank": 476,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -14182,7 +14218,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 476,
+      "rank": 477,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -14203,7 +14239,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 477,
+      "rank": 478,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -14223,7 +14259,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 478,
+      "rank": 479,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -14250,7 +14286,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 479,
+      "rank": 480,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -14280,7 +14316,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 480,
+      "rank": 481,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -14297,7 +14333,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 481,
+      "rank": 482,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -14324,7 +14360,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 482,
+      "rank": 483,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -14349,7 +14385,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 483,
+      "rank": 484,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -14392,7 +14428,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 484,
+      "rank": 485,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -14421,7 +14457,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 485,
+      "rank": 486,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -14448,7 +14484,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 486,
+      "rank": 487,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -14478,7 +14514,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 487,
+      "rank": 488,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -14506,7 +14542,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 488,
+      "rank": 489,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
@@ -14537,7 +14573,7 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 489,
+      "rank": 490,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -14559,7 +14595,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 490,
+      "rank": 491,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -14582,7 +14618,7 @@
       "lastModified": "2026-05-26T09:06:09.000Z"
     },
     {
-      "rank": 491,
+      "rank": 492,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -14609,7 +14645,7 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 492,
+      "rank": 493,
       "id": "UofTCSSLab/Maia3-79M",
       "author": "UofTCSSLab",
       "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
@@ -14633,7 +14669,7 @@
       "lastModified": "2026-05-24T16:12:28.000Z"
     },
     {
-      "rank": 493,
+      "rank": 494,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
@@ -14673,7 +14709,7 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 494,
+      "rank": 495,
       "id": "bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
@@ -14699,1295 +14735,13 @@
       "lastModified": "2026-05-22T17:02:24.000Z"
     },
     {
-      "rank": 495,
-      "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-      "author": "Lightricks",
-      "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-      "downloads": 4968,
-      "likes": 84,
-      "trendingScore": 12,
-      "pipelineTag": "any-to-any",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "ltx-video",
-        "image-to-video",
-        "text-to-video",
-        "any-to-any",
-        "en",
-        "arxiv:2601.03233",
-        "arxiv:2604.11788",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:finetune:Lightricks/LTX-2.3",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T09:46:13.000Z",
-      "lastModified": "2026-05-03T09:57:49.000Z"
-    },
-    {
       "rank": 496,
-      "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
-      "author": "sensenova",
-      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
-      "downloads": 876,
-      "likes": 44,
-      "trendingScore": 12,
-      "pipelineTag": "any-to-any",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "neo_chat",
-        "feature-extraction",
-        "multimodal",
-        "text-to-image",
-        "image-to-text",
-        "image-editing",
-        "interleaved-generation",
-        "custom_code",
-        "any-to-any",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-22T13:32:34.000Z",
-      "lastModified": "2026-04-27T15:27:42.000Z"
-    },
-    {
-      "rank": 497,
-      "id": "OpenMed/privacy-filter-nemotron",
-      "author": "OpenMed",
-      "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
-      "downloads": 3956,
-      "likes": 33,
-      "trendingScore": 12,
-      "pipelineTag": "token-classification",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "openai_privacy_filter",
-        "token-classification",
-        "pii",
-        "ner",
-        "privacy",
-        "redaction",
-        "nemotron",
-        "privacy-filter",
-        "openmed",
-        "en",
-        "dataset:nvidia/Nemotron-PII",
-        "base_model:openai/privacy-filter",
-        "base_model:finetune:openai/privacy-filter",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T11:31:59.000Z",
-      "lastModified": "2026-04-28T08:01:07.000Z"
-    },
-    {
-      "rank": 498,
-      "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
-      "author": "Dustoevsky",
-      "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
-      "downloads": 0,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "region:us"
-      ],
-      "createdAt": "2026-04-30T08:18:59.000Z",
-      "lastModified": "2026-04-30T08:26:18.000Z"
-    },
-    {
-      "rank": 499,
-      "id": "Eyeline-Labs/Vista4D",
-      "author": "Eyeline-Labs",
-      "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
-      "downloads": 227,
-      "likes": 26,
-      "trendingScore": 12,
-      "pipelineTag": "video-to-video",
-      "libraryName": null,
-      "tags": [
-        "video-to-video",
-        "dataset:KlingTeam/MultiCamVideo-Dataset",
-        "dataset:nkp37/OpenVid-1M",
-        "arxiv:2604.21915",
-        "base_model:Wan-AI/Wan2.1-T2V-14B",
-        "base_model:finetune:Wan-AI/Wan2.1-T2V-14B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-11-20T02:18:26.000Z",
-      "lastModified": "2026-04-26T17:38:29.000Z"
-    },
-    {
-      "rank": 500,
-      "id": "nvidia/MiniMax-M2.7-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
-      "downloads": 83748,
-      "likes": 34,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "minimax_m2",
-        "nvidia",
-        "ModelOpt",
-        "MiniMax",
-        "quantized",
-        "NVFP4",
-        "nvfp4",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "base_model:MiniMaxAI/MiniMax-M2.7",
-        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
-        "license:other",
-        "8-bit",
-        "modelopt",
-        "region:us",
-        "deploy:azure"
-      ],
-      "createdAt": "2026-04-13T22:04:24.000Z",
-      "lastModified": "2026-04-24T21:40:54.000Z"
-    },
-    {
-      "rank": 501,
-      "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
-      "author": "am17an",
-      "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
-      "downloads": 4245,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "license:mit",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-04T14:54:47.000Z",
-      "lastModified": "2026-05-04T14:59:29.000Z"
-    },
-    {
-      "rank": 502,
-      "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
-      "author": "CoreWorxLab",
-      "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
-      "downloads": 1024,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "qwen",
-        "qwen3",
-        "text-generation",
-        "quantization",
-        "int4",
-        "autoround",
-        "symmetric",
-        "base-model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-        "conversational",
-        "base_model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-        "base_model:quantized:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "4-bit",
-        "auto-round",
-        "region:us"
-      ],
-      "createdAt": "2026-05-02T09:31:48.000Z",
-      "lastModified": "2026-05-03T18:35:34.000Z"
-    },
-    {
-      "rank": 503,
-      "id": "HuggingFaceTB/nanowhale-100m-base",
-      "author": "HuggingFaceTB",
-      "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
-      "downloads": 595,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "deepseek_v4",
-        "text-generation",
-        "deepseek",
-        "moe",
-        "causal-lm",
-        "pretrained",
-        "conversational",
-        "custom_code",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-24T13:33:34.000Z",
-      "lastModified": "2026-05-04T14:34:18.000Z"
-    },
-    {
-      "rank": 504,
-      "id": "kyutai/pocket-tts",
-      "author": "kyutai",
-      "url": "https://huggingface.co/kyutai/pocket-tts",
-      "downloads": 6729,
-      "likes": 622,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": "pocket-tts",
-      "tags": [
-        "pocket-tts",
-        "safetensors",
-        "en",
-        "arxiv:2509.06926",
-        "license:cc-by-4.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-29T14:06:48.000Z",
-      "lastModified": "2026-05-04T12:38:48.000Z"
-    },
-    {
-      "rank": 505,
-      "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
-      "author": "llmfan46",
-      "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
-      "downloads": 98968,
-      "likes": 76,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "heretic",
-        "uncensored",
-        "decensored",
-        "abliterated",
-        "ara",
-        "image-text-to-text",
-        "base_model:llmfan46/gemma-4-31B-it-uncensored-heretic",
-        "base_model:quantized:llmfan46/gemma-4-31B-it-uncensored-heretic",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-03T23:53:42.000Z",
-      "lastModified": "2026-05-05T17:08:34.000Z"
-    },
-    {
-      "rank": 506,
-      "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
-      "author": "cHunter789",
-      "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
-      "downloads": 5989,
-      "likes": 17,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "text-generation-inference",
-        "qwen",
-        "llama.cpp",
-        "quantized",
-        "text-generation",
-        "en",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-28T08:55:33.000Z",
-      "lastModified": "2026-05-02T08:44:09.000Z"
-    },
-    {
-      "rank": 507,
-      "id": "ACE-Step/Ace-Step1.5",
-      "author": "ACE-Step",
-      "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
-      "downloads": 49549,
-      "likes": 747,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-audio",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "diffusers",
-        "safetensors",
-        "acestep",
-        "feature-extraction",
-        "audio",
-        "music",
-        "text2music",
-        "text-to-audio",
-        "custom_code",
-        "arxiv:2602.00744",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-01-23T09:59:48.000Z",
-      "lastModified": "2026-02-03T11:37:37.000Z"
-    },
-    {
-      "rank": 508,
-      "id": "Qwen/Qwen3-VL-8B-Instruct",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
-      "downloads": 5539938,
-      "likes": 902,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_vl",
-        "image-text-to-text",
-        "conversational",
-        "arxiv:2505.09388",
-        "arxiv:2502.13923",
-        "arxiv:2409.12191",
-        "arxiv:2308.12966",
-        "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-10-11T07:23:39.000Z",
-      "lastModified": "2025-10-15T16:16:59.000Z"
-    },
-    {
-      "rank": 509,
-      "id": "SeeSee21/Z-Image-Turbo-AIO",
-      "author": "SeeSee21",
-      "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
-      "downloads": 130,
-      "likes": 254,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": null,
-      "tags": [
-        "z-image-turbo",
-        "text-to-image",
-        "image-generation",
-        "diffusion",
-        "comfyui",
-        "photorealistic",
-        "bilingual",
-        "chinese",
-        "english",
-        "8-step",
-        "fast-generation",
-        "en",
-        "zh",
-        "base_model:Tongyi-MAI/Z-Image-Turbo",
-        "base_model:finetune:Tongyi-MAI/Z-Image-Turbo",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-03T21:24:19.000Z",
-      "lastModified": "2026-01-03T14:49:06.000Z"
-    },
-    {
-      "rank": 510,
-      "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
-      "author": "Naphula",
-      "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
-      "downloads": 250,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "mergekit",
-        "merge",
-        "moe_karcher",
-        "conversational",
-        "eng",
-        "base_model:ApocalypseParty/G4-26B-SFT-6",
-        "base_model:merge:ApocalypseParty/G4-26B-SFT-6",
-        "base_model:AuriAetherwiing/G4-26B-A4B-Musica-v1",
-        "base_model:merge:AuriAetherwiing/G4-26B-A4B-Musica-v1",
-        "base_model:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
-        "base_model:merge:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:merge:google/gemma-4-26B-A4B-it",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-07T11:40:11.000Z",
-      "lastModified": "2026-05-08T14:22:31.000Z"
-    },
-    {
-      "rank": 511,
-      "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
-      "downloads": 3058,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "nemotron_h",
-        "text-generation",
-        "nvidia",
-        "pytorch",
-        "elastic",
-        "conversational",
-        "custom_code",
-        "en",
-        "es",
-        "fr",
-        "de",
-        "ja",
-        "it",
-        "arxiv:2512.20848",
-        "arxiv:2511.16664",
-        "base_model:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "base_model:finetune:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-        "license:other",
-        "endpoints_compatible",
-        "8-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T16:04:08.000Z",
-      "lastModified": "2026-05-08T03:42:19.000Z"
-    },
-    {
-      "rank": 512,
-      "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
-      "author": "IAAR-Shanghai",
-      "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
-      "downloads": 1024,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "privacy",
-        "privacy-detection",
-        "memory",
-        "personalized-memory",
-        "memory-system",
-        "memory-management",
-        "agent",
-        "agent-memory",
-        "information-security",
-        "information-extraction",
-        "edge-cloud",
-        "conversational",
-        "en",
-        "zh",
-        "arxiv:2605.09530",
-        "base_model:Qwen/Qwen3-1.7B",
-        "base_model:finetune:Qwen/Qwen3-1.7B",
-        "license:cc-by-nc-nd-4.0",
-        "text-generation-inference",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T15:03:21.000Z",
-      "lastModified": "2026-05-15T03:09:28.000Z"
-    },
-    {
-      "rank": 513,
-      "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
-      "author": "Jiunsong",
-      "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
-      "downloads": 26377,
-      "likes": 236,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "gemma4",
-        "uncensored",
-        "apple-silicon",
-        "4bit",
-        "quantized",
-        "reasoning",
-        "tool-use",
-        "coding",
-        "browser-automation",
-        "korean",
-        "fast",
-        "text-generation",
-        "conversational",
-        "en",
-        "ko",
-        "base_model:google/gemma-4-26B-A4B-it",
-        "base_model:quantized:google/gemma-4-26B-A4B-it",
-        "license:gemma",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-10T07:52:18.000Z",
-      "lastModified": "2026-04-12T13:34:53.000Z"
-    },
-    {
-      "rank": 514,
-      "id": "Qwen/Qwen-Image-Edit-2509",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
-      "downloads": 222047,
-      "likes": 1137,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "license:apache-2.0",
-        "diffusers:QwenImageEditPlusPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-09-22T13:09:40.000Z",
-      "lastModified": "2025-09-22T13:37:12.000Z"
-    },
-    {
-      "rank": 515,
-      "id": "ggerganov/whisper.cpp",
-      "author": "ggerganov",
-      "url": "https://huggingface.co/ggerganov/whisper.cpp",
-      "downloads": 0,
-      "likes": 1409,
-      "trendingScore": 12,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": null,
-      "tags": [
-        "automatic-speech-recognition",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2023-03-22T08:01:21.000Z",
-      "lastModified": "2024-10-29T18:25:17.000Z"
-    },
-    {
-      "rank": 516,
-      "id": "infly/Infinity-Parser2-Flash",
-      "author": "infly",
-      "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
-      "downloads": 4190,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_5",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-02-27T07:54:48.000Z",
-      "lastModified": "2026-05-16T01:59:44.000Z"
-    },
-    {
-      "rank": 517,
-      "id": "0G-AI/0GM-1.0-35B-A3B-0427",
-      "author": "0G-AI",
-      "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
-      "downloads": 299,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "moe",
-        "mixture-of-experts",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-04-27T02:18:11.000Z",
-      "lastModified": "2026-05-14T02:31:20.000Z"
-    },
-    {
-      "rank": 518,
-      "id": "PaddlePaddle/PaddleOCR-VL-1.5",
-      "author": "PaddlePaddle",
-      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
-      "downloads": 33832,
-      "likes": 640,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "PaddleOCR",
-      "tags": [
-        "PaddleOCR",
-        "safetensors",
-        "ERNIE4.5",
-        "PaddlePaddle",
-        "image-to-text",
-        "ocr",
-        "document-parse",
-        "layout",
-        "table",
-        "formula",
-        "chart",
-        "seal",
-        "spotting",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "multilingual",
-        "arxiv:2601.21957",
-        "base_model:baidu/ERNIE-4.5-0.3B-Paddle",
-        "base_model:finetune:baidu/ERNIE-4.5-0.3B-Paddle",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-01-28T12:43:01.000Z",
-      "lastModified": "2026-04-30T09:36:47.000Z"
-    },
-    {
-      "rank": 519,
-      "id": "google/gemma-4-26B-A4B",
-      "author": "google",
-      "url": "https://huggingface.co/google/gemma-4-26B-A4B",
-      "downloads": 221885,
-      "likes": 270,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gemma4",
-        "image-text-to-text",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-03-12T00:38:03.000Z",
-      "lastModified": "2026-04-02T16:13:38.000Z"
-    },
-    {
-      "rank": 520,
-      "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "author": "OsaurusAI",
-      "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
-      "downloads": 5987,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "deepseek_v4",
-        "jang",
-        "jangtq",
-        "jangtq2",
-        "jangtq-prestack",
-        "mxtq",
-        "deepseek",
-        "deepseek-v4",
-        "deepseek-v4-flash",
-        "moe",
-        "mla",
-        "hash-layers",
-        "mtp",
-        "apple-silicon",
-        "osaurus",
-        "text-generation",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-12T13:08:35.000Z",
-      "lastModified": "2026-05-12T13:09:29.000Z"
-    },
-    {
-      "rank": 521,
-      "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "author": "treadon",
-      "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
-      "downloads": 4918,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "gguf",
-        "minicpmv4_6",
-        "image-text-to-text",
-        "abliteration",
-        "disinhibition",
-        "minicpm-v",
-        "mechanistic-interpretability",
-        "conversational",
-        "base_model:openbmb/MiniCPM-V-4.6",
-        "base_model:quantized:openbmb/MiniCPM-V-4.6",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-11T21:34:24.000Z",
-      "lastModified": "2026-05-12T02:18:15.000Z"
-    },
-    {
-      "rank": 522,
-      "id": "Datadog/Toto-2.0-1B",
-      "author": "Datadog",
-      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
-      "downloads": 1105,
-      "likes": 14,
-      "trendingScore": 12,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "time-series-forecasting",
-        "foundation-models",
-        "pretrained-models",
-        "time-series",
-        "timeseries",
-        "forecasting",
-        "observability",
-        "pytorch_model_hub_mixin",
-        "arxiv:2602.12147",
-        "arxiv:2605.20119",
-        "license:apache-2.0",
-        "model-index",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T20:41:57.000Z",
-      "lastModified": "2026-05-20T14:30:49.000Z"
-    },
-    {
-      "rank": 523,
-      "id": "Qwen/Qwen3-1.7B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
-      "downloads": 3611424,
-      "likes": 473,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3",
-        "text-generation",
-        "conversational",
-        "arxiv:2505.09388",
-        "base_model:Qwen/Qwen3-1.7B-Base",
-        "base_model:finetune:Qwen/Qwen3-1.7B-Base",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-04-27T03:41:05.000Z",
-      "lastModified": "2025-07-26T03:46:32.000Z"
-    },
-    {
-      "rank": 524,
-      "id": "black-forest-labs/FLUX.1-Kontext-dev",
-      "author": "black-forest-labs",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
-      "downloads": 77442,
-      "likes": 2630,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "image-generation",
-        "flux",
-        "diffusion-single-file",
-        "image-to-image",
-        "en",
-        "arxiv:2506.15742",
-        "license:other",
-        "diffusers:FluxKontextPipeline",
-        "region:us"
-      ],
-      "createdAt": "2025-05-28T22:23:43.000Z",
-      "lastModified": "2026-01-01T15:35:36.000Z"
-    },
-    {
-      "rank": 525,
-      "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
-      "downloads": 151146,
-      "likes": 482,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-image",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "quantized",
-        "unsloth",
-        "qwen",
-        "image-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "base_model:Qwen/Qwen-Image-Edit-2511",
-        "base_model:quantized:Qwen/Qwen-Image-Edit-2511",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2025-12-20T02:31:59.000Z",
-      "lastModified": "2026-01-08T21:13:12.000Z"
-    },
-    {
-      "rank": 526,
-      "id": "openbmb/BitCPM4-CANN-8B",
-      "author": "openbmb",
-      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
-      "downloads": 204,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "pytorch",
-        "minicpm",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "zh",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-15T13:10:51.000Z",
-      "lastModified": "2026-05-22T10:05:30.000Z"
-    },
-    {
-      "rank": 527,
-      "id": "SeeSee21/AniSee",
-      "author": "SeeSee21",
-      "url": "https://huggingface.co/SeeSee21/AniSee",
-      "downloads": 90,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "anisee",
-        "text-to-image",
-        "anime",
-        "anima",
-        "diffusion",
-        "comfyui",
-        "fine-tune",
-        "safetensors",
-        "en",
-        "base_model:circlestone-labs/Anima",
-        "base_model:finetune:circlestone-labs/Anima",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T16:28:42.000Z",
-      "lastModified": "2026-05-17T17:06:08.000Z"
-    },
-    {
-      "rank": 528,
-      "id": "unsloth/MiniMax-M2.7-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
-      "downloads": 163268,
-      "likes": 185,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "minimax_m2",
-        "unsloth",
-        "text-generation",
-        "base_model:MiniMaxAI/MiniMax-M2.7",
-        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-04-11T23:31:02.000Z",
-      "lastModified": "2026-04-14T16:48:17.000Z"
-    },
-    {
-      "rank": 529,
-      "id": "nicolas-dufour/miro",
-      "author": "nicolas-dufour",
-      "url": "https://huggingface.co/nicolas-dufour/miro",
-      "downloads": 514,
-      "likes": 13,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "miro-t2i",
-      "tags": [
-        "miro-t2i",
-        "safetensors",
-        "sdxl",
-        "text-to-image",
-        "diffusion",
-        "flow-matching",
-        "miro",
-        "reward-conditioning",
-        "arxiv:2510.25897",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-18T14:53:08.000Z",
-      "lastModified": "2026-05-19T23:10:01.000Z"
-    },
-    {
-      "rank": 530,
-      "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "author": "mistralai",
-      "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
-      "downloads": 1261358,
-      "likes": 860,
-      "trendingScore": 12,
-      "pipelineTag": "automatic-speech-recognition",
-      "libraryName": "vllm",
-      "tags": [
-        "vllm",
-        "safetensors",
-        "voxtral_realtime",
-        "mistral-common",
-        "automatic-speech-recognition",
-        "en",
-        "fr",
-        "es",
-        "de",
-        "ru",
-        "zh",
-        "ja",
-        "it",
-        "pt",
-        "nl",
-        "ar",
-        "hi",
-        "ko",
-        "arxiv:2602.11298",
-        "base_model:mistralai/Ministral-3-3B-Base-2512",
-        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-01-21T17:22:02.000Z",
-      "lastModified": "2026-03-11T15:04:02.000Z"
-    },
-    {
-      "rank": 531,
-      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "author": "huihui-ai",
-      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
-      "downloads": 13041,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "abliterated",
-        "uncensored",
-        "GGUF",
-        "MTP",
-        "image-text-to-text",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-19T11:53:48.000Z",
-      "lastModified": "2026-05-19T13:01:22.000Z"
-    },
-    {
-      "rank": 532,
-      "id": "zemelee/qwen2.5-jailbreak",
-      "author": "zemelee",
-      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
-      "downloads": 883,
-      "likes": 24,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "base_model:Qwen/Qwen2.5-3B-Instruct",
-        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2025-05-08T06:14:45.000Z",
-      "lastModified": "2025-05-08T06:56:32.000Z"
-    },
-    {
-      "rank": 533,
-      "id": "SupraLabs/Supra-50M-Base",
-      "author": "SupraLabs",
-      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
-      "downloads": 786,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "llama",
-        "text-generation",
-        "supra",
-        "chimera",
-        "50m",
-        "small",
-        "open",
-        "open-source",
-        "cpu",
-        "tiny",
-        "slm",
-        "en",
-        "dataset:HuggingFaceFW/fineweb-edu",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T05:00:44.000Z",
-      "lastModified": "2026-05-27T13:53:55.000Z"
-    },
-    {
-      "rank": 534,
-      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "author": "alibaba-pai",
-      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
-      "downloads": 9841,
-      "likes": 157,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "videox_fun",
-      "tags": [
-        "videox_fun",
-        "lora",
-        "text-to-image",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-02-02T09:37:39.000Z",
-      "lastModified": "2026-03-02T11:46:41.000Z"
-    },
-    {
-      "rank": 535,
-      "id": "ruvnet/wifi-densepose-pretrained",
-      "author": "ruvnet",
-      "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
-      "downloads": 493,
-      "likes": 18,
-      "trendingScore": 12,
-      "pipelineTag": "other",
-      "libraryName": "onnxruntime",
-      "tags": [
-        "onnxruntime",
-        "safetensors",
-        "sona-lora",
-        "wifi-sensing",
-        "vital-signs",
-        "presence-detection",
-        "edge-ai",
-        "esp32",
-        "self-supervised",
-        "cognitum",
-        "through-wall",
-        "privacy-preserving",
-        "spiking-neural-network",
-        "ruvector",
-        "other",
-        "en",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-03T14:07:29.000Z",
-      "lastModified": "2026-04-03T18:21:10.000Z"
-    },
-    {
-      "rank": 536,
-      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "author": "opendatalab",
-      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
-      "downloads": 535,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2_vl",
-        "image-text-to-text",
-        "conversational",
-        "zh",
-        "en",
-        "arxiv:2604.04771",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-20T11:00:43.000Z",
-      "lastModified": "2026-05-25T10:58:41.000Z"
-    },
-    {
-      "rank": 537,
-      "id": "joyfox/LTX-2.3-Transition-LORA",
-      "author": "joyfox",
-      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
-      "downloads": 36829,
-      "likes": 117,
-      "trendingScore": 12,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "lora",
-        "ValiantCat",
-        "Lightricks",
-        "LTX-2.3",
-        "image-to-video",
-        "en",
-        "base_model:Lightricks/LTX-2.3",
-        "base_model:adapter:Lightricks/LTX-2.3",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-03-20T10:25:10.000Z",
-      "lastModified": "2026-03-30T03:28:58.000Z"
-    },
-    {
-      "rank": 538,
-      "id": "sailing-lab/SR2AM-v1.0-30B",
-      "author": "sailing-lab",
-      "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
-      "downloads": 238,
-      "likes": 12,
-      "trendingScore": 12,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_moe",
-        "text-generation",
-        "agent",
-        "reasoning",
-        "tool-use",
-        "simulative-planning",
-        "conversational",
-        "en",
-        "arxiv:2605.22138",
-        "base_model:Qwen/Qwen3-30B-A3B-Thinking-2507",
-        "base_model:finetune:Qwen/Qwen3-30B-A3B-Thinking-2507",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-19T23:10:39.000Z",
-      "lastModified": "2026-05-22T05:10:20.000Z"
-    },
-    {
-      "rank": 539,
-      "id": "stabilityai/stable-diffusion-3.5-large",
-      "author": "stabilityai",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
-      "downloads": 33558,
-      "likes": 3501,
-      "trendingScore": 12,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "stable-diffusion",
-        "en",
-        "arxiv:2403.03206",
-        "license:other",
-        "region:us"
-      ],
-      "createdAt": "2024-10-22T07:29:57.000Z",
-      "lastModified": "2024-10-22T14:36:33.000Z"
-    },
-    {
-      "rank": 540,
       "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
       "downloads": 4440,
-      "likes": 12,
-      "trendingScore": 12,
+      "likes": 13,
+      "trendingScore": 13,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -16026,7 +14780,1336 @@
       "lastModified": "2026-05-24T04:55:49.000Z"
     },
     {
+      "rank": 497,
+      "id": "litert-community/gemma-4-E4B-it-litert-lm",
+      "author": "litert-community",
+      "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
+      "downloads": 536817,
+      "likes": 112,
+      "trendingScore": 13,
+      "pipelineTag": null,
+      "libraryName": "litert-lm",
+      "tags": [
+        "litert-lm",
+        "base_model:google/gemma-4-E4B-it",
+        "base_model:finetune:google/gemma-4-E4B-it",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-26T00:20:57.000Z",
+      "lastModified": "2026-05-20T21:47:36.000Z"
+    },
+    {
+      "rank": 498,
+      "id": "unsloth/Step-3.7-Flash-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Step-3.7-Flash-GGUF",
+      "downloads": 2692,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "vision-language",
+        "unsloth - multimodal - moe",
+        "image-text-to-text",
+        "en",
+        "base_model:stepfun-ai/Step-3.7-Flash",
+        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-29T12:19:10.000Z",
+      "lastModified": "2026-05-30T04:48:31.000Z"
+    },
+    {
+      "rank": 499,
+      "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
+      "author": "Lightricks",
+      "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
+      "downloads": 4968,
+      "likes": 84,
+      "trendingScore": 12,
+      "pipelineTag": "any-to-any",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "ltx-video",
+        "image-to-video",
+        "text-to-video",
+        "any-to-any",
+        "en",
+        "arxiv:2601.03233",
+        "arxiv:2604.11788",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:finetune:Lightricks/LTX-2.3",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-04-20T09:46:13.000Z",
+      "lastModified": "2026-05-03T09:57:49.000Z"
+    },
+    {
+      "rank": 500,
+      "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
+      "author": "sensenova",
+      "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
+      "downloads": 876,
+      "likes": 44,
+      "trendingScore": 12,
+      "pipelineTag": "any-to-any",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "neo_chat",
+        "feature-extraction",
+        "multimodal",
+        "text-to-image",
+        "image-to-text",
+        "image-editing",
+        "interleaved-generation",
+        "custom_code",
+        "any-to-any",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-22T13:32:34.000Z",
+      "lastModified": "2026-04-27T15:27:42.000Z"
+    },
+    {
+      "rank": 501,
+      "id": "OpenMed/privacy-filter-nemotron",
+      "author": "OpenMed",
+      "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
+      "downloads": 3956,
+      "likes": 33,
+      "trendingScore": 12,
+      "pipelineTag": "token-classification",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "openai_privacy_filter",
+        "token-classification",
+        "pii",
+        "ner",
+        "privacy",
+        "redaction",
+        "nemotron",
+        "privacy-filter",
+        "openmed",
+        "en",
+        "dataset:nvidia/Nemotron-PII",
+        "base_model:openai/privacy-filter",
+        "base_model:finetune:openai/privacy-filter",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-24T11:31:59.000Z",
+      "lastModified": "2026-04-28T08:01:07.000Z"
+    },
+    {
+      "rank": 502,
+      "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
+      "author": "Dustoevsky",
+      "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
+      "downloads": 0,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "region:us"
+      ],
+      "createdAt": "2026-04-30T08:18:59.000Z",
+      "lastModified": "2026-04-30T08:26:18.000Z"
+    },
+    {
+      "rank": 503,
+      "id": "Eyeline-Labs/Vista4D",
+      "author": "Eyeline-Labs",
+      "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
+      "downloads": 227,
+      "likes": 26,
+      "trendingScore": 12,
+      "pipelineTag": "video-to-video",
+      "libraryName": null,
+      "tags": [
+        "video-to-video",
+        "dataset:KlingTeam/MultiCamVideo-Dataset",
+        "dataset:nkp37/OpenVid-1M",
+        "arxiv:2604.21915",
+        "base_model:Wan-AI/Wan2.1-T2V-14B",
+        "base_model:finetune:Wan-AI/Wan2.1-T2V-14B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-11-20T02:18:26.000Z",
+      "lastModified": "2026-04-26T17:38:29.000Z"
+    },
+    {
+      "rank": 504,
+      "id": "nvidia/MiniMax-M2.7-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
+      "downloads": 83748,
+      "likes": 34,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "minimax_m2",
+        "nvidia",
+        "ModelOpt",
+        "MiniMax",
+        "quantized",
+        "NVFP4",
+        "nvfp4",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "base_model:MiniMaxAI/MiniMax-M2.7",
+        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
+        "license:other",
+        "8-bit",
+        "modelopt",
+        "region:us",
+        "deploy:azure"
+      ],
+      "createdAt": "2026-04-13T22:04:24.000Z",
+      "lastModified": "2026-04-24T21:40:54.000Z"
+    },
+    {
+      "rank": 505,
+      "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
+      "author": "am17an",
+      "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
+      "downloads": 4245,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "license:mit",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-04T14:54:47.000Z",
+      "lastModified": "2026-05-04T14:59:29.000Z"
+    },
+    {
+      "rank": 506,
+      "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
+      "author": "CoreWorxLab",
+      "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
+      "downloads": 1024,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "qwen",
+        "qwen3",
+        "text-generation",
+        "quantization",
+        "int4",
+        "autoround",
+        "symmetric",
+        "base-model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
+        "conversational",
+        "base_model:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
+        "base_model:quantized:TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "4-bit",
+        "auto-round",
+        "region:us"
+      ],
+      "createdAt": "2026-05-02T09:31:48.000Z",
+      "lastModified": "2026-05-03T18:35:34.000Z"
+    },
+    {
+      "rank": 507,
+      "id": "HuggingFaceTB/nanowhale-100m-base",
+      "author": "HuggingFaceTB",
+      "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
+      "downloads": 595,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "deepseek_v4",
+        "text-generation",
+        "deepseek",
+        "moe",
+        "causal-lm",
+        "pretrained",
+        "conversational",
+        "custom_code",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-24T13:33:34.000Z",
+      "lastModified": "2026-05-04T14:34:18.000Z"
+    },
+    {
+      "rank": 508,
+      "id": "kyutai/pocket-tts",
+      "author": "kyutai",
+      "url": "https://huggingface.co/kyutai/pocket-tts",
+      "downloads": 6729,
+      "likes": 622,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": "pocket-tts",
+      "tags": [
+        "pocket-tts",
+        "safetensors",
+        "en",
+        "arxiv:2509.06926",
+        "license:cc-by-4.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-29T14:06:48.000Z",
+      "lastModified": "2026-05-04T12:38:48.000Z"
+    },
+    {
+      "rank": 509,
+      "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
+      "author": "llmfan46",
+      "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
+      "downloads": 98968,
+      "likes": 76,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "heretic",
+        "uncensored",
+        "decensored",
+        "abliterated",
+        "ara",
+        "image-text-to-text",
+        "base_model:llmfan46/gemma-4-31B-it-uncensored-heretic",
+        "base_model:quantized:llmfan46/gemma-4-31B-it-uncensored-heretic",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-03T23:53:42.000Z",
+      "lastModified": "2026-05-05T17:08:34.000Z"
+    },
+    {
+      "rank": 510,
+      "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
+      "author": "cHunter789",
+      "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
+      "downloads": 5989,
+      "likes": 17,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "text-generation-inference",
+        "qwen",
+        "llama.cpp",
+        "quantized",
+        "text-generation",
+        "en",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-28T08:55:33.000Z",
+      "lastModified": "2026-05-02T08:44:09.000Z"
+    },
+    {
+      "rank": 511,
+      "id": "ACE-Step/Ace-Step1.5",
+      "author": "ACE-Step",
+      "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
+      "downloads": 49549,
+      "likes": 747,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-audio",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "diffusers",
+        "safetensors",
+        "acestep",
+        "feature-extraction",
+        "audio",
+        "music",
+        "text2music",
+        "text-to-audio",
+        "custom_code",
+        "arxiv:2602.00744",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-01-23T09:59:48.000Z",
+      "lastModified": "2026-02-03T11:37:37.000Z"
+    },
+    {
+      "rank": 512,
+      "id": "Qwen/Qwen3-VL-8B-Instruct",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
+      "downloads": 5539938,
+      "likes": 902,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_vl",
+        "image-text-to-text",
+        "conversational",
+        "arxiv:2505.09388",
+        "arxiv:2502.13923",
+        "arxiv:2409.12191",
+        "arxiv:2308.12966",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-10-11T07:23:39.000Z",
+      "lastModified": "2025-10-15T16:16:59.000Z"
+    },
+    {
+      "rank": 513,
+      "id": "SeeSee21/Z-Image-Turbo-AIO",
+      "author": "SeeSee21",
+      "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
+      "downloads": 130,
+      "likes": 254,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": null,
+      "tags": [
+        "z-image-turbo",
+        "text-to-image",
+        "image-generation",
+        "diffusion",
+        "comfyui",
+        "photorealistic",
+        "bilingual",
+        "chinese",
+        "english",
+        "8-step",
+        "fast-generation",
+        "en",
+        "zh",
+        "base_model:Tongyi-MAI/Z-Image-Turbo",
+        "base_model:finetune:Tongyi-MAI/Z-Image-Turbo",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-03T21:24:19.000Z",
+      "lastModified": "2026-01-03T14:49:06.000Z"
+    },
+    {
+      "rank": 514,
+      "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
+      "author": "Naphula",
+      "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
+      "downloads": 250,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "mergekit",
+        "merge",
+        "moe_karcher",
+        "conversational",
+        "eng",
+        "base_model:ApocalypseParty/G4-26B-SFT-6",
+        "base_model:merge:ApocalypseParty/G4-26B-SFT-6",
+        "base_model:AuriAetherwiing/G4-26B-A4B-Musica-v1",
+        "base_model:merge:AuriAetherwiing/G4-26B-A4B-Musica-v1",
+        "base_model:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
+        "base_model:merge:Darkhn/Gemma-4-26B-A4B-Animus-V14.1-FFT",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:merge:google/gemma-4-26B-A4B-it",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-07T11:40:11.000Z",
+      "lastModified": "2026-05-08T14:22:31.000Z"
+    },
+    {
+      "rank": 515,
+      "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
+      "downloads": 3058,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "nemotron_h",
+        "text-generation",
+        "nvidia",
+        "pytorch",
+        "elastic",
+        "conversational",
+        "custom_code",
+        "en",
+        "es",
+        "fr",
+        "de",
+        "ja",
+        "it",
+        "arxiv:2512.20848",
+        "arxiv:2511.16664",
+        "base_model:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "base_model:finetune:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "license:other",
+        "endpoints_compatible",
+        "8-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T16:04:08.000Z",
+      "lastModified": "2026-05-08T03:42:19.000Z"
+    },
+    {
+      "rank": 516,
+      "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
+      "author": "IAAR-Shanghai",
+      "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
+      "downloads": 1024,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "privacy",
+        "privacy-detection",
+        "memory",
+        "personalized-memory",
+        "memory-system",
+        "memory-management",
+        "agent",
+        "agent-memory",
+        "information-security",
+        "information-extraction",
+        "edge-cloud",
+        "conversational",
+        "en",
+        "zh",
+        "arxiv:2605.09530",
+        "base_model:Qwen/Qwen3-1.7B",
+        "base_model:finetune:Qwen/Qwen3-1.7B",
+        "license:cc-by-nc-nd-4.0",
+        "text-generation-inference",
+        "region:us"
+      ],
+      "createdAt": "2026-05-09T15:03:21.000Z",
+      "lastModified": "2026-05-15T03:09:28.000Z"
+    },
+    {
+      "rank": 517,
+      "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
+      "author": "Jiunsong",
+      "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
+      "downloads": 26377,
+      "likes": 236,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "gemma4",
+        "uncensored",
+        "apple-silicon",
+        "4bit",
+        "quantized",
+        "reasoning",
+        "tool-use",
+        "coding",
+        "browser-automation",
+        "korean",
+        "fast",
+        "text-generation",
+        "conversational",
+        "en",
+        "ko",
+        "base_model:google/gemma-4-26B-A4B-it",
+        "base_model:quantized:google/gemma-4-26B-A4B-it",
+        "license:gemma",
+        "4-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-10T07:52:18.000Z",
+      "lastModified": "2026-04-12T13:34:53.000Z"
+    },
+    {
+      "rank": 518,
+      "id": "Qwen/Qwen-Image-Edit-2509",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
+      "downloads": 222047,
+      "likes": 1137,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "license:apache-2.0",
+        "diffusers:QwenImageEditPlusPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-09-22T13:09:40.000Z",
+      "lastModified": "2025-09-22T13:37:12.000Z"
+    },
+    {
+      "rank": 519,
+      "id": "ggerganov/whisper.cpp",
+      "author": "ggerganov",
+      "url": "https://huggingface.co/ggerganov/whisper.cpp",
+      "downloads": 0,
+      "likes": 1409,
+      "trendingScore": 12,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": null,
+      "tags": [
+        "automatic-speech-recognition",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2023-03-22T08:01:21.000Z",
+      "lastModified": "2024-10-29T18:25:17.000Z"
+    },
+    {
+      "rank": 520,
+      "id": "infly/Infinity-Parser2-Flash",
+      "author": "infly",
+      "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
+      "downloads": 4190,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-02-27T07:54:48.000Z",
+      "lastModified": "2026-05-16T01:59:44.000Z"
+    },
+    {
+      "rank": 521,
+      "id": "0G-AI/0GM-1.0-35B-A3B-0427",
+      "author": "0G-AI",
+      "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
+      "downloads": 299,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "moe",
+        "mixture-of-experts",
+        "conversational",
+        "en",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-27T02:18:11.000Z",
+      "lastModified": "2026-05-14T02:31:20.000Z"
+    },
+    {
+      "rank": 522,
+      "id": "PaddlePaddle/PaddleOCR-VL-1.5",
+      "author": "PaddlePaddle",
+      "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
+      "downloads": 33832,
+      "likes": 640,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "PaddleOCR",
+      "tags": [
+        "PaddleOCR",
+        "safetensors",
+        "ERNIE4.5",
+        "PaddlePaddle",
+        "image-to-text",
+        "ocr",
+        "document-parse",
+        "layout",
+        "table",
+        "formula",
+        "chart",
+        "seal",
+        "spotting",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "multilingual",
+        "arxiv:2601.21957",
+        "base_model:baidu/ERNIE-4.5-0.3B-Paddle",
+        "base_model:finetune:baidu/ERNIE-4.5-0.3B-Paddle",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-28T12:43:01.000Z",
+      "lastModified": "2026-04-30T09:36:47.000Z"
+    },
+    {
+      "rank": 523,
+      "id": "google/gemma-4-26B-A4B",
+      "author": "google",
+      "url": "https://huggingface.co/google/gemma-4-26B-A4B",
+      "downloads": 221885,
+      "likes": 270,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gemma4",
+        "image-text-to-text",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-03-12T00:38:03.000Z",
+      "lastModified": "2026-04-02T16:13:38.000Z"
+    },
+    {
+      "rank": 524,
+      "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+      "author": "OsaurusAI",
+      "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+      "downloads": 5987,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "deepseek_v4",
+        "jang",
+        "jangtq",
+        "jangtq2",
+        "jangtq-prestack",
+        "mxtq",
+        "deepseek",
+        "deepseek-v4",
+        "deepseek-v4-flash",
+        "moe",
+        "mla",
+        "hash-layers",
+        "mtp",
+        "apple-silicon",
+        "osaurus",
+        "text-generation",
+        "base_model:deepseek-ai/DeepSeek-V4-Flash",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-12T13:08:35.000Z",
+      "lastModified": "2026-05-12T13:09:29.000Z"
+    },
+    {
+      "rank": 525,
+      "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
+      "author": "treadon",
+      "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
+      "downloads": 4918,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "gguf",
+        "minicpmv4_6",
+        "image-text-to-text",
+        "abliteration",
+        "disinhibition",
+        "minicpm-v",
+        "mechanistic-interpretability",
+        "conversational",
+        "base_model:openbmb/MiniCPM-V-4.6",
+        "base_model:quantized:openbmb/MiniCPM-V-4.6",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-11T21:34:24.000Z",
+      "lastModified": "2026-05-12T02:18:15.000Z"
+    },
+    {
+      "rank": 526,
+      "id": "Datadog/Toto-2.0-1B",
+      "author": "Datadog",
+      "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
+      "downloads": 1105,
+      "likes": 14,
+      "trendingScore": 12,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "time-series-forecasting",
+        "foundation-models",
+        "pretrained-models",
+        "time-series",
+        "timeseries",
+        "forecasting",
+        "observability",
+        "pytorch_model_hub_mixin",
+        "arxiv:2602.12147",
+        "arxiv:2605.20119",
+        "license:apache-2.0",
+        "model-index",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T20:41:57.000Z",
+      "lastModified": "2026-05-20T14:30:49.000Z"
+    },
+    {
+      "rank": 527,
+      "id": "Qwen/Qwen3-1.7B",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
+      "downloads": 3611424,
+      "likes": 473,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3",
+        "text-generation",
+        "conversational",
+        "arxiv:2505.09388",
+        "base_model:Qwen/Qwen3-1.7B-Base",
+        "base_model:finetune:Qwen/Qwen3-1.7B-Base",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "deploy:azure",
+        "region:us"
+      ],
+      "createdAt": "2025-04-27T03:41:05.000Z",
+      "lastModified": "2025-07-26T03:46:32.000Z"
+    },
+    {
+      "rank": 528,
+      "id": "black-forest-labs/FLUX.1-Kontext-dev",
+      "author": "black-forest-labs",
+      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+      "downloads": 77442,
+      "likes": 2630,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "image-generation",
+        "flux",
+        "diffusion-single-file",
+        "image-to-image",
+        "en",
+        "arxiv:2506.15742",
+        "license:other",
+        "diffusers:FluxKontextPipeline",
+        "region:us"
+      ],
+      "createdAt": "2025-05-28T22:23:43.000Z",
+      "lastModified": "2026-01-01T15:35:36.000Z"
+    },
+    {
+      "rank": 529,
+      "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
+      "downloads": 151146,
+      "likes": 482,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-image",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "quantized",
+        "unsloth",
+        "qwen",
+        "image-to-image",
+        "en",
+        "zh",
+        "arxiv:2508.02324",
+        "base_model:Qwen/Qwen-Image-Edit-2511",
+        "base_model:quantized:Qwen/Qwen-Image-Edit-2511",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2025-12-20T02:31:59.000Z",
+      "lastModified": "2026-01-08T21:13:12.000Z"
+    },
+    {
+      "rank": 530,
+      "id": "openbmb/BitCPM4-CANN-8B",
+      "author": "openbmb",
+      "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
+      "downloads": 204,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "pytorch",
+        "minicpm",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "zh",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T13:10:51.000Z",
+      "lastModified": "2026-05-22T10:05:30.000Z"
+    },
+    {
+      "rank": 531,
+      "id": "SeeSee21/AniSee",
+      "author": "SeeSee21",
+      "url": "https://huggingface.co/SeeSee21/AniSee",
+      "downloads": 90,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "anisee",
+        "text-to-image",
+        "anime",
+        "anima",
+        "diffusion",
+        "comfyui",
+        "fine-tune",
+        "safetensors",
+        "en",
+        "base_model:circlestone-labs/Anima",
+        "base_model:finetune:circlestone-labs/Anima",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-17T16:28:42.000Z",
+      "lastModified": "2026-05-17T17:06:08.000Z"
+    },
+    {
+      "rank": 532,
+      "id": "unsloth/MiniMax-M2.7-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
+      "downloads": 163268,
+      "likes": 185,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "minimax_m2",
+        "unsloth",
+        "text-generation",
+        "base_model:MiniMaxAI/MiniMax-M2.7",
+        "base_model:quantized:MiniMaxAI/MiniMax-M2.7",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-04-11T23:31:02.000Z",
+      "lastModified": "2026-04-14T16:48:17.000Z"
+    },
+    {
+      "rank": 533,
+      "id": "nicolas-dufour/miro",
+      "author": "nicolas-dufour",
+      "url": "https://huggingface.co/nicolas-dufour/miro",
+      "downloads": 514,
+      "likes": 13,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "miro-t2i",
+      "tags": [
+        "miro-t2i",
+        "safetensors",
+        "sdxl",
+        "text-to-image",
+        "diffusion",
+        "flow-matching",
+        "miro",
+        "reward-conditioning",
+        "arxiv:2510.25897",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-18T14:53:08.000Z",
+      "lastModified": "2026-05-19T23:10:01.000Z"
+    },
+    {
+      "rank": 534,
+      "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "author": "mistralai",
+      "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "downloads": 1261358,
+      "likes": 860,
+      "trendingScore": 12,
+      "pipelineTag": "automatic-speech-recognition",
+      "libraryName": "vllm",
+      "tags": [
+        "vllm",
+        "safetensors",
+        "voxtral_realtime",
+        "mistral-common",
+        "automatic-speech-recognition",
+        "en",
+        "fr",
+        "es",
+        "de",
+        "ru",
+        "zh",
+        "ja",
+        "it",
+        "pt",
+        "nl",
+        "ar",
+        "hi",
+        "ko",
+        "arxiv:2602.11298",
+        "base_model:mistralai/Ministral-3-3B-Base-2512",
+        "base_model:finetune:mistralai/Ministral-3-3B-Base-2512",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-01-21T17:22:02.000Z",
+      "lastModified": "2026-03-11T15:04:02.000Z"
+    },
+    {
+      "rank": 535,
+      "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "author": "huihui-ai",
+      "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "downloads": 13041,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "abliterated",
+        "uncensored",
+        "GGUF",
+        "MTP",
+        "image-text-to-text",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-19T11:53:48.000Z",
+      "lastModified": "2026-05-19T13:01:22.000Z"
+    },
+    {
+      "rank": 536,
+      "id": "zemelee/qwen2.5-jailbreak",
+      "author": "zemelee",
+      "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
+      "downloads": 883,
+      "likes": 24,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2",
+        "text-generation",
+        "conversational",
+        "base_model:Qwen/Qwen2.5-3B-Instruct",
+        "base_model:finetune:Qwen/Qwen2.5-3B-Instruct",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2025-05-08T06:14:45.000Z",
+      "lastModified": "2025-05-08T06:56:32.000Z"
+    },
+    {
+      "rank": 537,
+      "id": "SupraLabs/Supra-50M-Base",
+      "author": "SupraLabs",
+      "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
+      "downloads": 786,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "llama",
+        "text-generation",
+        "supra",
+        "chimera",
+        "50m",
+        "small",
+        "open",
+        "open-source",
+        "cpu",
+        "tiny",
+        "slm",
+        "en",
+        "dataset:HuggingFaceFW/fineweb-edu",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:00:44.000Z",
+      "lastModified": "2026-05-27T13:53:55.000Z"
+    },
+    {
+      "rank": 538,
+      "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "author": "alibaba-pai",
+      "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
+      "downloads": 9841,
+      "likes": 157,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "videox_fun",
+      "tags": [
+        "videox_fun",
+        "lora",
+        "text-to-image",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-02-02T09:37:39.000Z",
+      "lastModified": "2026-03-02T11:46:41.000Z"
+    },
+    {
+      "rank": 539,
+      "id": "ruvnet/wifi-densepose-pretrained",
+      "author": "ruvnet",
+      "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
+      "downloads": 493,
+      "likes": 18,
+      "trendingScore": 12,
+      "pipelineTag": "other",
+      "libraryName": "onnxruntime",
+      "tags": [
+        "onnxruntime",
+        "safetensors",
+        "sona-lora",
+        "wifi-sensing",
+        "vital-signs",
+        "presence-detection",
+        "edge-ai",
+        "esp32",
+        "self-supervised",
+        "cognitum",
+        "through-wall",
+        "privacy-preserving",
+        "spiking-neural-network",
+        "ruvector",
+        "other",
+        "en",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-03T14:07:29.000Z",
+      "lastModified": "2026-04-03T18:21:10.000Z"
+    },
+    {
+      "rank": 540,
+      "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "author": "opendatalab",
+      "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
+      "downloads": 535,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen2_vl",
+        "image-text-to-text",
+        "conversational",
+        "zh",
+        "en",
+        "arxiv:2604.04771",
+        "license:apache-2.0",
+        "text-generation-inference",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-20T11:00:43.000Z",
+      "lastModified": "2026-05-25T10:58:41.000Z"
+    },
+    {
       "rank": 541,
+      "id": "joyfox/LTX-2.3-Transition-LORA",
+      "author": "joyfox",
+      "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
+      "downloads": 36829,
+      "likes": 117,
+      "trendingScore": 12,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "lora",
+        "ValiantCat",
+        "Lightricks",
+        "LTX-2.3",
+        "image-to-video",
+        "en",
+        "base_model:Lightricks/LTX-2.3",
+        "base_model:adapter:Lightricks/LTX-2.3",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-03-20T10:25:10.000Z",
+      "lastModified": "2026-03-30T03:28:58.000Z"
+    },
+    {
+      "rank": 542,
+      "id": "sailing-lab/SR2AM-v1.0-30B",
+      "author": "sailing-lab",
+      "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
+      "downloads": 238,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_moe",
+        "text-generation",
+        "agent",
+        "reasoning",
+        "tool-use",
+        "simulative-planning",
+        "conversational",
+        "en",
+        "arxiv:2605.22138",
+        "base_model:Qwen/Qwen3-30B-A3B-Thinking-2507",
+        "base_model:finetune:Qwen/Qwen3-30B-A3B-Thinking-2507",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-19T23:10:39.000Z",
+      "lastModified": "2026-05-22T05:10:20.000Z"
+    },
+    {
+      "rank": 543,
+      "id": "stabilityai/stable-diffusion-3.5-large",
+      "author": "stabilityai",
+      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+      "downloads": 33558,
+      "likes": 3501,
+      "trendingScore": 12,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "text-to-image",
+        "stable-diffusion",
+        "en",
+        "arxiv:2403.03206",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2024-10-22T07:29:57.000Z",
+      "lastModified": "2024-10-22T14:36:33.000Z"
+    },
+    {
+      "rank": 544,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -16067,7 +16150,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 542,
+      "rank": 545,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
@@ -16089,7 +16172,7 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 543,
+      "rank": 546,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
@@ -16134,7 +16217,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 544,
+      "rank": 547,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -16161,7 +16244,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 545,
+      "rank": 548,
       "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
       "author": "Leon1000",
       "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
@@ -16189,7 +16272,7 @@
       "lastModified": "2026-05-20T00:22:04.000Z"
     },
     {
-      "rank": 546,
+      "rank": 549,
       "id": "Qwen/Qwen2.5-1.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct",
@@ -16219,7 +16302,7 @@
       "lastModified": "2024-09-25T12:32:50.000Z"
     },
     {
-      "rank": 547,
+      "rank": 550,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
@@ -16244,27 +16327,69 @@
       "lastModified": "2026-05-26T05:28:12.000Z"
     },
     {
-      "rank": 548,
-      "id": "litert-community/gemma-4-E4B-it-litert-lm",
-      "author": "litert-community",
-      "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
-      "downloads": 536817,
-      "likes": 111,
+      "rank": 551,
+      "id": "dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
+      "author": "dealignai",
+      "url": "https://huggingface.co/dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
+      "downloads": 2378,
+      "likes": 13,
       "trendingScore": 12,
-      "pipelineTag": null,
-      "libraryName": "litert-lm",
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "mlx",
       "tags": [
-        "litert-lm",
-        "base_model:google/gemma-4-E4B-it",
-        "base_model:finetune:google/gemma-4-E4B-it",
+        "mlx",
+        "safetensors",
+        "qwen3_5_moe",
+        "apple-silicon",
+        "abliterated",
+        "uncensored",
+        "crack",
+        "mtp",
+        "speculative-decoding",
+        "vision",
+        "video",
+        "reasoning",
+        "thinking",
+        "harmbench",
+        "mmlu",
+        "qwen3_6",
+        "image-text-to-text",
+        "moe",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
         "license:apache-2.0",
         "region:us"
       ],
-      "createdAt": "2026-03-26T00:20:57.000Z",
-      "lastModified": "2026-05-20T21:47:36.000Z"
+      "createdAt": "2026-05-24T19:35:48.000Z",
+      "lastModified": "2026-05-24T21:04:29.000Z"
     },
     {
-      "rank": 549,
+      "rank": 552,
+      "id": "lightx2v/Wan2.2-NVFP4-Sparse",
+      "author": "lightx2v",
+      "url": "https://huggingface.co/lightx2v/Wan2.2-NVFP4-Sparse",
+      "downloads": 571,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": null,
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "video_generation",
+        "NVFP4",
+        "Sparse_Attention",
+        "Wan",
+        "base_model:Wan-AI/Wan2.2-T2V-A14B",
+        "base_model:finetune:Wan-AI/Wan2.2-T2V-A14B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-28T05:17:32.000Z",
+      "lastModified": "2026-05-28T07:10:10.000Z"
+    },
+    {
+      "rank": 553,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -16309,7 +16434,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 550,
+      "rank": 554,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -16351,7 +16476,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 551,
+      "rank": 555,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -16377,7 +16502,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 552,
+      "rank": 556,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -16402,7 +16527,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 553,
+      "rank": 557,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -16419,7 +16544,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 554,
+      "rank": 558,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -16447,7 +16572,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 555,
+      "rank": 559,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -16473,7 +16598,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 556,
+      "rank": 560,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -16500,7 +16625,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 557,
+      "rank": 561,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -16528,7 +16653,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 558,
+      "rank": 562,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -16561,7 +16686,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 559,
+      "rank": 563,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -16595,7 +16720,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 560,
+      "rank": 564,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -16624,7 +16749,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 561,
+      "rank": 565,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -16653,7 +16778,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 562,
+      "rank": 566,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -16686,7 +16811,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 563,
+      "rank": 567,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -16713,7 +16838,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 564,
+      "rank": 568,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -16743,7 +16868,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 565,
+      "rank": 569,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -16769,7 +16894,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 566,
+      "rank": 570,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -16793,7 +16918,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 567,
+      "rank": 571,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -16820,7 +16945,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 568,
+      "rank": 572,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -16854,7 +16979,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 569,
+      "rank": 573,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -16870,7 +16995,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 570,
+      "rank": 574,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -16901,7 +17026,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 571,
+      "rank": 575,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -16923,7 +17048,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 572,
+      "rank": 576,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -16943,7 +17068,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 573,
+      "rank": 577,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -16965,7 +17090,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 574,
+      "rank": 578,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -16994,7 +17119,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 575,
+      "rank": 579,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -17019,7 +17144,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 576,
+      "rank": 580,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -17044,7 +17169,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 577,
+      "rank": 581,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -17079,7 +17204,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 578,
+      "rank": 582,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -17103,7 +17228,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 579,
+      "rank": 583,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -17134,7 +17259,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 580,
+      "rank": 584,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -17164,7 +17289,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 581,
+      "rank": 585,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -17190,7 +17315,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 582,
+      "rank": 586,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -17235,7 +17360,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 583,
+      "rank": 587,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -17262,7 +17387,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 584,
+      "rank": 588,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -17289,7 +17414,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 585,
+      "rank": 589,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -17334,7 +17459,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 586,
+      "rank": 590,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -17360,7 +17485,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 587,
+      "rank": 591,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -17389,7 +17514,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 588,
+      "rank": 592,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -17434,7 +17559,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 589,
+      "rank": 593,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -17466,7 +17591,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 590,
+      "rank": 594,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -17501,7 +17626,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 591,
+      "rank": 595,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -17546,7 +17671,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 592,
+      "rank": 596,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -17571,7 +17696,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 593,
+      "rank": 597,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -17610,7 +17735,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 594,
+      "rank": 598,
       "id": "Abiray/L2P-model-1k-merge-INT8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
@@ -17635,7 +17760,7 @@
       "lastModified": "2026-05-23T17:24:01.000Z"
     },
     {
-      "rank": 595,
+      "rank": 599,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
@@ -17665,7 +17790,7 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 596,
+      "rank": 600,
       "id": "mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
@@ -17695,7 +17820,7 @@
       "lastModified": "2026-05-10T04:13:55.000Z"
     },
     {
-      "rank": 597,
+      "rank": 601,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -17721,7 +17846,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 598,
+      "rank": 602,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
@@ -17756,7 +17881,7 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 599,
+      "rank": 603,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -17782,7 +17907,7 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 600,
+      "rank": 604,
       "id": "FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
@@ -17815,69 +17940,7 @@
       "lastModified": "2026-05-27T07:55:25.000Z"
     },
     {
-      "rank": 601,
-      "id": "dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
-      "author": "dealignai",
-      "url": "https://huggingface.co/dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
-      "downloads": 2378,
-      "likes": 12,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5_moe",
-        "apple-silicon",
-        "abliterated",
-        "uncensored",
-        "crack",
-        "mtp",
-        "speculative-decoding",
-        "vision",
-        "video",
-        "reasoning",
-        "thinking",
-        "harmbench",
-        "mmlu",
-        "qwen3_6",
-        "image-text-to-text",
-        "moe",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-24T19:35:48.000Z",
-      "lastModified": "2026-05-24T21:04:29.000Z"
-    },
-    {
-      "rank": 602,
-      "id": "lightx2v/Wan2.2-NVFP4-Sparse",
-      "author": "lightx2v",
-      "url": "https://huggingface.co/lightx2v/Wan2.2-NVFP4-Sparse",
-      "downloads": 571,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": null,
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "video_generation",
-        "NVFP4",
-        "Sparse_Attention",
-        "Wan",
-        "base_model:Wan-AI/Wan2.2-T2V-A14B",
-        "base_model:finetune:Wan-AI/Wan2.2-T2V-A14B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-28T05:17:32.000Z",
-      "lastModified": "2026-05-28T07:10:10.000Z"
-    },
-    {
-      "rank": 603,
+      "rank": 605,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -17922,7 +17985,7 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 604,
+      "rank": 606,
       "id": "Roboflow/rf-detr-segmentation",
       "author": "Roboflow",
       "url": "https://huggingface.co/Roboflow/rf-detr-segmentation",
@@ -17948,43 +18011,7 @@
       "lastModified": "2026-05-20T16:47:13.000Z"
     },
     {
-      "rank": 605,
-      "id": "LiquidAI/LFM2.5-8B-A1B-Base",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-Base",
-      "downloads": 421,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "lfm2_moe",
-        "text-generation",
-        "liquid",
-        "lfm2.5",
-        "edge",
-        "conversational",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "arxiv:2511.23404",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-28T10:01:08.000Z",
-      "lastModified": "2026-05-28T20:22:31.000Z"
-    },
-    {
-      "rank": 606,
+      "rank": 607,
       "id": "openbmb/MiniCPM-o-4_5",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-o-4_5",
@@ -18013,7 +18040,7 @@
       "lastModified": "2026-05-10T07:38:49.000Z"
     },
     {
-      "rank": 607,
+      "rank": 608,
       "id": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -18047,7 +18074,7 @@
       "lastModified": "2026-04-06T02:20:06.000Z"
     },
     {
-      "rank": 608,
+      "rank": 609,
       "id": "microsoft/VibeVoice-ASR-HF",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-ASR-HF",
@@ -18092,7 +18119,7 @@
       "lastModified": "2026-03-09T03:11:35.000Z"
     },
     {
-      "rank": 609,
+      "rank": 610,
       "id": "OpenMOSS-Team/MOSS-Audio-4B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-4B-Instruct",
@@ -18121,7 +18148,7 @@
       "lastModified": "2026-04-14T03:33:32.000Z"
     },
     {
-      "rank": 610,
+      "rank": 611,
       "id": "Motif-Technologies/Motif-Video-2B-GGUF",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B-GGUF",
@@ -18146,7 +18173,7 @@
       "lastModified": "2026-05-06T12:40:44.000Z"
     },
     {
-      "rank": 611,
+      "rank": 612,
       "id": "FINAL-Bench/Darwin-28B-KR-Legal",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-KR-Legal",
@@ -18181,7 +18208,7 @@
       "lastModified": "2026-04-26T13:45:08.000Z"
     },
     {
-      "rank": 612,
+      "rank": 613,
       "id": "Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Qwen3.6-27B-MTP-Q8_0-GGUF",
@@ -18208,7 +18235,7 @@
       "lastModified": "2026-04-26T23:33:09.000Z"
     },
     {
-      "rank": 613,
+      "rank": 614,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash",
@@ -18253,7 +18280,7 @@
       "lastModified": "2026-05-02T14:33:15.000Z"
     },
     {
-      "rank": 614,
+      "rank": 615,
       "id": "lukealonso/MiMo-V2.5-NVFP4",
       "author": "lukealonso",
       "url": "https://huggingface.co/lukealonso/MiMo-V2.5-NVFP4",
@@ -18275,7 +18302,7 @@
       "lastModified": "2026-05-05T17:03:02.000Z"
     },
     {
-      "rank": 615,
+      "rank": 616,
       "id": "Blazed-Forge/Gemma-4-Gemsicle-31B",
       "author": "Blazed-Forge",
       "url": "https://huggingface.co/Blazed-Forge/Gemma-4-Gemsicle-31B",
@@ -18307,7 +18334,7 @@
       "lastModified": "2026-05-03T06:49:58.000Z"
     },
     {
-      "rank": 616,
+      "rank": 617,
       "id": "caiovicentino1/qwen36-27b-sae-fullstack",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/qwen36-27b-sae-fullstack",
@@ -18332,7 +18359,7 @@
       "lastModified": "2026-05-04T16:47:07.000Z"
     },
     {
-      "rank": 617,
+      "rank": 618,
       "id": "CompactAI-O/Shard-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Shard-1",
@@ -18356,7 +18383,7 @@
       "lastModified": "2026-05-07T12:25:45.000Z"
     },
     {
-      "rank": 618,
+      "rank": 619,
       "id": "OpenMOSS-Team/MOSS-TTS-Nano-100M",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Nano-100M",
@@ -18399,7 +18426,7 @@
       "lastModified": "2026-04-13T09:32:58.000Z"
     },
     {
-      "rank": 619,
+      "rank": 620,
       "id": "bartowski/google_gemma-4-31B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF",
@@ -18423,7 +18450,7 @@
       "lastModified": "2026-05-03T20:15:16.000Z"
     },
     {
-      "rank": 620,
+      "rank": 621,
       "id": "elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
       "author": "elix3r",
       "url": "https://huggingface.co/elix3r/LTX-2.3-22b-AV-LoRA-talking-head",
@@ -18452,7 +18479,7 @@
       "lastModified": "2026-03-24T15:09:53.000Z"
     },
     {
-      "rank": 621,
+      "rank": 622,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Wasserstein-GGUF",
@@ -18484,7 +18511,7 @@
       "lastModified": "2026-05-08T18:00:15.000Z"
     },
     {
-      "rank": 622,
+      "rank": 623,
       "id": "RedHatAI/gemma-4-31B-it-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash",
@@ -18508,7 +18535,7 @@
       "lastModified": "2026-04-29T15:35:00.000Z"
     },
     {
-      "rank": 623,
+      "rank": 624,
       "id": "zerofata/G4-MeroMero-31B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-31B-gguf",
@@ -18530,7 +18557,7 @@
       "lastModified": "2026-05-02T09:07:31.000Z"
     },
     {
-      "rank": 624,
+      "rank": 625,
       "id": "lodestones/taggerine",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/taggerine",
@@ -18555,7 +18582,7 @@
       "lastModified": "2026-04-28T12:25:03.000Z"
     },
     {
-      "rank": 625,
+      "rank": 626,
       "id": "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8",
@@ -18583,7 +18610,7 @@
       "lastModified": "2026-05-08T22:31:23.000Z"
     },
     {
-      "rank": 626,
+      "rank": 627,
       "id": "xinsir/controlnet-union-sdxl-1.0",
       "author": "xinsir",
       "url": "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0",
@@ -18607,7 +18634,7 @@
       "lastModified": "2024-07-30T09:01:56.000Z"
     },
     {
-      "rank": 627,
+      "rank": 628,
       "id": "ACE-Step/acestep-v15-xl-turbo",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo",
@@ -18634,7 +18661,7 @@
       "lastModified": "2026-04-07T12:39:26.000Z"
     },
     {
-      "rank": 628,
+      "rank": 629,
       "id": "dx8152/AI-tools",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/AI-tools",
@@ -18651,7 +18678,7 @@
       "lastModified": "2026-05-10T12:10:59.000Z"
     },
     {
-      "rank": 629,
+      "rank": 630,
       "id": "bartowski/google_gemma-4-26B-A4B-it-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/google_gemma-4-26B-A4B-it-GGUF",
@@ -18675,7 +18702,7 @@
       "lastModified": "2026-05-03T19:20:37.000Z"
     },
     {
-      "rank": 630,
+      "rank": 631,
       "id": "pipecat-ai/smart-turn-v3",
       "author": "pipecat-ai",
       "url": "https://huggingface.co/pipecat-ai/smart-turn-v3",
@@ -18699,7 +18726,7 @@
       "lastModified": "2026-01-07T18:00:39.000Z"
     },
     {
-      "rank": 631,
+      "rank": 632,
       "id": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
       "author": "Youssofal",
       "url": "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
@@ -18732,7 +18759,7 @@
       "lastModified": "2026-05-04T23:51:48.000Z"
     },
     {
-      "rank": 632,
+      "rank": 633,
       "id": "YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-TQ3_4S",
@@ -18766,7 +18793,7 @@
       "lastModified": "2026-04-18T21:46:23.000Z"
     },
     {
-      "rank": 633,
+      "rank": 634,
       "id": "stabilityai/stable-diffusion-3-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3-medium",
@@ -18788,7 +18815,7 @@
       "lastModified": "2024-08-12T12:37:42.000Z"
     },
     {
-      "rank": 634,
+      "rank": 635,
       "id": "RedHatAI/Qwen3-8B-speculator.dflash",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash",
@@ -18811,7 +18838,7 @@
       "lastModified": "2026-05-07T20:33:12.000Z"
     },
     {
-      "rank": 635,
+      "rank": 636,
       "id": "BAAI/OpenSeek-Mid-v1",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/OpenSeek-Mid-v1",
@@ -18831,7 +18858,7 @@
       "lastModified": "2026-05-08T07:46:29.000Z"
     },
     {
-      "rank": 636,
+      "rank": 637,
       "id": "faunix/QwenSeek-2B-GGUF",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B-GGUF",
@@ -18863,7 +18890,7 @@
       "lastModified": "2026-05-11T19:20:31.000Z"
     },
     {
-      "rank": 637,
+      "rank": 638,
       "id": "Vortex5/Nether-Moon-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Nether-Moon-12B",
@@ -18902,7 +18929,7 @@
       "lastModified": "2026-05-08T23:47:59.000Z"
     },
     {
-      "rank": 638,
+      "rank": 639,
       "id": "google-bert/bert-base-uncased",
       "author": "google-bert",
       "url": "https://huggingface.co/google-bert/bert-base-uncased",
@@ -18936,7 +18963,7 @@
       "lastModified": "2024-02-19T11:06:12.000Z"
     },
     {
-      "rank": 639,
+      "rank": 640,
       "id": "unsloth/MiMo-V2.5-Pro-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-Pro-GGUF",
@@ -18965,7 +18992,7 @@
       "lastModified": "2026-05-11T02:54:10.000Z"
     },
     {
-      "rank": 640,
+      "rank": 641,
       "id": "AesSedai/MiMo-V2.5-Pro-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-Pro-GGUF",
@@ -18987,7 +19014,7 @@
       "lastModified": "2026-05-10T20:51:48.000Z"
     },
     {
-      "rank": 641,
+      "rank": 642,
       "id": "bartowski/MiMo-V2.5-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/MiMo-V2.5-GGUF",
@@ -19019,7 +19046,7 @@
       "lastModified": "2026-05-08T12:26:09.000Z"
     },
     {
-      "rank": 642,
+      "rank": 643,
       "id": "openai/clip-vit-large-patch14",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-large-patch14",
@@ -19046,7 +19073,7 @@
       "lastModified": "2023-09-15T15:49:35.000Z"
     },
     {
-      "rank": 643,
+      "rank": 644,
       "id": "dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/MiniMax-M2.7-JANGTQ_K-CRACK",
@@ -19090,7 +19117,7 @@
       "lastModified": "2026-05-09T02:11:25.000Z"
     },
     {
-      "rank": 644,
+      "rank": 645,
       "id": "Laxhar/sensenova-u1-lora-trainer",
       "author": "Laxhar",
       "url": "https://huggingface.co/Laxhar/sensenova-u1-lora-trainer",
@@ -19108,7 +19135,7 @@
       "lastModified": "2026-05-13T04:41:09.000Z"
     },
     {
-      "rank": 645,
+      "rank": 646,
       "id": "IAAR-Shanghai/MemPrivacy-4B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-SFT",
@@ -19147,7 +19174,7 @@
       "lastModified": "2026-05-15T03:10:49.000Z"
     },
     {
-      "rank": 646,
+      "rank": 647,
       "id": "IAAR-Shanghai/MemPrivacy-4B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-4B-RL",
@@ -19186,7 +19213,7 @@
       "lastModified": "2026-05-15T03:11:44.000Z"
     },
     {
-      "rank": 647,
+      "rank": 648,
       "id": "domyn/Domyn-Small-v1.0",
       "author": "domyn",
       "url": "https://huggingface.co/domyn/Domyn-Small-v1.0",
@@ -19220,7 +19247,7 @@
       "lastModified": "2026-05-12T19:23:35.000Z"
     },
     {
-      "rank": 648,
+      "rank": 649,
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
@@ -19248,7 +19275,7 @@
       "lastModified": "2025-03-27T04:01:59.000Z"
     },
     {
-      "rank": 649,
+      "rank": 650,
       "id": "pixai-labs/pixai-tagger-v0.9",
       "author": "pixai-labs",
       "url": "https://huggingface.co/pixai-labs/pixai-tagger-v0.9",
@@ -19270,7 +19297,7 @@
       "lastModified": "2025-09-11T09:38:59.000Z"
     },
     {
-      "rank": 650,
+      "rank": 651,
       "id": "nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-Wan2.1-T2V-14B-Diffusers",
@@ -19298,7 +19325,7 @@
       "lastModified": "2026-05-14T07:08:59.000Z"
     },
     {
-      "rank": 651,
+      "rank": 652,
       "id": "Comfy-Org/z_image_turbo",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
@@ -19316,7 +19343,7 @@
       "lastModified": "2026-01-10T04:11:54.000Z"
     },
     {
-      "rank": 652,
+      "rank": 653,
       "id": "spiritbuun/Qwen3.6-27B-DFlash-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Qwen3.6-27B-DFlash-GGUF",
@@ -19344,7 +19371,7 @@
       "lastModified": "2026-04-24T12:49:10.000Z"
     },
     {
-      "rank": 653,
+      "rank": 654,
       "id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct",
@@ -19375,7 +19402,7 @@
       "lastModified": "2025-04-06T16:23:01.000Z"
     },
     {
-      "rank": 654,
+      "rank": 655,
       "id": "maximsobolev275/LTX-10Eros-LoRA-r768",
       "author": "maximsobolev275",
       "url": "https://huggingface.co/maximsobolev275/LTX-10Eros-LoRA-r768",
@@ -19391,7 +19418,7 @@
       "lastModified": "2026-05-15T13:00:33.000Z"
     },
     {
-      "rank": 655,
+      "rank": 656,
       "id": "FrontiersMind/Nandi-Mini-600M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-600M-GuardRails",
@@ -19418,7 +19445,7 @@
       "lastModified": "2026-05-18T18:29:37.000Z"
     },
     {
-      "rank": 656,
+      "rank": 657,
       "id": "Datadog/Toto-2.0-22m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-22m",
@@ -19447,7 +19474,7 @@
       "lastModified": "2026-05-20T14:30:32.000Z"
     },
     {
-      "rank": 657,
+      "rank": 658,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
@@ -19475,7 +19502,7 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 658,
+      "rank": 659,
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
@@ -19504,7 +19531,7 @@
       "lastModified": "2024-09-07T16:20:30.000Z"
     },
     {
-      "rank": 659,
+      "rank": 660,
       "id": "ggml-org/Qwen3.6-27B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-27B-MTP-GGUF",
@@ -19525,7 +19552,7 @@
       "lastModified": "2026-05-19T09:05:17.000Z"
     },
     {
-      "rank": 660,
+      "rank": 661,
       "id": "ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -19546,7 +19573,7 @@
       "lastModified": "2026-05-19T09:20:22.000Z"
     },
     {
-      "rank": 661,
+      "rank": 662,
       "id": "Qwen/Qwen3-VL-Embedding-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-2B",
@@ -19576,7 +19603,7 @@
       "lastModified": "2026-04-16T08:54:25.000Z"
     },
     {
-      "rank": 662,
+      "rank": 663,
       "id": "HiveLabsAI/hivemind-32b-preview",
       "author": "HiveLabsAI",
       "url": "https://huggingface.co/HiveLabsAI/hivemind-32b-preview",
@@ -19600,7 +19627,7 @@
       "lastModified": "2026-05-15T14:46:28.000Z"
     },
     {
-      "rank": 663,
+      "rank": 664,
       "id": "Qwen/Qwen3-VL-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-Embedding-8B",
@@ -19630,7 +19657,7 @@
       "lastModified": "2026-04-16T08:55:18.000Z"
     },
     {
-      "rank": 664,
+      "rank": 665,
       "id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
@@ -19661,7 +19688,7 @@
       "lastModified": "2025-05-12T01:04:20.000Z"
     },
     {
-      "rank": 665,
+      "rank": 666,
       "id": "black-forest-labs/FLUX.2-klein-base-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9B",
@@ -19687,7 +19714,7 @@
       "lastModified": "2026-02-24T00:19:46.000Z"
     },
     {
-      "rank": 666,
+      "rank": 667,
       "id": "Comfy-Org/mediapipe",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/mediapipe",
@@ -19705,7 +19732,7 @@
       "lastModified": "2026-05-21T05:21:52.000Z"
     },
     {
-      "rank": 667,
+      "rank": 668,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-NVFP4-GGUF",
@@ -19738,7 +19765,7 @@
       "lastModified": "2026-05-07T14:55:51.000Z"
     },
     {
-      "rank": 668,
+      "rank": 669,
       "id": "stabilityai/stable-audio-3-small-music-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-small-music-base",
@@ -19763,7 +19790,7 @@
       "lastModified": "2026-05-20T15:19:54.000Z"
     },
     {
-      "rank": 669,
+      "rank": 670,
       "id": "douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
       "author": "douyamv",
       "url": "https://huggingface.co/douyamv/Gemma-4-31B-JANG_4M-CRACK-GGUF",
@@ -19788,7 +19815,7 @@
       "lastModified": "2026-04-09T01:27:17.000Z"
     },
     {
-      "rank": 670,
+      "rank": 671,
       "id": "RunDiffusion/Juggernaut-XL-v9",
       "author": "RunDiffusion",
       "url": "https://huggingface.co/RunDiffusion/Juggernaut-XL-v9",
@@ -19822,7 +19849,7 @@
       "lastModified": "2026-05-08T17:14:44.000Z"
     },
     {
-      "rank": 671,
+      "rank": 672,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_KS-GGUF",
@@ -19851,7 +19878,7 @@
       "lastModified": "2026-05-22T20:32:34.000Z"
     },
     {
-      "rank": 672,
+      "rank": 673,
       "id": "kepeng/PRSIMVL-LoRA-V1",
       "author": "kepeng",
       "url": "https://huggingface.co/kepeng/PRSIMVL-LoRA-V1",
@@ -19882,7 +19909,7 @@
       "lastModified": "2026-05-27T06:35:24.000Z"
     },
     {
-      "rank": 673,
+      "rank": 674,
       "id": "Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
       "author": "Andycurrent",
       "url": "https://huggingface.co/Andycurrent/Gemma-3-1B-it-GLM-4.7-Flash-Heretic-Uncensored-Thinking_GGUF",
@@ -19910,12 +19937,12 @@
       "lastModified": "2026-02-18T10:06:23.000Z"
     },
     {
-      "rank": 674,
+      "rank": 675,
       "id": "FunAudioLLM/SenseVoiceSmall",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/SenseVoiceSmall",
       "downloads": 4394,
-      "likes": 406,
+      "likes": 407,
       "trendingScore": 10,
       "pipelineTag": "automatic-speech-recognition",
       "libraryName": "funasr",
@@ -19943,7 +19970,7 @@
       "lastModified": "2026-05-25T17:28:01.000Z"
     },
     {
-      "rank": 675,
+      "rank": 676,
       "id": "Anbeeld/Qwen3.6-27B-DFlash-GGUF",
       "author": "Anbeeld",
       "url": "https://huggingface.co/Anbeeld/Qwen3.6-27B-DFlash-GGUF",
@@ -19964,7 +19991,7 @@
       "lastModified": "2026-05-22T17:31:30.000Z"
     },
     {
-      "rank": 676,
+      "rank": 677,
       "id": "huytd189/Qwen3.6-27B-pure-GGUF",
       "author": "huytd189",
       "url": "https://huggingface.co/huytd189/Qwen3.6-27B-pure-GGUF",
@@ -19987,7 +20014,7 @@
       "lastModified": "2026-05-27T05:35:38.000Z"
     },
     {
-      "rank": 677,
+      "rank": 678,
       "id": "w-ahmad/Qwen3.5-9B-GGUF-MoQ",
       "author": "w-ahmad",
       "url": "https://huggingface.co/w-ahmad/Qwen3.5-9B-GGUF-MoQ",
@@ -20016,7 +20043,7 @@
       "lastModified": "2026-05-29T11:40:13.000Z"
     },
     {
-      "rank": 678,
+      "rank": 679,
       "id": "daydreamlive/DreamVAE",
       "author": "daydreamlive",
       "url": "https://huggingface.co/daydreamlive/DreamVAE",
@@ -20050,7 +20077,7 @@
       "lastModified": "2026-04-22T15:11:47.000Z"
     },
     {
-      "rank": 679,
+      "rank": 680,
       "id": "stabilityai/stable-diffusion-3.5-medium",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-medium",
@@ -20073,7 +20100,7 @@
       "lastModified": "2024-10-31T08:18:43.000Z"
     },
     {
-      "rank": 680,
+      "rank": 681,
       "id": "llmfan46/Gemma-4-Harmonia-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Harmonia-31B-uncensored-heretic-GGUF",
@@ -20103,7 +20130,7 @@
       "lastModified": "2026-05-28T19:02:45.000Z"
     },
     {
-      "rank": 681,
+      "rank": 682,
       "id": "Kaikaku/epicure-core",
       "author": "Kaikaku",
       "url": "https://huggingface.co/Kaikaku/epicure-core",
@@ -20139,7 +20166,7 @@
       "lastModified": "2026-05-27T13:44:13.000Z"
     },
     {
-      "rank": 682,
+      "rank": 683,
       "id": "circlestone-labs/Anima-Official-LoRAs",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Official-LoRAs",
@@ -20155,34 +20182,39 @@
       "lastModified": "2026-05-26T18:57:37.000Z"
     },
     {
-      "rank": 683,
-      "id": "unsloth/Step-3.7-Flash-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Step-3.7-Flash-GGUF",
-      "downloads": 2692,
-      "likes": 10,
+      "rank": 684,
+      "id": "Convence/Aroow-Rust-Coder-9B",
+      "author": "Convence",
+      "url": "https://huggingface.co/Convence/Aroow-Rust-Coder-9B",
+      "downloads": 208,
+      "likes": 11,
       "trendingScore": 10,
-      "pipelineTag": "image-text-to-text",
+      "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
         "transformers",
-        "gguf",
-        "vision-language",
-        "unsloth - multimodal - moe",
+        "safetensors",
+        "qwen3_5",
         "image-text-to-text",
+        "rust",
+        "code",
+        "code-generation",
+        "code-completion",
+        "fill-in-the-middle",
+        "text-generation",
+        "conversational",
         "en",
-        "base_model:stepfun-ai/Step-3.7-Flash",
-        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "base_model:Qwen/Qwen3.5-9B",
+        "base_model:finetune:Qwen/Qwen3.5-9B",
         "license:apache-2.0",
         "endpoints_compatible",
-        "region:us",
-        "conversational"
+        "region:us"
       ],
-      "createdAt": "2026-05-29T12:19:10.000Z",
-      "lastModified": "2026-05-30T04:48:31.000Z"
+      "createdAt": "2026-05-23T19:05:37.000Z",
+      "lastModified": "2026-05-23T19:16:54.000Z"
     },
     {
-      "rank": 684,
+      "rank": 685,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -20208,7 +20240,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 685,
+      "rank": 686,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -20236,7 +20268,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 686,
+      "rank": 687,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -20262,7 +20294,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 687,
+      "rank": 688,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -20302,7 +20334,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 688,
+      "rank": 689,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -20338,7 +20370,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 689,
+      "rank": 690,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -20382,7 +20414,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 690,
+      "rank": 691,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -20407,7 +20439,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 691,
+      "rank": 692,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -20452,7 +20484,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 692,
+      "rank": 693,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -20471,7 +20503,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 693,
+      "rank": 694,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -20496,7 +20528,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 694,
+      "rank": 695,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -20535,7 +20567,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 695,
+      "rank": 696,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -20552,7 +20584,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 696,
+      "rank": 697,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -20580,7 +20612,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 697,
+      "rank": 698,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -20609,7 +20641,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 698,
+      "rank": 699,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -20634,7 +20666,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 699,
+      "rank": 700,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -20669,7 +20701,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 700,
+      "rank": 701,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -20699,7 +20731,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 701,
+      "rank": 702,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -20735,7 +20767,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 702,
+      "rank": 703,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -20758,7 +20790,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 703,
+      "rank": 704,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -20775,7 +20807,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 704,
+      "rank": 705,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -20795,7 +20827,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 705,
+      "rank": 706,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -20822,7 +20854,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 706,
+      "rank": 707,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -20846,7 +20878,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 707,
+      "rank": 708,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -20868,7 +20900,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 708,
+      "rank": 709,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -20900,7 +20932,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 709,
+      "rank": 710,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -20928,12 +20960,12 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 710,
+      "rank": 711,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
-      "downloads": 5887459,
-      "likes": 707,
+      "downloads": 5395358,
+      "likes": 722,
       "trendingScore": 9,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
@@ -20946,7 +20978,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 711,
+      "rank": 712,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -20971,7 +21003,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 712,
+      "rank": 713,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -20994,7 +21026,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 713,
+      "rank": 714,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -21012,7 +21044,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 714,
+      "rank": 715,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -21047,7 +21079,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 715,
+      "rank": 716,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -21075,7 +21107,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 716,
+      "rank": 717,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -21097,7 +21129,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 717,
+      "rank": 718,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -21124,7 +21156,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 718,
+      "rank": 719,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -21149,7 +21181,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 719,
+      "rank": 720,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -21183,7 +21215,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 720,
+      "rank": 721,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -21210,7 +21242,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 721,
+      "rank": 722,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -21237,7 +21269,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 722,
+      "rank": 723,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -21278,7 +21310,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 723,
+      "rank": 724,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -21308,7 +21340,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 724,
+      "rank": 725,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -21345,7 +21377,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 725,
+      "rank": 726,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -21377,7 +21409,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 726,
+      "rank": 727,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -21419,7 +21451,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 727,
+      "rank": 728,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -21464,7 +21496,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 728,
+      "rank": 729,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -21491,7 +21523,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 729,
+      "rank": 730,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -21523,7 +21555,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 730,
+      "rank": 731,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -21557,7 +21589,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 731,
+      "rank": 732,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -21587,7 +21619,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 732,
+      "rank": 733,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -21612,7 +21644,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 733,
+      "rank": 734,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -21639,7 +21671,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 734,
+      "rank": 735,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -21671,7 +21703,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 735,
+      "rank": 736,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -21716,7 +21748,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 736,
+      "rank": 737,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -21744,7 +21776,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 737,
+      "rank": 738,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -21770,7 +21802,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 738,
+      "rank": 739,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -21799,7 +21831,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 739,
+      "rank": 740,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -21841,7 +21873,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 740,
+      "rank": 741,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -21869,7 +21901,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 741,
+      "rank": 742,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -21898,7 +21930,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 742,
+      "rank": 743,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -21928,7 +21960,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 743,
+      "rank": 744,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -21955,7 +21987,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 744,
+      "rank": 745,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -21984,7 +22016,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 745,
+      "rank": 746,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -22011,7 +22043,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 746,
+      "rank": 747,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -22040,7 +22072,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 747,
+      "rank": 748,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -22080,7 +22112,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 748,
+      "rank": 749,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -22098,7 +22130,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 749,
+      "rank": 750,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -22123,7 +22155,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 750,
+      "rank": 751,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -22139,7 +22171,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 751,
+      "rank": 752,
       "id": "google/gemma-7b",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-7b",
@@ -22184,7 +22216,7 @@
       "lastModified": "2024-06-27T14:09:40.000Z"
     },
     {
-      "rank": 752,
+      "rank": 753,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -22207,7 +22239,7 @@
       "lastModified": "2026-05-26T09:06:26.000Z"
     },
     {
-      "rank": 753,
+      "rank": 754,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -22240,7 +22272,7 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 754,
+      "rank": 755,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
@@ -22270,7 +22302,7 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 755,
+      "rank": 756,
       "id": "tencent/Hy-MT2-1.8B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
@@ -22293,7 +22325,7 @@
       "lastModified": "2026-05-26T09:06:01.000Z"
     },
     {
-      "rank": 756,
+      "rank": 757,
       "id": "zeroentropy/zembed-1-embedding",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
@@ -22327,7 +22359,7 @@
       "lastModified": "2026-03-12T21:10:43.000Z"
     },
     {
-      "rank": 757,
+      "rank": 758,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -22351,7 +22383,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 758,
+      "rank": 759,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -22388,7 +22420,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 759,
+      "rank": 760,
       "id": "tencent/Hy-MT2-7B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
@@ -22409,38 +22441,6 @@
       ],
       "createdAt": "2026-05-12T10:23:53.000Z",
       "lastModified": "2026-05-26T09:06:05.000Z"
-    },
-    {
-      "rank": 760,
-      "id": "Convence/Aroow-Rust-Coder-9B",
-      "author": "Convence",
-      "url": "https://huggingface.co/Convence/Aroow-Rust-Coder-9B",
-      "downloads": 208,
-      "likes": 10,
-      "trendingScore": 9,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "rust",
-        "code",
-        "code-generation",
-        "code-completion",
-        "fill-in-the-middle",
-        "text-generation",
-        "conversational",
-        "en",
-        "base_model:Qwen/Qwen3.5-9B",
-        "base_model:finetune:Qwen/Qwen3.5-9B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T19:05:37.000Z",
-      "lastModified": "2026-05-23T19:16:54.000Z"
     },
     {
       "rank": 761,
@@ -22596,7 +22596,7 @@
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "downloads": 2049551,
-      "likes": 402,
+      "likes": 403,
       "trendingScore": 9,
       "pipelineTag": null,
       "libraryName": null,
@@ -22828,6 +22828,90 @@
     },
     {
       "rank": 774,
+      "id": "mlx-community/Qwen3.6-27B-OptiQ-4bit",
+      "author": "mlx-community",
+      "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-OptiQ-4bit",
+      "downloads": 14408,
+      "likes": 23,
+      "trendingScore": 9,
+      "pipelineTag": "text-generation",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "qwen3_5",
+        "quantized",
+        "mixed-precision",
+        "4bit",
+        "8bit",
+        "optiq",
+        "apple-silicon",
+        "text-generation",
+        "qwen3.6",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:quantized:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "4-bit",
+        "region:us"
+      ],
+      "createdAt": "2026-04-25T10:12:23.000Z",
+      "lastModified": "2026-05-26T06:39:22.000Z"
+    },
+    {
+      "rank": 775,
+      "id": "NeoQuasar/Kronos-base",
+      "author": "NeoQuasar",
+      "url": "https://huggingface.co/NeoQuasar/Kronos-base",
+      "downloads": 1383839,
+      "likes": 168,
+      "trendingScore": 9,
+      "pipelineTag": "time-series-forecasting",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "Finance",
+        "Candlestick",
+        "K-line",
+        "time-series-forecasting",
+        "arxiv:2508.02739",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2025-06-30T17:11:20.000Z",
+      "lastModified": "2025-09-09T14:08:15.000Z"
+    },
+    {
+      "rank": 776,
+      "id": "stepfun-ai/Step-3.7-Flash-FP8",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8",
+      "downloads": 8500,
+      "likes": 9,
+      "trendingScore": 9,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T12:49:10.000Z",
+      "lastModified": "2026-05-29T10:04:17.000Z"
+    },
+    {
+      "rank": 777,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -22854,7 +22938,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 775,
+      "rank": 778,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -22878,7 +22962,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 776,
+      "rank": 779,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -22897,7 +22981,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 777,
+      "rank": 780,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -22931,7 +23015,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 778,
+      "rank": 781,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -22963,7 +23047,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 779,
+      "rank": 782,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -22985,7 +23069,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 780,
+      "rank": 783,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -23030,7 +23114,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 781,
+      "rank": 784,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -23049,7 +23133,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 782,
+      "rank": 785,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -23083,7 +23167,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 783,
+      "rank": 786,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -23111,7 +23195,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 784,
+      "rank": 787,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -23139,7 +23223,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 785,
+      "rank": 788,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -23162,7 +23246,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 786,
+      "rank": 789,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -23189,7 +23273,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 787,
+      "rank": 790,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -23234,7 +23318,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 788,
+      "rank": 791,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -23270,7 +23354,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 789,
+      "rank": 792,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -23310,7 +23394,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 790,
+      "rank": 793,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -23339,7 +23423,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 791,
+      "rank": 794,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -23367,7 +23451,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 792,
+      "rank": 795,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -23386,7 +23470,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 793,
+      "rank": 796,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -23405,7 +23489,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 794,
+      "rank": 797,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -23437,7 +23521,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 795,
+      "rank": 798,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -23464,7 +23548,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 796,
+      "rank": 799,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -23486,7 +23570,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 797,
+      "rank": 800,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -23504,7 +23588,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 798,
+      "rank": 801,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -23533,7 +23617,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 799,
+      "rank": 802,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -23554,7 +23638,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 800,
+      "rank": 803,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -23582,7 +23666,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 801,
+      "rank": 804,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -23603,7 +23687,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 802,
+      "rank": 805,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -23639,7 +23723,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 803,
+      "rank": 806,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -23662,7 +23746,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 804,
+      "rank": 807,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -23687,7 +23771,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 805,
+      "rank": 808,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -23722,7 +23806,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 806,
+      "rank": 809,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -23767,7 +23851,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 807,
+      "rank": 810,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -23794,7 +23878,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 808,
+      "rank": 811,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -23823,7 +23907,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 809,
+      "rank": 812,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -23842,7 +23926,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 810,
+      "rank": 813,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -23863,7 +23947,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 811,
+      "rank": 814,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -23889,7 +23973,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 812,
+      "rank": 815,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -23915,7 +23999,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 813,
+      "rank": 816,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -23952,7 +24036,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 814,
+      "rank": 817,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -23997,7 +24081,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 815,
+      "rank": 818,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -24022,7 +24106,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 816,
+      "rank": 819,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -24039,7 +24123,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 817,
+      "rank": 820,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -24066,7 +24150,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 818,
+      "rank": 821,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -24084,7 +24168,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 819,
+      "rank": 822,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -24109,7 +24193,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 820,
+      "rank": 823,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -24141,7 +24225,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 821,
+      "rank": 824,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -24162,7 +24246,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 822,
+      "rank": 825,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -24181,7 +24265,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 823,
+      "rank": 826,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -24212,7 +24296,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 824,
+      "rank": 827,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -24235,7 +24319,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 825,
+      "rank": 828,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -24252,7 +24336,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 826,
+      "rank": 829,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -24280,7 +24364,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 827,
+      "rank": 830,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -24297,7 +24381,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 828,
+      "rank": 831,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -24333,7 +24417,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 829,
+      "rank": 832,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -24363,7 +24447,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 830,
+      "rank": 833,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -24386,7 +24470,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 831,
+      "rank": 834,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -24419,7 +24503,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 832,
+      "rank": 835,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -24450,7 +24534,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 833,
+      "rank": 836,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -24473,7 +24557,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 834,
+      "rank": 837,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -24506,7 +24590,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 835,
+      "rank": 838,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -24529,7 +24613,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 836,
+      "rank": 839,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -24559,7 +24643,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 837,
+      "rank": 840,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -24588,7 +24672,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 838,
+      "rank": 841,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -24617,7 +24701,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 839,
+      "rank": 842,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -24653,7 +24737,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 840,
+      "rank": 843,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -24676,7 +24760,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 841,
+      "rank": 844,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -24701,7 +24785,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 842,
+      "rank": 845,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -24731,7 +24815,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 843,
+      "rank": 846,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -24767,7 +24851,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 844,
+      "rank": 847,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -24801,7 +24885,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 845,
+      "rank": 848,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -24828,7 +24912,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 846,
+      "rank": 849,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -24861,7 +24945,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 847,
+      "rank": 850,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -24889,7 +24973,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 848,
+      "rank": 851,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -24909,7 +24993,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 849,
+      "rank": 852,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -24932,7 +25016,7 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 850,
+      "rank": 853,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -24977,7 +25061,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 851,
+      "rank": 854,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -25009,7 +25093,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 852,
+      "rank": 855,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -25034,7 +25118,7 @@
       "lastModified": "2026-05-26T08:37:41.000Z"
     },
     {
-      "rank": 853,
+      "rank": 856,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -25056,7 +25140,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 854,
+      "rank": 857,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -25080,7 +25164,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 855,
+      "rank": 858,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -25125,7 +25209,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 856,
+      "rank": 859,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
@@ -25155,7 +25239,7 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 857,
+      "rank": 860,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -25171,7 +25255,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 858,
+      "rank": 861,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -25191,7 +25275,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 859,
+      "rank": 862,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -25215,7 +25299,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 860,
+      "rank": 863,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -25248,7 +25332,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 861,
+      "rank": 864,
       "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
@@ -25268,7 +25352,7 @@
       "lastModified": "2026-05-22T21:06:00.000Z"
     },
     {
-      "rank": 862,
+      "rank": 865,
       "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
@@ -25313,7 +25397,7 @@
       "lastModified": "2026-05-20T02:34:32.000Z"
     },
     {
-      "rank": 863,
+      "rank": 866,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -25337,7 +25421,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 864,
+      "rank": 867,
       "id": "huihui-ai/DeepSeek-V4-Flash-BF16",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/DeepSeek-V4-Flash-BF16",
@@ -25363,7 +25447,7 @@
       "lastModified": "2026-05-25T09:42:03.000Z"
     },
     {
-      "rank": 865,
+      "rank": 868,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -25390,7 +25474,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 866,
+      "rank": 869,
       "id": "Danrisi/UltraReal_FineTune_Anima_base1",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
@@ -25414,7 +25498,7 @@
       "lastModified": "2026-05-22T13:40:23.000Z"
     },
     {
-      "rank": 867,
+      "rank": 870,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -25459,7 +25543,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 868,
+      "rank": 871,
       "id": "MassivDash/Gemma-4-Rust-Coder",
       "author": "MassivDash",
       "url": "https://huggingface.co/MassivDash/Gemma-4-Rust-Coder",
@@ -25488,7 +25572,7 @@
       "lastModified": "2026-04-24T09:46:25.000Z"
     },
     {
-      "rank": 869,
+      "rank": 872,
       "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
@@ -25515,7 +25599,7 @@
       "lastModified": "2026-05-20T20:34:29.000Z"
     },
     {
-      "rank": 870,
+      "rank": 873,
       "id": "LiquidAI/LFM2-8B-A1B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF",
@@ -25552,7 +25636,7 @@
       "lastModified": "2026-03-30T13:41:14.000Z"
     },
     {
-      "rank": 871,
+      "rank": 874,
       "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -25592,7 +25676,7 @@
       "lastModified": "2025-05-22T23:44:50.000Z"
     },
     {
-      "rank": 872,
+      "rank": 875,
       "id": "google/gemma-2b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-2b-it",
@@ -25637,7 +25721,7 @@
       "lastModified": "2024-09-27T12:19:02.000Z"
     },
     {
-      "rank": 873,
+      "rank": 876,
       "id": "QuantStack/Wan2.2-I2V-A14B-GGUF",
       "author": "QuantStack",
       "url": "https://huggingface.co/QuantStack/Wan2.2-I2V-A14B-GGUF",
@@ -25660,39 +25744,7 @@
       "lastModified": "2025-07-29T13:04:00.000Z"
     },
     {
-      "rank": 874,
-      "id": "mlx-community/Qwen3.6-27B-OptiQ-4bit",
-      "author": "mlx-community",
-      "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-OptiQ-4bit",
-      "downloads": 14408,
-      "likes": 23,
-      "trendingScore": 8,
-      "pipelineTag": "text-generation",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5",
-        "quantized",
-        "mixed-precision",
-        "4bit",
-        "8bit",
-        "optiq",
-        "apple-silicon",
-        "text-generation",
-        "qwen3.6",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:quantized:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "4-bit",
-        "region:us"
-      ],
-      "createdAt": "2026-04-25T10:12:23.000Z",
-      "lastModified": "2026-05-26T06:39:22.000Z"
-    },
-    {
-      "rank": 875,
+      "rank": 877,
       "id": "Jackrong/Qwopus3.5-9B-v3-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-v3-GGUF",
@@ -25725,7 +25777,7 @@
       "lastModified": "2026-04-12T15:46:14.000Z"
     },
     {
-      "rank": 876,
+      "rank": 878,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
@@ -25751,7 +25803,7 @@
       "lastModified": "2026-01-29T08:04:19.000Z"
     },
     {
-      "rank": 877,
+      "rank": 879,
       "id": "google/paligemma-3b-pt-224",
       "author": "google",
       "url": "https://huggingface.co/google/paligemma-3b-pt-224",
@@ -25794,7 +25846,7 @@
       "lastModified": "2024-09-21T10:14:25.000Z"
     },
     {
-      "rank": 878,
+      "rank": 880,
       "id": "ControlLight/ControlLight",
       "author": "ControlLight",
       "url": "https://huggingface.co/ControlLight/ControlLight",
@@ -25817,7 +25869,7 @@
       "lastModified": "2026-05-26T04:28:29.000Z"
     },
     {
-      "rank": 879,
+      "rank": 881,
       "id": "nvidia/Cosmos-Reason2-2B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-2B",
@@ -25846,12 +25898,12 @@
       "lastModified": "2026-04-30T03:14:52.000Z"
     },
     {
-      "rank": 880,
+      "rank": 882,
       "id": "dealignai/DeepSeek-V4-Flash-JANG-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/DeepSeek-V4-Flash-JANG-CRACK",
       "downloads": 2371,
-      "likes": 8,
+      "likes": 9,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
       "libraryName": "mlx",
@@ -25873,7 +25925,7 @@
       "lastModified": "2026-05-24T07:37:34.000Z"
     },
     {
-      "rank": 881,
+      "rank": 883,
       "id": "AlicanKiraz0/Titus-CybersecurityLLM-v1.0-mlx-4Bit",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Titus-CybersecurityLLM-v1.0-mlx-4Bit",
@@ -25907,7 +25959,7 @@
       "lastModified": "2026-05-27T17:50:50.000Z"
     },
     {
-      "rank": 882,
+      "rank": 884,
       "id": "LyliaEngine/Pony_Diffusion_V6_XL",
       "author": "LyliaEngine",
       "url": "https://huggingface.co/LyliaEngine/Pony_Diffusion_V6_XL",
@@ -25931,30 +25983,7 @@
       "lastModified": "2024-05-25T09:45:40.000Z"
     },
     {
-      "rank": 883,
-      "id": "NeoQuasar/Kronos-base",
-      "author": "NeoQuasar",
-      "url": "https://huggingface.co/NeoQuasar/Kronos-base",
-      "downloads": 1383839,
-      "likes": 166,
-      "trendingScore": 8,
-      "pipelineTag": "time-series-forecasting",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "Finance",
-        "Candlestick",
-        "K-line",
-        "time-series-forecasting",
-        "arxiv:2508.02739",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2025-06-30T17:11:20.000Z",
-      "lastModified": "2025-09-09T14:08:15.000Z"
-    },
-    {
-      "rank": 884,
+      "rank": 885,
       "id": "Qwen/Qwen-Image",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image",
@@ -25979,7 +26008,7 @@
       "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 885,
+      "rank": 886,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-NVFP4-Experts-Only-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-NVFP4-Experts-Only-GGUF",
@@ -26012,36 +26041,31 @@
       "lastModified": "2026-05-09T02:29:40.000Z"
     },
     {
-      "rank": 886,
-      "id": "stepfun-ai/Step-3.7-Flash-FP8",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8",
-      "downloads": 8500,
-      "likes": 8,
+      "rank": 887,
+      "id": "Wan-AI/Wan2.2-Animate-14B",
+      "author": "Wan-AI",
+      "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
+      "downloads": 17408,
+      "likes": 1167,
       "trendingScore": 8,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "video-to-video",
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
+        "diffusers",
+        "onnx",
         "safetensors",
-        "step3p7",
-        "text-generation",
-        "vision-language",
-        "multimodal",
-        "moe",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
+        "video-to-video",
+        "arxiv:2503.20314",
+        "base_model:Wan-AI/Wan2.2-I2V-A14B",
+        "base_model:quantized:Wan-AI/Wan2.2-I2V-A14B",
         "license:apache-2.0",
-        "fp8",
         "region:us"
       ],
-      "createdAt": "2026-05-23T12:49:10.000Z",
-      "lastModified": "2026-05-29T10:04:17.000Z"
+      "createdAt": "2025-09-11T12:53:31.000Z",
+      "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 887,
+      "rank": 888,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -26067,7 +26091,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 888,
+      "rank": 889,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -26084,7 +26108,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 889,
+      "rank": 890,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -26112,7 +26136,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 890,
+      "rank": 891,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -26147,7 +26171,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 891,
+      "rank": 892,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -26172,7 +26196,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 892,
+      "rank": 893,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -26202,7 +26226,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 893,
+      "rank": 894,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -26231,7 +26255,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 894,
+      "rank": 895,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -26258,7 +26282,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 895,
+      "rank": 896,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -26284,7 +26308,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 896,
+      "rank": 897,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -26315,7 +26339,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 897,
+      "rank": 898,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -26333,7 +26357,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 898,
+      "rank": 899,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -26362,7 +26386,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 899,
+      "rank": 900,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -26385,7 +26409,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 900,
+      "rank": 901,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -26430,7 +26454,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 901,
+      "rank": 902,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -26456,7 +26480,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 902,
+      "rank": 903,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -26484,7 +26508,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 903,
+      "rank": 904,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -26522,7 +26546,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 904,
+      "rank": 905,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -26549,7 +26573,7 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 905,
+      "rank": 906,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
@@ -26575,7 +26599,7 @@
       "lastModified": "2026-04-10T08:00:12.000Z"
     },
     {
-      "rank": 906,
+      "rank": 907,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -26593,7 +26617,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 907,
+      "rank": 908,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -26619,7 +26643,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 908,
+      "rank": 909,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -26660,7 +26684,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 909,
+      "rank": 910,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -26677,7 +26701,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 910,
+      "rank": 911,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -26710,7 +26734,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 911,
+      "rank": 912,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -26744,7 +26768,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 912,
+      "rank": 913,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -26783,7 +26807,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 913,
+      "rank": 914,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -26813,7 +26837,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 914,
+      "rank": 915,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -26839,7 +26863,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 915,
+      "rank": 916,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -26875,7 +26899,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 916,
+      "rank": 917,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -26905,7 +26929,7 @@
       "lastModified": "2026-05-18T17:52:06.000Z"
     },
     {
-      "rank": 917,
+      "rank": 918,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -26943,7 +26967,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 918,
+      "rank": 919,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -26978,7 +27002,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 919,
+      "rank": 920,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -26995,7 +27019,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 920,
+      "rank": 921,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -27037,7 +27061,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 921,
+      "rank": 922,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -27067,7 +27091,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 922,
+      "rank": 923,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -27092,7 +27116,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 923,
+      "rank": 924,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -27120,7 +27144,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 924,
+      "rank": 925,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -27137,7 +27161,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 925,
+      "rank": 926,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -27164,7 +27188,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 926,
+      "rank": 927,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -27207,7 +27231,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 927,
+      "rank": 928,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -27247,7 +27271,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 928,
+      "rank": 929,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -27271,7 +27295,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 929,
+      "rank": 930,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -27300,7 +27324,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 930,
+      "rank": 931,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -27326,7 +27350,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 931,
+      "rank": 932,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -27365,7 +27389,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 932,
+      "rank": 933,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -27389,7 +27413,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 933,
+      "rank": 934,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -27417,7 +27441,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 934,
+      "rank": 935,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -27449,7 +27473,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 935,
+      "rank": 936,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -27479,7 +27503,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 936,
+      "rank": 937,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -27508,7 +27532,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 937,
+      "rank": 938,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -27537,7 +27561,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 938,
+      "rank": 939,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -27557,7 +27581,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 939,
+      "rank": 940,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -27587,7 +27611,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 940,
+      "rank": 941,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -27617,7 +27641,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 941,
+      "rank": 942,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -27635,7 +27659,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 942,
+      "rank": 943,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -27652,7 +27676,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 943,
+      "rank": 944,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -27688,7 +27712,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 944,
+      "rank": 945,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -27719,7 +27743,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 945,
+      "rank": 946,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -27750,7 +27774,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 946,
+      "rank": 947,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -27783,7 +27807,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 947,
+      "rank": 948,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -27811,7 +27835,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 948,
+      "rank": 949,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -27836,7 +27860,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 949,
+      "rank": 950,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -27859,7 +27883,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 950,
+      "rank": 951,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -27887,7 +27911,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 951,
+      "rank": 952,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -27920,7 +27944,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 952,
+      "rank": 953,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -27950,7 +27974,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 953,
+      "rank": 954,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -27985,7 +28009,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 954,
+      "rank": 955,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -28017,7 +28041,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 955,
+      "rank": 956,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -28042,7 +28066,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 956,
+      "rank": 957,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -28065,7 +28089,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 957,
+      "rank": 958,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -28092,7 +28116,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 958,
+      "rank": 959,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -28115,7 +28139,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 959,
+      "rank": 960,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -28160,7 +28184,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 960,
+      "rank": 961,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -28192,7 +28216,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 961,
+      "rank": 962,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -28219,7 +28243,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 962,
+      "rank": 963,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -28245,7 +28269,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 963,
+      "rank": 964,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -28277,7 +28301,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 964,
+      "rank": 965,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -28306,7 +28330,7 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 965,
+      "rank": 966,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
@@ -28338,7 +28362,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 966,
+      "rank": 967,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -28368,7 +28392,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 967,
+      "rank": 968,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -28385,7 +28409,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 968,
+      "rank": 969,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -28405,7 +28429,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 969,
+      "rank": 970,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -28444,7 +28468,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 970,
+      "rank": 971,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -28482,7 +28506,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 971,
+      "rank": 972,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -28510,7 +28534,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 972,
+      "rank": 973,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -28555,7 +28579,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 973,
+      "rank": 974,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -28585,7 +28609,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 974,
+      "rank": 975,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -28612,7 +28636,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 975,
+      "rank": 976,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -28638,7 +28662,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 976,
+      "rank": 977,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -28667,7 +28691,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 977,
+      "rank": 978,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -28685,7 +28709,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 978,
+      "rank": 979,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -28717,7 +28741,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 979,
+      "rank": 980,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -28744,7 +28768,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 980,
+      "rank": 981,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -28762,7 +28786,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 981,
+      "rank": 982,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -28789,7 +28813,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 982,
+      "rank": 983,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -28813,7 +28837,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 983,
+      "rank": 984,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -28858,7 +28882,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 984,
+      "rank": 985,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -28889,7 +28913,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 985,
+      "rank": 986,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -28914,7 +28938,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 986,
+      "rank": 987,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -28948,7 +28972,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 987,
+      "rank": 988,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -28989,7 +29013,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 988,
+      "rank": 989,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -29016,7 +29040,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 989,
+      "rank": 990,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -29045,7 +29069,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 990,
+      "rank": 991,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -29077,7 +29101,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 991,
+      "rank": 992,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -29101,7 +29125,7 @@
       "lastModified": "2026-05-22T10:10:07.000Z"
     },
     {
-      "rank": 992,
+      "rank": 993,
       "id": "Qwen/Qwen2.5-0.5B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
@@ -29128,7 +29152,7 @@
       "lastModified": "2024-09-25T12:32:36.000Z"
     },
     {
-      "rank": 993,
+      "rank": 994,
       "id": "Vortex5/Elysian-Sunrise-12B",
       "author": "Vortex5",
       "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
@@ -29167,7 +29191,7 @@
       "lastModified": "2026-05-17T12:38:01.000Z"
     },
     {
-      "rank": 994,
+      "rank": 995,
       "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "canada-quant",
       "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
@@ -29199,7 +29223,7 @@
       "lastModified": "2026-05-25T02:40:36.000Z"
     },
     {
-      "rank": 995,
+      "rank": 996,
       "id": "HuggingFaceTB/SmolLM3-3B",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/SmolLM3-3B",
@@ -29233,7 +29257,7 @@
       "lastModified": "2025-09-10T12:28:11.000Z"
     },
     {
-      "rank": 996,
+      "rank": 997,
       "id": "unsloth/Qwen-Image-2512-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-2512-GGUF",
@@ -29260,7 +29284,7 @@
       "lastModified": "2026-01-06T22:28:00.000Z"
     },
     {
-      "rank": 997,
+      "rank": 998,
       "id": "StableQuant/Qwen-Templates-Rebuild-Project",
       "author": "StableQuant",
       "url": "https://huggingface.co/StableQuant/Qwen-Templates-Rebuild-Project",
@@ -29288,7 +29312,7 @@
       "lastModified": "2026-05-25T09:46:59.000Z"
     },
     {
-      "rank": 998,
+      "rank": 999,
       "id": "zai-org/GLM-4.7-Flash",
       "author": "zai-org",
       "url": "https://huggingface.co/zai-org/GLM-4.7-Flash",
@@ -29316,7 +29340,7 @@
       "lastModified": "2026-01-29T08:06:19.000Z"
     },
     {
-      "rank": 999,
+      "rank": 1000,
       "id": "tiiuae/Falcon-OCR",
       "author": "tiiuae",
       "url": "https://huggingface.co/tiiuae/Falcon-OCR",
@@ -29343,51 +29367,6 @@
       ],
       "createdAt": "2026-02-22T11:17:53.000Z",
       "lastModified": "2026-05-13T07:13:52.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
-      "author": "DavidAU",
-      "url": "https://huggingface.co/DavidAU/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
-      "downloads": 4843,
-      "likes": 197,
-      "trendingScore": 7,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "unsloth",
-        "fine tune",
-        "heretic",
-        "uncensored",
-        "abliterated",
-        "multi-stage tuned.",
-        "all use cases",
-        "coder",
-        "creative",
-        "creative writing",
-        "fiction writing",
-        "plot generation",
-        "sub-plot generation",
-        "story generation",
-        "scene continue",
-        "storytelling",
-        "fiction story",
-        "science fiction",
-        "romance",
-        "all genres",
-        "story",
-        "writing",
-        "vivid prosing",
-        "vivid writing",
-        "fiction",
-        "roleplaying"
-      ],
-      "createdAt": "2026-03-15T13:09:21.000Z",
-      "lastModified": "2026-05-15T06:27:56.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26685797474

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.