### PR TITLE
chore(data): refresh lobsters signals 2026-05-30T17:39:17Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T15:50:34.418Z",
+  "ts": "2026-05-30T17:39:17.673Z",
   "count": 1,
-  "durationMs": 2900,
+  "durationMs": 3007,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T15:50:31.540Z",
+  "fetchedAt": "2026-05-30T17:39:14.685Z",
   "windowDays": 7,
   "scannedStories": 78,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T15:50:31.540Z",
+  "fetchedAt": "2026-05-30T17:39:14.685Z",
   "windowHours": 72,
   "scannedTotal": 78,
   "stories": [
@@ -196,6 +196,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "pudkct",
+      "title": "NixOS 26.05 released",
+      "url": "https://nixos.org/blog/announcements/2026/nixos-2605/",
+      "commentsUrl": "https://lobste.rs/s/pudkct/nixos_26_05_released",
+      "by": "",
+      "score": 26,
+      "commentCount": 1,
+      "createdUtc": 1780152460,
+      "ageHours": 2.8594444444444442,
+      "trendingScore": 2.427132109995446,
+      "tags": [
+        "nix",
+        "release"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "5y9u93",
       "title": "How my minimal, memory-safe Go rsync steers clear of vulnerabilities",
       "url": "https://michael.stapelberg.ch/posts/2026-05-24-minimal-memory-safe-go-rsync-vulns/",
@@ -244,24 +262,6 @@
       "trendingScore": 2.256839588407484,
       "tags": [
         "philosophy"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "pudkct",
-      "title": "NixOS 26.05 released",
-      "url": "https://nixos.org/blog/announcements/2026/nixos-2605/",
-      "commentsUrl": "https://lobste.rs/s/pudkct/nixos_26_05_released",
-      "by": "",
-      "score": 12,
-      "commentCount": 1,
-      "createdUtc": 1780152460,
-      "ageHours": 1.0475,
-      "trendingScore": 2.2556186387250063,
-      "tags": [
-        "nix",
-        "release"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26690490525

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.