### PR TITLE
chore(data): refresh lobsters signals 2026-05-30T15:50:34Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T14:17:49.907Z",
+  "ts": "2026-05-30T15:50:34.418Z",
   "count": 1,
-  "durationMs": 2973,
+  "durationMs": 2900,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T14:17:46.958Z",
+  "fetchedAt": "2026-05-30T15:50:31.540Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,
@@ -429,7 +429,7 @@
         "score": 4,
         "url": "https://github.com/google/ax",
         "commentsUrl": "https://lobste.rs/s/3k9g2c/ax_google_s_new_highly_distributed_agent",
-        "hoursSincePosted": 51.64611111111111
+        "hoursSincePosted": 53.191944444444445
       },
       "stories": [
         {
@@ -441,8 +441,8 @@
           "score": 4,
           "commentCount": 2,
           "createdUtc": 1779964740,
-          "ageHours": 51.64611111111111,
-          "trendingScore": 0.010180113596449714,
+          "ageHours": 53.191944444444445,
+          "trendingScore": 0.009755430722439938,
           "tags": [
             "distributed",
             "vibecoding"

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-30T14:17:46.958Z",
+  "fetchedAt": "2026-05-30T15:50:31.540Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -244,6 +244,24 @@
       "trendingScore": 2.256839588407484,
       "tags": [
         "philosophy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
+      "shortId": "pudkct",
+      "title": "NixOS 26.05 released",
+      "url": "https://nixos.org/blog/announcements/2026/nixos-2605/",
+      "commentsUrl": "https://lobste.rs/s/pudkct/nixos_26_05_released",
+      "by": "",
+      "score": 12,
+      "commentCount": 1,
+      "createdUtc": 1780152460,
+      "ageHours": 1.0475,
+      "trendingScore": 2.2556186387250063,
+      "tags": [
+        "nix",
+        "release"
       ],
       "description": "",
       "linkedRepos": []
@@ -867,24 +885,6 @@
       "tags": [
         "distributed",
         "math"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "neclbs",
-      "title": "Native all the way, until you need text",
-      "url": "https://justsitandgrin.im/posts/native-all-the-way-until-you-need-text/",
-      "commentsUrl": "https://lobste.rs/s/neclbs/native_all_way_until_you_need_text",
-      "by": "",
-      "score": 32,
-      "commentCount": 12,
-      "createdUtc": 1779022627,
-      "ageHours": 6.831111111111111,
-      "trendingScore": 1.219345991271624,
-      "tags": [
-        "mac",
-        "swift"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26688096228

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.