### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-31T04:57:32Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-30T19:46:15.979Z",
+  "ts": "2026-05-31T04:57:32.932Z",
   "count": 1,
-  "durationMs": 5454,
+  "durationMs": 1616,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T19:46:10.526Z",
+  "fetchedAt": "2026-05-31T04:57:31.318Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -9,8 +9,8 @@
       "author": "openbmb",
       "url": "https://huggingface.co/datasets/openbmb/UltraData-SFT-2605",
       "downloads": 8096,
-      "likes": 220,
-      "trendingScore": 163,
+      "likes": 223,
+      "trendingScore": 166,
       "tags": [
         "task_categories:text-generation",
         "task_categories:question-answering",
@@ -297,8 +297,8 @@
       "author": "jasperai",
       "url": "https://huggingface.co/datasets/jasperai/monet",
       "downloads": 256618,
-      "likes": 75,
-      "trendingScore": 67,
+      "likes": 76,
+      "trendingScore": 68,
       "tags": [
         "task_categories:text-to-image",
         "task_categories:image-feature-extraction",
@@ -1130,10 +1130,27 @@
         "dataset"
       ],
       "createdAt": "2026-05-28T01:58:50.000Z",
-      "lastModified": "2026-05-28T02:11:42.000Z"
+      "lastModified": "2026-05-31T02:31:10.000Z"
     },
     {
       "rank": 38,
+      "id": "stanford-vision-lab/gpic",
+      "author": "stanford-vision-lab",
+      "url": "https://huggingface.co/datasets/stanford-vision-lab/gpic",
+      "downloads": 7322,
+      "likes": 27,
+      "trendingScore": 22,
+      "tags": [
+        "language:en",
+        "license:mit",
+        "arxiv:2605.30341",
+        "region:us"
+      ],
+      "createdAt": "2026-05-03T20:45:00.000Z",
+      "lastModified": "2026-05-29T09:50:14.000Z"
+    },
+    {
+      "rank": 39,
       "id": "SALT-NLP/SWE-chat",
       "author": "SALT-NLP",
       "url": "https://huggingface.co/datasets/SALT-NLP/SWE-chat",
@@ -1166,7 +1183,7 @@
       "lastModified": "2026-04-29T15:05:22.000Z"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "id": "r0b0tlab/deepseek-hermes-reasoning-traces",
       "author": "r0b0tlab",
       "url": "https://huggingface.co/datasets/r0b0tlab/deepseek-hermes-reasoning-traces",
@@ -1201,7 +1218,7 @@
       "lastModified": "2026-05-04T00:18:27.000Z"
     },
     {
-      "rank": 40,
+      "rank": 41,
       "id": "ShadenA/MathNet",
       "author": "ShadenA",
       "url": "https://huggingface.co/datasets/ShadenA/MathNet",
@@ -1244,7 +1261,7 @@
       "lastModified": "2026-04-27T23:48:47.000Z"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "id": "LukaDev13/Liminal-Dreamcore-1K",
       "author": "LukaDev13",
       "url": "https://huggingface.co/datasets/LukaDev13/Liminal-Dreamcore-1K",
@@ -1265,7 +1282,7 @@
       "lastModified": "2026-05-18T22:03:11.000Z"
     },
     {
-      "rank": 42,
+      "rank": 43,
       "id": "roneneldan/TinyStories",
       "author": "roneneldan",
       "url": "https://huggingface.co/datasets/roneneldan/TinyStories",
@@ -1290,7 +1307,7 @@
       "lastModified": "2024-08-12T13:27:26.000Z"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "id": "SWE-bench/SWE-bench_Verified",
       "author": "SWE-bench",
       "url": "https://huggingface.co/datasets/SWE-bench/SWE-bench_Verified",
@@ -1313,7 +1330,7 @@
       "lastModified": "2026-02-27T20:36:38.000Z"
     },
     {
-      "rank": 44,
+      "rank": 45,
       "id": "unh1nge/comfyui-character-composer",
       "author": "unh1nge",
       "url": "https://huggingface.co/datasets/unh1nge/comfyui-character-composer",
@@ -1341,7 +1358,7 @@
       "lastModified": "2026-05-07T19:19:01.000Z"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "Kwai-Klear/GoLongRL",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/datasets/Kwai-Klear/GoLongRL",
@@ -1362,23 +1379,6 @@
       ],
       "createdAt": "2026-05-19T11:22:48.000Z",
       "lastModified": "2026-05-26T08:10:01.000Z"
-    },
-    {
-      "rank": 46,
-      "id": "stanford-vision-lab/gpic",
-      "author": "stanford-vision-lab",
-      "url": "https://huggingface.co/datasets/stanford-vision-lab/gpic",
-      "downloads": 7322,
-      "likes": 23,
-      "trendingScore": 18,
-      "tags": [
-        "language:en",
-        "license:mit",
-        "arxiv:2605.30341",
-        "region:us"
-      ],
-      "createdAt": "2026-05-03T20:45:00.000Z",
-      "lastModified": "2026-05-29T09:50:14.000Z"
     },
     {
       "rank": 47,


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26703686719

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.