### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-30T16:14:03Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-30T12:12:53.870Z",
+  "ts": "2026-05-30T16:14:03.141Z",
   "count": 1,
-  "durationMs": 15013,
+  "durationMs": 13419,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-30T12:12:48.863Z",
+  "lastFetchedAt": "2026-05-30T16:13:58.135Z",
   "windowDays": 7,
   "launches": [
     {
@@ -1891,6 +1891,48 @@
       "aiAdjacent": false
     },
     {
+      "id": "1046734",
+      "name": "Wandesk",
+      "tagline": "Build Your Own AI Desktop ",
+      "description": "Wandesk is an AI desktop. Build the apps you need just by describing them. Plug in Claude Code, Codex, DeepSeek, OpenAI, Kimi, Qwen — anything OpenAI-compatible. Apps share context. AI remembers you. All local. No signup.",
+      "url": "https://www.producthunt.com/products/wandesk-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/5A3ODZHHI5HVA6",
+      "votesCount": 275,
+      "commentsCount": 27,
+      "createdAt": "2026-05-30T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/c91ea294-08fa-42b5-9546-b5b3a552dd6e.png?auto=format",
+      "topics": [
+        "productivity",
+        "open-source",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1141939",
       "name": "Minions",
       "tagline": "Open source mission control for Hermes agent",
@@ -2350,72 +2392,6 @@
         "messaging"
       ],
       "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1050396",
-      "name": "Genpire",
-      "tagline": "Make Real Products with AI, literally.",
-      "description": "Most AI stops at the idea. Genpire takes it to the factory. Think Lovable, but for consumer goods manufacturing - an agentic platform that turns prompts and sketches into products, collections, and factory-ready specs, then lets you work with your own factory or tap into a vetted network for instant quotation, sampling, and bulk production. One workflow, all the way from an idea to the factory floor. Genpire makes building physical products faster, simpler, and finally accessible to anyone.",
-      "url": "https://www.producthunt.com/products/genpire-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/SBMCMSDZBENDWN",
-      "votesCount": 250,
-      "commentsCount": 30,
-      "createdAt": "2026-05-11T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/1970372c-97bb-47b6-bebc-098b71c1e4cc.png?auto=format",
-      "topics": [
-        "design-tools",
-        "artificial-intelligence",
-        "maker-tools"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26688614932

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.