### PR TITLE
chore(data): refresh awesome-skills index 2026-05-31T07:55:52Z

### DIFF
--- a/data/_meta/awesome-skills.json
+++ b/data/_meta/awesome-skills.json
@@ -1,8 +1,8 @@
 {
   "source": "awesome-skills",
   "reason": "ok",
-  "ts": "2026-05-30T07:24:53.748Z",
+  "ts": "2026-05-31T07:55:52.766Z",
   "count": 1,
-  "durationMs": 2671,
+  "durationMs": 2224,
   "extra": {}
 }

--- a/data/awesome-skills.json
+++ b/data/awesome-skills.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-30T07:24:51.078Z",
+  "fetchedAt": "2026-05-31T07:55:50.543Z",
   "source": "awesome-skills aggregate",
   "lists": [
     "sickn33/antigravity-awesome-skills",
@@ -62,6 +62,9 @@
       "sickn33/antigravity-awesome-skills"
     ],
     "huggingface/skills": [
+      "sickn33/antigravity-awesome-skills"
+    ],
+    "longbridge/skills": [
       "sickn33/antigravity-awesome-skills"
     ],
     "neondatabase/agent-skills": [
@@ -8710,6 +8713,6 @@
   "counts": {
     "lists": 4,
     "listsAttempted": 5,
-    "uniqueSkills": 2824
+    "uniqueSkills": 2825
   }
 }


### PR DESCRIPTION
Automated data refresh from `Refresh awesome-skills index`.

- Files changed: 3
- Run: https://github.com/0motionguy/starscreener/actions/runs/26707026863

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.