### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-31T00:13:19Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-30T20:16:40.262Z",
+  "ts": "2026-05-31T00:13:19.063Z",
   "count": 1,
-  "durationMs": 13860,
+  "durationMs": 14227,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-30T20:16:35.256Z",
+  "lastFetchedAt": "2026-05-31T00:13:14.057Z",
   "windowDays": 7,
   "launches": [
     {
@@ -871,6 +871,48 @@
       "aiAdjacent": true
     },
     {
+      "id": "1046734",
+      "name": "Wandesk",
+      "tagline": "Build Your Own AI Desktop ",
+      "description": "Wandesk is an AI desktop. Build the apps you need just by describing them. Plug in Claude Code, Codex, DeepSeek, OpenAI, Kimi, Qwen — anything OpenAI-compatible. Apps share context. AI remembers you. All local. No signup.",
+      "url": "https://www.producthunt.com/products/wandesk-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/5A3ODZHHI5HVA6",
+      "votesCount": 352,
+      "commentsCount": 33,
+      "createdAt": "2026-05-30T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/c91ea294-08fa-42b5-9546-b5b3a552dd6e.png?auto=format",
+      "topics": [
+        "productivity",
+        "open-source",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1136902",
       "name": "OpenHuman",
       "tagline": "An open source AI harness built with the human in mind",
@@ -1014,48 +1056,6 @@
           "twitterUsername": null,
           "websiteUrl": null
         },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
-    },
-    {
-      "id": "1046734",
-      "name": "Wandesk",
-      "tagline": "Build Your Own AI Desktop ",
-      "description": "Wandesk is an AI desktop. Build the apps you need just by describing them. Plug in Claude Code, Codex, DeepSeek, OpenAI, Kimi, Qwen — anything OpenAI-compatible. Apps share context. AI remembers you. All local. No signup.",
-      "url": "https://www.producthunt.com/products/wandesk-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/5A3ODZHHI5HVA6",
-      "votesCount": 332,
-      "commentsCount": 32,
-      "createdAt": "2026-05-30T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/c91ea294-08fa-42b5-9546-b5b3a552dd6e.png?auto=format",
-      "topics": [
-        "productivity",
-        "open-source",
-        "artificial-intelligence"
-      ],
-      "makers": [
         {
           "name": "[REDACTED]",
           "username": "[REDACTED]",


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26698601621

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.