### PR TITLE
chore(data): refresh lobsters signals 2026-05-30T14:17:49Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T11:56:58.236Z",
+  "ts": "2026-05-30T14:17:49.907Z",
   "count": 1,
-  "durationMs": 3139,
+  "durationMs": 2973,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T11:56:55.117Z",
+  "fetchedAt": "2026-05-30T14:17:46.958Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 49.298611111111114
+        "hoursSincePosted": 51.64611111111111
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 49.298611111111114,
-          "trendingScore": 0.010886833498476937,
+          "ageHours": 51.64611111111111,
+          "trendingScore": 0.010180113596449714,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T11:56:55.117Z",
+  "fetchedAt": "2026-05-30T14:17:46.958Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26686026985

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.