### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T01:37:52Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-30T23:36:58.100Z",
+  "ts": "2026-05-31T01:37:52.353Z",
   "count": 1,
-  "durationMs": 3332,
+  "durationMs": 2181,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T23:36:54.790Z",
+  "fetchedAt": "2026-05-31T01:37:50.193Z",
   "windowDays": 7,
   "scannedStories": 79,
   "mentions": {

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T23:36:54.790Z",
+  "fetchedAt": "2026-05-31T01:37:50.193Z",
   "windowHours": 72,
   "scannedTotal": 79,
   "stories": [


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26700127015

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.