### PR TITLE
chore(data): refresh huggingface space signals 2026-05-30T19:53:03Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-30T14:18:10.274Z",
+  "ts": "2026-05-30T19:53:02.961Z",
   "count": 1,
-  "durationMs": 8743,
+  "durationMs": 8491,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T14:18:01.534Z",
+  "fetchedAt": "2026-05-30T19:52:54.472Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -25,8 +25,8 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 164,
-      "trendingScore": 154,
+      "likes": 166,
+      "trendingScore": 156,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -111,8 +111,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 124,
-      "trendingScore": 117,
+      "likes": 126,
+      "trendingScore": 119,
       "sdk": "static",
       "tags": [
         "static",
@@ -210,6 +210,23 @@
     },
     {
       "rank": 13,
+      "id": "nvidia/LocateAnything",
+      "author": "nvidia",
+      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
+      "likes": 76,
+      "trendingScore": 76,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "arxiv:2605.27365",
+        "region:us"
+      ],
+      "createdAt": "2026-03-18T08:09:56.000Z",
+      "lastModified": "2026-05-30T12:58:14.000Z",
+      "models": []
+    },
+    {
+      "rank": 14,
       "id": "bytedance-research/Lance",
       "author": "bytedance-research",
       "url": "https://huggingface.co/spaces/bytedance-research/Lance",
@@ -225,7 +242,7 @@
       "models": []
     },
     {
-      "rank": 14,
+      "rank": 15,
       "id": "HiDream-ai/HiDream-O1-Image",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image",
@@ -241,7 +258,7 @@
       "models": []
     },
     {
-      "rank": 15,
+      "rank": 16,
       "id": "techfreakworm/LTX2.3-Studio",
       "author": "techfreakworm",
       "url": "https://huggingface.co/spaces/techfreakworm/LTX2.3-Studio",
@@ -257,7 +274,7 @@
       "models": []
     },
     {
-      "rank": 16,
+      "rank": 17,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/spaces/ResembleAI/Dramabox",
@@ -270,23 +287,6 @@
       ],
       "createdAt": "2026-04-28T05:09:42.000Z",
       "lastModified": "2026-05-20T05:14:48.000Z",
-      "models": []
-    },
-    {
-      "rank": 17,
-      "id": "nvidia/LocateAnything",
-      "author": "nvidia",
-      "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 72,
-      "trendingScore": 72,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "arxiv:2605.27365",
-        "region:us"
-      ],
-      "createdAt": "2026-03-18T08:09:56.000Z",
-      "lastModified": "2026-05-30T12:58:14.000Z",
       "models": []
     },
     {
@@ -507,7 +507,7 @@
       "id": "mrfakename/Z-Image-Turbo",
       "author": "mrfakename",
       "url": "https://huggingface.co/spaces/mrfakename/Z-Image-Turbo",
-      "likes": 3261,
+      "likes": 3263,
       "trendingScore": 41,
       "sdk": "gradio",
       "tags": [
@@ -669,6 +669,22 @@
     },
     {
       "rank": 41,
+      "id": "build-small-hackathon/registration",
+      "author": "build-small-hackathon",
+      "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
+      "likes": 66,
+      "trendingScore": 31,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-06T17:25:59.000Z",
+      "lastModified": "2026-05-29T10:23:33.000Z",
+      "models": []
+    },
+    {
+      "rank": 42,
       "id": "multimodalart/talkie-1930",
       "author": "multimodalart",
       "url": "https://huggingface.co/spaces/multimodalart/talkie-1930",
@@ -684,7 +700,7 @@
       "models": []
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -700,7 +716,7 @@
       "models": []
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -716,7 +732,23 @@
       "models": []
     },
     {
-      "rank": 44,
+      "rank": 45,
+      "id": "prism-ml/Bonsai-Image-Demo",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/spaces/prism-ml/Bonsai-Image-Demo",
+      "likes": 31,
+      "trendingScore": 31,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T23:49:03.000Z",
+      "lastModified": "2026-05-27T09:27:24.000Z",
+      "models": []
+    },
+    {
+      "rank": 46,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -732,7 +764,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 47,
       "id": "r3gm/wan2-2-fp8da-aoti-old-backup",
       "author": "r3gm",
       "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-old-backup",
@@ -749,7 +781,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 48,
       "id": "CohereLabs/command-a-plus-05-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/spaces/CohereLabs/command-a-plus-05-2026",
@@ -765,7 +797,7 @@
       "models": []
     },
     {
-      "rank": 47,
+      "rank": 49,
       "id": "alexander00001/Private.Test.Space.2",
       "author": "alexander00001",
       "url": "https://huggingface.co/spaces/alexander00001/Private.Test.Space.2",
@@ -781,45 +813,12 @@
       "models": []
     },
     {
-      "rank": 48,
-      "id": "build-small-hackathon/registration",
-      "author": "build-small-hackathon",
-      "url": "https://huggingface.co/spaces/build-small-hackathon/registration",
-      "likes": 64,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-06T17:25:59.000Z",
-      "lastModified": "2026-05-29T10:23:33.000Z",
-      "models": []
-    },
-    {
-      "rank": 49,
-      "id": "r3gm/wan2-2-fp8da-aoti-previewE",
-      "author": "r3gm",
-      "url": "https://huggingface.co/spaces/r3gm/wan2-2-fp8da-aoti-previewE",
-      "likes": 37,
-      "trendingScore": 29,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "mcp-server",
-        "region:us"
-      ],
-      "createdAt": "2026-03-28T19:57:45.000Z",
-      "lastModified": "2026-05-15T03:44:05.000Z",
-      "models": []
-    },
-    {
       "rank": 50,
       "id": "facebook/vggt-omega",
       "author": "facebook",
       "url": "https://huggingface.co/spaces/facebook/vggt-omega",
-      "likes": 43,
-      "trendingScore": 27,
+      "likes": 45,
+      "trendingScore": 29,
       "sdk": "gradio",
       "tags": [
         "gradio",


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26693335015

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.