### PR TITLE
chore(data): refresh arxiv signals 2026-05-30T14:24:57Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-30T09:05:59.882Z",
+  "ts": "2026-05-30T14:20:11.033Z",
   "count": 1,
-  "durationMs": 61250,
+  "durationMs": 60894,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T09:05:59.931Z",
+  "fetchedAt": "2026-05-30T14:20:11.082Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -15,11 +15,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30352v1",
+      "arxivId": "2605.30348v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30350v1",
@@ -29,27 +29,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30349v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30347v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30346v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30344v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -57,18 +36,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30342v1",
+      "arxivId": "2605.30343v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30339v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30337v1",
@@ -78,13 +50,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30338v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30336v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -92,11 +57,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30332v1",
+      "arxivId": "2605.30335v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30330v1",
@@ -113,13 +78,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30328v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30326v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -127,11 +85,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30325v1",
+      "arxivId": "2605.30324v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30323v1",
@@ -148,13 +106,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30320v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30319v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -162,18 +113,18 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30317v1",
+      "arxivId": "2605.30311v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30307v1",
+      "arxivId": "2605.30310v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30292v1",
@@ -181,6 +132,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30290v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30289v1",
@@ -225,25 +183,32 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30269v1",
+      "arxivId": "2605.30274v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30263v1",
+      "arxivId": "2605.30273v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30257v1",
+      "arxivId": "2605.30268v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30265v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30253v1",
@@ -253,18 +218,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30250v1",
+      "arxivId": "2605.30251v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30248v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30247v1",
@@ -274,25 +232,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30239v1",
+      "arxivId": "2605.30232v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30235v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30230v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30229v1",
@@ -337,25 +281,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30215v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30213v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30211v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30208v1",
@@ -370,6 +300,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30202v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30201v1",
@@ -407,6 +344,13 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
+      "arxivId": "2605.30189v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
       "arxivId": "2605.30188v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -442,13 +386,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30174v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30169v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -456,11 +393,11 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30168v1",
+      "arxivId": "2605.30167v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30166v1",
@@ -475,13 +412,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30161v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30160v1",
@@ -526,13 +456,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30140v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30135v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -540,340 +463,18 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30132v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30123v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30116v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30115v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30111v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30099v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30093v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30083v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30073v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30351v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30348v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30345v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30343v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30341v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30335v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30334v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30333v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30327v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30324v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30318v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30315v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30311v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30310v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30295v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30290v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30280v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30274v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30273v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30268v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30265v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30260v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30256v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30251v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30245v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30244v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30241v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30237v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30233v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30232v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30231v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30219v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30214v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30202v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30189v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30170v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30167v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30152v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30133v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30132v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30131v1",
@@ -890,32 +491,11 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30107v1",
+      "arxivId": "2605.30123v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30104v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30090v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30085v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30080v1",
@@ -953,27 +533,6 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30040v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30036v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30031v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30022v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -986,20 +545,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30018v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.29992v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.29987v1",
@@ -1021,6 +566,461 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30352v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30351v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30349v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30347v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30346v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30345v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30342v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30341v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30339v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30338v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30334v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30333v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30332v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30328v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30327v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30325v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30320v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30318v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30317v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30315v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30307v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30295v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30280v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30269v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30263v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30260v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30257v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30256v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30250v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30248v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30245v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30244v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30241v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30239v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30237v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30235v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30233v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30231v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30230v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30219v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30215v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30214v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30211v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30174v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30170v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30168v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30161v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30152v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30140v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30116v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30115v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30111v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30107v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30104v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30099v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30093v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30090v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30085v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30083v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30073v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30040v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T14:20:11.082Z"
+    },
+    {
+      "arxivId": "2605.30036v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30031v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30018v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.29992v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T09:04:58.655Z",
+  "fetchedAt": "2026-05-30T14:19:10.158Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26686055851

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.