### PR TITLE
chore(data): refresh huggingface signals 2026-05-31T09:26:12Z

### DIFF
--- a/data/_meta/huggingface.json
+++ b/data/_meta/huggingface.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface",
   "reason": "ok",
-  "ts": "2026-05-31T04:54:09.424Z",
+  "ts": "2026-05-31T09:26:11.998Z",
   "count": 1,
-  "durationMs": 5052,
+  "durationMs": 4981,
   "extra": {}
 }

--- a/data/huggingface-trending.json
+++ b/data/huggingface-trending.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T04:54:04.373Z",
+  "fetchedAt": "2026-05-31T09:26:07.018Z",
   "source": "huggingface.co/api/models (default sort = trending)",
   "count": 1000,
   "models": [
@@ -112,9 +112,9 @@
       "id": "openbmb/MiniCPM5-1B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B",
-      "downloads": 28793,
-      "likes": 612,
-      "trendingScore": 533,
+      "downloads": 36730,
+      "likes": 629,
+      "trendingScore": 546,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -149,33 +149,12 @@
     },
     {
       "rank": 5,
-      "id": "SulphurAI/Sulphur-2-base",
-      "author": "SulphurAI",
-      "url": "https://huggingface.co/SulphurAI/Sulphur-2-base",
-      "downloads": 875370,
-      "likes": 1001,
-      "trendingScore": 497,
-      "pipelineTag": "text-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "gguf",
-        "text-to-video",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-03T00:33:24.000Z",
-      "lastModified": "2026-05-08T22:57:06.000Z"
-    },
-    {
-      "rank": 6,
       "id": "nvidia/LocateAnything-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/LocateAnything-3B",
-      "downloads": 18327,
-      "likes": 509,
-      "trendingScore": 490,
+      "downloads": 24586,
+      "likes": 527,
+      "trendingScore": 508,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
       "tags": [
@@ -207,6 +186,27 @@
       ],
       "createdAt": "2026-03-02T20:05:49.000Z",
       "lastModified": "2026-05-27T08:30:54.000Z"
+    },
+    {
+      "rank": 6,
+      "id": "SulphurAI/Sulphur-2-base",
+      "author": "SulphurAI",
+      "url": "https://huggingface.co/SulphurAI/Sulphur-2-base",
+      "downloads": 875370,
+      "likes": 1001,
+      "trendingScore": 497,
+      "pipelineTag": "text-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "gguf",
+        "text-to-video",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-03T00:33:24.000Z",
+      "lastModified": "2026-05-08T22:57:06.000Z"
     },
     {
       "rank": 7,
@@ -302,6 +302,38 @@
     },
     {
       "rank": 10,
+      "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "author": "HauhauCS",
+      "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
+      "downloads": 2439402,
+      "likes": 1129,
+      "trendingScore": 361,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "uncensored",
+        "qwen3.6",
+        "moe",
+        "vision",
+        "multimodal",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "multilingual",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "imatrix",
+        "conversational"
+      ],
+      "createdAt": "2026-04-17T00:15:26.000Z",
+      "lastModified": "2026-04-17T02:59:21.000Z"
+    },
+    {
+      "rank": 11,
       "id": "deepseek-ai/DeepSeek-V4-Pro",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro",
@@ -327,7 +359,7 @@
       "lastModified": "2026-05-06T04:18:44.000Z"
     },
     {
-      "rank": 11,
+      "rank": 12,
       "id": "NemoStation/Marlin-2B",
       "author": "NemoStation",
       "url": "https://huggingface.co/NemoStation/Marlin-2B",
@@ -359,38 +391,6 @@
       ],
       "createdAt": "2026-05-13T16:23:12.000Z",
       "lastModified": "2026-05-20T07:54:57.000Z"
-    },
-    {
-      "rank": 12,
-      "id": "HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "author": "HauhauCS",
-      "url": "https://huggingface.co/HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive",
-      "downloads": 2227885,
-      "likes": 1118,
-      "trendingScore": 354,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "uncensored",
-        "qwen3.6",
-        "moe",
-        "vision",
-        "multimodal",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "multilingual",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "imatrix",
-        "conversational"
-      ],
-      "createdAt": "2026-04-17T00:15:26.000Z",
-      "lastModified": "2026-04-17T02:59:21.000Z"
     },
     {
       "rank": 13,
@@ -524,9 +524,9 @@
       "id": "LiquidAI/LFM2.5-8B-A1B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B",
-      "downloads": 17084,
-      "likes": 284,
-      "trendingScore": 278,
+      "downloads": 27677,
+      "likes": 291,
+      "trendingScore": 285,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -727,6 +727,33 @@
     },
     {
       "rank": 24,
+      "id": "nvidia/PiD",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/PiD",
+      "downloads": 498,
+      "likes": 202,
+      "trendingScore": 198,
+      "pipelineTag": "image-to-image",
+      "libraryName": "pytorch",
+      "tags": [
+        "pytorch",
+        "diffusers",
+        "safetensors",
+        "super-resolution",
+        "diffusion",
+        "pixel-diffusion-decoder",
+        "vae-decoder",
+        "image-to-image",
+        "arxiv:2605.23902",
+        "base_model:Tongyi-MAI/Z-Image",
+        "base_model:finetune:Tongyi-MAI/Z-Image",
+        "region:us"
+      ],
+      "createdAt": "2026-04-28T00:41:46.000Z",
+      "lastModified": "2026-05-26T01:17:21.000Z"
+    },
+    {
+      "rank": 25,
       "id": "ResembleAI/Dramabox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/Dramabox",
@@ -753,33 +780,6 @@
       ],
       "createdAt": "2026-04-17T07:17:52.000Z",
       "lastModified": "2026-05-13T16:39:38.000Z"
-    },
-    {
-      "rank": 25,
-      "id": "nvidia/PiD",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/PiD",
-      "downloads": 437,
-      "likes": 195,
-      "trendingScore": 191,
-      "pipelineTag": "image-to-image",
-      "libraryName": "pytorch",
-      "tags": [
-        "pytorch",
-        "diffusers",
-        "safetensors",
-        "super-resolution",
-        "diffusion",
-        "pixel-diffusion-decoder",
-        "vae-decoder",
-        "image-to-image",
-        "arxiv:2605.23902",
-        "base_model:Tongyi-MAI/Z-Image",
-        "base_model:finetune:Tongyi-MAI/Z-Image",
-        "region:us"
-      ],
-      "createdAt": "2026-04-28T00:41:46.000Z",
-      "lastModified": "2026-05-26T01:17:21.000Z"
     },
     {
       "rank": 26,
@@ -1077,6 +1077,35 @@
     },
     {
       "rank": 34,
+      "id": "stepfun-ai/Step-3.7-Flash",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash",
+      "downloads": 7638,
+      "likes": 145,
+      "trendingScore": 143,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T02:13:46.000Z",
+      "lastModified": "2026-05-29T10:03:47.000Z"
+    },
+    {
+      "rank": 35,
       "id": "XiaomiMiMo/MiMo-V2.5-Pro",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro",
@@ -1103,35 +1132,6 @@
       ],
       "createdAt": "2026-04-27T12:52:53.000Z",
       "lastModified": "2026-04-28T07:01:37.000Z"
-    },
-    {
-      "rank": 35,
-      "id": "stepfun-ai/Step-3.7-Flash",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash",
-      "downloads": 3400,
-      "likes": 140,
-      "trendingScore": 138,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "step3p7",
-        "text-generation",
-        "vision-language",
-        "multimodal",
-        "moe",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T02:13:46.000Z",
-      "lastModified": "2026-05-29T10:03:47.000Z"
     },
     {
       "rank": 36,
@@ -1246,6 +1246,41 @@
     },
     {
       "rank": 40,
+      "id": "LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF",
+      "downloads": 41828,
+      "likes": 126,
+      "trendingScore": 126,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "liquid",
+        "lfm2",
+        "edge",
+        "llama.cpp",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "base_model:LiquidAI/LFM2.5-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-24T22:16:45.000Z",
+      "lastModified": "2026-05-29T16:25:34.000Z"
+    },
+    {
+      "rank": 41,
       "id": "CohereLabs/command-a-plus-05-2026-bf16",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/command-a-plus-05-2026-bf16",
@@ -1288,41 +1323,6 @@
       ],
       "createdAt": "2026-05-11T12:31:04.000Z",
       "lastModified": "2026-05-22T14:40:13.000Z"
-    },
-    {
-      "rank": 41,
-      "id": "LiquidAI/LFM2.5-8B-A1B-GGUF",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-GGUF",
-      "downloads": 23685,
-      "likes": 124,
-      "trendingScore": 124,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "liquid",
-        "lfm2",
-        "edge",
-        "llama.cpp",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "base_model:LiquidAI/LFM2.5-8B-A1B",
-        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-24T22:16:45.000Z",
-      "lastModified": "2026-05-29T16:25:34.000Z"
     },
     {
       "rank": 42,
@@ -1587,9 +1587,9 @@
       "id": "PaddlePaddle/PaddleOCR-VL-1.6",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6",
-      "downloads": 2294,
-      "likes": 108,
-      "trendingScore": 104,
+      "downloads": 2731,
+      "likes": 109,
+      "trendingScore": 105,
       "pipelineTag": "image-text-to-text",
       "libraryName": "PaddleOCR",
       "tags": [
@@ -2422,32 +2422,12 @@
     },
     {
       "rank": 79,
-      "id": "talkie-lm/talkie-1930-13b-it",
-      "author": "talkie-lm",
-      "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
-      "downloads": 0,
-      "likes": 242,
-      "trendingScore": 73,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "en",
-        "base_model:talkie-lm/talkie-1930-13b-base",
-        "base_model:finetune:talkie-lm/talkie-1930-13b-base",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-04-20T10:43:41.000Z",
-      "lastModified": "2026-04-23T09:04:42.000Z"
-    },
-    {
-      "rank": 80,
       "id": "OpenMOSS-Team/MOSS-TTS-v1.5",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-v1.5",
-      "downloads": 11254,
-      "likes": 74,
-      "trendingScore": 71,
+      "downloads": 14272,
+      "likes": 77,
+      "trendingScore": 74,
       "pipelineTag": "text-to-speech",
       "libraryName": null,
       "tags": [
@@ -2484,6 +2464,26 @@
       ],
       "createdAt": "2026-05-25T12:40:42.000Z",
       "lastModified": "2026-05-26T08:49:43.000Z"
+    },
+    {
+      "rank": 80,
+      "id": "talkie-lm/talkie-1930-13b-it",
+      "author": "talkie-lm",
+      "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-it",
+      "downloads": 0,
+      "likes": 242,
+      "trendingScore": 73,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "en",
+        "base_model:talkie-lm/talkie-1930-13b-base",
+        "base_model:finetune:talkie-lm/talkie-1930-13b-base",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-04-20T10:43:41.000Z",
+      "lastModified": "2026-04-23T09:04:42.000Z"
     },
     {
       "rank": 81,
@@ -2622,6 +2622,48 @@
     },
     {
       "rank": 86,
+      "id": "stepfun-ai/Step-3.7-Flash-GGUF",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-GGUF",
+      "downloads": 35511,
+      "likes": 67,
+      "trendingScore": 67,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "gguf",
+      "tags": [
+        "gguf",
+        "llama.cpp",
+        "quantized",
+        "imatrix",
+        "moe",
+        "agent",
+        "tool-calling",
+        "reasoning",
+        "vision",
+        "multimodal",
+        "image-text-to-text",
+        "en",
+        "zh",
+        "ja",
+        "ko",
+        "ar",
+        "hi",
+        "de",
+        "fr",
+        "es",
+        "ru",
+        "base_model:stepfun-ai/Step-3.7-Flash",
+        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-28T11:34:17.000Z",
+      "lastModified": "2026-05-30T10:00:54.000Z"
+    },
+    {
+      "rank": 87,
       "id": "prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-gemlite-2bit",
@@ -2652,7 +2694,39 @@
       "lastModified": "2026-05-26T16:16:59.000Z"
     },
     {
-      "rank": 87,
+      "rank": 88,
+      "id": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4",
+      "downloads": 105608,
+      "likes": 68,
+      "trendingScore": 66,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "qwen3_5_moe",
+        "nvidia",
+        "ModelOpt",
+        "Qwen3.6",
+        "quantized",
+        "FP4",
+        "fp4",
+        "text-generation",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "8-bit",
+        "modelopt",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T18:09:46.000Z",
+      "lastModified": "2026-05-29T19:10:41.000Z"
+    },
+    {
+      "rank": 89,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-GGUF",
@@ -2697,82 +2771,13 @@
       "lastModified": "2026-05-02T14:32:42.000Z"
     },
     {
-      "rank": 88,
-      "id": "stepfun-ai/Step-3.7-Flash-GGUF",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-GGUF",
-      "downloads": 29666,
-      "likes": 64,
-      "trendingScore": 64,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "gguf",
-      "tags": [
-        "gguf",
-        "llama.cpp",
-        "quantized",
-        "imatrix",
-        "moe",
-        "agent",
-        "tool-calling",
-        "reasoning",
-        "vision",
-        "multimodal",
-        "image-text-to-text",
-        "en",
-        "zh",
-        "ja",
-        "ko",
-        "ar",
-        "hi",
-        "de",
-        "fr",
-        "es",
-        "ru",
-        "base_model:stepfun-ai/Step-3.7-Flash",
-        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-28T11:34:17.000Z",
-      "lastModified": "2026-05-30T10:00:54.000Z"
-    },
-    {
-      "rank": 89,
-      "id": "moonshotai/Kimi-K2.6",
-      "author": "moonshotai",
-      "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
-      "downloads": 1696084,
-      "likes": 1274,
-      "trendingScore": 63,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "kimi_k25",
-        "feature-extraction",
-        "compressed-tensors",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "arxiv:2602.02276",
-        "license:other",
-        "eval-results",
-        "region:us"
-      ],
-      "createdAt": "2026-04-14T04:23:36.000Z",
-      "lastModified": "2026-05-12T03:12:21.000Z"
-    },
-    {
       "rank": 90,
       "id": "jedisct1/MiMo-V2.5-coder-Q2",
       "author": "jedisct1",
       "url": "https://huggingface.co/jedisct1/MiMo-V2.5-coder-Q2",
-      "downloads": 1718,
-      "likes": 64,
-      "trendingScore": 63,
+      "downloads": 1898,
+      "likes": 65,
+      "trendingScore": 64,
       "pipelineTag": "text-generation",
       "libraryName": "llama.cpp",
       "tags": [
@@ -2799,6 +2804,33 @@
     },
     {
       "rank": 91,
+      "id": "moonshotai/Kimi-K2.6",
+      "author": "moonshotai",
+      "url": "https://huggingface.co/moonshotai/Kimi-K2.6",
+      "downloads": 1696084,
+      "likes": 1274,
+      "trendingScore": 63,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "kimi_k25",
+        "feature-extraction",
+        "compressed-tensors",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "arxiv:2602.02276",
+        "license:other",
+        "eval-results",
+        "region:us"
+      ],
+      "createdAt": "2026-04-14T04:23:36.000Z",
+      "lastModified": "2026-05-12T03:12:21.000Z"
+    },
+    {
+      "rank": 92,
       "id": "joyfox/LTX2.3-ICEdit-Insight",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX2.3-ICEdit-Insight",
@@ -2831,7 +2863,7 @@
       "lastModified": "2026-05-10T14:23:59.000Z"
     },
     {
-      "rank": 92,
+      "rank": 93,
       "id": "zhifeixie/Mega-ASR",
       "author": "zhifeixie",
       "url": "https://huggingface.co/zhifeixie/Mega-ASR",
@@ -2857,7 +2889,7 @@
       "lastModified": "2026-05-27T03:03:58.000Z"
     },
     {
-      "rank": 93,
+      "rank": 94,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
@@ -2886,7 +2918,7 @@
       "lastModified": "2026-05-12T11:38:27.000Z"
     },
     {
-      "rank": 94,
+      "rank": 95,
       "id": "AIDC-AI/Ovis2.6-80B-A3B",
       "author": "AIDC-AI",
       "url": "https://huggingface.co/AIDC-AI/Ovis2.6-80B-A3B",
@@ -2911,7 +2943,7 @@
       "lastModified": "2026-05-14T08:44:07.000Z"
     },
     {
-      "rank": 95,
+      "rank": 96,
       "id": "Lightricks/LTX-2.3",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3",
@@ -2955,7 +2987,7 @@
       "lastModified": "2026-04-13T14:07:43.000Z"
     },
     {
-      "rank": 96,
+      "rank": 97,
       "id": "ibm-granite/granite-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-8b",
@@ -2983,7 +3015,7 @@
       "lastModified": "2026-05-04T17:36:29.000Z"
     },
     {
-      "rank": 97,
+      "rank": 98,
       "id": "google/gemma-4-E4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B-it",
@@ -3010,7 +3042,7 @@
       "lastModified": "2026-05-07T07:39:39.000Z"
     },
     {
-      "rank": 98,
+      "rank": 99,
       "id": "google/gemma-4-26B-A4B-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B-it",
@@ -3037,7 +3069,7 @@
       "lastModified": "2026-05-07T07:39:32.000Z"
     },
     {
-      "rank": 99,
+      "rank": 100,
       "id": "openbmb/BitCPM-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-8B",
@@ -3062,67 +3094,13 @@
       "lastModified": "2026-05-24T10:43:34.000Z"
     },
     {
-      "rank": 100,
-      "id": "vantagewithai/LTX2.3-10Eros-GGUF",
-      "author": "vantagewithai",
-      "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
-      "downloads": 62704,
-      "likes": 64,
-      "trendingScore": 57,
-      "pipelineTag": "image-to-video",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "gguf",
-        "image-to-video",
-        "ltx-2-3",
-        "ltx-video",
-        "sulphur-2",
-        "10Eros",
-        "region:us"
-      ],
-      "createdAt": "2026-05-08T16:54:04.000Z",
-      "lastModified": "2026-05-08T18:31:07.000Z"
-    },
-    {
       "rank": 101,
-      "id": "fastino/gliguard-LLMGuardrails-300M",
-      "author": "fastino",
-      "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
-      "downloads": 2485,
-      "likes": 58,
-      "trendingScore": 57,
-      "pipelineTag": "text-classification",
-      "libraryName": "gliner2",
-      "tags": [
-        "gliner2",
-        "safetensors",
-        "extractor",
-        "safety",
-        "moderation",
-        "guardrails",
-        "text-classification",
-        "multi-label-classification",
-        "jailbreak-detection",
-        "toxicity-classification",
-        "en",
-        "arxiv:2605.07982",
-        "base_model:fastino/gliner2-base-v1",
-        "base_model:finetune:fastino/gliner2-base-v1",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-09T04:20:48.000Z",
-      "lastModified": "2026-05-14T16:04:55.000Z"
-    },
-    {
-      "rank": 102,
       "id": "openbmb/MiniCPM5-1B-GGUF",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-GGUF",
-      "downloads": 18770,
-      "likes": 121,
-      "trendingScore": 57,
+      "downloads": 21435,
+      "likes": 123,
+      "trendingScore": 58,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
       "tags": [
@@ -3155,7 +3133,87 @@
       "lastModified": "2026-05-25T10:55:40.000Z"
     },
     {
+      "rank": 102,
+      "id": "vantagewithai/LTX2.3-10Eros-GGUF",
+      "author": "vantagewithai",
+      "url": "https://huggingface.co/vantagewithai/LTX2.3-10Eros-GGUF",
+      "downloads": 62704,
+      "likes": 64,
+      "trendingScore": 57,
+      "pipelineTag": "image-to-video",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "gguf",
+        "image-to-video",
+        "ltx-2-3",
+        "ltx-video",
+        "sulphur-2",
+        "10Eros",
+        "region:us"
+      ],
+      "createdAt": "2026-05-08T16:54:04.000Z",
+      "lastModified": "2026-05-08T18:31:07.000Z"
+    },
+    {
       "rank": 103,
+      "id": "fastino/gliguard-LLMGuardrails-300M",
+      "author": "fastino",
+      "url": "https://huggingface.co/fastino/gliguard-LLMGuardrails-300M",
+      "downloads": 2485,
+      "likes": 58,
+      "trendingScore": 57,
+      "pipelineTag": "text-classification",
+      "libraryName": "gliner2",
+      "tags": [
+        "gliner2",
+        "safetensors",
+        "extractor",
+        "safety",
+        "moderation",
+        "guardrails",
+        "text-classification",
+        "multi-label-classification",
+        "jailbreak-detection",
+        "toxicity-classification",
+        "en",
+        "arxiv:2605.07982",
+        "base_model:fastino/gliner2-base-v1",
+        "base_model:finetune:fastino/gliner2-base-v1",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-09T04:20:48.000Z",
+      "lastModified": "2026-05-14T16:04:55.000Z"
+    },
+    {
+      "rank": 104,
+      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "author": "Kwai-Keye",
+      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
+      "downloads": 714,
+      "likes": 57,
+      "trendingScore": 57,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "KeyeVL2",
+        "feature-extraction",
+        "multimodal",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-25T15:32:15.000Z",
+      "lastModified": "2026-05-29T03:57:43.000Z"
+    },
+    {
+      "rank": 105,
       "id": "XiaomiMiMo/MiMo-V2.5",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5",
@@ -3185,33 +3243,7 @@
       "lastModified": "2026-05-07T04:23:16.000Z"
     },
     {
-      "rank": 104,
-      "id": "Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "author": "Kwai-Keye",
-      "url": "https://huggingface.co/Kwai-Keye/Keye-VL-2.0-30B-A3B",
-      "downloads": 666,
-      "likes": 56,
-      "trendingScore": 56,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "KeyeVL2",
-        "feature-extraction",
-        "multimodal",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-25T15:32:15.000Z",
-      "lastModified": "2026-05-29T03:57:43.000Z"
-    },
-    {
-      "rank": 105,
+      "rank": 106,
       "id": "Comfy-Org/HiDream-O1-Image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/HiDream-O1-Image",
@@ -3229,7 +3261,7 @@
       "lastModified": "2026-05-12T09:46:36.000Z"
     },
     {
-      "rank": 106,
+      "rank": 107,
       "id": "Lakonik/AsymFLUX.2-klein-9B",
       "author": "Lakonik",
       "url": "https://huggingface.co/Lakonik/AsymFLUX.2-klein-9B",
@@ -3256,7 +3288,7 @@
       "lastModified": "2026-05-14T02:37:15.000Z"
     },
     {
-      "rank": 107,
+      "rank": 108,
       "id": "black-forest-labs/FLUX.1-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev",
@@ -3281,7 +3313,7 @@
       "lastModified": "2025-06-27T16:22:19.000Z"
     },
     {
-      "rank": 108,
+      "rank": 109,
       "id": "HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Gemma-4-E4B-Uncensored-HauhauCS-Aggressive",
@@ -3311,7 +3343,7 @@
       "lastModified": "2026-04-06T03:50:35.000Z"
     },
     {
-      "rank": 109,
+      "rank": 110,
       "id": "havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
       "author": "havenoammo",
       "url": "https://huggingface.co/havenoammo/Qwen3.6-35B-A3B-MTP-GGUF",
@@ -3338,7 +3370,7 @@
       "lastModified": "2026-05-10T15:43:13.000Z"
     },
     {
-      "rank": 110,
+      "rank": 111,
       "id": "froggeric/Qwen3.6-27B-MTP-GGUF",
       "author": "froggeric",
       "url": "https://huggingface.co/froggeric/Qwen3.6-27B-MTP-GGUF",
@@ -3369,38 +3401,6 @@
       ],
       "createdAt": "2026-05-05T18:45:32.000Z",
       "lastModified": "2026-05-07T09:30:56.000Z"
-    },
-    {
-      "rank": 111,
-      "id": "nvidia/Qwen3.6-35B-A3B-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4",
-      "downloads": 67020,
-      "likes": 54,
-      "trendingScore": 53,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "qwen3_5_moe",
-        "nvidia",
-        "ModelOpt",
-        "Qwen3.6",
-        "quantized",
-        "FP4",
-        "fp4",
-        "text-generation",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:quantized:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "8-bit",
-        "modelopt",
-        "region:us"
-      ],
-      "createdAt": "2026-05-27T18:09:46.000Z",
-      "lastModified": "2026-05-29T19:10:41.000Z"
     },
     {
       "rank": 112,
@@ -3476,6 +3476,27 @@
     },
     {
       "rank": 114,
+      "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "downloads": 1854845,
+      "likes": 1553,
+      "trendingScore": 52,
+      "pipelineTag": "text-to-speech",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_tts",
+        "text-to-speech",
+        "arxiv:2601.15621",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-01-21T08:56:49.000Z",
+      "lastModified": "2026-01-29T08:00:54.000Z"
+    },
+    {
+      "rank": 115,
       "id": "ibm-granite/granite-4.1-30b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-4.1-30b",
@@ -3501,27 +3522,6 @@
       ],
       "createdAt": "2026-04-06T13:19:18.000Z",
       "lastModified": "2026-05-04T17:31:52.000Z"
-    },
-    {
-      "rank": 115,
-      "id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
-      "downloads": 1833315,
-      "likes": 1551,
-      "trendingScore": 50,
-      "pipelineTag": "text-to-speech",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_tts",
-        "text-to-speech",
-        "arxiv:2601.15621",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-01-21T08:56:49.000Z",
-      "lastModified": "2026-01-29T08:00:54.000Z"
     },
     {
       "rank": 116,
@@ -3881,6 +3881,37 @@
     },
     {
       "rank": 129,
+      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+      "downloads": 0,
+      "likes": 45,
+      "trendingScore": 45,
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
+      "tags": [
+        "diffusers",
+        "safetensors",
+        "ternary",
+        "1.58-bit",
+        "mlx",
+        "apple-silicon",
+        "on-device",
+        "text-to-image",
+        "diffusion",
+        "flux",
+        "prismml",
+        "bonsai",
+        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T16:15:18.000Z",
+      "lastModified": "2026-05-28T15:51:28.000Z"
+    },
+    {
+      "rank": 130,
       "id": "facebook/sam3",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/sam3",
@@ -3905,37 +3936,6 @@
       ],
       "createdAt": "2025-11-07T05:17:48.000Z",
       "lastModified": "2025-11-20T22:05:08.000Z"
-    },
-    {
-      "rank": 130,
-      "id": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-mlx-2bit",
-      "downloads": 0,
-      "likes": 44,
-      "trendingScore": 44,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "ternary",
-        "1.58-bit",
-        "mlx",
-        "apple-silicon",
-        "on-device",
-        "text-to-image",
-        "diffusion",
-        "flux",
-        "prismml",
-        "bonsai",
-        "base_model:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "base_model:finetune:prism-ml/bonsai-image-ternary-4B-unpacked",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T16:15:18.000Z",
-      "lastModified": "2026-05-28T15:51:28.000Z"
     },
     {
       "rank": 131,
@@ -4747,6 +4747,44 @@
     },
     {
       "rank": 162,
+      "id": "unsloth/LFM2.5-8B-A1B-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/LFM2.5-8B-A1B-GGUF",
+      "downloads": 19959,
+      "likes": 34,
+      "trendingScore": 34,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "liquid",
+        "unsloth",
+        "lfm2.5",
+        "edge",
+        "text-generation",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "pt",
+        "arxiv:2511.23404",
+        "base_model:LiquidAI/LFM2.5-8B-A1B",
+        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
+        "license:other",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-29T09:11:04.000Z",
+      "lastModified": "2026-05-30T11:13:02.000Z"
+    },
+    {
+      "rank": 163,
       "id": "ibm-granite/granite-embedding-97m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2",
@@ -4791,7 +4829,7 @@
       "lastModified": "2026-04-29T01:27:50.000Z"
     },
     {
-      "rank": 163,
+      "rank": 164,
       "id": "ibm-granite/granite-embedding-311m-multilingual-r2",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2",
@@ -4836,7 +4874,7 @@
       "lastModified": "2026-04-29T01:19:42.000Z"
     },
     {
-      "rank": 164,
+      "rank": 165,
       "id": "Qwen/WebWorld-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-8B",
@@ -4880,7 +4918,7 @@
       "lastModified": "2026-05-08T12:10:29.000Z"
     },
     {
-      "rank": 165,
+      "rank": 166,
       "id": "MedAIBase/AntAngelMed",
       "author": "MedAIBase",
       "url": "https://huggingface.co/MedAIBase/AntAngelMed",
@@ -4906,7 +4944,7 @@
       "lastModified": "2026-04-14T06:03:51.000Z"
     },
     {
-      "rank": 166,
+      "rank": 167,
       "id": "sentence-transformers/all-MiniLM-L6-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
@@ -4951,11 +4989,11 @@
       "lastModified": "2025-03-06T13:37:44.000Z"
     },
     {
-      "rank": 167,
+      "rank": 168,
       "id": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
-      "downloads": 101,
+      "downloads": 123,
       "likes": 33,
       "trendingScore": 33,
       "pipelineTag": "text-to-audio",
@@ -4980,7 +5018,38 @@
       "lastModified": "2026-05-26T09:41:39.000Z"
     },
     {
-      "rank": 168,
+      "rank": 169,
+      "id": "nvidia/DeepSeek-V4-Pro-NVFP4",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4",
+      "downloads": 2530,
+      "likes": 34,
+      "trendingScore": 33,
+      "pipelineTag": "text-generation",
+      "libraryName": "Model Optimizer",
+      "tags": [
+        "Model Optimizer",
+        "safetensors",
+        "deepseek_v4",
+        "nvidia",
+        "ModelOpt",
+        "DeepSeekV4",
+        "quantized",
+        "NVFP4",
+        "nvfp4",
+        "text-generation",
+        "base_model:deepseek-ai/DeepSeek-V4-Pro",
+        "base_model:quantized:deepseek-ai/DeepSeek-V4-Pro",
+        "license:mit",
+        "8-bit",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-14T19:48:36.000Z",
+      "lastModified": "2026-05-29T05:47:42.000Z"
+    },
+    {
+      "rank": 170,
       "id": "Qwen/WebWorld-32B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/WebWorld-32B",
@@ -5024,7 +5093,7 @@
       "lastModified": "2026-05-08T12:11:35.000Z"
     },
     {
-      "rank": 169,
+      "rank": 171,
       "id": "fishaudio/s2-pro",
       "author": "fishaudio",
       "url": "https://huggingface.co/fishaudio/s2-pro",
@@ -5069,7 +5138,7 @@
       "lastModified": "2026-03-11T15:32:58.000Z"
     },
     {
-      "rank": 170,
+      "rank": 172,
       "id": "Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ",
@@ -5097,7 +5166,7 @@
       "lastModified": "2026-05-19T21:32:32.000Z"
     },
     {
-      "rank": 171,
+      "rank": 173,
       "id": "tencent/Hy-MT2-7B-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-GGUF",
@@ -5120,7 +5189,7 @@
       "lastModified": "2026-05-26T09:06:21.000Z"
     },
     {
-      "rank": 172,
+      "rank": 174,
       "id": "black-forest-labs/FLUX.2-klein-9B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B",
@@ -5145,11 +5214,11 @@
       "lastModified": "2026-02-24T00:17:09.000Z"
     },
     {
-      "rank": 173,
+      "rank": 175,
       "id": "ernie-research/NAVA",
       "author": "ernie-research",
       "url": "https://huggingface.co/ernie-research/NAVA",
-      "downloads": 25,
+      "downloads": 71,
       "likes": 32,
       "trendingScore": 32,
       "pipelineTag": "text-to-video",
@@ -5173,75 +5242,6 @@
       ],
       "createdAt": "2026-05-29T02:17:22.000Z",
       "lastModified": "2026-05-30T18:07:53.000Z"
-    },
-    {
-      "rank": 174,
-      "id": "nvidia/DeepSeek-V4-Pro-NVFP4",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/DeepSeek-V4-Pro-NVFP4",
-      "downloads": 2356,
-      "likes": 33,
-      "trendingScore": 32,
-      "pipelineTag": "text-generation",
-      "libraryName": "Model Optimizer",
-      "tags": [
-        "Model Optimizer",
-        "safetensors",
-        "deepseek_v4",
-        "nvidia",
-        "ModelOpt",
-        "DeepSeekV4",
-        "quantized",
-        "NVFP4",
-        "nvfp4",
-        "text-generation",
-        "base_model:deepseek-ai/DeepSeek-V4-Pro",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Pro",
-        "license:mit",
-        "8-bit",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-14T19:48:36.000Z",
-      "lastModified": "2026-05-29T05:47:42.000Z"
-    },
-    {
-      "rank": 175,
-      "id": "unsloth/LFM2.5-8B-A1B-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/LFM2.5-8B-A1B-GGUF",
-      "downloads": 7170,
-      "likes": 32,
-      "trendingScore": 32,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "liquid",
-        "unsloth",
-        "lfm2.5",
-        "edge",
-        "text-generation",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "arxiv:2511.23404",
-        "base_model:LiquidAI/LFM2.5-8B-A1B",
-        "base_model:quantized:LiquidAI/LFM2.5-8B-A1B",
-        "license:other",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-29T09:11:04.000Z",
-      "lastModified": "2026-05-30T11:13:02.000Z"
     },
     {
       "rank": 176,
@@ -5762,6 +5762,39 @@
     },
     {
       "rank": 193,
+      "id": "Qwen/Qwen-Image-Bench",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image-Bench",
+      "downloads": 2580,
+      "likes": 30,
+      "trendingScore": 30,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5",
+        "image-text-to-text",
+        "judge-model",
+        "text-to-image",
+        "evaluation",
+        "benchmark",
+        "qwen",
+        "conversational",
+        "en",
+        "zh",
+        "arxiv:2605.28091",
+        "base_model:Qwen/Qwen3.6-27B",
+        "base_model:finetune:Qwen/Qwen3.6-27B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T04:15:56.000Z",
+      "lastModified": "2026-05-28T08:07:27.000Z"
+    },
+    {
+      "rank": 194,
       "id": "ibm-granite/granite-vision-4.1-4b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-vision-4.1-4b",
@@ -5792,7 +5825,7 @@
       "lastModified": "2026-05-06T14:23:30.000Z"
     },
     {
-      "rank": 194,
+      "rank": 195,
       "id": "Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
       "author": "Cseti",
       "url": "https://huggingface.co/Cseti/LTX2.3-22B_ReStyle_IC-LoRA",
@@ -5815,7 +5848,7 @@
       "lastModified": "2026-05-06T07:55:41.000Z"
     },
     {
-      "rank": 195,
+      "rank": 196,
       "id": "oumoumad/ltx-2.3-dearchive-lora",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/ltx-2.3-dearchive-lora",
@@ -5842,7 +5875,7 @@
       "lastModified": "2026-05-09T14:52:36.000Z"
     },
     {
-      "rank": 196,
+      "rank": 197,
       "id": "Grio43/OppaiOracle",
       "author": "Grio43",
       "url": "https://huggingface.co/Grio43/OppaiOracle",
@@ -5873,7 +5906,7 @@
       "lastModified": "2026-05-10T01:13:14.000Z"
     },
     {
-      "rank": 197,
+      "rank": 198,
       "id": "sensenova/SenseNova-U1-8B-MoT-Infographic",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic",
@@ -5902,7 +5935,7 @@
       "lastModified": "2026-05-16T06:48:11.000Z"
     },
     {
-      "rank": 198,
+      "rank": 199,
       "id": "pyannote/speaker-diarization-community-1",
       "author": "pyannote",
       "url": "https://huggingface.co/pyannote/speaker-diarization-community-1",
@@ -5935,7 +5968,7 @@
       "lastModified": "2025-09-29T08:43:24.000Z"
     },
     {
-      "rank": 199,
+      "rank": 200,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF",
@@ -5966,7 +5999,7 @@
       "lastModified": "2026-05-28T12:10:52.000Z"
     },
     {
-      "rank": 200,
+      "rank": 201,
       "id": "Jackrong/Qwopus3.6-27B-v2",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2",
@@ -6010,7 +6043,7 @@
       "lastModified": "2026-05-23T00:38:29.000Z"
     },
     {
-      "rank": 201,
+      "rank": 202,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-V2-APEX-MTP-GGUF",
@@ -6041,39 +6074,6 @@
       ],
       "createdAt": "2026-05-21T12:23:23.000Z",
       "lastModified": "2026-05-29T14:35:58.000Z"
-    },
-    {
-      "rank": 202,
-      "id": "Qwen/Qwen-Image-Bench",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image-Bench",
-      "downloads": 1838,
-      "likes": 29,
-      "trendingScore": 29,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen3_5",
-        "image-text-to-text",
-        "judge-model",
-        "text-to-image",
-        "evaluation",
-        "benchmark",
-        "qwen",
-        "conversational",
-        "en",
-        "zh",
-        "arxiv:2605.28091",
-        "base_model:Qwen/Qwen3.6-27B",
-        "base_model:finetune:Qwen/Qwen3.6-27B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T04:15:56.000Z",
-      "lastModified": "2026-05-28T08:07:27.000Z"
     },
     {
       "rank": 203,
@@ -6753,7 +6753,7 @@
       "id": "Kaikaku/epicure-cooc",
       "author": "Kaikaku",
       "url": "https://huggingface.co/Kaikaku/epicure-cooc",
-      "downloads": 291,
+      "downloads": 564,
       "likes": 26,
       "trendingScore": 26,
       "pipelineTag": "feature-extraction",
@@ -6789,7 +6789,7 @@
       "id": "Comfy-Org/PixelDiT",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/PixelDiT",
-      "downloads": 16844,
+      "downloads": 20582,
       "likes": 26,
       "trendingScore": 26,
       "pipelineTag": null,
@@ -6805,6 +6805,59 @@
     },
     {
       "rank": 228,
+      "id": "nvidia/kokoro-82M-onnx-opt",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/kokoro-82M-onnx-opt",
+      "downloads": 0,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "onnx",
+        "en",
+        "arxiv:2306.07691",
+        "arxiv:2203.02395",
+        "base_model:hexgrad/Kokoro-82M",
+        "base_model:quantized:hexgrad/Kokoro-82M",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-28T18:52:47.000Z",
+      "lastModified": "2026-05-29T12:44:09.000Z"
+    },
+    {
+      "rank": 229,
+      "id": "stepfun-ai/Step-3.7-Flash-NVFP4",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-NVFP4",
+      "downloads": 23998,
+      "likes": 26,
+      "trendingScore": 26,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "8-bit",
+        "modelopt",
+        "region:us"
+      ],
+      "createdAt": "2026-05-27T12:35:59.000Z",
+      "lastModified": "2026-05-29T10:04:39.000Z"
+    },
+    {
+      "rank": 230,
       "id": "lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
       "author": "lordx64",
       "url": "https://huggingface.co/lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled",
@@ -6842,7 +6895,7 @@
       "lastModified": "2026-04-23T02:35:07.000Z"
     },
     {
-      "rank": 229,
+      "rank": 231,
       "id": "talkie-lm/talkie-1930-13b-base",
       "author": "talkie-lm",
       "url": "https://huggingface.co/talkie-lm/talkie-1930-13b-base",
@@ -6860,7 +6913,7 @@
       "lastModified": "2026-04-23T09:04:31.000Z"
     },
     {
-      "rank": 230,
+      "rank": 232,
       "id": "nvidia/Lyra-2.0",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Lyra-2.0",
@@ -6880,7 +6933,7 @@
       "lastModified": "2026-04-23T19:32:47.000Z"
     },
     {
-      "rank": 231,
+      "rank": 233,
       "id": "nvidia/Efficient-DLM-4B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-4B",
@@ -6907,7 +6960,7 @@
       "lastModified": "2026-05-03T00:42:52.000Z"
     },
     {
-      "rank": 232,
+      "rank": 234,
       "id": "WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
       "author": "WarmBloodAban",
       "url": "https://huggingface.co/WarmBloodAban/Singularity_LTX-2.3_OmniCine_Preview0.1",
@@ -6933,7 +6986,7 @@
       "lastModified": "2026-05-09T18:26:39.000Z"
     },
     {
-      "rank": 233,
+      "rank": 235,
       "id": "OrionLLM/GRM-2.6-Opus",
       "author": "OrionLLM",
       "url": "https://huggingface.co/OrionLLM/GRM-2.6-Opus",
@@ -6959,7 +7012,7 @@
       "lastModified": "2026-05-10T22:11:12.000Z"
     },
     {
-      "rank": 234,
+      "rank": 236,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-BF16",
@@ -6996,7 +7049,7 @@
       "lastModified": "2026-05-08T03:42:12.000Z"
     },
     {
-      "rank": 235,
+      "rank": 237,
       "id": "rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
       "author": "rizzlaa",
       "url": "https://huggingface.co/rizzlaa/INSTARAW-2.0-WORKFLOW-CUSTOM",
@@ -7012,7 +7065,7 @@
       "lastModified": "2026-05-16T22:29:06.000Z"
     },
     {
-      "rank": 236,
+      "rank": 238,
       "id": "ggml-org/MiniCPM-V-4.6-GGUF",
       "author": "ggml-org",
       "url": "https://huggingface.co/ggml-org/MiniCPM-V-4.6-GGUF",
@@ -7035,7 +7088,7 @@
       "lastModified": "2026-05-11T21:40:48.000Z"
     },
     {
-      "rank": 237,
+      "rank": 239,
       "id": "Nimbz/Gemma-4-Gembrain-31B",
       "author": "Nimbz",
       "url": "https://huggingface.co/Nimbz/Gemma-4-Gembrain-31B",
@@ -7077,7 +7130,7 @@
       "lastModified": "2026-05-12T12:42:49.000Z"
     },
     {
-      "rank": 238,
+      "rank": 240,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-SFT",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-SFT",
@@ -7116,7 +7169,7 @@
       "lastModified": "2026-05-15T03:09:50.000Z"
     },
     {
-      "rank": 239,
+      "rank": 241,
       "id": "FINAL-Bench/Darwin-28B-REASON",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-REASON",
@@ -7161,7 +7214,7 @@
       "lastModified": "2026-05-17T09:32:18.000Z"
     },
     {
-      "rank": 240,
+      "rank": 242,
       "id": "HuggingFaceBio/Carbon-500M",
       "author": "HuggingFaceBio",
       "url": "https://huggingface.co/HuggingFaceBio/Carbon-500M",
@@ -7187,30 +7240,7 @@
       "lastModified": "2026-05-20T13:40:43.000Z"
     },
     {
-      "rank": 241,
-      "id": "nvidia/kokoro-82M-onnx-opt",
-      "author": "nvidia",
-      "url": "https://huggingface.co/nvidia/kokoro-82M-onnx-opt",
-      "downloads": 0,
-      "likes": 25,
-      "trendingScore": 25,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "onnx",
-        "en",
-        "arxiv:2306.07691",
-        "arxiv:2203.02395",
-        "base_model:hexgrad/Kokoro-82M",
-        "base_model:quantized:hexgrad/Kokoro-82M",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-28T18:52:47.000Z",
-      "lastModified": "2026-05-29T12:44:09.000Z"
-    },
-    {
-      "rank": 242,
+      "rank": 243,
       "id": "nvidia/Gemma-4-31B-IT-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Gemma-4-31B-IT-NVFP4",
@@ -7242,7 +7272,7 @@
       "lastModified": "2026-05-08T03:33:34.000Z"
     },
     {
-      "rank": 243,
+      "rank": 244,
       "id": "wikeeyang/Flux2-Klein-9B-True-V2",
       "author": "wikeeyang",
       "url": "https://huggingface.co/wikeeyang/Flux2-Klein-9B-True-V2",
@@ -7266,7 +7296,7 @@
       "lastModified": "2026-04-16T01:57:36.000Z"
     },
     {
-      "rank": 244,
+      "rank": 245,
       "id": "kpsss34/FHDR_Uncensored",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/FHDR_Uncensored",
@@ -7293,7 +7323,7 @@
       "lastModified": "2026-02-27T02:17:36.000Z"
     },
     {
-      "rank": 245,
+      "rank": 246,
       "id": "LocalAI-io/LocalVQE",
       "author": "LocalAI-io",
       "url": "https://huggingface.co/LocalAI-io/LocalVQE",
@@ -7318,7 +7348,7 @@
       "lastModified": "2026-05-05T05:46:29.000Z"
     },
     {
-      "rank": 246,
+      "rank": 247,
       "id": "ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
       "author": "ADSKAILab",
       "url": "https://huggingface.co/ADSKAILab/Zero-To-CAD-Qwen3-VL-2B",
@@ -7354,7 +7384,7 @@
       "lastModified": "2026-05-05T21:50:47.000Z"
     },
     {
-      "rank": 247,
+      "rank": 248,
       "id": "Kijai/hidream-O1-image_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/hidream-O1-image_comfy",
@@ -7370,7 +7400,7 @@
       "lastModified": "2026-05-15T16:12:13.000Z"
     },
     {
-      "rank": 248,
+      "rank": 249,
       "id": "Abiray/LTX2.3-10Eros-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX2.3-10Eros-GGUF",
@@ -7391,7 +7421,7 @@
       "lastModified": "2026-05-12T04:18:52.000Z"
     },
     {
-      "rank": 249,
+      "rank": 250,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B",
@@ -7414,7 +7444,7 @@
       "lastModified": "2026-05-23T01:01:21.000Z"
     },
     {
-      "rank": 250,
+      "rank": 251,
       "id": "zghhui/OmniNFT",
       "author": "zghhui",
       "url": "https://huggingface.co/zghhui/OmniNFT",
@@ -7441,7 +7471,7 @@
       "lastModified": "2026-05-19T03:47:56.000Z"
     },
     {
-      "rank": 251,
+      "rank": 252,
       "id": "SupraLabs/Supra-50M-Instruct",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Instruct",
@@ -7480,11 +7510,11 @@
       "lastModified": "2026-05-27T13:52:37.000Z"
     },
     {
-      "rank": 252,
+      "rank": 253,
       "id": "Jackrong/Qwopus3.5-4B-Coder-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-4B-Coder-MTP-GGUF",
-      "downloads": 2315,
+      "downloads": 3903,
       "likes": 24,
       "trendingScore": 24,
       "pipelineTag": "image-text-to-text",
@@ -7525,7 +7555,7 @@
       "lastModified": "2026-05-30T10:44:25.000Z"
     },
     {
-      "rank": 253,
+      "rank": 254,
       "id": "Qwen/Qwen3.6-27B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-27B-FP8",
@@ -7552,7 +7582,7 @@
       "lastModified": "2026-04-24T02:39:18.000Z"
     },
     {
-      "rank": 254,
+      "rank": 255,
       "id": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
@@ -7581,7 +7611,7 @@
       "lastModified": "2026-01-30T06:29:38.000Z"
     },
     {
-      "rank": 255,
+      "rank": 256,
       "id": "vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Music_Video_Creator_ComfyUI",
@@ -7598,7 +7628,7 @@
       "lastModified": "2026-05-09T03:08:46.000Z"
     },
     {
-      "rank": 256,
+      "rank": 257,
       "id": "Abiray/Sulphur-2-base-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Sulphur-2-base-GGUF",
@@ -7619,7 +7649,7 @@
       "lastModified": "2026-05-12T04:19:47.000Z"
     },
     {
-      "rank": 257,
+      "rank": 258,
       "id": "microsoft/TRELLIS.2-4B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
@@ -7640,7 +7670,7 @@
       "lastModified": "2025-12-27T13:21:56.000Z"
     },
     {
-      "rank": 258,
+      "rank": 259,
       "id": "nvidia/Kimi-K2.6-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Kimi-K2.6-NVFP4",
@@ -7672,7 +7702,7 @@
       "lastModified": "2026-05-15T17:40:07.000Z"
     },
     {
-      "rank": 259,
+      "rank": 260,
       "id": "Simplified-Reasoning/SU-01",
       "author": "Simplified-Reasoning",
       "url": "https://huggingface.co/Simplified-Reasoning/SU-01",
@@ -7703,7 +7733,7 @@
       "lastModified": "2026-05-20T09:44:56.000Z"
     },
     {
-      "rank": 260,
+      "rank": 261,
       "id": "prism-ml/bonsai-image-binary-4B-gemlite-1bit",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-binary-4B-gemlite-1bit",
@@ -7733,11 +7763,11 @@
       "lastModified": "2026-05-26T16:16:58.000Z"
     },
     {
-      "rank": 261,
+      "rank": 262,
       "id": "FINAL-Bench/Darwin-60B-DUO",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-60B-DUO",
-      "downloads": 370,
+      "downloads": 398,
       "likes": 29,
       "trendingScore": 23,
       "pipelineTag": "text-generation",
@@ -7772,7 +7802,7 @@
       "lastModified": "2026-05-28T03:21:23.000Z"
     },
     {
-      "rank": 262,
+      "rank": 263,
       "id": "prism-ml/bonsai-image-ternary-4B-unpacked",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
@@ -7796,36 +7826,6 @@
       ],
       "createdAt": "2026-05-21T16:07:19.000Z",
       "lastModified": "2026-05-28T22:23:51.000Z"
-    },
-    {
-      "rank": 263,
-      "id": "stepfun-ai/Step-3.7-Flash-NVFP4",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-NVFP4",
-      "downloads": 15300,
-      "likes": 23,
-      "trendingScore": 23,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "step3p7",
-        "text-generation",
-        "vision-language",
-        "multimodal",
-        "moe",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "8-bit",
-        "modelopt",
-        "region:us"
-      ],
-      "createdAt": "2026-05-27T12:35:59.000Z",
-      "lastModified": "2026-05-29T10:04:39.000Z"
     },
     {
       "rank": 264,
@@ -9568,7 +9568,7 @@
       "id": "avaturn-live/avtr-1",
       "author": "avaturn-live",
       "url": "https://huggingface.co/avaturn-live/avtr-1",
-      "downloads": 235,
+      "downloads": 281,
       "likes": 19,
       "trendingScore": 19,
       "pipelineTag": "image-to-video",
@@ -9619,7 +9619,7 @@
       "id": "openbmb/MiniCPM5-1B-SFT",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM5-1B-SFT",
-      "downloads": 2077,
+      "downloads": 2646,
       "likes": 22,
       "trendingScore": 19,
       "pipelineTag": "text-generation",
@@ -9656,6 +9656,56 @@
     },
     {
       "rank": 326,
+      "id": "AmmarkoV/SAM3DBody-cpp-onnx-models",
+      "author": "AmmarkoV",
+      "url": "https://huggingface.co/AmmarkoV/SAM3DBody-cpp-onnx-models",
+      "downloads": 0,
+      "likes": 21,
+      "trendingScore": 19,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "onnx",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-24T08:43:15.000Z",
+      "lastModified": "2026-05-28T20:44:53.000Z"
+    },
+    {
+      "rank": 327,
+      "id": "Abiray/MiniCPM5-1B-GGUF",
+      "author": "Abiray",
+      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
+      "downloads": 5815,
+      "likes": 19,
+      "trendingScore": 19,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "gguf",
+        "minicpm",
+        "minicpm5",
+        "llama",
+        "text-generation",
+        "tool-calling",
+        "on-device",
+        "edge-ai",
+        "llama.cpp",
+        "en",
+        "zh",
+        "base_model:openbmb/MiniCPM5-1B",
+        "base_model:quantized:openbmb/MiniCPM5-1B",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-26T04:47:48.000Z",
+      "lastModified": "2026-05-28T14:08:39.000Z"
+    },
+    {
+      "rank": 328,
       "id": "AesSedai/MiMo-V2.5-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/MiMo-V2.5-GGUF",
@@ -9677,7 +9727,7 @@
       "lastModified": "2026-05-07T10:17:59.000Z"
     },
     {
-      "rank": 327,
+      "rank": 329,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Thinking",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Thinking",
@@ -9711,7 +9761,7 @@
       "lastModified": "2026-05-01T15:12:38.000Z"
     },
     {
-      "rank": 328,
+      "rank": 330,
       "id": "kpsss34/Walkyrie-1.3B-v1.0",
       "author": "kpsss34",
       "url": "https://huggingface.co/kpsss34/Walkyrie-1.3B-v1.0",
@@ -9735,7 +9785,7 @@
       "lastModified": "2026-05-11T09:01:21.000Z"
     },
     {
-      "rank": 329,
+      "rank": 331,
       "id": "baidu/ERNIE-Image",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image",
@@ -9757,7 +9807,7 @@
       "lastModified": "2026-04-17T02:33:16.000Z"
     },
     {
-      "rank": 330,
+      "rank": 332,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-GGUF",
@@ -9786,7 +9836,7 @@
       "lastModified": "2026-05-10T08:57:13.000Z"
     },
     {
-      "rank": 331,
+      "rank": 333,
       "id": "openbmb/MiniCPM-V-4.6-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf",
@@ -9818,7 +9868,7 @@
       "lastModified": "2026-05-19T15:33:30.000Z"
     },
     {
-      "rank": 332,
+      "rank": 334,
       "id": "BigDannyPt/Wan-2.2-Remix-GGUF",
       "author": "BigDannyPt",
       "url": "https://huggingface.co/BigDannyPt/Wan-2.2-Remix-GGUF",
@@ -9836,7 +9886,7 @@
       "lastModified": "2026-03-30T16:27:22.000Z"
     },
     {
-      "rank": 333,
+      "rank": 335,
       "id": "Comfy-Org/TRELLIS.2",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/TRELLIS.2",
@@ -9854,7 +9904,7 @@
       "lastModified": "2026-05-19T23:22:30.000Z"
     },
     {
-      "rank": 334,
+      "rank": 336,
       "id": "stabilityai/stable-audio-3-medium-base",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-medium-base",
@@ -9880,7 +9930,7 @@
       "lastModified": "2026-05-19T20:02:40.000Z"
     },
     {
-      "rank": 335,
+      "rank": 337,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated-MTP-GGUF",
@@ -9908,7 +9958,7 @@
       "lastModified": "2026-05-19T08:16:03.000Z"
     },
     {
-      "rank": 336,
+      "rank": 338,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-MTP-GGUF",
@@ -9940,7 +9990,7 @@
       "lastModified": "2026-05-21T21:34:54.000Z"
     },
     {
-      "rank": 337,
+      "rank": 339,
       "id": "rhasspy/piper-voices",
       "author": "rhasspy",
       "url": "https://huggingface.co/rhasspy/piper-voices",
@@ -9985,7 +10035,7 @@
       "lastModified": "2026-05-15T17:21:53.000Z"
     },
     {
-      "rank": 338,
+      "rank": 340,
       "id": "meta-llama/Llama-3.2-1B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B",
@@ -10022,7 +10072,7 @@
       "lastModified": "2024-10-24T15:08:03.000Z"
     },
     {
-      "rank": 339,
+      "rank": 341,
       "id": "Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-35B-A3B-v1-MTP-GGUF",
@@ -10067,12 +10117,12 @@
       "lastModified": "2026-05-28T04:24:45.000Z"
     },
     {
-      "rank": 340,
+      "rank": 342,
       "id": "KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
       "author": "KevinJK51",
       "url": "https://huggingface.co/KevinJK51/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking-V2-Hightop-GGUF",
-      "downloads": 28634,
-      "likes": 33,
+      "downloads": 40664,
+      "likes": 32,
       "trendingScore": 18,
       "pipelineTag": "text-generation",
       "libraryName": null,
@@ -10097,7 +10147,7 @@
       "lastModified": "2026-05-22T09:41:49.000Z"
     },
     {
-      "rank": 341,
+      "rank": 343,
       "id": "Qwen/Qwen3-ASR-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-ASR-1.7B",
@@ -10120,29 +10170,11 @@
       "lastModified": "2026-01-30T03:00:12.000Z"
     },
     {
-      "rank": 342,
-      "id": "AmmarkoV/SAM3DBody-cpp-onnx-models",
-      "author": "AmmarkoV",
-      "url": "https://huggingface.co/AmmarkoV/SAM3DBody-cpp-onnx-models",
-      "downloads": 0,
-      "likes": 20,
-      "trendingScore": 18,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "onnx",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-24T08:43:15.000Z",
-      "lastModified": "2026-05-28T20:44:53.000Z"
-    },
-    {
-      "rank": 343,
+      "rank": 344,
       "id": "AesSedai/Step-3.7-Flash-GGUF",
       "author": "AesSedai",
       "url": "https://huggingface.co/AesSedai/Step-3.7-Flash-GGUF",
-      "downloads": 702,
+      "downloads": 1322,
       "likes": 18,
       "trendingScore": 18,
       "pipelineTag": null,
@@ -10160,7 +10192,7 @@
       "lastModified": "2026-05-29T18:39:12.000Z"
     },
     {
-      "rank": 344,
+      "rank": 345,
       "id": "DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking",
@@ -10205,7 +10237,7 @@
       "lastModified": "2026-04-30T07:44:29.000Z"
     },
     {
-      "rank": 345,
+      "rank": 346,
       "id": "josephmayo/Qwopus-9B-Unfettered",
       "author": "josephmayo",
       "url": "https://huggingface.co/josephmayo/Qwopus-9B-Unfettered",
@@ -10234,7 +10266,7 @@
       "lastModified": "2026-05-03T01:12:27.000Z"
     },
     {
-      "rank": 346,
+      "rank": 347,
       "id": "LH-Tech-AI/TinyMozart_v2_85M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/TinyMozart_v2_85M",
@@ -10263,7 +10295,7 @@
       "lastModified": "2026-05-03T18:43:45.000Z"
     },
     {
-      "rank": 347,
+      "rank": 348,
       "id": "mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-APEX-GGUF",
@@ -10295,7 +10327,7 @@
       "lastModified": "2026-04-27T14:00:34.000Z"
     },
     {
-      "rank": 348,
+      "rank": 349,
       "id": "AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -10325,7 +10357,7 @@
       "lastModified": "2026-05-09T08:57:56.000Z"
     },
     {
-      "rank": 349,
+      "rank": 350,
       "id": "houyuanchen/UniVidX",
       "author": "houyuanchen",
       "url": "https://huggingface.co/houyuanchen/UniVidX",
@@ -10346,7 +10378,7 @@
       "lastModified": "2026-05-04T02:12:15.000Z"
     },
     {
-      "rank": 350,
+      "rank": 351,
       "id": "DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-3-it-vl-40B-Gemini-Heretic-Uncensored-Thinking",
@@ -10391,7 +10423,7 @@
       "lastModified": "2026-04-04T07:35:47.000Z"
     },
     {
-      "rank": 351,
+      "rank": 352,
       "id": "llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-26B-A4B-it-ultra-uncensored-heretic-GGUF",
@@ -10420,7 +10452,7 @@
       "lastModified": "2026-04-11T00:25:57.000Z"
     },
     {
-      "rank": 352,
+      "rank": 353,
       "id": "caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
       "author": "caiovicentino1",
       "url": "https://huggingface.co/caiovicentino1/LTX-2.3-22B-HLWQ-Q5",
@@ -10448,7 +10480,7 @@
       "lastModified": "2026-04-13T18:51:02.000Z"
     },
     {
-      "rank": 353,
+      "rank": 354,
       "id": "Qwen/Qwen-Image-2512",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-2512",
@@ -10473,7 +10505,7 @@
       "lastModified": "2025-12-31T09:47:56.000Z"
     },
     {
-      "rank": 354,
+      "rank": 355,
       "id": "google/gemma-4-E4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E4B",
@@ -10496,7 +10528,7 @@
       "lastModified": "2026-04-02T16:14:15.000Z"
     },
     {
-      "rank": 355,
+      "rank": 356,
       "id": "tencent/Hunyuan3D-2.1",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
@@ -10523,7 +10555,7 @@
       "lastModified": "2025-10-17T10:10:42.000Z"
     },
     {
-      "rank": 356,
+      "rank": 357,
       "id": "openbmb/MiniCPM-V-4.6-Thinking",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking",
@@ -10549,7 +10581,7 @@
       "lastModified": "2026-05-11T14:57:17.000Z"
     },
     {
-      "rank": 357,
+      "rank": 358,
       "id": "Datadog/Toto-2.0-313m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-313m",
@@ -10578,7 +10610,7 @@
       "lastModified": "2026-05-20T14:31:46.000Z"
     },
     {
-      "rank": 358,
+      "rank": 359,
       "id": "coqui/XTTS-v2",
       "author": "coqui",
       "url": "https://huggingface.co/coqui/XTTS-v2",
@@ -10597,7 +10629,7 @@
       "lastModified": "2023-12-11T17:50:00.000Z"
     },
     {
-      "rank": 359,
+      "rank": 360,
       "id": "Qwen/Qwen3-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-0.6B",
@@ -10625,7 +10657,7 @@
       "lastModified": "2025-07-26T03:46:27.000Z"
     },
     {
-      "rank": 360,
+      "rank": 361,
       "id": "openai/whisper-large-v3-turbo",
       "author": "openai",
       "url": "https://huggingface.co/openai/whisper-large-v3-turbo",
@@ -10670,7 +10702,7 @@
       "lastModified": "2024-10-04T14:51:11.000Z"
     },
     {
-      "rank": 361,
+      "rank": 362,
       "id": "datalab-to/chandra-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/chandra-ocr-2",
@@ -10698,7 +10730,7 @@
       "lastModified": "2026-03-18T18:21:07.000Z"
     },
     {
-      "rank": 362,
+      "rank": 363,
       "id": "numind/NuMarkdown-8B-Thinking",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuMarkdown-8B-Thinking",
@@ -10729,7 +10761,7 @@
       "lastModified": "2026-05-19T19:01:34.000Z"
     },
     {
-      "rank": 363,
+      "rank": 364,
       "id": "meta-llama/Llama-3.2-1B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
@@ -10767,7 +10799,7 @@
       "lastModified": "2024-10-24T15:07:51.000Z"
     },
     {
-      "rank": 364,
+      "rank": 365,
       "id": "allura-org/Qwen3.6-35B-A3B-Anko",
       "author": "allura-org",
       "url": "https://huggingface.co/allura-org/Qwen3.6-35B-A3B-Anko",
@@ -10790,43 +10822,11 @@
       "lastModified": "2026-04-23T15:43:25.000Z"
     },
     {
-      "rank": 365,
-      "id": "Abiray/MiniCPM5-1B-GGUF",
-      "author": "Abiray",
-      "url": "https://huggingface.co/Abiray/MiniCPM5-1B-GGUF",
-      "downloads": 4861,
-      "likes": 17,
-      "trendingScore": 17,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "gguf",
-        "minicpm",
-        "minicpm5",
-        "llama",
-        "text-generation",
-        "tool-calling",
-        "on-device",
-        "edge-ai",
-        "llama.cpp",
-        "en",
-        "zh",
-        "base_model:openbmb/MiniCPM5-1B",
-        "base_model:quantized:openbmb/MiniCPM5-1B",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-26T04:47:48.000Z",
-      "lastModified": "2026-05-28T14:08:39.000Z"
-    },
-    {
       "rank": 366,
       "id": "syntropy-ai/Soren-1-Small",
       "author": "syntropy-ai",
       "url": "https://huggingface.co/syntropy-ai/Soren-1-Small",
-      "downloads": 286,
+      "downloads": 842,
       "likes": 17,
       "trendingScore": 17,
       "pipelineTag": "text-generation",
@@ -10864,7 +10864,7 @@
         "supervised-finetuning"
       ],
       "createdAt": "2026-05-20T13:40:32.000Z",
-      "lastModified": "2026-05-29T15:19:32.000Z"
+      "lastModified": "2026-05-31T08:41:51.000Z"
     },
     {
       "rank": 367,
@@ -11245,8 +11245,8 @@
       "id": "Kijai/WanVideo_comfy",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy",
-      "downloads": 5065786,
-      "likes": 2339,
+      "downloads": 4614677,
+      "likes": 2343,
       "trendingScore": 16,
       "pipelineTag": null,
       "libraryName": "diffusion-single-file",
@@ -11608,7 +11608,7 @@
       "id": "huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-DeepSeek-V4-Flash-abliterated-ds4-GGUF",
-      "downloads": 6496,
+      "downloads": 8130,
       "likes": 16,
       "trendingScore": 16,
       "pipelineTag": null,
@@ -11642,10 +11642,46 @@
         "conversational"
       ],
       "createdAt": "2026-05-26T10:31:39.000Z",
-      "lastModified": "2026-05-27T18:15:42.000Z"
+      "lastModified": "2026-05-31T09:04:22.000Z"
     },
     {
       "rank": 392,
+      "id": "LiquidAI/LFM2.5-8B-A1B-Base",
+      "author": "LiquidAI",
+      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-Base",
+      "downloads": 596,
+      "likes": 16,
+      "trendingScore": 16,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "lfm2_moe",
+        "text-generation",
+        "liquid",
+        "lfm2.5",
+        "edge",
+        "conversational",
+        "en",
+        "ar",
+        "zh",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "es",
+        "pt",
+        "arxiv:2511.23404",
+        "license:other",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-28T10:01:08.000Z",
+      "lastModified": "2026-05-28T20:22:31.000Z"
+    },
+    {
+      "rank": 393,
       "id": "XiaomiMiMo/MiMo-V2.5-ASR",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR",
@@ -11672,7 +11708,7 @@
       "lastModified": "2026-04-24T03:45:28.000Z"
     },
     {
-      "rank": 393,
+      "rank": 394,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
@@ -11717,7 +11753,7 @@
       "lastModified": "2026-05-01T19:37:58.000Z"
     },
     {
-      "rank": 394,
+      "rank": 395,
       "id": "oumoumad/LumiPic",
       "author": "oumoumad",
       "url": "https://huggingface.co/oumoumad/LumiPic",
@@ -11747,7 +11783,7 @@
       "lastModified": "2026-05-07T08:28:25.000Z"
     },
     {
-      "rank": 395,
+      "rank": 396,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-GGUF",
@@ -11777,7 +11813,7 @@
       "lastModified": "2026-05-06T12:11:47.000Z"
     },
     {
-      "rank": 396,
+      "rank": 397,
       "id": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-Medium-3.5-128B-EAGLE",
@@ -11822,7 +11858,7 @@
       "lastModified": "2026-04-30T06:32:10.000Z"
     },
     {
-      "rank": 397,
+      "rank": 398,
       "id": "MaxedOut/ComfyUI-Starter-Packs",
       "author": "MaxedOut",
       "url": "https://huggingface.co/MaxedOut/ComfyUI-Starter-Packs",
@@ -11857,7 +11893,7 @@
       "lastModified": "2026-02-27T09:26:36.000Z"
     },
     {
-      "rank": 398,
+      "rank": 399,
       "id": "Qwen/Qwen3-VL-2B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct",
@@ -11886,7 +11922,7 @@
       "lastModified": "2025-10-23T11:30:44.000Z"
     },
     {
-      "rank": 399,
+      "rank": 400,
       "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -11911,7 +11947,7 @@
       "lastModified": "2025-12-03T08:05:17.000Z"
     },
     {
-      "rank": 400,
+      "rank": 401,
       "id": "pnnbao-ump/VieNeu-TTS-v2",
       "author": "pnnbao-ump",
       "url": "https://huggingface.co/pnnbao-ump/VieNeu-TTS-v2",
@@ -11939,7 +11975,7 @@
       "lastModified": "2026-05-09T00:33:24.000Z"
     },
     {
-      "rank": 401,
+      "rank": 402,
       "id": "unsloth/MiMo-V2.5-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiMo-V2.5-GGUF",
@@ -11970,7 +12006,7 @@
       "lastModified": "2026-05-10T00:13:16.000Z"
     },
     {
-      "rank": 402,
+      "rank": 403,
       "id": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
       "author": "sakamakismile",
       "url": "https://huggingface.co/sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
@@ -12015,7 +12051,7 @@
       "lastModified": "2026-04-29T00:23:09.000Z"
     },
     {
-      "rank": 403,
+      "rank": 404,
       "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
@@ -12042,7 +12078,7 @@
       "lastModified": "2026-04-17T09:42:30.000Z"
     },
     {
-      "rank": 404,
+      "rank": 405,
       "id": "ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
       "author": "ggufbench",
       "url": "https://huggingface.co/ggufbench/Qwen3.6-27B-4bpw-16GB-VRAM",
@@ -12065,7 +12101,7 @@
       "lastModified": "2026-05-06T21:18:36.000Z"
     },
     {
-      "rank": 405,
+      "rank": 406,
       "id": "microsoft/Phi-Ground-Any",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Phi-Ground-Any",
@@ -12092,7 +12128,7 @@
       "lastModified": "2026-05-13T04:00:19.000Z"
     },
     {
-      "rank": 406,
+      "rank": 407,
       "id": "FrontiersMind/Nandi-Mini-150M-Tool-Calling",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-Tool-Calling",
@@ -12118,7 +12154,7 @@
       "lastModified": "2026-04-22T14:02:04.000Z"
     },
     {
-      "rank": 407,
+      "rank": 408,
       "id": "nvidia/personaplex-7b-v1",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/personaplex-7b-v1",
@@ -12148,7 +12184,7 @@
       "lastModified": "2026-03-02T18:03:29.000Z"
     },
     {
-      "rank": 408,
+      "rank": 409,
       "id": "GD-ML/DreamX-World-5B-Cam",
       "author": "GD-ML",
       "url": "https://huggingface.co/GD-ML/DreamX-World-5B-Cam",
@@ -12175,7 +12211,7 @@
       "lastModified": "2026-05-18T11:55:16.000Z"
     },
     {
-      "rank": 409,
+      "rank": 410,
       "id": "llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF",
@@ -12206,7 +12242,7 @@
       "lastModified": "2026-04-10T23:39:26.000Z"
     },
     {
-      "rank": 410,
+      "rank": 411,
       "id": "mudler/Darwin-36B-Opus-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Darwin-36B-Opus-APEX-GGUF",
@@ -12238,7 +12274,7 @@
       "lastModified": "2026-05-15T12:12:22.000Z"
     },
     {
-      "rank": 411,
+      "rank": 412,
       "id": "WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
       "author": "WithinUsAI",
       "url": "https://huggingface.co/WithinUsAI/Opus4.7-GODs.Ghost.Codex-4B.GGuF",
@@ -12283,7 +12319,7 @@
       "lastModified": "2026-05-03T03:53:41.000Z"
     },
     {
-      "rank": 412,
+      "rank": 413,
       "id": "FINAL-Bench/Darwin-28B-Coder",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-28B-Coder",
@@ -12316,7 +12352,7 @@
       "lastModified": "2026-05-20T04:57:31.000Z"
     },
     {
-      "rank": 413,
+      "rank": 414,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic-GGUF",
@@ -12356,7 +12392,7 @@
       "lastModified": "2026-05-23T00:51:18.000Z"
     },
     {
-      "rank": 414,
+      "rank": 415,
       "id": "NousResearch/Hermes-3-Llama-3.1-8B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-8B",
@@ -12397,7 +12433,7 @@
       "lastModified": "2024-09-08T07:39:55.000Z"
     },
     {
-      "rank": 415,
+      "rank": 416,
       "id": "google/gemma-4-E2B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-E2B",
@@ -12420,7 +12456,7 @@
       "lastModified": "2026-04-02T16:14:53.000Z"
     },
     {
-      "rank": 416,
+      "rank": 417,
       "id": "Phr00t/WAN2.2-14B-Rapid-AllInOne",
       "author": "Phr00t",
       "url": "https://huggingface.co/Phr00t/WAN2.2-14B-Rapid-AllInOne",
@@ -12443,7 +12479,7 @@
       "lastModified": "2026-04-06T05:31:09.000Z"
     },
     {
-      "rank": 417,
+      "rank": 418,
       "id": "Qwen/Qwen2.5-7B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
@@ -12474,7 +12510,7 @@
       "lastModified": "2025-01-12T02:10:10.000Z"
     },
     {
-      "rank": 418,
+      "rank": 419,
       "id": "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
       "author": "HauhauCS",
       "url": "https://huggingface.co/HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive",
@@ -12505,7 +12541,7 @@
       "lastModified": "2026-04-05T19:00:54.000Z"
     },
     {
-      "rank": 419,
+      "rank": 420,
       "id": "SyFeee/LTX2.3-Dual-Character-en",
       "author": "SyFeee",
       "url": "https://huggingface.co/SyFeee/LTX2.3-Dual-Character-en",
@@ -12534,7 +12570,7 @@
       "lastModified": "2026-05-21T06:57:29.000Z"
     },
     {
-      "rank": 420,
+      "rank": 421,
       "id": "openai-community/gpt2",
       "author": "openai-community",
       "url": "https://huggingface.co/openai-community/gpt2",
@@ -12567,7 +12603,7 @@
       "lastModified": "2024-02-19T10:57:45.000Z"
     },
     {
-      "rank": 421,
+      "rank": 422,
       "id": "nvidia/Nemotron-Labs-Diffusion-VLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B",
@@ -12593,7 +12629,7 @@
       "lastModified": "2026-05-19T18:52:46.000Z"
     },
     {
-      "rank": 422,
+      "rank": 423,
       "id": "CohereLabs/cohere-transcribe-03-2026",
       "author": "CohereLabs",
       "url": "https://huggingface.co/CohereLabs/cohere-transcribe-03-2026",
@@ -12637,7 +12673,7 @@
       "lastModified": "2026-05-29T16:18:29.000Z"
     },
     {
-      "rank": 423,
+      "rank": 424,
       "id": "stabilityai/SAME-L",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-L",
@@ -12662,11 +12698,11 @@
       "lastModified": "2026-05-19T20:11:14.000Z"
     },
     {
-      "rank": 424,
+      "rank": 425,
       "id": "google/medgemma-1.5-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/medgemma-1.5-4b-it",
-      "downloads": 284535,
+      "downloads": 303369,
       "likes": 640,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
@@ -12707,7 +12743,7 @@
       "lastModified": "2026-04-13T23:20:55.000Z"
     },
     {
-      "rank": 425,
+      "rank": 426,
       "id": "microsoft/Lens-Base",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/Lens-Base",
@@ -12730,11 +12766,11 @@
       "lastModified": "2026-05-22T03:10:01.000Z"
     },
     {
-      "rank": 426,
+      "rank": 427,
       "id": "datalab-to/surya-ocr-2",
       "author": "datalab-to",
       "url": "https://huggingface.co/datalab-to/surya-ocr-2",
-      "downloads": 4908,
+      "downloads": 7865,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
@@ -12759,7 +12795,7 @@
       "lastModified": "2026-05-27T20:33:29.000Z"
     },
     {
-      "rank": 427,
+      "rank": 428,
       "id": "fuckSelf/GPT-SoVITS-Russian",
       "author": "fuckSelf",
       "url": "https://huggingface.co/fuckSelf/GPT-SoVITS-Russian",
@@ -12783,11 +12819,11 @@
       "lastModified": "2025-09-11T14:59:49.000Z"
     },
     {
-      "rank": 428,
+      "rank": 429,
       "id": "biohub/ESMFold2",
       "author": "biohub",
       "url": "https://huggingface.co/biohub/ESMFold2",
-      "downloads": 20465,
+      "downloads": 26882,
       "likes": 18,
       "trendingScore": 15,
       "pipelineTag": null,
@@ -12815,47 +12851,11 @@
       "lastModified": "2026-05-27T16:46:45.000Z"
     },
     {
-      "rank": 429,
-      "id": "LiquidAI/LFM2.5-8B-A1B-Base",
-      "author": "LiquidAI",
-      "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-Base",
-      "downloads": 421,
-      "likes": 15,
-      "trendingScore": 15,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "lfm2_moe",
-        "text-generation",
-        "liquid",
-        "lfm2.5",
-        "edge",
-        "conversational",
-        "en",
-        "ar",
-        "zh",
-        "fr",
-        "de",
-        "ja",
-        "ko",
-        "es",
-        "pt",
-        "arxiv:2511.23404",
-        "license:other",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-28T10:01:08.000Z",
-      "lastModified": "2026-05-28T20:22:31.000Z"
-    },
-    {
       "rank": 430,
       "id": "nvidia/vgg-ttt",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/vgg-ttt",
-      "downloads": 588,
+      "downloads": 626,
       "likes": 16,
       "trendingScore": 15,
       "pipelineTag": "image-to-3d",
@@ -12884,7 +12884,7 @@
       "id": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-35B-A3B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF",
-      "downloads": 5932,
+      "downloads": 6599,
       "likes": 15,
       "trendingScore": 15,
       "pipelineTag": "image-text-to-text",
@@ -12911,6 +12911,33 @@
     },
     {
       "rank": 432,
+      "id": "unsloth/Step-3.7-Flash-GGUF",
+      "author": "unsloth",
+      "url": "https://huggingface.co/unsloth/Step-3.7-Flash-GGUF",
+      "downloads": 6384,
+      "likes": 15,
+      "trendingScore": 15,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "gguf",
+        "vision-language",
+        "unsloth - multimodal - moe",
+        "image-text-to-text",
+        "en",
+        "base_model:stepfun-ai/Step-3.7-Flash",
+        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us",
+        "conversational"
+      ],
+      "createdAt": "2026-05-29T12:19:10.000Z",
+      "lastModified": "2026-05-30T04:48:31.000Z"
+    },
+    {
+      "rank": 433,
       "id": "moondream/moondream3-preview",
       "author": "moondream",
       "url": "https://huggingface.co/moondream/moondream3-preview",
@@ -12934,7 +12961,7 @@
       "lastModified": "2026-04-09T22:55:40.000Z"
     },
     {
-      "rank": 433,
+      "rank": 434,
       "id": "Qwen/Qwen3.5-0.8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-0.8B",
@@ -12961,7 +12988,7 @@
       "lastModified": "2026-03-02T11:26:58.000Z"
     },
     {
-      "rank": 434,
+      "rank": 435,
       "id": "unsloth/Kimi-K2.6-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Kimi-K2.6-GGUF",
@@ -12989,7 +13016,7 @@
       "lastModified": "2026-04-22T11:59:50.000Z"
     },
     {
-      "rank": 435,
+      "rank": 436,
       "id": "deepseek-ai/DeepSeek-V4-Pro-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -13008,7 +13035,7 @@
       "lastModified": "2026-04-27T06:51:19.000Z"
     },
     {
-      "rank": 436,
+      "rank": 437,
       "id": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
@@ -13040,7 +13067,7 @@
       "lastModified": "2026-05-05T14:35:05.000Z"
     },
     {
-      "rank": 437,
+      "rank": 438,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-GGUF",
@@ -13069,7 +13096,7 @@
       "lastModified": "2026-04-27T22:11:46.000Z"
     },
     {
-      "rank": 438,
+      "rank": 439,
       "id": "black-forest-labs/FLUX.2-klein-4B",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
@@ -13095,7 +13122,7 @@
       "lastModified": "2026-02-24T00:18:56.000Z"
     },
     {
-      "rank": 439,
+      "rank": 440,
       "id": "microsoft/VibeVoice-1.5B",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/VibeVoice-1.5B",
@@ -13123,7 +13150,7 @@
       "lastModified": "2026-01-22T07:22:28.000Z"
     },
     {
-      "rank": 440,
+      "rank": 441,
       "id": "cmpatino/nanowhale-100m",
       "author": "cmpatino",
       "url": "https://huggingface.co/cmpatino/nanowhale-100m",
@@ -13157,7 +13184,7 @@
       "lastModified": "2026-05-05T13:26:44.000Z"
     },
     {
-      "rank": 441,
+      "rank": 442,
       "id": "Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
       "author": "Radamanthys11",
       "url": "https://huggingface.co/Radamanthys11/Gemma-4-31B-it-assistant-GGUF",
@@ -13183,7 +13210,7 @@
       "lastModified": "2026-05-10T14:40:50.000Z"
     },
     {
-      "rank": 442,
+      "rank": 443,
       "id": "Jackrong/Negentropy-claude-opus-4.7-9B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-9B",
@@ -13225,7 +13252,7 @@
       "lastModified": "2026-05-07T16:57:19.000Z"
     },
     {
-      "rank": 443,
+      "rank": 444,
       "id": "Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
       "author": "Brian6145",
       "url": "https://huggingface.co/Brian6145/Qwen3.6-27B-Claude-Opus-Sonnet-Distilled-NVFP4-MTP",
@@ -13263,7 +13290,7 @@
       "lastModified": "2026-05-08T01:16:27.000Z"
     },
     {
-      "rank": 444,
+      "rank": 445,
       "id": "SakanaAI/kame",
       "author": "SakanaAI",
       "url": "https://huggingface.co/SakanaAI/kame",
@@ -13282,7 +13309,7 @@
       "lastModified": "2026-04-27T06:47:39.000Z"
     },
     {
-      "rank": 445,
+      "rank": 446,
       "id": "lodestones/Zeta-Chroma",
       "author": "lodestones",
       "url": "https://huggingface.co/lodestones/Zeta-Chroma",
@@ -13302,7 +13329,7 @@
       "lastModified": "2026-05-15T08:29:16.000Z"
     },
     {
-      "rank": 446,
+      "rank": 447,
       "id": "opendatalab/MinerU2.5-Pro-2604-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2604-1.2B",
@@ -13329,7 +13356,7 @@
       "lastModified": "2026-04-14T08:38:33.000Z"
     },
     {
-      "rank": 447,
+      "rank": 448,
       "id": "google/embeddinggemma-300m",
       "author": "google",
       "url": "https://huggingface.co/google/embeddinggemma-300m",
@@ -13355,7 +13382,7 @@
       "lastModified": "2025-09-25T15:11:17.000Z"
     },
     {
-      "rank": 448,
+      "rank": 449,
       "id": "unsloth/Qwen3.6-35B-A3B-NVFP4",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-NVFP4",
@@ -13380,7 +13407,7 @@
       "lastModified": "2026-05-06T18:50:29.000Z"
     },
     {
-      "rank": 449,
+      "rank": 450,
       "id": "Datadog/Toto-2.0-4m",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-4m",
@@ -13409,7 +13436,7 @@
       "lastModified": "2026-05-20T14:30:24.000Z"
     },
     {
-      "rank": 450,
+      "rank": 451,
       "id": "tencent/HY-MT1.5-1.8B",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/HY-MT1.5-1.8B",
@@ -13454,7 +13481,7 @@
       "lastModified": "2026-01-01T02:35:18.000Z"
     },
     {
-      "rank": 451,
+      "rank": 452,
       "id": "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
       "author": "ibm-research",
       "url": "https://huggingface.co/ibm-research/biomed.omics.bl.sm.ma-ted-458m",
@@ -13481,7 +13508,7 @@
       "lastModified": "2024-12-19T17:04:32.000Z"
     },
     {
-      "rank": 452,
+      "rank": 453,
       "id": "aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
       "author": "aifeifei798",
       "url": "https://huggingface.co/aifeifei798/llama3-8B-DarkIdol-2.3-Uncensored-32K",
@@ -13510,7 +13537,7 @@
       "lastModified": "2024-07-23T10:35:13.000Z"
     },
     {
-      "rank": 453,
+      "rank": 454,
       "id": "stabilityai/stable-audio-3-optimized",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-3-optimized",
@@ -13536,7 +13563,7 @@
       "lastModified": "2026-05-20T20:49:04.000Z"
     },
     {
-      "rank": 454,
+      "rank": 455,
       "id": "Wan-AI/Wan2.2-TI2V-5B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B",
@@ -13561,7 +13588,7 @@
       "lastModified": "2025-08-07T10:22:24.000Z"
     },
     {
-      "rank": 455,
+      "rank": 456,
       "id": "numind/NuExtract3-GGUF",
       "author": "numind",
       "url": "https://huggingface.co/numind/NuExtract3-GGUF",
@@ -13598,7 +13625,7 @@
       "lastModified": "2026-05-20T10:49:42.000Z"
     },
     {
-      "rank": 456,
+      "rank": 457,
       "id": "unsloth/Z-Image-Turbo-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Z-Image-Turbo-GGUF",
@@ -13626,7 +13653,7 @@
       "lastModified": "2026-01-08T02:11:45.000Z"
     },
     {
-      "rank": 457,
+      "rank": 458,
       "id": "Qwen/Qwen3.6-35B-A3B-FP8",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
@@ -13653,7 +13680,7 @@
       "lastModified": "2026-04-24T02:39:23.000Z"
     },
     {
-      "rank": 458,
+      "rank": 459,
       "id": "agents-course/notebooks",
       "author": "agents-course",
       "url": "https://huggingface.co/agents-course/notebooks",
@@ -13670,7 +13697,7 @@
       "lastModified": "2026-04-27T08:00:30.000Z"
     },
     {
-      "rank": 459,
+      "rank": 460,
       "id": "Qwen/Qwen3.5-122B-A10B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-122B-A10B",
@@ -13695,7 +13722,7 @@
       "lastModified": "2026-04-24T03:55:23.000Z"
     },
     {
-      "rank": 460,
+      "rank": 461,
       "id": "Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-MLX-4bit",
@@ -13740,38 +13767,11 @@
       "lastModified": "2026-05-23T00:19:59.000Z"
     },
     {
-      "rank": 461,
-      "id": "unsloth/Step-3.7-Flash-GGUF",
-      "author": "unsloth",
-      "url": "https://huggingface.co/unsloth/Step-3.7-Flash-GGUF",
-      "downloads": 2692,
-      "likes": 14,
-      "trendingScore": 14,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "gguf",
-        "vision-language",
-        "unsloth - multimodal - moe",
-        "image-text-to-text",
-        "en",
-        "base_model:stepfun-ai/Step-3.7-Flash",
-        "base_model:quantized:stepfun-ai/Step-3.7-Flash",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us",
-        "conversational"
-      ],
-      "createdAt": "2026-05-29T12:19:10.000Z",
-      "lastModified": "2026-05-30T04:48:31.000Z"
-    },
-    {
       "rank": 462,
       "id": "lightx2v/Wan2.2-NVFP4-Sparse",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Wan2.2-NVFP4-Sparse",
-      "downloads": 571,
+      "downloads": 663,
       "likes": 14,
       "trendingScore": 14,
       "pipelineTag": null,
@@ -13792,6 +13792,44 @@
     },
     {
       "rank": 463,
+      "id": "dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
+      "author": "dealignai",
+      "url": "https://huggingface.co/dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
+      "downloads": 2821,
+      "likes": 15,
+      "trendingScore": 14,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "mlx",
+      "tags": [
+        "mlx",
+        "safetensors",
+        "qwen3_5_moe",
+        "apple-silicon",
+        "abliterated",
+        "uncensored",
+        "crack",
+        "mtp",
+        "speculative-decoding",
+        "vision",
+        "video",
+        "reasoning",
+        "thinking",
+        "harmbench",
+        "mmlu",
+        "qwen3_6",
+        "image-text-to-text",
+        "moe",
+        "conversational",
+        "base_model:Qwen/Qwen3.6-35B-A3B",
+        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-24T19:35:48.000Z",
+      "lastModified": "2026-05-24T21:04:29.000Z"
+    },
+    {
+      "rank": 464,
       "id": "amazon/chronos-2",
       "author": "amazon",
       "url": "https://huggingface.co/amazon/chronos-2",
@@ -13820,7 +13858,7 @@
       "lastModified": "2026-01-06T09:44:02.000Z"
     },
     {
-      "rank": 464,
+      "rank": 465,
       "id": "Lightricks/LTX-2",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2",
@@ -13865,7 +13903,7 @@
       "lastModified": "2026-03-02T12:38:08.000Z"
     },
     {
-      "rank": 465,
+      "rank": 466,
       "id": "mudler/gemma-4-26B-A4B-it-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/gemma-4-26B-A4B-it-APEX-GGUF",
@@ -13894,7 +13932,7 @@
       "lastModified": "2026-05-04T16:22:29.000Z"
     },
     {
-      "rank": 466,
+      "rank": 467,
       "id": "TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-GGUF",
@@ -13921,7 +13959,7 @@
       "lastModified": "2026-04-27T23:45:12.000Z"
     },
     {
-      "rank": 467,
+      "rank": 468,
       "id": "prism-ml/Ternary-Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf",
@@ -13952,7 +13990,7 @@
       "lastModified": "2026-04-20T08:26:48.000Z"
     },
     {
-      "rank": 468,
+      "rank": 469,
       "id": "RedHatAI/Qwen3.6-35B-A3B-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4",
@@ -13976,7 +14014,7 @@
       "lastModified": "2026-04-20T16:53:00.000Z"
     },
     {
-      "rank": 469,
+      "rank": 470,
       "id": "mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
@@ -14003,7 +14041,7 @@
       "lastModified": "2026-05-05T17:10:54.000Z"
     },
     {
-      "rank": 470,
+      "rank": 471,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
@@ -14039,7 +14077,7 @@
       "lastModified": "2026-04-06T02:17:04.000Z"
     },
     {
-      "rank": 471,
+      "rank": 472,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
@@ -14070,7 +14108,7 @@
       "lastModified": "2026-05-07T14:55:34.000Z"
     },
     {
-      "rank": 472,
+      "rank": 473,
       "id": "rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
       "author": "rdtand",
       "url": "https://huggingface.co/rdtand/Qwen3.6-27B-PrismaSCOUT-Blackwell-NVFP4-BF16-vllm",
@@ -14101,7 +14139,7 @@
       "lastModified": "2026-05-04T18:03:00.000Z"
     },
     {
-      "rank": 473,
+      "rank": 474,
       "id": "WepeNerd/Obscura_Remova",
       "author": "WepeNerd",
       "url": "https://huggingface.co/WepeNerd/Obscura_Remova",
@@ -14134,11 +14172,11 @@
       "lastModified": "2026-05-03T14:00:00.000Z"
     },
     {
-      "rank": 474,
+      "rank": 475,
       "id": "Qwen/Qwen3-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-8B",
-      "downloads": 12845530,
+      "downloads": 12876148,
       "likes": 1109,
       "trendingScore": 13,
       "pipelineTag": "text-generation",
@@ -14163,7 +14201,7 @@
       "lastModified": "2025-07-26T03:49:13.000Z"
     },
     {
-      "rank": 475,
+      "rank": 476,
       "id": "kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
       "author": "kizuna-intelligence",
       "url": "https://huggingface.co/kizuna-intelligence/Irodori-TTS-500M-v2-duration-control",
@@ -14189,7 +14227,7 @@
       "lastModified": "2026-05-04T06:23:17.000Z"
     },
     {
-      "rank": 476,
+      "rank": 477,
       "id": "AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-26B-A4B-it-assistant-GGUF",
@@ -14219,7 +14257,7 @@
       "lastModified": "2026-05-07T09:11:50.000Z"
     },
     {
-      "rank": 477,
+      "rank": 478,
       "id": "z-lab/MiniMax-M2.7-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/MiniMax-M2.7-DFlash",
@@ -14237,7 +14275,7 @@
       "lastModified": "2026-05-11T11:20:57.000Z"
     },
     {
-      "rank": 478,
+      "rank": 479,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4-GGUF",
@@ -14268,7 +14306,7 @@
       "lastModified": "2026-04-30T12:31:51.000Z"
     },
     {
-      "rank": 479,
+      "rank": 480,
       "id": "sensenova/SenseNova-U1-A3B-MoT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT",
@@ -14289,7 +14327,7 @@
       "lastModified": "2026-05-15T02:57:48.000Z"
     },
     {
-      "rank": 480,
+      "rank": 481,
       "id": "joydriver/UltimateDetailerWorkflow",
       "author": "joydriver",
       "url": "https://huggingface.co/joydriver/UltimateDetailerWorkflow",
@@ -14309,7 +14347,7 @@
       "lastModified": "2026-05-12T09:38:20.000Z"
     },
     {
-      "rank": 481,
+      "rank": 482,
       "id": "Alissonerdx/BFS-Best-Face-Swap-Video",
       "author": "Alissonerdx",
       "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
@@ -14336,7 +14374,7 @@
       "lastModified": "2026-03-27T13:35:04.000Z"
     },
     {
-      "rank": 482,
+      "rank": 483,
       "id": "Qwen/Qwen3-Embedding-0.6B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-0.6B",
@@ -14366,7 +14404,7 @@
       "lastModified": "2026-04-20T02:45:58.000Z"
     },
     {
-      "rank": 483,
+      "rank": 484,
       "id": "lrzjason/Consistance_Edit_Lora",
       "author": "lrzjason",
       "url": "https://huggingface.co/lrzjason/Consistance_Edit_Lora",
@@ -14383,7 +14421,7 @@
       "lastModified": "2026-04-17T14:26:21.000Z"
     },
     {
-      "rank": 484,
+      "rank": 485,
       "id": "FrontiersMind/Nandi-Mini-150M-GuardRails",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-150M-GuardRails",
@@ -14410,7 +14448,7 @@
       "lastModified": "2026-05-18T17:32:55.000Z"
     },
     {
-      "rank": 485,
+      "rank": 486,
       "id": "unsloth/Qwen3.5-4B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF",
@@ -14435,7 +14473,7 @@
       "lastModified": "2026-03-02T14:08:17.000Z"
     },
     {
-      "rank": 486,
+      "rank": 487,
       "id": "Jackrong/Qwopus3.5-9B-Coder",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-Coder",
@@ -14478,7 +14516,7 @@
       "lastModified": "2026-05-19T08:45:22.000Z"
     },
     {
-      "rank": 487,
+      "rank": 488,
       "id": "cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-DeepSeek-V4-Flash-abliterated-GGUF",
@@ -14507,7 +14545,7 @@
       "lastModified": "2026-05-06T16:14:55.000Z"
     },
     {
-      "rank": 488,
+      "rank": 489,
       "id": "dphn/Dolphin-Mistral-24B-Venice-Edition",
       "author": "dphn",
       "url": "https://huggingface.co/dphn/Dolphin-Mistral-24B-Venice-Edition",
@@ -14534,7 +14572,7 @@
       "lastModified": "2026-04-24T13:52:18.000Z"
     },
     {
-      "rank": 489,
+      "rank": 490,
       "id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct",
@@ -14564,7 +14602,7 @@
       "lastModified": "2025-06-18T23:49:51.000Z"
     },
     {
-      "rank": 490,
+      "rank": 491,
       "id": "BAAI/bge-reranker-v2-m3",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-reranker-v2-m3",
@@ -14592,7 +14630,7 @@
       "lastModified": "2024-06-24T14:08:45.000Z"
     },
     {
-      "rank": 491,
+      "rank": 492,
       "id": "YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwopus3.6-27B-v2-TQ3_4S",
@@ -14623,7 +14661,7 @@
       "lastModified": "2026-05-23T08:47:41.000Z"
     },
     {
-      "rank": 492,
+      "rank": 493,
       "id": "google/gemma-4-31B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-31B",
@@ -14645,7 +14683,7 @@
       "lastModified": "2026-04-02T16:12:23.000Z"
     },
     {
-      "rank": 493,
+      "rank": 494,
       "id": "tencent/Hy-MT2-30B-A3B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-30B-A3B-FP8",
@@ -14668,7 +14706,7 @@
       "lastModified": "2026-05-26T09:06:09.000Z"
     },
     {
-      "rank": 494,
+      "rank": 495,
       "id": "Abiray/Lance_3B_Video-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/Lance_3B_Video-GGUF",
@@ -14695,7 +14733,7 @@
       "lastModified": "2026-05-21T09:49:53.000Z"
     },
     {
-      "rank": 495,
+      "rank": 496,
       "id": "UofTCSSLab/Maia3-79M",
       "author": "UofTCSSLab",
       "url": "https://huggingface.co/UofTCSSLab/Maia3-79M",
@@ -14719,7 +14757,7 @@
       "lastModified": "2026-05-24T16:12:28.000Z"
     },
     {
-      "rank": 496,
+      "rank": 497,
       "id": "virtuous7373/Gemma-4-Harmonia-31B",
       "author": "virtuous7373",
       "url": "https://huggingface.co/virtuous7373/Gemma-4-Harmonia-31B",
@@ -14759,7 +14797,7 @@
       "lastModified": "2026-05-22T20:08:58.000Z"
     },
     {
-      "rank": 497,
+      "rank": 498,
       "id": "bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/allura-org_Qwen3.6-35B-A3B-Anko-GGUF",
@@ -14785,7 +14823,7 @@
       "lastModified": "2026-05-22T17:02:24.000Z"
     },
     {
-      "rank": 498,
+      "rank": 499,
       "id": "Jackrong/Qwopus3.6-27B-v2-FP8",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.6-27B-v2-FP8",
@@ -14830,7 +14868,7 @@
       "lastModified": "2026-05-24T04:55:49.000Z"
     },
     {
-      "rank": 499,
+      "rank": 500,
       "id": "litert-community/gemma-4-E4B-it-litert-lm",
       "author": "litert-community",
       "url": "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
@@ -14848,44 +14886,6 @@
       ],
       "createdAt": "2026-03-26T00:20:57.000Z",
       "lastModified": "2026-05-20T21:47:36.000Z"
-    },
-    {
-      "rank": 500,
-      "id": "dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
-      "author": "dealignai",
-      "url": "https://huggingface.co/dealignai/Qwen3.6-35B-A3B-MXFP4-CRACK-MTP",
-      "downloads": 2378,
-      "likes": 14,
-      "trendingScore": 13,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "mlx",
-      "tags": [
-        "mlx",
-        "safetensors",
-        "qwen3_5_moe",
-        "apple-silicon",
-        "abliterated",
-        "uncensored",
-        "crack",
-        "mtp",
-        "speculative-decoding",
-        "vision",
-        "video",
-        "reasoning",
-        "thinking",
-        "harmbench",
-        "mmlu",
-        "qwen3_6",
-        "image-text-to-text",
-        "moe",
-        "conversational",
-        "base_model:Qwen/Qwen3.6-35B-A3B",
-        "base_model:finetune:Qwen/Qwen3.6-35B-A3B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-24T19:35:48.000Z",
-      "lastModified": "2026-05-24T21:04:29.000Z"
     },
     {
       "rank": 501,
@@ -14919,6 +14919,76 @@
     },
     {
       "rank": 502,
+      "id": "dphn/Dolphin-X1-Trinity-Nano",
+      "author": "dphn",
+      "url": "https://huggingface.co/dphn/Dolphin-X1-Trinity-Nano",
+      "downloads": 140,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "afmoe",
+        "text-generation",
+        "conversational",
+        "custom_code",
+        "en",
+        "es",
+        "fr",
+        "de",
+        "it",
+        "pt",
+        "ru",
+        "ar",
+        "hi",
+        "ko",
+        "zh",
+        "base_model:arcee-ai/Trinity-Nano-Preview",
+        "base_model:finetune:arcee-ai/Trinity-Nano-Preview",
+        "license:apache-2.0",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-05-29T16:35:16.000Z",
+      "lastModified": "2026-05-29T18:46:13.000Z"
+    },
+    {
+      "rank": 503,
+      "id": "Gryphe/Pantheon-Reasoning-27B",
+      "author": "Gryphe",
+      "url": "https://huggingface.co/Gryphe/Pantheon-Reasoning-27B",
+      "downloads": 74,
+      "likes": 13,
+      "trendingScore": 13,
+      "pipelineTag": "text-generation",
+      "libraryName": null,
+      "tags": [
+        "safetensors",
+        "qwen3_5",
+        "qwen3_6",
+        "conversational",
+        "instruct",
+        "finetune",
+        "chatml",
+        "axolotl",
+        "roleplay",
+        "reasoning",
+        "creative-writing",
+        "text-generation",
+        "en",
+        "dataset:Gryphe/Opus-4.6-Reasoning-24k",
+        "base_model:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "base_model:finetune:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-29T11:16:28.000Z",
+      "lastModified": "2026-05-30T06:21:45.000Z"
+    },
+    {
+      "rank": 504,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
@@ -14945,7 +15015,7 @@
       "lastModified": "2026-05-03T09:57:49.000Z"
     },
     {
-      "rank": 503,
+      "rank": 505,
       "id": "sensenova/SenseNova-U1-8B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-SFT",
@@ -14973,7 +15043,7 @@
       "lastModified": "2026-04-27T15:27:42.000Z"
     },
     {
-      "rank": 504,
+      "rank": 506,
       "id": "OpenMed/privacy-filter-nemotron",
       "author": "OpenMed",
       "url": "https://huggingface.co/OpenMed/privacy-filter-nemotron",
@@ -15006,7 +15076,7 @@
       "lastModified": "2026-04-28T08:01:07.000Z"
     },
     {
-      "rank": 505,
+      "rank": 507,
       "id": "Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
       "author": "Dustoevsky",
       "url": "https://huggingface.co/Dustoevsky/pornmasterZImage_turboV35Fp8.safetensors",
@@ -15022,7 +15092,7 @@
       "lastModified": "2026-04-30T08:26:18.000Z"
     },
     {
-      "rank": 506,
+      "rank": 508,
       "id": "Eyeline-Labs/Vista4D",
       "author": "Eyeline-Labs",
       "url": "https://huggingface.co/Eyeline-Labs/Vista4D",
@@ -15045,7 +15115,7 @@
       "lastModified": "2026-04-26T17:38:29.000Z"
     },
     {
-      "rank": 507,
+      "rank": 509,
       "id": "nvidia/MiniMax-M2.7-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/MiniMax-M2.7-NVFP4",
@@ -15079,7 +15149,7 @@
       "lastModified": "2026-04-24T21:40:54.000Z"
     },
     {
-      "rank": 508,
+      "rank": 510,
       "id": "am17an/Qwen3.6-35BA3B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-35BA3B-MTP-GGUF",
@@ -15099,7 +15169,7 @@
       "lastModified": "2026-05-04T14:59:29.000Z"
     },
     {
-      "rank": 509,
+      "rank": 511,
       "id": "CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
       "author": "CoreWorxLab",
       "url": "https://huggingface.co/CoreWorxLab/Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound",
@@ -15134,7 +15204,7 @@
       "lastModified": "2026-05-03T18:35:34.000Z"
     },
     {
-      "rank": 510,
+      "rank": 512,
       "id": "HuggingFaceTB/nanowhale-100m-base",
       "author": "HuggingFaceTB",
       "url": "https://huggingface.co/HuggingFaceTB/nanowhale-100m-base",
@@ -15164,7 +15234,7 @@
       "lastModified": "2026-05-04T14:34:18.000Z"
     },
     {
-      "rank": 511,
+      "rank": 513,
       "id": "kyutai/pocket-tts",
       "author": "kyutai",
       "url": "https://huggingface.co/kyutai/pocket-tts",
@@ -15185,7 +15255,7 @@
       "lastModified": "2026-05-04T12:38:48.000Z"
     },
     {
-      "rank": 512,
+      "rank": 514,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF",
@@ -15214,7 +15284,7 @@
       "lastModified": "2026-05-05T17:08:34.000Z"
     },
     {
-      "rank": 513,
+      "rank": 515,
       "id": "cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
       "author": "cHunter789",
       "url": "https://huggingface.co/cHunter789/Qwen3.6-27B-i1-IQ4_XS-GGUF",
@@ -15244,7 +15314,7 @@
       "lastModified": "2026-05-02T08:44:09.000Z"
     },
     {
-      "rank": 514,
+      "rank": 516,
       "id": "ACE-Step/Ace-Step1.5",
       "author": "ACE-Step",
       "url": "https://huggingface.co/ACE-Step/Ace-Step1.5",
@@ -15272,7 +15342,7 @@
       "lastModified": "2026-02-03T11:37:37.000Z"
     },
     {
-      "rank": 515,
+      "rank": 517,
       "id": "Qwen/Qwen3-VL-8B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct",
@@ -15301,7 +15371,7 @@
       "lastModified": "2025-10-15T16:16:59.000Z"
     },
     {
-      "rank": 516,
+      "rank": 518,
       "id": "SeeSee21/Z-Image-Turbo-AIO",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/Z-Image-Turbo-AIO",
@@ -15333,7 +15403,7 @@
       "lastModified": "2026-01-03T14:49:06.000Z"
     },
     {
-      "rank": 517,
+      "rank": 519,
       "id": "Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
       "author": "Naphula",
       "url": "https://huggingface.co/Naphula/G4-Runic-Oarfish-26B-A4B-v1.2",
@@ -15368,7 +15438,7 @@
       "lastModified": "2026-05-08T14:22:31.000Z"
     },
     {
-      "rank": 518,
+      "rank": 520,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-NVFP4",
@@ -15406,7 +15476,7 @@
       "lastModified": "2026-05-08T03:42:19.000Z"
     },
     {
-      "rank": 519,
+      "rank": 521,
       "id": "IAAR-Shanghai/MemPrivacy-1.7B-RL",
       "author": "IAAR-Shanghai",
       "url": "https://huggingface.co/IAAR-Shanghai/MemPrivacy-1.7B-RL",
@@ -15445,7 +15515,7 @@
       "lastModified": "2026-05-15T03:09:28.000Z"
     },
     {
-      "rank": 520,
+      "rank": 522,
       "id": "Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-uncensored-mlx-4bit-v2",
@@ -15482,7 +15552,7 @@
       "lastModified": "2026-04-12T13:34:53.000Z"
     },
     {
-      "rank": 521,
+      "rank": 523,
       "id": "Qwen/Qwen-Image-Edit-2509",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit-2509",
@@ -15506,7 +15576,7 @@
       "lastModified": "2025-09-22T13:37:12.000Z"
     },
     {
-      "rank": 522,
+      "rank": 524,
       "id": "ggerganov/whisper.cpp",
       "author": "ggerganov",
       "url": "https://huggingface.co/ggerganov/whisper.cpp",
@@ -15524,7 +15594,7 @@
       "lastModified": "2024-10-29T18:25:17.000Z"
     },
     {
-      "rank": 523,
+      "rank": 525,
       "id": "infly/Infinity-Parser2-Flash",
       "author": "infly",
       "url": "https://huggingface.co/infly/Infinity-Parser2-Flash",
@@ -15543,7 +15613,7 @@
       "lastModified": "2026-05-16T01:59:44.000Z"
     },
     {
-      "rank": 524,
+      "rank": 526,
       "id": "0G-AI/0GM-1.0-35B-A3B-0427",
       "author": "0G-AI",
       "url": "https://huggingface.co/0G-AI/0GM-1.0-35B-A3B-0427",
@@ -15571,7 +15641,7 @@
       "lastModified": "2026-05-14T02:31:20.000Z"
     },
     {
-      "rank": 525,
+      "rank": 527,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5",
@@ -15609,7 +15679,7 @@
       "lastModified": "2026-04-30T09:36:47.000Z"
     },
     {
-      "rank": 526,
+      "rank": 528,
       "id": "google/gemma-4-26B-A4B",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-4-26B-A4B",
@@ -15631,7 +15701,7 @@
       "lastModified": "2026-04-02T16:13:38.000Z"
     },
     {
-      "rank": 527,
+      "rank": 529,
       "id": "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
       "author": "OsaurusAI",
       "url": "https://huggingface.co/OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
@@ -15668,7 +15738,7 @@
       "lastModified": "2026-05-12T13:09:29.000Z"
     },
     {
-      "rank": 528,
+      "rank": 530,
       "id": "treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
       "author": "treadon",
       "url": "https://huggingface.co/treadon/MiniCPM-V-4.6-Abliterated-AND-Disinhibited",
@@ -15698,7 +15768,7 @@
       "lastModified": "2026-05-12T02:18:15.000Z"
     },
     {
-      "rank": 529,
+      "rank": 531,
       "id": "Datadog/Toto-2.0-1B",
       "author": "Datadog",
       "url": "https://huggingface.co/Datadog/Toto-2.0-1B",
@@ -15727,7 +15797,7 @@
       "lastModified": "2026-05-20T14:30:49.000Z"
     },
     {
-      "rank": 530,
+      "rank": 532,
       "id": "Qwen/Qwen3-1.7B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-1.7B",
@@ -15755,7 +15825,7 @@
       "lastModified": "2025-07-26T03:46:32.000Z"
     },
     {
-      "rank": 531,
+      "rank": 533,
       "id": "black-forest-labs/FLUX.1-Kontext-dev",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
@@ -15781,7 +15851,7 @@
       "lastModified": "2026-01-01T15:35:36.000Z"
     },
     {
-      "rank": 532,
+      "rank": 534,
       "id": "unsloth/Qwen-Image-Edit-2511-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen-Image-Edit-2511-GGUF",
@@ -15808,7 +15878,7 @@
       "lastModified": "2026-01-08T21:13:12.000Z"
     },
     {
-      "rank": 533,
+      "rank": 535,
       "id": "openbmb/BitCPM4-CANN-8B",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B",
@@ -15833,7 +15903,7 @@
       "lastModified": "2026-05-22T10:05:30.000Z"
     },
     {
-      "rank": 534,
+      "rank": 536,
       "id": "SeeSee21/AniSee",
       "author": "SeeSee21",
       "url": "https://huggingface.co/SeeSee21/AniSee",
@@ -15862,7 +15932,7 @@
       "lastModified": "2026-05-17T17:06:08.000Z"
     },
     {
-      "rank": 535,
+      "rank": 537,
       "id": "unsloth/MiniMax-M2.7-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/MiniMax-M2.7-GGUF",
@@ -15887,7 +15957,7 @@
       "lastModified": "2026-04-14T16:48:17.000Z"
     },
     {
-      "rank": 536,
+      "rank": 538,
       "id": "nicolas-dufour/miro",
       "author": "nicolas-dufour",
       "url": "https://huggingface.co/nicolas-dufour/miro",
@@ -15913,7 +15983,7 @@
       "lastModified": "2026-05-19T23:10:01.000Z"
     },
     {
-      "rank": 537,
+      "rank": 539,
       "id": "mistralai/Voxtral-Mini-4B-Realtime-2602",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602",
@@ -15952,7 +16022,7 @@
       "lastModified": "2026-03-11T15:04:02.000Z"
     },
     {
-      "rank": 538,
+      "rank": 540,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
@@ -15980,7 +16050,7 @@
       "lastModified": "2026-05-19T13:01:22.000Z"
     },
     {
-      "rank": 539,
+      "rank": 541,
       "id": "zemelee/qwen2.5-jailbreak",
       "author": "zemelee",
       "url": "https://huggingface.co/zemelee/qwen2.5-jailbreak",
@@ -16006,7 +16076,7 @@
       "lastModified": "2025-05-08T06:56:32.000Z"
     },
     {
-      "rank": 540,
+      "rank": 542,
       "id": "SupraLabs/Supra-50M-Base",
       "author": "SupraLabs",
       "url": "https://huggingface.co/SupraLabs/Supra-50M-Base",
@@ -16040,7 +16110,7 @@
       "lastModified": "2026-05-27T13:53:55.000Z"
     },
     {
-      "rank": 541,
+      "rank": 543,
       "id": "alibaba-pai/Z-Image-Fun-Lora-Distill",
       "author": "alibaba-pai",
       "url": "https://huggingface.co/alibaba-pai/Z-Image-Fun-Lora-Distill",
@@ -16060,7 +16130,7 @@
       "lastModified": "2026-03-02T11:46:41.000Z"
     },
     {
-      "rank": 542,
+      "rank": 544,
       "id": "ruvnet/wifi-densepose-pretrained",
       "author": "ruvnet",
       "url": "https://huggingface.co/ruvnet/wifi-densepose-pretrained",
@@ -16093,7 +16163,7 @@
       "lastModified": "2026-04-03T18:21:10.000Z"
     },
     {
-      "rank": 543,
+      "rank": 545,
       "id": "opendatalab/MinerU2.5-Pro-2605-1.2B",
       "author": "opendatalab",
       "url": "https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B",
@@ -16120,7 +16190,7 @@
       "lastModified": "2026-05-25T10:58:41.000Z"
     },
     {
-      "rank": 544,
+      "rank": 546,
       "id": "joyfox/LTX-2.3-Transition-LORA",
       "author": "joyfox",
       "url": "https://huggingface.co/joyfox/LTX-2.3-Transition-LORA",
@@ -16146,7 +16216,7 @@
       "lastModified": "2026-03-30T03:28:58.000Z"
     },
     {
-      "rank": 545,
+      "rank": 547,
       "id": "sailing-lab/SR2AM-v1.0-30B",
       "author": "sailing-lab",
       "url": "https://huggingface.co/sailing-lab/SR2AM-v1.0-30B",
@@ -16177,7 +16247,7 @@
       "lastModified": "2026-05-22T05:10:20.000Z"
     },
     {
-      "rank": 546,
+      "rank": 548,
       "id": "stabilityai/stable-diffusion-3.5-large",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
@@ -16200,7 +16270,7 @@
       "lastModified": "2024-10-22T14:36:33.000Z"
     },
     {
-      "rank": 547,
+      "rank": 549,
       "id": "NousResearch/Hermes-4.3-36B",
       "author": "NousResearch",
       "url": "https://huggingface.co/NousResearch/Hermes-4.3-36B",
@@ -16241,7 +16311,7 @@
       "lastModified": "2025-12-06T15:04:17.000Z"
     },
     {
-      "rank": 548,
+      "rank": 550,
       "id": "Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-DeepSeek-V4-Flash-MTP-GGUF",
@@ -16263,12 +16333,12 @@
       "lastModified": "2026-05-22T10:25:05.000Z"
     },
     {
-      "rank": 549,
+      "rank": 551,
       "id": "google/gemma-3-1b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-1b-it",
-      "downloads": 1376992,
-      "likes": 970,
+      "downloads": 1558431,
+      "likes": 973,
       "trendingScore": 12,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -16308,7 +16378,7 @@
       "lastModified": "2025-04-04T13:12:40.000Z"
     },
     {
-      "rank": 550,
+      "rank": 552,
       "id": "Qwen/Qwen3-4B-Instruct-2507",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
@@ -16335,7 +16405,7 @@
       "lastModified": "2025-09-17T06:56:53.000Z"
     },
     {
-      "rank": 551,
+      "rank": 553,
       "id": "Leon1000/Flux-2-Multi-Angles-LoRA-v2",
       "author": "Leon1000",
       "url": "https://huggingface.co/Leon1000/Flux-2-Multi-Angles-LoRA-v2",
@@ -16363,7 +16433,7 @@
       "lastModified": "2026-05-20T00:22:04.000Z"
     },
     {
-      "rank": 552,
+      "rank": 554,
       "id": "tsolful/Z-Image-L2P-INT8",
       "author": "tsolful",
       "url": "https://huggingface.co/tsolful/Z-Image-L2P-INT8",
@@ -16388,7 +16458,36 @@
       "lastModified": "2026-05-26T05:28:12.000Z"
     },
     {
-      "rank": 553,
+      "rank": 555,
+      "id": "stepfun-ai/Step-3.7-Flash-FP8",
+      "author": "stepfun-ai",
+      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8",
+      "downloads": 13139,
+      "likes": 12,
+      "trendingScore": 12,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "step3p7",
+        "text-generation",
+        "vision-language",
+        "multimodal",
+        "moe",
+        "image-text-to-text",
+        "conversational",
+        "custom_code",
+        "en",
+        "license:apache-2.0",
+        "fp8",
+        "region:us"
+      ],
+      "createdAt": "2026-05-23T12:49:10.000Z",
+      "lastModified": "2026-05-29T10:04:17.000Z"
+    },
+    {
+      "rank": 556,
       "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "author": "sentence-transformers",
       "url": "https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
@@ -16433,7 +16532,7 @@
       "lastModified": "2026-01-28T10:02:26.000Z"
     },
     {
-      "rank": 554,
+      "rank": 557,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -16475,7 +16574,7 @@
       "lastModified": "2026-05-01T16:54:19.000Z"
     },
     {
-      "rank": 555,
+      "rank": 558,
       "id": "Motif-Technologies/Motif-Video-2B",
       "author": "Motif-Technologies",
       "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
@@ -16501,7 +16600,7 @@
       "lastModified": "2026-05-06T12:40:55.000Z"
     },
     {
-      "rank": 556,
+      "rank": 559,
       "id": "zerofata/G4-MeroMero-26B-A4B",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B",
@@ -16526,7 +16625,7 @@
       "lastModified": "2026-05-02T03:51:29.000Z"
     },
     {
-      "rank": 557,
+      "rank": 560,
       "id": "robbyant/lingbot-map",
       "author": "robbyant",
       "url": "https://huggingface.co/robbyant/lingbot-map",
@@ -16543,7 +16642,7 @@
       "lastModified": "2026-04-26T02:00:25.000Z"
     },
     {
-      "rank": 558,
+      "rank": 561,
       "id": "unsloth/granite-4.1-30b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-30b-GGUF",
@@ -16571,7 +16670,7 @@
       "lastModified": "2026-04-30T07:19:37.000Z"
     },
     {
-      "rank": 559,
+      "rank": 562,
       "id": "latence/privacy-filter-GLiNER-v0.1",
       "author": "latence",
       "url": "https://huggingface.co/latence/privacy-filter-GLiNER-v0.1",
@@ -16597,7 +16696,7 @@
       "lastModified": "2026-04-30T15:30:55.000Z"
     },
     {
-      "rank": 560,
+      "rank": 563,
       "id": "unsloth/granite-4.1-3b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/granite-4.1-3b-GGUF",
@@ -16624,7 +16723,7 @@
       "lastModified": "2026-04-30T08:57:46.000Z"
     },
     {
-      "rank": 561,
+      "rank": 564,
       "id": "sensenova/SenseNova-U1-8B-MoT-8step-preview",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-8step-preview",
@@ -16652,7 +16751,7 @@
       "lastModified": "2026-04-30T13:55:17.000Z"
     },
     {
-      "rank": 562,
+      "rank": 565,
       "id": "HebArabNlpProject/Hebatron",
       "author": "HebArabNlpProject",
       "url": "https://huggingface.co/HebArabNlpProject/Hebatron",
@@ -16685,7 +16784,7 @@
       "lastModified": "2026-05-05T17:12:38.000Z"
     },
     {
-      "rank": 563,
+      "rank": 566,
       "id": "OpenMOSS-Team/MOSS-Music-8B-Instruct",
       "author": "OpenMOSS-Team",
       "url": "https://huggingface.co/OpenMOSS-Team/MOSS-Music-8B-Instruct",
@@ -16719,7 +16818,7 @@
       "lastModified": "2026-05-01T15:10:37.000Z"
     },
     {
-      "rank": 564,
+      "rank": 567,
       "id": "SkunkWorkLabs/varuna-stt",
       "author": "SkunkWorkLabs",
       "url": "https://huggingface.co/SkunkWorkLabs/varuna-stt",
@@ -16748,7 +16847,7 @@
       "lastModified": "2026-05-04T17:46:04.000Z"
     },
     {
-      "rank": 565,
+      "rank": 568,
       "id": "tencent/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -16777,7 +16876,7 @@
       "lastModified": "2026-04-29T04:26:09.000Z"
     },
     {
-      "rank": 566,
+      "rank": 569,
       "id": "Hcompany/Holo3-35B-A3B",
       "author": "Hcompany",
       "url": "https://huggingface.co/Hcompany/Holo3-35B-A3B",
@@ -16810,7 +16909,7 @@
       "lastModified": "2026-04-02T08:03:58.000Z"
     },
     {
-      "rank": 567,
+      "rank": 570,
       "id": "nvidia/Efficient-DLM-8B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Efficient-DLM-8B",
@@ -16837,7 +16936,7 @@
       "lastModified": "2026-05-03T00:43:05.000Z"
     },
     {
-      "rank": 568,
+      "rank": 571,
       "id": "deepseek-ai/DeepSeek-OCR-2",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR-2",
@@ -16867,7 +16966,7 @@
       "lastModified": "2026-02-03T00:33:19.000Z"
     },
     {
-      "rank": 569,
+      "rank": 572,
       "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4",
@@ -16893,7 +16992,7 @@
       "lastModified": "2026-04-30T21:33:50.000Z"
     },
     {
-      "rank": 570,
+      "rank": 573,
       "id": "huaichang/PersonaLive",
       "author": "huaichang",
       "url": "https://huggingface.co/huaichang/PersonaLive",
@@ -16917,7 +17016,7 @@
       "lastModified": "2025-12-26T08:59:09.000Z"
     },
     {
-      "rank": 571,
+      "rank": 574,
       "id": "mlx-community/gemma-4-31B-it-assistant-bf16",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/gemma-4-31B-it-assistant-bf16",
@@ -16944,7 +17043,7 @@
       "lastModified": "2026-05-05T17:10:55.000Z"
     },
     {
-      "rank": 572,
+      "rank": 575,
       "id": "nomic-ai/nomic-embed-text-v1.5",
       "author": "nomic-ai",
       "url": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5",
@@ -16978,7 +17077,7 @@
       "lastModified": "2026-04-07T14:17:02.000Z"
     },
     {
-      "rank": 573,
+      "rank": 576,
       "id": "Winnougan/Sulphur-2-LTX-2.3",
       "author": "Winnougan",
       "url": "https://huggingface.co/Winnougan/Sulphur-2-LTX-2.3",
@@ -16994,7 +17093,7 @@
       "lastModified": "2026-05-05T19:23:38.000Z"
     },
     {
-      "rank": 574,
+      "rank": 577,
       "id": "ZhengPeng7/BiRefNet",
       "author": "ZhengPeng7",
       "url": "https://huggingface.co/ZhengPeng7/BiRefNet",
@@ -17025,7 +17124,7 @@
       "lastModified": "2026-02-04T22:43:55.000Z"
     },
     {
-      "rank": 575,
+      "rank": 578,
       "id": "byliutao/Longcat-Image-Turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/Longcat-Image-Turbo",
@@ -17047,7 +17146,7 @@
       "lastModified": "2026-05-09T12:55:01.000Z"
     },
     {
-      "rank": 576,
+      "rank": 579,
       "id": "turboderp/Qwen3.6-27B-DFlash-exl3",
       "author": "turboderp",
       "url": "https://huggingface.co/turboderp/Qwen3.6-27B-DFlash-exl3",
@@ -17067,7 +17166,7 @@
       "lastModified": "2026-05-06T20:39:20.000Z"
     },
     {
-      "rank": 577,
+      "rank": 580,
       "id": "IndexTeam/IndexTTS-2",
       "author": "IndexTeam",
       "url": "https://huggingface.co/IndexTeam/IndexTTS-2",
@@ -17089,7 +17188,7 @@
       "lastModified": "2026-01-20T13:41:51.000Z"
     },
     {
-      "rank": 578,
+      "rank": 581,
       "id": "deepseek-ai/DeepSeek-OCR",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-OCR",
@@ -17118,7 +17217,7 @@
       "lastModified": "2025-11-04T02:36:12.000Z"
     },
     {
-      "rank": 579,
+      "rank": 582,
       "id": "netflix/void-model",
       "author": "netflix",
       "url": "https://huggingface.co/netflix/void-model",
@@ -17143,7 +17242,7 @@
       "lastModified": "2026-04-06T17:28:28.000Z"
     },
     {
-      "rank": 580,
+      "rank": 583,
       "id": "Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
       "author": "Xanthius",
       "url": "https://huggingface.co/Xanthius/Ace-Step-1.5-XL-Concept-Sliders",
@@ -17168,7 +17267,7 @@
       "lastModified": "2026-05-11T02:25:09.000Z"
     },
     {
-      "rank": 581,
+      "rank": 584,
       "id": "LilaRest/gemma-4-31B-it-NVFP4-turbo",
       "author": "LilaRest",
       "url": "https://huggingface.co/LilaRest/gemma-4-31B-it-NVFP4-turbo",
@@ -17203,7 +17302,7 @@
       "lastModified": "2026-04-10T09:20:46.000Z"
     },
     {
-      "rank": 582,
+      "rank": 585,
       "id": "SG161222/SPARK.Chroma_v1",
       "author": "SG161222",
       "url": "https://huggingface.co/SG161222/SPARK.Chroma_v1",
@@ -17227,7 +17326,7 @@
       "lastModified": "2026-05-03T21:26:05.000Z"
     },
     {
-      "rank": 583,
+      "rank": 586,
       "id": "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
@@ -17258,7 +17357,7 @@
       "lastModified": "2026-05-20T07:12:07.000Z"
     },
     {
-      "rank": 584,
+      "rank": 587,
       "id": "microsoft/GridSFM_Open",
       "author": "microsoft",
       "url": "https://huggingface.co/microsoft/GridSFM_Open",
@@ -17288,7 +17387,7 @@
       "lastModified": "2026-05-13T13:45:10.000Z"
     },
     {
-      "rank": 585,
+      "rank": 588,
       "id": "Abiray/ZAYA1-8B-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/ZAYA1-8B-GGUF",
@@ -17314,7 +17413,7 @@
       "lastModified": "2026-05-16T14:23:36.000Z"
     },
     {
-      "rank": 586,
+      "rank": 589,
       "id": "ResembleAI/chatterbox",
       "author": "ResembleAI",
       "url": "https://huggingface.co/ResembleAI/chatterbox",
@@ -17359,7 +17458,7 @@
       "lastModified": "2026-04-22T17:58:28.000Z"
     },
     {
-      "rank": 587,
+      "rank": 590,
       "id": "unsloth/Qwen3.5-2B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-2B-MTP-GGUF",
@@ -17386,7 +17485,7 @@
       "lastModified": "2026-05-16T12:38:56.000Z"
     },
     {
-      "rank": 588,
+      "rank": 591,
       "id": "Qwen/Qwen3.5-2B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-2B",
@@ -17413,7 +17512,7 @@
       "lastModified": "2026-03-02T11:26:29.000Z"
     },
     {
-      "rank": 589,
+      "rank": 592,
       "id": "FINAL-Bench/Darwin-36B-Opus",
       "author": "FINAL-Bench",
       "url": "https://huggingface.co/FINAL-Bench/Darwin-36B-Opus",
@@ -17458,7 +17557,7 @@
       "lastModified": "2026-05-15T04:06:39.000Z"
     },
     {
-      "rank": 590,
+      "rank": 593,
       "id": "noctrex/Qwopus3.5-9B-Coder-MTP",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.5-9B-Coder-MTP",
@@ -17484,7 +17583,7 @@
       "lastModified": "2026-05-17T12:48:32.000Z"
     },
     {
-      "rank": 591,
+      "rank": 594,
       "id": "GestaltLabs/BusyBeaver-50M",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/BusyBeaver-50M",
@@ -17513,7 +17612,7 @@
       "lastModified": "2026-05-19T00:07:41.000Z"
     },
     {
-      "rank": 592,
+      "rank": 595,
       "id": "ansulev/Darwin-9B-NEG",
       "author": "ansulev",
       "url": "https://huggingface.co/ansulev/Darwin-9B-NEG",
@@ -17558,7 +17657,7 @@
       "lastModified": "2026-05-18T21:17:34.000Z"
     },
     {
-      "rank": 593,
+      "rank": 596,
       "id": "mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwopus3.6-35B-A3B-v1-APEX-MTP-GGUF",
@@ -17590,7 +17689,7 @@
       "lastModified": "2026-05-21T21:34:59.000Z"
     },
     {
-      "rank": 594,
+      "rank": 597,
       "id": "llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF",
@@ -17625,7 +17724,7 @@
       "lastModified": "2026-05-18T01:02:09.000Z"
     },
     {
-      "rank": 595,
+      "rank": 598,
       "id": "DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/OpenAi-GPT-oss-20b-HERETIC-uncensored-NEO-Imatrix-gguf",
@@ -17670,7 +17769,7 @@
       "lastModified": "2025-11-30T01:55:32.000Z"
     },
     {
-      "rank": 596,
+      "rank": 599,
       "id": "stabilityai/SAME-S",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/SAME-S",
@@ -17695,7 +17794,7 @@
       "lastModified": "2026-05-19T20:11:16.000Z"
     },
     {
-      "rank": 597,
+      "rank": 600,
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
@@ -17734,7 +17833,7 @@
       "lastModified": "2024-12-21T18:28:01.000Z"
     },
     {
-      "rank": 598,
+      "rank": 601,
       "id": "Abiray/L2P-model-1k-merge-INT8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/L2P-model-1k-merge-INT8",
@@ -17759,7 +17858,7 @@
       "lastModified": "2026-05-23T17:24:01.000Z"
     },
     {
-      "rank": 599,
+      "rank": 602,
       "id": "zeroentropy/zerank-2-reranker",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zerank-2-reranker",
@@ -17789,7 +17888,7 @@
       "lastModified": "2026-05-05T17:47:28.000Z"
     },
     {
-      "rank": 600,
+      "rank": 603,
       "id": "mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/m51Lab-MiniMax-M2.7-REAP-139B-A10B-i1-GGUF",
@@ -17819,7 +17918,7 @@
       "lastModified": "2026-05-10T04:13:55.000Z"
     },
     {
-      "rank": 601,
+      "rank": 604,
       "id": "meituan-longcat/LongCat-Video",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video",
@@ -17845,7 +17944,7 @@
       "lastModified": "2025-10-29T06:22:46.000Z"
     },
     {
-      "rank": 602,
+      "rank": 605,
       "id": "sinimiini/HRM-Text-1B-GGUF",
       "author": "sinimiini",
       "url": "https://huggingface.co/sinimiini/HRM-Text-1B-GGUF",
@@ -17880,7 +17979,7 @@
       "lastModified": "2026-05-21T09:49:08.000Z"
     },
     {
-      "rank": 603,
+      "rank": 606,
       "id": "Qwen/Qwen-Image-Layered",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Layered",
@@ -17906,11 +18005,11 @@
       "lastModified": "2025-12-19T09:11:18.000Z"
     },
     {
-      "rank": 604,
+      "rank": 607,
       "id": "FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
       "author": "FrontiersMind",
       "url": "https://huggingface.co/FrontiersMind/Nandi-Mini-V1.1-600M-Early-Checkpoint-250GT",
-      "downloads": 299,
+      "downloads": 331,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "text-generation",
@@ -17939,7 +18038,7 @@
       "lastModified": "2026-05-27T07:55:25.000Z"
     },
     {
-      "rank": 605,
+      "rank": 608,
       "id": "google/gemma-3-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-4b-it",
@@ -17984,11 +18083,11 @@
       "lastModified": "2025-03-21T20:20:53.000Z"
     },
     {
-      "rank": 606,
+      "rank": 609,
       "id": "Roboflow/rf-detr-segmentation",
       "author": "Roboflow",
       "url": "https://huggingface.co/Roboflow/rf-detr-segmentation",
-      "downloads": 74,
+      "downloads": 86,
       "likes": 12,
       "trendingScore": 11,
       "pipelineTag": "image-segmentation",
@@ -18010,48 +18109,11 @@
       "lastModified": "2026-05-20T16:47:13.000Z"
     },
     {
-      "rank": 607,
-      "id": "dphn/Dolphin-X1-Trinity-Nano",
-      "author": "dphn",
-      "url": "https://huggingface.co/dphn/Dolphin-X1-Trinity-Nano",
-      "downloads": 51,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "afmoe",
-        "text-generation",
-        "conversational",
-        "custom_code",
-        "en",
-        "es",
-        "fr",
-        "de",
-        "it",
-        "pt",
-        "ru",
-        "ar",
-        "hi",
-        "ko",
-        "zh",
-        "base_model:arcee-ai/Trinity-Nano-Preview",
-        "base_model:finetune:arcee-ai/Trinity-Nano-Preview",
-        "license:apache-2.0",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-29T16:35:16.000Z",
-      "lastModified": "2026-05-29T18:46:13.000Z"
-    },
-    {
-      "rank": 608,
+      "rank": 610,
       "id": "unsloth/FLUX.2-klein-9B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF",
-      "downloads": 103493,
+      "downloads": 104157,
       "likes": 224,
       "trendingScore": 11,
       "pipelineTag": "image-to-image",
@@ -18075,11 +18137,11 @@
       "lastModified": "2026-01-16T15:48:16.000Z"
     },
     {
-      "rank": 609,
+      "rank": 611,
       "id": "daydreamlive/DreamVAE",
       "author": "daydreamlive",
       "url": "https://huggingface.co/daydreamlive/DreamVAE",
-      "downloads": 18,
+      "downloads": 28,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": "audio-to-audio",
@@ -18109,11 +18171,11 @@
       "lastModified": "2026-04-22T15:11:47.000Z"
     },
     {
-      "rank": 610,
+      "rank": 612,
       "id": "llmfan46/Gemma-4-Harmonia-31B-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Gemma-4-Harmonia-31B-uncensored-heretic-GGUF",
-      "downloads": 5547,
+      "downloads": 6875,
       "likes": 11,
       "trendingScore": 11,
       "pipelineTag": null,
@@ -18139,7 +18201,7 @@
       "lastModified": "2026-05-28T19:02:45.000Z"
     },
     {
-      "rank": 611,
+      "rank": 613,
       "id": "circlestone-labs/Anima-Official-LoRAs",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Official-LoRAs",
@@ -18153,68 +18215,6 @@
       ],
       "createdAt": "2026-05-26T18:50:31.000Z",
       "lastModified": "2026-05-26T18:57:37.000Z"
-    },
-    {
-      "rank": 612,
-      "id": "stepfun-ai/Step-3.7-Flash-FP8",
-      "author": "stepfun-ai",
-      "url": "https://huggingface.co/stepfun-ai/Step-3.7-Flash-FP8",
-      "downloads": 8500,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "step3p7",
-        "text-generation",
-        "vision-language",
-        "multimodal",
-        "moe",
-        "image-text-to-text",
-        "conversational",
-        "custom_code",
-        "en",
-        "license:apache-2.0",
-        "fp8",
-        "region:us"
-      ],
-      "createdAt": "2026-05-23T12:49:10.000Z",
-      "lastModified": "2026-05-29T10:04:17.000Z"
-    },
-    {
-      "rank": 613,
-      "id": "Gryphe/Pantheon-Reasoning-27B",
-      "author": "Gryphe",
-      "url": "https://huggingface.co/Gryphe/Pantheon-Reasoning-27B",
-      "downloads": 36,
-      "likes": 11,
-      "trendingScore": 11,
-      "pipelineTag": "text-generation",
-      "libraryName": null,
-      "tags": [
-        "safetensors",
-        "qwen3_5",
-        "qwen3_6",
-        "conversational",
-        "instruct",
-        "finetune",
-        "chatml",
-        "axolotl",
-        "roleplay",
-        "reasoning",
-        "creative-writing",
-        "text-generation",
-        "en",
-        "dataset:Gryphe/Opus-4.6-Reasoning-24k",
-        "base_model:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
-        "base_model:finetune:llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-29T11:16:28.000Z",
-      "lastModified": "2026-05-30T06:21:45.000Z"
     },
     {
       "rank": 614,
@@ -19457,8 +19457,8 @@
       "id": "deepseek-ai/DeepSeek-R1",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
-      "downloads": 3813218,
-      "likes": 13332,
+      "downloads": 5123751,
+      "likes": 13353,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
       "libraryName": "transformers",
@@ -19684,8 +19684,8 @@
       "id": "stable-diffusion-v1-5/stable-diffusion-v1-5",
       "author": "stable-diffusion-v1-5",
       "url": "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
-      "downloads": 1780151,
-      "likes": 1133,
+      "downloads": 1785421,
+      "likes": 1134,
       "trendingScore": 10,
       "pipelineTag": "text-to-image",
       "libraryName": "diffusers",
@@ -20194,7 +20194,7 @@
       "id": "w-ahmad/Qwen3.5-9B-GGUF-MoQ",
       "author": "w-ahmad",
       "url": "https://huggingface.co/w-ahmad/Qwen3.5-9B-GGUF-MoQ",
-      "downloads": 92595,
+      "downloads": 53827,
       "likes": 13,
       "trendingScore": 10,
       "pipelineTag": "text-generation",
@@ -20246,7 +20246,7 @@
       "id": "Kaikaku/epicure-core",
       "author": "Kaikaku",
       "url": "https://huggingface.co/Kaikaku/epicure-core",
-      "downloads": 464,
+      "downloads": 582,
       "likes": 11,
       "trendingScore": 10,
       "pipelineTag": "feature-extraction",
@@ -20314,7 +20314,7 @@
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base",
-      "downloads": 2049551,
+      "downloads": 2067701,
       "likes": 404,
       "trendingScore": 10,
       "pipelineTag": null,
@@ -20376,6 +20376,70 @@
     },
     {
       "rank": 690,
+      "id": "ControlLight/ControlLight",
+      "author": "ControlLight",
+      "url": "https://huggingface.co/ControlLight/ControlLight",
+      "downloads": 0,
+      "likes": 10,
+      "trendingScore": 10,
+      "pipelineTag": null,
+      "libraryName": null,
+      "tags": [
+        "en",
+        "zh",
+        "dataset:ControlLight/Light100K",
+        "arxiv:2605.25569",
+        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
+        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
+        "license:apache-2.0",
+        "region:us"
+      ],
+      "createdAt": "2026-05-21T05:46:43.000Z",
+      "lastModified": "2026-05-26T04:28:29.000Z"
+    },
+    {
+      "rank": 691,
+      "id": "infly/Infinity-Parser2-Pro",
+      "author": "infly",
+      "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
+      "downloads": 4531,
+      "likes": 50,
+      "trendingScore": 10,
+      "pipelineTag": "image-text-to-text",
+      "libraryName": "transformers",
+      "tags": [
+        "transformers",
+        "safetensors",
+        "qwen3_5_moe",
+        "image-text-to-text",
+        "ocr",
+        "pdf",
+        "document-parsing",
+        "document-understanding",
+        "layout-analysis",
+        "table-recognition",
+        "chart-parsing",
+        "formula-recognition",
+        "chemical-formula",
+        "markdown",
+        "vision-language",
+        "infinity-parser",
+        "infinity_parser2",
+        "conversational",
+        "en",
+        "zh",
+        "multilingual",
+        "dataset:infly/Infinity-Doc2-5M",
+        "license:apache-2.0",
+        "eval-results",
+        "endpoints_compatible",
+        "region:us"
+      ],
+      "createdAt": "2026-04-08T12:28:55.000Z",
+      "lastModified": "2026-05-28T11:39:11.000Z"
+    },
+    {
+      "rank": 692,
       "id": "NewBie-AI/NewBie-image-Exp0.1",
       "author": "NewBie-AI",
       "url": "https://huggingface.co/NewBie-AI/NewBie-image-Exp0.1",
@@ -20401,7 +20465,7 @@
       "lastModified": "2026-02-18T17:29:25.000Z"
     },
     {
-      "rank": 691,
+      "rank": 693,
       "id": "lovis93/Flux-2-Multi-Angles-LoRA-v2",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/Flux-2-Multi-Angles-LoRA-v2",
@@ -20429,7 +20493,7 @@
       "lastModified": "2025-12-01T15:46:43.000Z"
     },
     {
-      "rank": 692,
+      "rank": 694,
       "id": "google/translategemma-4b-it",
       "author": "google",
       "url": "https://huggingface.co/google/translategemma-4b-it",
@@ -20455,7 +20519,7 @@
       "lastModified": "2026-01-28T17:28:43.000Z"
     },
     {
-      "rank": 693,
+      "rank": 695,
       "id": "LiquidAI/LFM2.5-350M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-350M",
@@ -20495,7 +20559,7 @@
       "lastModified": "2026-04-01T19:39:31.000Z"
     },
     {
-      "rank": 694,
+      "rank": 696,
       "id": "nvidia/nemotron-ocr-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-ocr-v2",
@@ -20531,7 +20595,7 @@
       "lastModified": "2026-04-28T02:04:16.000Z"
     },
     {
-      "rank": 695,
+      "rank": 697,
       "id": "Jackrong/Qwopus-GLM-18B-Merged-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus-GLM-18B-Merged-GGUF",
@@ -20575,7 +20639,7 @@
       "lastModified": "2026-04-20T01:08:18.000Z"
     },
     {
-      "rank": 696,
+      "rank": 698,
       "id": "PleIAs/CommonLingua",
       "author": "PleIAs",
       "url": "https://huggingface.co/PleIAs/CommonLingua",
@@ -20600,7 +20664,7 @@
       "lastModified": "2026-04-28T10:01:57.000Z"
     },
     {
-      "rank": 697,
+      "rank": 699,
       "id": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
@@ -20645,7 +20709,7 @@
       "lastModified": "2026-05-01T06:44:12.000Z"
     },
     {
-      "rank": 698,
+      "rank": 700,
       "id": "Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/Ltx2.3-real-nudity-early-alpha-30k-steps",
@@ -20664,7 +20728,7 @@
       "lastModified": "2026-04-30T16:04:09.000Z"
     },
     {
-      "rank": 699,
+      "rank": 701,
       "id": "RedHatAI/Kimi-K2.6-NVFP4",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/Kimi-K2.6-NVFP4",
@@ -20689,7 +20753,7 @@
       "lastModified": "2026-04-30T16:20:25.000Z"
     },
     {
-      "rank": 700,
+      "rank": 702,
       "id": "AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Mihenk-LLM-v2-35B-A3B-Turkish-Financial-Model",
@@ -20728,7 +20792,7 @@
       "lastModified": "2026-05-04T15:54:27.000Z"
     },
     {
-      "rank": 701,
+      "rank": 703,
       "id": "reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
       "author": "reverentelusarca",
       "url": "https://huggingface.co/reverentelusarca/flux2-klein-9b-4b-scribbly-doodle-lora",
@@ -20745,7 +20809,7 @@
       "lastModified": "2026-05-02T22:57:06.000Z"
     },
     {
-      "rank": 702,
+      "rank": 704,
       "id": "deepcrayon/LibreHPS-4B-v1.1",
       "author": "deepcrayon",
       "url": "https://huggingface.co/deepcrayon/LibreHPS-4B-v1.1",
@@ -20773,7 +20837,7 @@
       "lastModified": "2026-05-03T17:21:07.000Z"
     },
     {
-      "rank": 703,
+      "rank": 705,
       "id": "huihui-ai/Huihui-granite-4.1-30b-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-granite-4.1-30b-abliterated",
@@ -20802,7 +20866,7 @@
       "lastModified": "2026-05-04T03:00:22.000Z"
     },
     {
-      "rank": 704,
+      "rank": 706,
       "id": "mlx-community/Qwen3.6-35B-A3B-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit",
@@ -20827,7 +20891,7 @@
       "lastModified": "2026-04-16T16:32:41.000Z"
     },
     {
-      "rank": 705,
+      "rank": 707,
       "id": "inclusionAI/LLaDA2.0-Uni",
       "author": "inclusionAI",
       "url": "https://huggingface.co/inclusionAI/LLaDA2.0-Uni",
@@ -20862,7 +20926,7 @@
       "lastModified": "2026-05-06T10:27:45.000Z"
     },
     {
-      "rank": 706,
+      "rank": 708,
       "id": "tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-1.25bit-GGUF",
@@ -20892,7 +20956,7 @@
       "lastModified": "2026-04-29T04:36:14.000Z"
     },
     {
-      "rank": 707,
+      "rank": 709,
       "id": "ibm-granite/granite-speech-4.1-2b-plus",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-plus",
@@ -20928,7 +20992,7 @@
       "lastModified": "2026-04-29T14:11:28.000Z"
     },
     {
-      "rank": 708,
+      "rank": 710,
       "id": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/DeepSeek-V4-Flash-2bit-DQ",
@@ -20951,7 +21015,7 @@
       "lastModified": "2026-04-26T23:23:24.000Z"
     },
     {
-      "rank": 709,
+      "rank": 711,
       "id": "dx8152/Video-dataset-slices",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Video-dataset-slices",
@@ -20968,7 +21032,7 @@
       "lastModified": "2026-05-04T06:38:41.000Z"
     },
     {
-      "rank": 710,
+      "rank": 712,
       "id": "am17an/Qwen3.6-27B-MTP-GGUF",
       "author": "am17an",
       "url": "https://huggingface.co/am17an/Qwen3.6-27B-MTP-GGUF",
@@ -20988,7 +21052,7 @@
       "lastModified": "2026-05-04T09:36:58.000Z"
     },
     {
-      "rank": 711,
+      "rank": 713,
       "id": "mrfakename/Qwen3-ASR-Enhanced-v0.1",
       "author": "mrfakename",
       "url": "https://huggingface.co/mrfakename/Qwen3-ASR-Enhanced-v0.1",
@@ -21015,7 +21079,7 @@
       "lastModified": "2026-05-05T16:17:32.000Z"
     },
     {
-      "rank": 712,
+      "rank": 714,
       "id": "google/timesfm-2.5-200m-transformers",
       "author": "google",
       "url": "https://huggingface.co/google/timesfm-2.5-200m-transformers",
@@ -21039,7 +21103,7 @@
       "lastModified": "2026-04-10T23:15:28.000Z"
     },
     {
-      "rank": 713,
+      "rank": 715,
       "id": "baidu/ERNIE-Image-Turbo",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Turbo",
@@ -21061,7 +21125,7 @@
       "lastModified": "2026-04-17T02:33:45.000Z"
     },
     {
-      "rank": 714,
+      "rank": 716,
       "id": "morphic/reshoot-anything",
       "author": "morphic",
       "url": "https://huggingface.co/morphic/reshoot-anything",
@@ -21093,7 +21157,7 @@
       "lastModified": "2026-04-26T03:10:44.000Z"
     },
     {
-      "rank": 715,
+      "rank": 717,
       "id": "Tesslate/OmniCoder-9B-GGUF",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B-GGUF",
@@ -21121,11 +21185,11 @@
       "lastModified": "2026-03-12T07:09:41.000Z"
     },
     {
-      "rank": 716,
+      "rank": 718,
       "id": "Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged",
-      "downloads": 5395358,
+      "downloads": 5729235,
       "likes": 722,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -21139,7 +21203,7 @@
       "lastModified": "2025-12-09T09:02:14.000Z"
     },
     {
-      "rank": 717,
+      "rank": 719,
       "id": "Aratako/Irodori-TTS-500M-v2-VoiceDesign",
       "author": "Aratako",
       "url": "https://huggingface.co/Aratako/Irodori-TTS-500M-v2-VoiceDesign",
@@ -21164,7 +21228,7 @@
       "lastModified": "2026-04-11T16:12:30.000Z"
     },
     {
-      "rank": 718,
+      "rank": 720,
       "id": "allenai/MolmoAct2",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2",
@@ -21187,7 +21251,7 @@
       "lastModified": "2026-05-09T17:43:08.000Z"
     },
     {
-      "rank": 719,
+      "rank": 721,
       "id": "tilde-research/aurora-1.1B",
       "author": "tilde-research",
       "url": "https://huggingface.co/tilde-research/aurora-1.1B",
@@ -21205,7 +21269,7 @@
       "lastModified": "2026-05-08T02:16:50.000Z"
     },
     {
-      "rank": 720,
+      "rank": 722,
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -21240,7 +21304,7 @@
       "lastModified": "2026-05-12T15:09:27.000Z"
     },
     {
-      "rank": 721,
+      "rank": 723,
       "id": "unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF-MTP",
@@ -21268,7 +21332,7 @@
       "lastModified": "2026-05-11T19:24:43.000Z"
     },
     {
-      "rank": 722,
+      "rank": 724,
       "id": "Jundot/Qwen3.6-27B-oQ4-mtp",
       "author": "Jundot",
       "url": "https://huggingface.co/Jundot/Qwen3.6-27B-oQ4-mtp",
@@ -21290,7 +21354,7 @@
       "lastModified": "2026-05-06T15:53:30.000Z"
     },
     {
-      "rank": 723,
+      "rank": 725,
       "id": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
@@ -21317,7 +21381,7 @@
       "lastModified": "2026-04-13T14:12:39.000Z"
     },
     {
-      "rank": 724,
+      "rank": 726,
       "id": "Zyphra/ZAYA1-base",
       "author": "Zyphra",
       "url": "https://huggingface.co/Zyphra/ZAYA1-base",
@@ -21342,7 +21406,7 @@
       "lastModified": "2025-11-26T20:29:15.000Z"
     },
     {
-      "rank": 725,
+      "rank": 727,
       "id": "postcn/Jeju-Standard_Korean_Translator",
       "author": "postcn",
       "url": "https://huggingface.co/postcn/Jeju-Standard_Korean_Translator",
@@ -21376,7 +21440,7 @@
       "lastModified": "2026-05-07T07:20:30.000Z"
     },
     {
-      "rank": 726,
+      "rank": 728,
       "id": "teamblobfish/DeepSeek-V4-Flash-GGUF",
       "author": "teamblobfish",
       "url": "https://huggingface.co/teamblobfish/DeepSeek-V4-Flash-GGUF",
@@ -21403,7 +21467,7 @@
       "lastModified": "2026-05-14T13:20:08.000Z"
     },
     {
-      "rank": 727,
+      "rank": 729,
       "id": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-27B-abliterated",
@@ -21430,7 +21494,7 @@
       "lastModified": "2026-04-23T14:23:25.000Z"
     },
     {
-      "rank": 728,
+      "rank": 730,
       "id": "lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
       "author": "lablab-ai-amd-developer-hackathon",
       "url": "https://huggingface.co/lablab-ai-amd-developer-hackathon/CyberSecQwen-4B",
@@ -21471,7 +21535,7 @@
       "lastModified": "2026-05-08T12:20:22.000Z"
     },
     {
-      "rank": 729,
+      "rank": 731,
       "id": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
@@ -21501,7 +21565,7 @@
       "lastModified": "2026-05-03T03:44:10.000Z"
     },
     {
-      "rank": 730,
+      "rank": 732,
       "id": "nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Elastic-30B-A3B-FP8",
@@ -21538,7 +21602,7 @@
       "lastModified": "2026-05-08T03:42:15.000Z"
     },
     {
-      "rank": 731,
+      "rank": 733,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved",
@@ -21570,7 +21634,7 @@
       "lastModified": "2026-05-09T02:15:11.000Z"
     },
     {
-      "rank": 732,
+      "rank": 734,
       "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -21612,7 +21676,7 @@
       "lastModified": "2026-04-29T16:15:40.000Z"
     },
     {
-      "rank": 733,
+      "rank": 735,
       "id": "Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
@@ -21657,7 +21721,7 @@
       "lastModified": "2026-04-18T12:11:43.000Z"
     },
     {
-      "rank": 734,
+      "rank": 736,
       "id": "huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-gemma-4-26B-A4B-it-abliterated",
@@ -21684,7 +21748,7 @@
       "lastModified": "2026-05-12T16:29:55.000Z"
     },
     {
-      "rank": 735,
+      "rank": 737,
       "id": "openbmb/MiniCPM-V-4.6-Thinking-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-gguf",
@@ -21716,7 +21780,7 @@
       "lastModified": "2026-05-19T15:33:43.000Z"
     },
     {
-      "rank": 736,
+      "rank": 738,
       "id": "GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Qwen3.6-35B-A3B-NSC-ACE-SABER-GGUF-MTP",
@@ -21750,7 +21814,7 @@
       "lastModified": "2026-05-14T17:32:11.000Z"
     },
     {
-      "rank": 737,
+      "rank": 739,
       "id": "Ultralytics/YOLO26",
       "author": "Ultralytics",
       "url": "https://huggingface.co/Ultralytics/YOLO26",
@@ -21780,7 +21844,7 @@
       "lastModified": "2026-01-27T13:43:16.000Z"
     },
     {
-      "rank": 738,
+      "rank": 740,
       "id": "black-forest-labs/FLUX.2-small-decoder",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
@@ -21805,7 +21869,7 @@
       "lastModified": "2026-04-07T20:42:04.000Z"
     },
     {
-      "rank": 739,
+      "rank": 741,
       "id": "moonshotai/Kimi-K2.5",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/Kimi-K2.5",
@@ -21832,7 +21896,7 @@
       "lastModified": "2026-04-30T03:56:40.000Z"
     },
     {
-      "rank": 740,
+      "rank": 742,
       "id": "LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
       "author": "LuffyTheFox",
       "url": "https://huggingface.co/LuffyTheFox/Qwen3.6-35B-A3B-Uncensored-Genesis-GGUF",
@@ -21864,7 +21928,7 @@
       "lastModified": "2026-05-16T15:03:33.000Z"
     },
     {
-      "rank": 741,
+      "rank": 743,
       "id": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -21909,7 +21973,7 @@
       "lastModified": "2026-04-14T05:56:20.000Z"
     },
     {
-      "rank": 742,
+      "rank": 744,
       "id": "mistralai/Mistral-7B-Instruct-v0.2",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
@@ -21937,7 +22001,7 @@
       "lastModified": "2025-07-24T16:57:21.000Z"
     },
     {
-      "rank": 743,
+      "rank": 745,
       "id": "noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
       "author": "noctrex",
       "url": "https://huggingface.co/noctrex/Qwopus3.6-27B-v1-preview-MTP-GGUF",
@@ -21963,7 +22027,7 @@
       "lastModified": "2026-05-21T10:37:21.000Z"
     },
     {
-      "rank": 744,
+      "rank": 746,
       "id": "LiquidAI/LFM2.5-Audio-1.5B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B",
@@ -21992,7 +22056,7 @@
       "lastModified": "2026-03-30T14:43:52.000Z"
     },
     {
-      "rank": 745,
+      "rank": 747,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B-GGUF",
@@ -22034,7 +22098,7 @@
       "lastModified": "2026-05-07T17:23:36.000Z"
     },
     {
-      "rank": 746,
+      "rank": 748,
       "id": "google/functiongemma-270m-it",
       "author": "google",
       "url": "https://huggingface.co/google/functiongemma-270m-it",
@@ -22062,7 +22126,7 @@
       "lastModified": "2026-01-14T09:33:54.000Z"
     },
     {
-      "rank": 747,
+      "rank": 749,
       "id": "llmfan46/G4-MeroMero-31B-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/G4-MeroMero-31B-uncensored-heretic",
@@ -22091,7 +22155,7 @@
       "lastModified": "2026-05-15T23:03:21.000Z"
     },
     {
-      "rank": 748,
+      "rank": 750,
       "id": "llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.5-9B-ultra-uncensored-heretic-v2-GGUF",
@@ -22121,7 +22185,7 @@
       "lastModified": "2026-03-30T22:38:36.000Z"
     },
     {
-      "rank": 749,
+      "rank": 751,
       "id": "Qwen/Qwen3.5-35B-A3B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-35B-A3B",
@@ -22148,7 +22212,7 @@
       "lastModified": "2026-04-24T02:38:38.000Z"
     },
     {
-      "rank": 750,
+      "rank": 752,
       "id": "Efficient-Large-Model/SANA-Video_2B_720p",
       "author": "Efficient-Large-Model",
       "url": "https://huggingface.co/Efficient-Large-Model/SANA-Video_2B_720p",
@@ -22177,7 +22241,7 @@
       "lastModified": "2026-03-16T13:38:42.000Z"
     },
     {
-      "rank": 751,
+      "rank": 753,
       "id": "BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
       "author": "BennyDaBall",
       "url": "https://huggingface.co/BennyDaBall/Qwen3-4b-Z-Image-Engineer-V4",
@@ -22204,7 +22268,7 @@
       "lastModified": "2026-02-04T21:29:30.000Z"
     },
     {
-      "rank": 752,
+      "rank": 754,
       "id": "lightx2v/Qwen-Image-Edit-2511-Lightning",
       "author": "lightx2v",
       "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
@@ -22233,7 +22297,7 @@
       "lastModified": "2026-01-15T10:41:12.000Z"
     },
     {
-      "rank": 753,
+      "rank": 755,
       "id": "llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic",
@@ -22273,7 +22337,7 @@
       "lastModified": "2026-05-18T20:15:32.000Z"
     },
     {
-      "rank": 754,
+      "rank": 756,
       "id": "Lora-Daddy/LTX2.3-cum-on-face-transition",
       "author": "Lora-Daddy",
       "url": "https://huggingface.co/Lora-Daddy/LTX2.3-cum-on-face-transition",
@@ -22291,7 +22355,7 @@
       "lastModified": "2026-05-19T13:07:28.000Z"
     },
     {
-      "rank": 755,
+      "rank": 757,
       "id": "Falconsai/nsfw_image_detection",
       "author": "Falconsai",
       "url": "https://huggingface.co/Falconsai/nsfw_image_detection",
@@ -22316,7 +22380,7 @@
       "lastModified": "2025-04-06T13:42:07.000Z"
     },
     {
-      "rank": 756,
+      "rank": 758,
       "id": "allenai/OlmoEarth-v1_1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1_1-Base",
@@ -22332,7 +22396,7 @@
       "lastModified": "2026-05-15T15:53:18.000Z"
     },
     {
-      "rank": 757,
+      "rank": 759,
       "id": "tencent/Hy-MT2-1.8B-2Bit-GGUF",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-2Bit-GGUF",
@@ -22355,7 +22419,7 @@
       "lastModified": "2026-05-26T09:06:26.000Z"
     },
     {
-      "rank": 758,
+      "rank": 760,
       "id": "cyberneurova/CyberNeurova-Lance-3B-abliterated",
       "author": "cyberneurova",
       "url": "https://huggingface.co/cyberneurova/CyberNeurova-Lance-3B-abliterated",
@@ -22388,7 +22452,7 @@
       "lastModified": "2026-05-20T10:40:41.000Z"
     },
     {
-      "rank": 759,
+      "rank": 761,
       "id": "Fortytwo-Network/Strand-Rust-Coder-14B-v1",
       "author": "Fortytwo-Network",
       "url": "https://huggingface.co/Fortytwo-Network/Strand-Rust-Coder-14B-v1",
@@ -22418,7 +22482,7 @@
       "lastModified": "2026-01-05T17:19:35.000Z"
     },
     {
-      "rank": 760,
+      "rank": 762,
       "id": "tencent/Hy-MT2-1.8B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-1.8B-FP8",
@@ -22441,7 +22505,7 @@
       "lastModified": "2026-05-26T09:06:01.000Z"
     },
     {
-      "rank": 761,
+      "rank": 763,
       "id": "zeroentropy/zembed-1-embedding",
       "author": "zeroentropy",
       "url": "https://huggingface.co/zeroentropy/zembed-1-embedding",
@@ -22475,7 +22539,7 @@
       "lastModified": "2026-03-12T21:10:43.000Z"
     },
     {
-      "rank": 762,
+      "rank": 764,
       "id": "FireRedTeam/FireRed-Image-Edit-1.1",
       "author": "FireRedTeam",
       "url": "https://huggingface.co/FireRedTeam/FireRed-Image-Edit-1.1",
@@ -22499,7 +22563,7 @@
       "lastModified": "2026-03-09T09:24:51.000Z"
     },
     {
-      "rank": 763,
+      "rank": 765,
       "id": "meta-llama/Llama-3.2-3B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-3.2-3B",
@@ -22536,7 +22600,7 @@
       "lastModified": "2024-10-24T15:07:40.000Z"
     },
     {
-      "rank": 764,
+      "rank": 766,
       "id": "tencent/Hy-MT2-7B-FP8",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT2-7B-FP8",
@@ -22559,7 +22623,7 @@
       "lastModified": "2026-05-26T09:06:05.000Z"
     },
     {
-      "rank": 765,
+      "rank": 767,
       "id": "google/gemma-3-12b-it-qat-q4_0-unquantized",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized",
@@ -22604,7 +22668,7 @@
       "lastModified": "2025-04-15T21:07:07.000Z"
     },
     {
-      "rank": 766,
+      "rank": 768,
       "id": "ubergarm/Qwen3.6-27B-GGUF",
       "author": "ubergarm",
       "url": "https://huggingface.co/ubergarm/Qwen3.6-27B-GGUF",
@@ -22630,7 +22694,7 @@
       "lastModified": "2026-05-04T18:37:44.000Z"
     },
     {
-      "rank": 767,
+      "rank": 769,
       "id": "openbmb/BitCPM-CANN-0.5B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM-CANN-0.5B-gguf",
@@ -22654,7 +22718,7 @@
       "lastModified": "2026-05-23T18:11:41.000Z"
     },
     {
-      "rank": 768,
+      "rank": 770,
       "id": "nhathoangfoto/Flux.2-Klein-9B-Mannequin",
       "author": "nhathoangfoto",
       "url": "https://huggingface.co/nhathoangfoto/Flux.2-Klein-9B-Mannequin",
@@ -22684,7 +22748,7 @@
       "lastModified": "2026-05-07T13:17:14.000Z"
     },
     {
-      "rank": 769,
+      "rank": 771,
       "id": "meituan-longcat/WBench-weights",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/WBench-weights",
@@ -22707,11 +22771,11 @@
       "lastModified": "2026-05-29T02:38:08.000Z"
     },
     {
-      "rank": 770,
+      "rank": 772,
       "id": "meituan-longcat/LongCat-Video-Avatar",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar",
-      "downloads": 424,
+      "downloads": 427,
       "likes": 250,
       "trendingScore": 9,
       "pipelineTag": null,
@@ -22736,7 +22800,7 @@
       "lastModified": "2025-12-17T05:12:35.000Z"
     },
     {
-      "rank": 771,
+      "rank": 773,
       "id": "nvidia/PixelDiT-1300M-1024px",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px",
@@ -22761,7 +22825,7 @@
       "lastModified": "2026-04-15T21:45:01.000Z"
     },
     {
-      "rank": 772,
+      "rank": 774,
       "id": "Jackrong/Qwopus3.5-27B-v3",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-27B-v3",
@@ -22794,7 +22858,7 @@
       "lastModified": "2026-04-16T09:12:00.000Z"
     },
     {
-      "rank": 773,
+      "rank": 775,
       "id": "meta-llama/Meta-Llama-3-8B",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Meta-Llama-3-8B",
@@ -22822,7 +22886,7 @@
       "lastModified": "2024-09-27T15:52:33.000Z"
     },
     {
-      "rank": 774,
+      "rank": 776,
       "id": "Jackrong/Qwopus3.5-4B-v3-MTP-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-4B-v3-MTP-GGUF",
@@ -22844,11 +22908,11 @@
       "lastModified": "2026-05-22T11:38:18.000Z"
     },
     {
-      "rank": 775,
+      "rank": 777,
       "id": "EssentialAI/rnj-1.5-instruct",
       "author": "EssentialAI",
       "url": "https://huggingface.co/EssentialAI/rnj-1.5-instruct",
-      "downloads": 472,
+      "downloads": 279,
       "likes": 9,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -22878,11 +22942,11 @@
       "lastModified": "2026-05-26T06:18:03.000Z"
     },
     {
-      "rank": 776,
+      "rank": 778,
       "id": "Systran/faster-whisper-large-v3",
       "author": "Systran",
       "url": "https://huggingface.co/Systran/faster-whisper-large-v3",
-      "downloads": 933639,
+      "downloads": 937584,
       "likes": 587,
       "trendingScore": 9,
       "pipelineTag": "automatic-speech-recognition",
@@ -22923,11 +22987,11 @@
       "lastModified": "2023-11-23T09:41:12.000Z"
     },
     {
-      "rank": 777,
+      "rank": 779,
       "id": "mlx-community/Qwen3.6-27B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.6-27B-OptiQ-4bit",
-      "downloads": 14408,
+      "downloads": 14576,
       "likes": 24,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -22955,7 +23019,7 @@
       "lastModified": "2026-05-31T04:02:19.000Z"
     },
     {
-      "rank": 778,
+      "rank": 780,
       "id": "NeoQuasar/Kronos-base",
       "author": "NeoQuasar",
       "url": "https://huggingface.co/NeoQuasar/Kronos-base",
@@ -22978,11 +23042,11 @@
       "lastModified": "2025-09-09T14:08:15.000Z"
     },
     {
-      "rank": 779,
+      "rank": 781,
       "id": "Jackrong/Qwopus3.5-9B-v3-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwopus3.5-9B-v3-GGUF",
-      "downloads": 34300,
+      "downloads": 34927,
       "likes": 355,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -23011,11 +23075,11 @@
       "lastModified": "2026-04-12T15:46:14.000Z"
     },
     {
-      "rank": 780,
+      "rank": 782,
       "id": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-NVFP4-Experts-Only-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-NVFP4-Experts-Only-GGUF",
-      "downloads": 13302,
+      "downloads": 13982,
       "likes": 14,
       "trendingScore": 9,
       "pipelineTag": "image-text-to-text",
@@ -23044,11 +23108,11 @@
       "lastModified": "2026-05-09T02:29:40.000Z"
     },
     {
-      "rank": 781,
+      "rank": 783,
       "id": "Qwen/Qwen2.5-3B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct",
-      "downloads": 13821532,
+      "downloads": 13948947,
       "likes": 475,
       "trendingScore": 9,
       "pipelineTag": "text-generation",
@@ -23074,34 +23138,11 @@
       "lastModified": "2024-09-25T12:33:00.000Z"
     },
     {
-      "rank": 782,
-      "id": "ControlLight/ControlLight",
-      "author": "ControlLight",
-      "url": "https://huggingface.co/ControlLight/ControlLight",
-      "downloads": 0,
-      "likes": 9,
-      "trendingScore": 9,
-      "pipelineTag": null,
-      "libraryName": null,
-      "tags": [
-        "en",
-        "zh",
-        "dataset:ControlLight/Light100K",
-        "arxiv:2605.25569",
-        "base_model:black-forest-labs/FLUX.2-klein-base-9B",
-        "base_model:finetune:black-forest-labs/FLUX.2-klein-base-9B",
-        "license:apache-2.0",
-        "region:us"
-      ],
-      "createdAt": "2026-05-21T05:46:43.000Z",
-      "lastModified": "2026-05-26T04:28:29.000Z"
-    },
-    {
-      "rank": 783,
+      "rank": 784,
       "id": "Wan-AI/Wan2.2-Animate-14B",
       "author": "Wan-AI",
       "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B",
-      "downloads": 17408,
+      "downloads": 17424,
       "likes": 1169,
       "trendingScore": 9,
       "pipelineTag": "video-to-video",
@@ -23121,48 +23162,32 @@
       "lastModified": "2025-11-05T10:15:40.000Z"
     },
     {
-      "rank": 784,
-      "id": "infly/Infinity-Parser2-Pro",
-      "author": "infly",
-      "url": "https://huggingface.co/infly/Infinity-Parser2-Pro",
-      "downloads": 4608,
-      "likes": 49,
+      "rank": 785,
+      "id": "Qwen/Qwen-Image",
+      "author": "Qwen",
+      "url": "https://huggingface.co/Qwen/Qwen-Image",
+      "downloads": 171340,
+      "likes": 2499,
       "trendingScore": 9,
-      "pipelineTag": "image-text-to-text",
-      "libraryName": "transformers",
+      "pipelineTag": "text-to-image",
+      "libraryName": "diffusers",
       "tags": [
-        "transformers",
+        "diffusers",
         "safetensors",
-        "qwen3_5_moe",
-        "image-text-to-text",
-        "ocr",
-        "pdf",
-        "document-parsing",
-        "document-understanding",
-        "layout-analysis",
-        "table-recognition",
-        "chart-parsing",
-        "formula-recognition",
-        "chemical-formula",
-        "markdown",
-        "vision-language",
-        "infinity-parser",
-        "infinity_parser2",
-        "conversational",
+        "text-to-image",
         "en",
         "zh",
-        "multilingual",
-        "dataset:infly/Infinity-Doc2-5M",
+        "arxiv:2508.02324",
         "license:apache-2.0",
-        "eval-results",
-        "endpoints_compatible",
+        "diffusers:QwenImagePipeline",
+        "deploy:azure",
         "region:us"
       ],
-      "createdAt": "2026-04-08T12:28:55.000Z",
-      "lastModified": "2026-05-28T11:39:11.000Z"
+      "createdAt": "2025-08-02T04:58:07.000Z",
+      "lastModified": "2025-08-18T02:42:19.000Z"
     },
     {
-      "rank": 785,
+      "rank": 786,
       "id": "AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Cybersecurity-BaronLLM_Offensive_Security_LLM_Q6_K_GGUF",
@@ -23189,7 +23214,7 @@
       "lastModified": "2025-06-04T20:56:33.000Z"
     },
     {
-      "rank": 786,
+      "rank": 787,
       "id": "ibm-granite/granitelib-rag-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-rag-r1.0",
@@ -23213,7 +23238,7 @@
       "lastModified": "2026-05-06T20:38:34.000Z"
     },
     {
-      "rank": 787,
+      "rank": 788,
       "id": "dx8152/Flux2-Klein-9B-Enhanced-Details",
       "author": "dx8152",
       "url": "https://huggingface.co/dx8152/Flux2-Klein-9B-Enhanced-Details",
@@ -23232,7 +23257,7 @@
       "lastModified": "2026-03-09T05:52:48.000Z"
     },
     {
-      "rank": 788,
+      "rank": 789,
       "id": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
@@ -23266,7 +23291,7 @@
       "lastModified": "2026-04-06T02:11:58.000Z"
     },
     {
-      "rank": 789,
+      "rank": 790,
       "id": "prism-ml/Bonsai-8B-gguf",
       "author": "prism-ml",
       "url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf",
@@ -23298,7 +23323,7 @@
       "lastModified": "2026-04-18T20:45:02.000Z"
     },
     {
-      "rank": 790,
+      "rank": 791,
       "id": "zerofata/G4-MeroMero-26B-A4B-gguf",
       "author": "zerofata",
       "url": "https://huggingface.co/zerofata/G4-MeroMero-26B-A4B-gguf",
@@ -23320,7 +23345,7 @@
       "lastModified": "2026-05-02T03:51:45.000Z"
     },
     {
-      "rank": 791,
+      "rank": 792,
       "id": "AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
       "author": "AEON-7",
       "url": "https://huggingface.co/AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4",
@@ -23365,7 +23390,7 @@
       "lastModified": "2026-05-01T06:44:19.000Z"
     },
     {
-      "rank": 792,
+      "rank": 793,
       "id": "deepseek-ai/DeepSeek-V4-Flash-Base",
       "author": "deepseek-ai",
       "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -23384,7 +23409,7 @@
       "lastModified": "2026-04-27T06:51:43.000Z"
     },
     {
-      "rank": 793,
+      "rank": 794,
       "id": "kai-os/Carnice-V2-27b",
       "author": "kai-os",
       "url": "https://huggingface.co/kai-os/Carnice-V2-27b",
@@ -23418,7 +23443,7 @@
       "lastModified": "2026-04-26T13:08:54.000Z"
     },
     {
-      "rank": 794,
+      "rank": 795,
       "id": "tencent/Hy-MT1.5-1.8B-2bit",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit",
@@ -23446,7 +23471,7 @@
       "lastModified": "2026-04-29T04:35:49.000Z"
     },
     {
-      "rank": 795,
+      "rank": 796,
       "id": "tori29umai/rtdetrv4-x-manga109s",
       "author": "tori29umai",
       "url": "https://huggingface.co/tori29umai/rtdetrv4-x-manga109s",
@@ -23474,7 +23499,7 @@
       "lastModified": "2026-05-01T07:27:54.000Z"
     },
     {
-      "rank": 796,
+      "rank": 797,
       "id": "thomasgauthier/talkie-1930-13b-it-GGUF",
       "author": "thomasgauthier",
       "url": "https://huggingface.co/thomasgauthier/talkie-1930-13b-it-GGUF",
@@ -23497,7 +23522,7 @@
       "lastModified": "2026-05-04T04:27:45.000Z"
     },
     {
-      "rank": 797,
+      "rank": 798,
       "id": "LH-Tech-AI/Flare-TTS-28M",
       "author": "LH-Tech-AI",
       "url": "https://huggingface.co/LH-Tech-AI/Flare-TTS-28M",
@@ -23524,7 +23549,7 @@
       "lastModified": "2026-05-06T17:18:43.000Z"
     },
     {
-      "rank": 798,
+      "rank": 799,
       "id": "facebook/nllb-200-distilled-600M",
       "author": "facebook",
       "url": "https://huggingface.co/facebook/nllb-200-distilled-600M",
@@ -23569,7 +23594,7 @@
       "lastModified": "2024-02-14T17:18:36.000Z"
     },
     {
-      "rank": 799,
+      "rank": 800,
       "id": "mistralai/Ministral-3-3B-Instruct-2512",
       "author": "mistralai",
       "url": "https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512",
@@ -23605,7 +23630,7 @@
       "lastModified": "2026-01-15T11:15:08.000Z"
     },
     {
-      "rank": 800,
+      "rank": 801,
       "id": "anrilombard/mzansilm-125m",
       "author": "anrilombard",
       "url": "https://huggingface.co/anrilombard/mzansilm-125m",
@@ -23645,7 +23670,7 @@
       "lastModified": "2026-05-08T19:22:30.000Z"
     },
     {
-      "rank": 801,
+      "rank": 802,
       "id": "atlasia/moulsot.v0.3",
       "author": "atlasia",
       "url": "https://huggingface.co/atlasia/moulsot.v0.3",
@@ -23674,7 +23699,7 @@
       "lastModified": "2026-05-02T15:16:19.000Z"
     },
     {
-      "rank": 802,
+      "rank": 803,
       "id": "NucleusAI/Nucleus-Image",
       "author": "NucleusAI",
       "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
@@ -23702,7 +23727,7 @@
       "lastModified": "2026-04-16T01:55:09.000Z"
     },
     {
-      "rank": 803,
+      "rank": 804,
       "id": "Comfy-Org/Qwen-Image_ComfyUI",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI",
@@ -23721,7 +23746,7 @@
       "lastModified": "2026-01-09T02:55:12.000Z"
     },
     {
-      "rank": 804,
+      "rank": 805,
       "id": "darksidewalker/DaSiWa-LTX2.3",
       "author": "darksidewalker",
       "url": "https://huggingface.co/darksidewalker/DaSiWa-LTX2.3",
@@ -23740,7 +23765,7 @@
       "lastModified": "2026-05-05T11:41:45.000Z"
     },
     {
-      "rank": 805,
+      "rank": 806,
       "id": "allenai/Molmo2-ER",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/Molmo2-ER",
@@ -23772,7 +23797,7 @@
       "lastModified": "2026-05-08T01:26:17.000Z"
     },
     {
-      "rank": 806,
+      "rank": 807,
       "id": "stepfun-ai/Step-3.5-Flash",
       "author": "stepfun-ai",
       "url": "https://huggingface.co/stepfun-ai/Step-3.5-Flash",
@@ -23799,7 +23824,7 @@
       "lastModified": "2026-03-17T05:54:33.000Z"
     },
     {
-      "rank": 807,
+      "rank": 808,
       "id": "numz/SeedVR2_comfyUI",
       "author": "numz",
       "url": "https://huggingface.co/numz/SeedVR2_comfyUI",
@@ -23821,7 +23846,7 @@
       "lastModified": "2025-11-09T16:24:56.000Z"
     },
     {
-      "rank": 808,
+      "rank": 809,
       "id": "Comfy-Org/BiRefNet",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/BiRefNet",
@@ -23839,7 +23864,7 @@
       "lastModified": "2026-05-08T08:57:55.000Z"
     },
     {
-      "rank": 809,
+      "rank": 810,
       "id": "mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/granite-4.1-8b-Abliterated-AND-Disinhibited-i1-GGUF",
@@ -23868,7 +23893,7 @@
       "lastModified": "2026-05-02T22:17:27.000Z"
     },
     {
-      "rank": 810,
+      "rank": 811,
       "id": "Abiray/sulphur_dev-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/sulphur_dev-GGUF",
@@ -23889,7 +23914,7 @@
       "lastModified": "2026-05-10T15:36:43.000Z"
     },
     {
-      "rank": 811,
+      "rank": 812,
       "id": "ProsusAI/finbert",
       "author": "ProsusAI",
       "url": "https://huggingface.co/ProsusAI/finbert",
@@ -23917,7 +23942,7 @@
       "lastModified": "2023-05-23T12:43:35.000Z"
     },
     {
-      "rank": 812,
+      "rank": 813,
       "id": "PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
       "author": "PaddlePaddle",
       "url": "https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF",
@@ -23938,7 +23963,7 @@
       "lastModified": "2026-03-06T11:31:28.000Z"
     },
     {
-      "rank": 813,
+      "rank": 814,
       "id": "rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
       "author": "rico03",
       "url": "https://huggingface.co/rico03/Qwen3.6-27B-Claude-Opus-Reasoning-Distilled-GGUF",
@@ -23974,7 +23999,7 @@
       "lastModified": "2026-04-23T15:48:05.000Z"
     },
     {
-      "rank": 814,
+      "rank": 815,
       "id": "h94/IP-Adapter",
       "author": "h94",
       "url": "https://huggingface.co/h94/IP-Adapter",
@@ -23997,7 +24022,7 @@
       "lastModified": "2024-03-27T08:33:41.000Z"
     },
     {
-      "rank": 815,
+      "rank": 816,
       "id": "allenai/MolmoAct2-SO100_101",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/MolmoAct2-SO100_101",
@@ -24022,7 +24047,7 @@
       "lastModified": "2026-05-09T17:43:16.000Z"
     },
     {
-      "rank": 816,
+      "rank": 817,
       "id": "Tesslate/OmniCoder-9B",
       "author": "Tesslate",
       "url": "https://huggingface.co/Tesslate/OmniCoder-9B",
@@ -24057,7 +24082,7 @@
       "lastModified": "2026-03-13T03:17:34.000Z"
     },
     {
-      "rank": 817,
+      "rank": 818,
       "id": "DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Maximizing-Model-Performance-All-Quants-Types-And-Full-Precision-by-Samplers_Parameters",
@@ -24102,7 +24127,7 @@
       "lastModified": "2025-07-27T23:55:00.000Z"
     },
     {
-      "rank": 818,
+      "rank": 819,
       "id": "unsloth/gpt-oss-20b-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/gpt-oss-20b-GGUF",
@@ -24129,7 +24154,7 @@
       "lastModified": "2025-12-19T01:39:27.000Z"
     },
     {
-      "rank": 819,
+      "rank": 820,
       "id": "lovis93/next-scene-qwen-image-lora-2509",
       "author": "lovis93",
       "url": "https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509",
@@ -24158,7 +24183,7 @@
       "lastModified": "2025-10-21T13:28:48.000Z"
     },
     {
-      "rank": 820,
+      "rank": 821,
       "id": "Mininglamp-2718/Mano-P",
       "author": "Mininglamp-2718",
       "url": "https://huggingface.co/Mininglamp-2718/Mano-P",
@@ -24177,7 +24202,7 @@
       "lastModified": "2026-05-09T11:29:51.000Z"
     },
     {
-      "rank": 821,
+      "rank": 822,
       "id": "sensenova/SenseNova-U1-A3B-MoT-SFT",
       "author": "sensenova",
       "url": "https://huggingface.co/sensenova/SenseNova-U1-A3B-MoT-SFT",
@@ -24198,7 +24223,7 @@
       "lastModified": "2026-05-15T02:58:53.000Z"
     },
     {
-      "rank": 822,
+      "rank": 823,
       "id": "Minthy/ToriiGate-0.5",
       "author": "Minthy",
       "url": "https://huggingface.co/Minthy/ToriiGate-0.5",
@@ -24224,7 +24249,7 @@
       "lastModified": "2026-05-09T23:49:52.000Z"
     },
     {
-      "rank": 823,
+      "rank": 824,
       "id": "unsloth/Qwen3.5-35B-A3B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF",
@@ -24250,7 +24275,7 @@
       "lastModified": "2026-03-05T17:25:50.000Z"
     },
     {
-      "rank": 824,
+      "rank": 825,
       "id": "ByteDance-Seed/UI-TARS-1.5-7B",
       "author": "ByteDance-Seed",
       "url": "https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B",
@@ -24287,7 +24312,7 @@
       "lastModified": "2025-04-18T01:35:38.000Z"
     },
     {
-      "rank": 825,
+      "rank": 826,
       "id": "ibm-granite/granite-docling-258M",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-docling-258M",
@@ -24332,7 +24357,7 @@
       "lastModified": "2025-09-23T08:52:16.000Z"
     },
     {
-      "rank": 826,
+      "rank": 827,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-SigLIP",
@@ -24357,7 +24382,7 @@
       "lastModified": "2026-05-16T10:38:16.000Z"
     },
     {
-      "rank": 827,
+      "rank": 828,
       "id": "ussaaron/workflows",
       "author": "ussaaron",
       "url": "https://huggingface.co/ussaaron/workflows",
@@ -24374,7 +24399,7 @@
       "lastModified": "2026-05-14T19:56:59.000Z"
     },
     {
-      "rank": 828,
+      "rank": 829,
       "id": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
@@ -24401,7 +24426,7 @@
       "lastModified": "2026-04-18T07:31:49.000Z"
     },
     {
-      "rank": 829,
+      "rank": 830,
       "id": "smthem/HiDream-O1-Image-Dev",
       "author": "smthem",
       "url": "https://huggingface.co/smthem/HiDream-O1-Image-Dev",
@@ -24419,7 +24444,7 @@
       "lastModified": "2026-05-16T05:40:48.000Z"
     },
     {
-      "rank": 830,
+      "rank": 831,
       "id": "p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
       "author": "p1atdev",
       "url": "https://huggingface.co/p1atdev/Irodori-TTS-500M-v2-Character-Voice-Tagger",
@@ -24444,7 +24469,7 @@
       "lastModified": "2026-05-16T10:38:24.000Z"
     },
     {
-      "rank": 831,
+      "rank": 832,
       "id": "z-lab/Kimi-K2.6-DFlash",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/Kimi-K2.6-DFlash",
@@ -24476,7 +24501,7 @@
       "lastModified": "2026-05-16T05:07:15.000Z"
     },
     {
-      "rank": 832,
+      "rank": 833,
       "id": "Kijai/WanVideo_comfy_fp8_scaled",
       "author": "Kijai",
       "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
@@ -24497,7 +24522,7 @@
       "lastModified": "2026-02-23T22:33:29.000Z"
     },
     {
-      "rank": 833,
+      "rank": 834,
       "id": "Seregil13th/Sulphur-2-base",
       "author": "Seregil13th",
       "url": "https://huggingface.co/Seregil13th/Sulphur-2-base",
@@ -24516,7 +24541,7 @@
       "lastModified": "2026-05-05T10:22:20.000Z"
     },
     {
-      "rank": 834,
+      "rank": 835,
       "id": "mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Qwen3.6-35B-A3B-uncensored-heretic-APEX-GGUF",
@@ -24547,7 +24572,7 @@
       "lastModified": "2026-04-27T14:00:40.000Z"
     },
     {
-      "rank": 835,
+      "rank": 836,
       "id": "stabilityai/stable-audio-open-1.0",
       "author": "stabilityai",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0",
@@ -24570,7 +24595,7 @@
       "lastModified": "2025-06-19T21:53:23.000Z"
     },
     {
-      "rank": 836,
+      "rank": 837,
       "id": "Playtime-AI/Wan2.2_Model_Archive",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/Wan2.2_Model_Archive",
@@ -24587,7 +24612,7 @@
       "lastModified": "2026-05-15T13:04:24.000Z"
     },
     {
-      "rank": 837,
+      "rank": 838,
       "id": "Abiray/HiDream-O1-Image-Dev-FP8",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/HiDream-O1-Image-Dev-FP8",
@@ -24615,7 +24640,7 @@
       "lastModified": "2026-05-11T17:13:39.000Z"
     },
     {
-      "rank": 838,
+      "rank": 839,
       "id": "nvidia/nemotron-climb-fasttext-classifiers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-climb-fasttext-classifiers",
@@ -24632,7 +24657,7 @@
       "lastModified": "2026-05-11T22:14:28.000Z"
     },
     {
-      "rank": 839,
+      "rank": 840,
       "id": "BAAI/bge-small-en-v1.5",
       "author": "BAAI",
       "url": "https://huggingface.co/BAAI/bge-small-en-v1.5",
@@ -24668,7 +24693,7 @@
       "lastModified": "2024-02-22T03:36:23.000Z"
     },
     {
-      "rank": 840,
+      "rank": 841,
       "id": "TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
       "author": "TeichAI",
       "url": "https://huggingface.co/TeichAI/gemma-4-26B-A4B-it-Claude-Opus-Distill-v2-GGUF",
@@ -24698,7 +24723,7 @@
       "lastModified": "2026-05-08T00:58:04.000Z"
     },
     {
-      "rank": 841,
+      "rank": 842,
       "id": "Lightricks/LTX-Video",
       "author": "Lightricks",
       "url": "https://huggingface.co/Lightricks/LTX-Video",
@@ -24721,7 +24746,7 @@
       "lastModified": "2025-07-16T14:32:35.000Z"
     },
     {
-      "rank": 842,
+      "rank": 843,
       "id": "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
@@ -24754,7 +24779,7 @@
       "lastModified": "2026-03-06T02:44:20.000Z"
     },
     {
-      "rank": 843,
+      "rank": 844,
       "id": "minishlab/potion-code-16M",
       "author": "minishlab",
       "url": "https://huggingface.co/minishlab/potion-code-16M",
@@ -24785,7 +24810,7 @@
       "lastModified": "2026-04-27T05:13:51.000Z"
     },
     {
-      "rank": 844,
+      "rank": 845,
       "id": "Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Andro0s",
       "url": "https://huggingface.co/Andro0s/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -24808,7 +24833,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 845,
+      "rank": 846,
       "id": "YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
       "author": "YTan2000",
       "url": "https://huggingface.co/YTan2000/Qwen3.6-35B-A3B-MTP-TQ3_4S",
@@ -24841,7 +24866,7 @@
       "lastModified": "2026-05-20T19:22:15.000Z"
     },
     {
-      "rank": 846,
+      "rank": 847,
       "id": "Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
       "author": "Scrappy-Doo",
       "url": "https://huggingface.co/Scrappy-Doo/LTX_2.3_Pixar_Toon_Style_LoRa",
@@ -24864,7 +24889,7 @@
       "lastModified": "2026-05-14T20:54:58.000Z"
     },
     {
-      "rank": 847,
+      "rank": 848,
       "id": "AtomicChat/gemma-4-31B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-31B-it-assistant-GGUF",
@@ -24894,7 +24919,7 @@
       "lastModified": "2026-05-07T09:10:58.000Z"
     },
     {
-      "rank": 848,
+      "rank": 849,
       "id": "chiennv/Orthrus-Qwen3-1.7B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-1.7B",
@@ -24923,7 +24948,7 @@
       "lastModified": "2026-05-16T22:43:28.000Z"
     },
     {
-      "rank": 849,
+      "rank": 850,
       "id": "chiennv/Orthrus-Qwen3-4B",
       "author": "chiennv",
       "url": "https://huggingface.co/chiennv/Orthrus-Qwen3-4B",
@@ -24952,7 +24977,7 @@
       "lastModified": "2026-05-16T22:43:52.000Z"
     },
     {
-      "rank": 850,
+      "rank": 851,
       "id": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
       "author": "GestaltLabs",
       "url": "https://huggingface.co/GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
@@ -24988,7 +25013,7 @@
       "lastModified": "2026-05-14T12:07:07.000Z"
     },
     {
-      "rank": 851,
+      "rank": 852,
       "id": "bartowski/Qwen_Qwen3.6-27B-GGUF",
       "author": "bartowski",
       "url": "https://huggingface.co/bartowski/Qwen_Qwen3.6-27B-GGUF",
@@ -25011,7 +25036,7 @@
       "lastModified": "2026-05-20T03:50:15.000Z"
     },
     {
-      "rank": 852,
+      "rank": 853,
       "id": "HiDream-ai/Prompt-Refine",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/HiDream-ai/Prompt-Refine",
@@ -25036,7 +25061,7 @@
       "lastModified": "2026-05-14T07:24:09.000Z"
     },
     {
-      "rank": 853,
+      "rank": 854,
       "id": "Qwen/Qwen3-Embedding-8B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-Embedding-8B",
@@ -25066,7 +25091,7 @@
       "lastModified": "2025-07-07T09:02:21.000Z"
     },
     {
-      "rank": 854,
+      "rank": 855,
       "id": "AxiomicLabs/GPT-X2-125M",
       "author": "AxiomicLabs",
       "url": "https://huggingface.co/AxiomicLabs/GPT-X2-125M",
@@ -25102,7 +25127,7 @@
       "lastModified": "2026-05-19T03:58:06.000Z"
     },
     {
-      "rank": 855,
+      "rank": 856,
       "id": "meta-llama/Llama-Prompt-Guard-2-86M",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-86M",
@@ -25136,7 +25161,7 @@
       "lastModified": "2025-04-29T15:59:55.000Z"
     },
     {
-      "rank": 856,
+      "rank": 857,
       "id": "TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
       "author": "TrevorJS",
       "url": "https://huggingface.co/TrevorJS/gemma-4-E4B-it-uncensored-GGUF",
@@ -25163,7 +25188,7 @@
       "lastModified": "2026-04-05T16:05:23.000Z"
     },
     {
-      "rank": 857,
+      "rank": 858,
       "id": "Muse-research/Muse-1B",
       "author": "Muse-research",
       "url": "https://huggingface.co/Muse-research/Muse-1B",
@@ -25196,7 +25221,7 @@
       "lastModified": "2026-05-16T16:50:24.000Z"
     },
     {
-      "rank": 858,
+      "rank": 859,
       "id": "unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-MTP-GGUF",
@@ -25224,7 +25249,7 @@
       "lastModified": "2026-05-18T03:22:32.000Z"
     },
     {
-      "rank": 859,
+      "rank": 860,
       "id": "xai-org/grok-1",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-1",
@@ -25244,7 +25269,7 @@
       "lastModified": "2024-03-28T16:25:32.000Z"
     },
     {
-      "rank": 860,
+      "rank": 861,
       "id": "nvidia/Nemotron-Labs-Diffusion-3B-Base",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-3B-Base",
@@ -25267,7 +25292,7 @@
       "lastModified": "2026-05-23T01:01:23.000Z"
     },
     {
-      "rank": 861,
+      "rank": 862,
       "id": "mradermacher/Darwin-28B-REASON-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-28B-REASON-i1-GGUF",
@@ -25312,7 +25337,7 @@
       "lastModified": "2026-05-19T07:28:49.000Z"
     },
     {
-      "rank": 862,
+      "rank": 863,
       "id": "mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
       "author": "mudler",
       "url": "https://huggingface.co/mudler/Carnice-Qwen3.6-MoE-35B-A3B-APEX-MTP-GGUF",
@@ -25344,7 +25369,7 @@
       "lastModified": "2026-05-21T21:35:06.000Z"
     },
     {
-      "rank": 863,
+      "rank": 864,
       "id": "Kwai-Klear/GoLongRL-30B-A3B",
       "author": "Kwai-Klear",
       "url": "https://huggingface.co/Kwai-Klear/GoLongRL-30B-A3B",
@@ -25369,7 +25394,7 @@
       "lastModified": "2026-05-26T08:37:41.000Z"
     },
     {
-      "rank": 864,
+      "rank": 865,
       "id": "Bingsu/adetailer",
       "author": "Bingsu",
       "url": "https://huggingface.co/Bingsu/adetailer",
@@ -25391,7 +25416,7 @@
       "lastModified": "2024-11-21T12:40:27.000Z"
     },
     {
-      "rank": 865,
+      "rank": 866,
       "id": "Qwen/Qwen-Image-Edit",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
@@ -25415,7 +25440,7 @@
       "lastModified": "2025-08-25T04:41:11.000Z"
     },
     {
-      "rank": 866,
+      "rank": 867,
       "id": "nvidia/nemotron-speech-streaming-en-0.6b",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b",
@@ -25460,7 +25485,7 @@
       "lastModified": "2026-05-03T15:17:33.000Z"
     },
     {
-      "rank": 867,
+      "rank": 868,
       "id": "allenai/OlmoEarth-v1-Base",
       "author": "allenai",
       "url": "https://huggingface.co/allenai/OlmoEarth-v1-Base",
@@ -25476,7 +25501,7 @@
       "lastModified": "2025-11-04T05:52:11.000Z"
     },
     {
-      "rank": 868,
+      "rank": 869,
       "id": "baidu/ERNIE-Image-Aes",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/ERNIE-Image-Aes",
@@ -25496,7 +25521,7 @@
       "lastModified": "2026-05-20T14:14:45.000Z"
     },
     {
-      "rank": 869,
+      "rank": 870,
       "id": "Qwen/Qwen3.5-397B-A17B",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3.5-397B-A17B",
@@ -25520,7 +25545,7 @@
       "lastModified": "2026-04-24T05:51:23.000Z"
     },
     {
-      "rank": 870,
+      "rank": 871,
       "id": "RockTalk/Lance-3B-MLX",
       "author": "RockTalk",
       "url": "https://huggingface.co/RockTalk/Lance-3B-MLX",
@@ -25553,7 +25578,7 @@
       "lastModified": "2026-05-20T12:36:28.000Z"
     },
     {
-      "rank": 871,
+      "rank": 872,
       "id": "circlestone-labs/Anima-Base-v1.0-Diffusers",
       "author": "circlestone-labs",
       "url": "https://huggingface.co/circlestone-labs/Anima-Base-v1.0-Diffusers",
@@ -25573,7 +25598,7 @@
       "lastModified": "2026-05-22T21:06:00.000Z"
     },
     {
-      "rank": 872,
+      "rank": 873,
       "id": "DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-9B-Heretic-Uncensored-Thinking-Sweet-Madness",
@@ -25618,7 +25643,7 @@
       "lastModified": "2026-05-20T02:34:32.000Z"
     },
     {
-      "rank": 873,
+      "rank": 874,
       "id": "black-forest-labs/FLUX.2-klein-base-9b-fp8",
       "author": "black-forest-labs",
       "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8",
@@ -25642,7 +25667,7 @@
       "lastModified": "2026-02-24T00:47:48.000Z"
     },
     {
-      "rank": 874,
+      "rank": 875,
       "id": "huihui-ai/DeepSeek-V4-Flash-BF16",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/DeepSeek-V4-Flash-BF16",
@@ -25668,7 +25693,7 @@
       "lastModified": "2026-05-25T09:42:03.000Z"
     },
     {
-      "rank": 875,
+      "rank": 876,
       "id": "Overworld/Waypoint-1.5-1B",
       "author": "Overworld",
       "url": "https://huggingface.co/Overworld/Waypoint-1.5-1B",
@@ -25695,7 +25720,7 @@
       "lastModified": "2026-04-17T18:41:37.000Z"
     },
     {
-      "rank": 876,
+      "rank": 877,
       "id": "Danrisi/UltraReal_FineTune_Anima_base1",
       "author": "Danrisi",
       "url": "https://huggingface.co/Danrisi/UltraReal_FineTune_Anima_base1",
@@ -25719,7 +25744,7 @@
       "lastModified": "2026-05-22T13:40:23.000Z"
     },
     {
-      "rank": 877,
+      "rank": 878,
       "id": "thelamapi/neuvoice",
       "author": "thelamapi",
       "url": "https://huggingface.co/thelamapi/neuvoice",
@@ -25764,7 +25789,7 @@
       "lastModified": "2026-05-20T13:29:46.000Z"
     },
     {
-      "rank": 878,
+      "rank": 879,
       "id": "MassivDash/Gemma-4-Rust-Coder",
       "author": "MassivDash",
       "url": "https://huggingface.co/MassivDash/Gemma-4-Rust-Coder",
@@ -25793,7 +25818,7 @@
       "lastModified": "2026-04-24T09:46:25.000Z"
     },
     {
-      "rank": 879,
+      "rank": 880,
       "id": "spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
       "author": "spiritbuun",
       "url": "https://huggingface.co/spiritbuun/Nemotron-Labs-Diffusion-14B-Q8_0-GGUF",
@@ -25820,7 +25845,7 @@
       "lastModified": "2026-05-20T20:34:29.000Z"
     },
     {
-      "rank": 880,
+      "rank": 881,
       "id": "LiquidAI/LFM2-8B-A1B-GGUF",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-8B-A1B-GGUF",
@@ -25857,7 +25882,7 @@
       "lastModified": "2026-03-30T13:41:14.000Z"
     },
     {
-      "rank": 881,
+      "rank": 882,
       "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "author": "meta-llama",
       "url": "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -25897,7 +25922,7 @@
       "lastModified": "2025-05-22T23:44:50.000Z"
     },
     {
-      "rank": 882,
+      "rank": 883,
       "id": "google/gemma-2b-it",
       "author": "google",
       "url": "https://huggingface.co/google/gemma-2b-it",
@@ -25942,7 +25967,7 @@
       "lastModified": "2024-09-27T12:19:02.000Z"
     },
     {
-      "rank": 883,
+      "rank": 884,
       "id": "QuantStack/Wan2.2-I2V-A14B-GGUF",
       "author": "QuantStack",
       "url": "https://huggingface.co/QuantStack/Wan2.2-I2V-A14B-GGUF",
@@ -25965,7 +25990,7 @@
       "lastModified": "2025-07-29T13:04:00.000Z"
     },
     {
-      "rank": 884,
+      "rank": 885,
       "id": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
@@ -25991,12 +26016,12 @@
       "lastModified": "2026-01-29T08:04:19.000Z"
     },
     {
-      "rank": 885,
+      "rank": 886,
       "id": "google/paligemma-3b-pt-224",
       "author": "google",
       "url": "https://huggingface.co/google/paligemma-3b-pt-224",
-      "downloads": 554414,
-      "likes": 454,
+      "downloads": 562657,
+      "likes": 456,
       "trendingScore": 8,
       "pipelineTag": "image-text-to-text",
       "libraryName": "transformers",
@@ -26034,7 +26059,7 @@
       "lastModified": "2024-09-21T10:14:25.000Z"
     },
     {
-      "rank": 886,
+      "rank": 887,
       "id": "nvidia/Cosmos-Reason2-2B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Cosmos-Reason2-2B",
@@ -26063,11 +26088,11 @@
       "lastModified": "2026-04-30T03:14:52.000Z"
     },
     {
-      "rank": 887,
+      "rank": 888,
       "id": "dealignai/DeepSeek-V4-Flash-JANG-CRACK",
       "author": "dealignai",
       "url": "https://huggingface.co/dealignai/DeepSeek-V4-Flash-JANG-CRACK",
-      "downloads": 2371,
+      "downloads": 2556,
       "likes": 10,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -26090,11 +26115,11 @@
       "lastModified": "2026-05-24T07:37:34.000Z"
     },
     {
-      "rank": 888,
+      "rank": 889,
       "id": "AlicanKiraz0/Titus-CybersecurityLLM-v1.0-mlx-4Bit",
       "author": "AlicanKiraz0",
       "url": "https://huggingface.co/AlicanKiraz0/Titus-CybersecurityLLM-v1.0-mlx-4Bit",
-      "downloads": 210,
+      "downloads": 268,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -26124,7 +26149,7 @@
       "lastModified": "2026-05-27T17:50:50.000Z"
     },
     {
-      "rank": 889,
+      "rank": 890,
       "id": "LyliaEngine/Pony_Diffusion_V6_XL",
       "author": "LyliaEngine",
       "url": "https://huggingface.co/LyliaEngine/Pony_Diffusion_V6_XL",
@@ -26148,36 +26173,11 @@
       "lastModified": "2024-05-25T09:45:40.000Z"
     },
     {
-      "rank": 890,
-      "id": "Qwen/Qwen-Image",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen-Image",
-      "downloads": 172466,
-      "likes": 2498,
-      "trendingScore": 8,
-      "pipelineTag": "text-to-image",
-      "libraryName": "diffusers",
-      "tags": [
-        "diffusers",
-        "safetensors",
-        "text-to-image",
-        "en",
-        "zh",
-        "arxiv:2508.02324",
-        "license:apache-2.0",
-        "diffusers:QwenImagePipeline",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2025-08-02T04:58:07.000Z",
-      "lastModified": "2025-08-18T02:42:19.000Z"
-    },
-    {
       "rank": 891,
       "id": "moonshotai/MoonViT-SO-400M",
       "author": "moonshotai",
       "url": "https://huggingface.co/moonshotai/MoonViT-SO-400M",
-      "downloads": 1821,
+      "downloads": 1860,
       "likes": 51,
       "trendingScore": 8,
       "pipelineTag": "image-feature-extraction",
@@ -26201,7 +26201,7 @@
       "id": "LiquidAI/LFM2.5-8B-A1B-MLX-8bit",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-MLX-8bit",
-      "downloads": 2025,
+      "downloads": 2805,
       "likes": 8,
       "trendingScore": 8,
       "pipelineTag": "text-generation",
@@ -26237,6 +26237,76 @@
     },
     {
       "rank": 893,
+      "id": "nvidia/nemotron-3.5-asr-streaming-0.6b",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b",
+      "downloads": 201,
+      "likes": 37,
+      "trendingScore": 8,
+      "pipelineTag": null,
+      "libraryName": "nemo",
+      "tags": [
+        "nemo",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-15T21:52:25.000Z",
+      "lastModified": "2026-05-31T03:08:36.000Z"
+    },
+    {
+      "rank": 894,
+      "id": "lhmd/TriSplat",
+      "author": "lhmd",
+      "url": "https://huggingface.co/lhmd/TriSplat",
+      "downloads": 0,
+      "likes": 8,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-3d",
+      "libraryName": null,
+      "tags": [
+        "3d",
+        "novel-view-synthesis",
+        "triangle-splatting",
+        "simulation",
+        "image-to-3d",
+        "dataset:lhmd/re10k_torch",
+        "arxiv:2605.26115",
+        "license:mit",
+        "region:us"
+      ],
+      "createdAt": "2026-05-22T09:46:12.000Z",
+      "lastModified": "2026-05-26T15:17:02.000Z"
+    },
+    {
+      "rank": 895,
+      "id": "nvidia/dvlt",
+      "author": "nvidia",
+      "url": "https://huggingface.co/nvidia/dvlt",
+      "downloads": 104,
+      "likes": 9,
+      "trendingScore": 8,
+      "pipelineTag": "image-to-3d",
+      "libraryName": "dvlt",
+      "tags": [
+        "dvlt",
+        "safetensors",
+        "3d-reconstruction",
+        "depth-estimation",
+        "camera-pose",
+        "pointmap",
+        "looped-transformer",
+        "image-to-3d",
+        "arxiv:2605.30215",
+        "base_model:facebook/dinov2-base",
+        "base_model:finetune:facebook/dinov2-base",
+        "license:other",
+        "region:us"
+      ],
+      "createdAt": "2026-05-29T19:43:40.000Z",
+      "lastModified": "2026-05-30T20:37:41.000Z"
+    },
+    {
+      "rank": 896,
       "id": "openai/clip-vit-base-patch32",
       "author": "openai",
       "url": "https://huggingface.co/openai/clip-vit-base-patch32",
@@ -26262,7 +26332,7 @@
       "lastModified": "2024-02-29T09:45:55.000Z"
     },
     {
-      "rank": 894,
+      "rank": 897,
       "id": "lllyasviel/ControlNet-v1-1",
       "author": "lllyasviel",
       "url": "https://huggingface.co/lllyasviel/ControlNet-v1-1",
@@ -26279,7 +26349,7 @@
       "lastModified": "2023-04-25T22:46:12.000Z"
     },
     {
-      "rank": 895,
+      "rank": 898,
       "id": "nvidia/gliner-PII",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/gliner-PII",
@@ -26307,7 +26377,7 @@
       "lastModified": "2025-12-07T21:51:24.000Z"
     },
     {
-      "rank": 896,
+      "rank": 899,
       "id": "nvidia/magpie_tts_multilingual_357m",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/magpie_tts_multilingual_357m",
@@ -26342,7 +26412,7 @@
       "lastModified": "2026-05-03T14:04:03.000Z"
     },
     {
-      "rank": 897,
+      "rank": 900,
       "id": "XiaomiMiMo/MiMo-V2-Flash",
       "author": "XiaomiMiMo",
       "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash",
@@ -26367,7 +26437,7 @@
       "lastModified": "2026-04-20T12:56:42.000Z"
     },
     {
-      "rank": 898,
+      "rank": 901,
       "id": "ibm-granite/granitelib-guardian-r1.0",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granitelib-guardian-r1.0",
@@ -26397,7 +26467,7 @@
       "lastModified": "2026-05-06T14:31:22.000Z"
     },
     {
-      "rank": 899,
+      "rank": 902,
       "id": "z-lab/gemma-4-31B-it-PARO",
       "author": "z-lab",
       "url": "https://huggingface.co/z-lab/gemma-4-31B-it-PARO",
@@ -26426,7 +26496,7 @@
       "lastModified": "2026-05-08T06:20:06.000Z"
     },
     {
-      "rank": 900,
+      "rank": 903,
       "id": "google/tipsv2-b14",
       "author": "google",
       "url": "https://huggingface.co/google/tipsv2-b14",
@@ -26453,7 +26523,7 @@
       "lastModified": "2026-04-14T21:56:31.000Z"
     },
     {
-      "rank": 901,
+      "rank": 904,
       "id": "sbintuitions/sarashina2.2-tts",
       "author": "sbintuitions",
       "url": "https://huggingface.co/sbintuitions/sarashina2.2-tts",
@@ -26479,7 +26549,7 @@
       "lastModified": "2026-04-28T04:13:44.000Z"
     },
     {
-      "rank": 902,
+      "rank": 905,
       "id": "ibm-granite/granite-guardian-4.1-8b",
       "author": "ibm-granite",
       "url": "https://huggingface.co/ibm-granite/granite-guardian-4.1-8b",
@@ -26510,7 +26580,7 @@
       "lastModified": "2026-04-29T14:48:23.000Z"
     },
     {
-      "rank": 903,
+      "rank": 906,
       "id": "TheDrummer/Rocinante-XL-16B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-XL-16B-v1",
@@ -26528,7 +26598,7 @@
       "lastModified": "2026-04-28T13:07:27.000Z"
     },
     {
-      "rank": 904,
+      "rank": 907,
       "id": "Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
       "author": "Ex0bit",
       "url": "https://huggingface.co/Ex0bit/Qwen3.6-35B-A3B-PRISM-NVFP4",
@@ -26557,7 +26627,7 @@
       "lastModified": "2026-05-03T15:03:59.000Z"
     },
     {
-      "rank": 905,
+      "rank": 908,
       "id": "vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
       "author": "vrgamedevgirl84",
       "url": "https://huggingface.co/vrgamedevgirl84/LTX_2.3_Luxe_Sensual_Style_LoRa",
@@ -26580,7 +26650,7 @@
       "lastModified": "2026-04-24T02:24:58.000Z"
     },
     {
-      "rank": 906,
+      "rank": 909,
       "id": "DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-27B-NEO-CODE-Di-IMatrix-MAX-GGUF",
@@ -26625,7 +26695,7 @@
       "lastModified": "2026-04-30T07:47:43.000Z"
     },
     {
-      "rank": 907,
+      "rank": 910,
       "id": "poolside/Laguna-XS.2-NVFP4",
       "author": "poolside",
       "url": "https://huggingface.co/poolside/Laguna-XS.2-NVFP4",
@@ -26651,7 +26721,7 @@
       "lastModified": "2026-04-29T22:33:55.000Z"
     },
     {
-      "rank": 908,
+      "rank": 911,
       "id": "lewtun/talkie-1930-13b-it-hf",
       "author": "lewtun",
       "url": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf",
@@ -26679,7 +26749,7 @@
       "lastModified": "2026-04-28T19:50:27.000Z"
     },
     {
-      "rank": 909,
+      "rank": 912,
       "id": "AuriAetherwiing/G4-26B-A4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-26B-A4B-Musica-v1",
@@ -26717,7 +26787,7 @@
       "lastModified": "2026-04-29T13:28:21.000Z"
     },
     {
-      "rank": 910,
+      "rank": 913,
       "id": "CompactAI-O/Glint-1",
       "author": "CompactAI-O",
       "url": "https://huggingface.co/CompactAI-O/Glint-1",
@@ -26744,11 +26814,11 @@
       "lastModified": "2026-05-02T16:05:23.000Z"
     },
     {
-      "rank": 911,
+      "rank": 914,
       "id": "meituan-longcat/LongCat-Next",
       "author": "meituan-longcat",
       "url": "https://huggingface.co/meituan-longcat/LongCat-Next",
-      "downloads": 7348,
+      "downloads": 6767,
       "likes": 179,
       "trendingScore": 7,
       "pipelineTag": "any-to-any",
@@ -26770,7 +26840,7 @@
       "lastModified": "2026-04-10T08:00:12.000Z"
     },
     {
-      "rank": 912,
+      "rank": 915,
       "id": "n8te0/adonis_flux2klein",
       "author": "n8te0",
       "url": "https://huggingface.co/n8te0/adonis_flux2klein",
@@ -26788,7 +26858,7 @@
       "lastModified": "2026-05-26T02:44:18.000Z"
     },
     {
-      "rank": 913,
+      "rank": 916,
       "id": "unsloth/DeepSeek-V4-Pro",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/DeepSeek-V4-Pro",
@@ -26814,7 +26884,7 @@
       "lastModified": "2026-04-24T15:54:36.000Z"
     },
     {
-      "rank": 914,
+      "rank": 917,
       "id": "LiquidAI/LFM2.5-VL-450M",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-VL-450M",
@@ -26855,7 +26925,7 @@
       "lastModified": "2026-04-08T19:38:36.000Z"
     },
     {
-      "rank": 915,
+      "rank": 918,
       "id": "Playtime-AI/LTX-2.3-Titty_Drop",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Titty_Drop",
@@ -26872,7 +26942,7 @@
       "lastModified": "2026-05-01T16:37:44.000Z"
     },
     {
-      "rank": 916,
+      "rank": 919,
       "id": "faunix/QwenSeek-2B",
       "author": "faunix",
       "url": "https://huggingface.co/faunix/QwenSeek-2B",
@@ -26905,7 +26975,7 @@
       "lastModified": "2026-05-03T18:28:05.000Z"
     },
     {
-      "rank": 917,
+      "rank": 920,
       "id": "nvidia/Nemotron-Cascade-2-30B-A3B",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B",
@@ -26939,7 +27009,7 @@
       "lastModified": "2026-05-01T08:53:53.000Z"
     },
     {
-      "rank": 918,
+      "rank": 921,
       "id": "LiquidAI/LFM2.5-1.2B-Instruct",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct",
@@ -26978,7 +27048,7 @@
       "lastModified": "2026-03-30T12:48:13.000Z"
     },
     {
-      "rank": 919,
+      "rank": 922,
       "id": "Granddyser/biglove-klein2",
       "author": "Granddyser",
       "url": "https://huggingface.co/Granddyser/biglove-klein2",
@@ -27008,7 +27078,7 @@
       "lastModified": "2026-04-08T00:19:30.000Z"
     },
     {
-      "rank": 920,
+      "rank": 923,
       "id": "tencent/Hunyuan3D-2",
       "author": "tencent",
       "url": "https://huggingface.co/tencent/Hunyuan3D-2",
@@ -27034,7 +27104,7 @@
       "lastModified": "2025-10-17T10:09:17.000Z"
     },
     {
-      "rank": 921,
+      "rank": 924,
       "id": "LiquidAI/LFM2-24B-A2B",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2-24B-A2B",
@@ -27070,7 +27140,7 @@
       "lastModified": "2026-03-30T13:11:30.000Z"
     },
     {
-      "rank": 922,
+      "rank": 925,
       "id": "llmfan46/gemma-4-31B-it-uncensored-heretic",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/gemma-4-31B-it-uncensored-heretic",
@@ -27100,7 +27170,7 @@
       "lastModified": "2026-05-18T17:52:06.000Z"
     },
     {
-      "rank": 923,
+      "rank": 926,
       "id": "LiquidAI/LFM2.5-1.2B-Thinking",
       "author": "LiquidAI",
       "url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking",
@@ -27138,7 +27208,7 @@
       "lastModified": "2026-03-30T13:21:58.000Z"
     },
     {
-      "rank": 924,
+      "rank": 927,
       "id": "lianghsun/privacy-filter-tw",
       "author": "lianghsun",
       "url": "https://huggingface.co/lianghsun/privacy-filter-tw",
@@ -27173,7 +27243,7 @@
       "lastModified": "2026-05-04T03:53:22.000Z"
     },
     {
-      "rank": 925,
+      "rank": 928,
       "id": "malcolmrey/zimage",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/zimage",
@@ -27190,7 +27260,7 @@
       "lastModified": "2026-04-13T21:55:49.000Z"
     },
     {
-      "rank": 926,
+      "rank": 929,
       "id": "Jackrong/Negentropy-claude-opus-4.7-4B",
       "author": "Jackrong",
       "url": "https://huggingface.co/Jackrong/Negentropy-claude-opus-4.7-4B",
@@ -27232,7 +27302,7 @@
       "lastModified": "2026-05-07T16:46:18.000Z"
     },
     {
-      "rank": 927,
+      "rank": 930,
       "id": "unsloth/GLM-4.7-Flash-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF",
@@ -27262,7 +27332,7 @@
       "lastModified": "2026-02-12T20:47:50.000Z"
     },
     {
-      "rank": 928,
+      "rank": 931,
       "id": "unsloth/Qwen3.5-0.8B-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF",
@@ -27287,7 +27357,7 @@
       "lastModified": "2026-03-02T14:08:04.000Z"
     },
     {
-      "rank": 929,
+      "rank": 932,
       "id": "jinaai/jina-embeddings-v5-text-small",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-text-small",
@@ -27315,7 +27385,7 @@
       "lastModified": "2026-04-15T09:14:28.000Z"
     },
     {
-      "rank": 930,
+      "rank": 933,
       "id": "Playtime-AI/LTX-2.3-Cum_Shot_v2",
       "author": "Playtime-AI",
       "url": "https://huggingface.co/Playtime-AI/LTX-2.3-Cum_Shot_v2",
@@ -27332,7 +27402,7 @@
       "lastModified": "2026-05-04T13:30:32.000Z"
     },
     {
-      "rank": 931,
+      "rank": 934,
       "id": "paperscarecrow/Gemma-4-31B-it-abliterated",
       "author": "paperscarecrow",
       "url": "https://huggingface.co/paperscarecrow/Gemma-4-31B-it-abliterated",
@@ -27359,7 +27429,7 @@
       "lastModified": "2026-04-04T16:04:58.000Z"
     },
     {
-      "rank": 932,
+      "rank": 935,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
@@ -27402,7 +27472,7 @@
       "lastModified": "2026-03-16T21:10:15.000Z"
     },
     {
-      "rank": 933,
+      "rank": 936,
       "id": "AuriAetherwiing/G4-E4B-Musica-v1",
       "author": "AuriAetherwiing",
       "url": "https://huggingface.co/AuriAetherwiing/G4-E4B-Musica-v1",
@@ -27442,7 +27512,7 @@
       "lastModified": "2026-05-05T11:54:21.000Z"
     },
     {
-      "rank": 934,
+      "rank": 937,
       "id": "Wfloat/wfloat-tts",
       "author": "Wfloat",
       "url": "https://huggingface.co/Wfloat/wfloat-tts",
@@ -27466,7 +27536,7 @@
       "lastModified": "2026-05-11T01:23:40.000Z"
     },
     {
-      "rank": 935,
+      "rank": 938,
       "id": "RedHatAI/gemma-4-31B-it-FP8-block",
       "author": "RedHatAI",
       "url": "https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-block",
@@ -27495,7 +27565,7 @@
       "lastModified": "2026-05-04T21:10:01.000Z"
     },
     {
-      "rank": 936,
+      "rank": 939,
       "id": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
@@ -27521,7 +27591,7 @@
       "lastModified": "2026-05-06T21:59:55.000Z"
     },
     {
-      "rank": 937,
+      "rank": 940,
       "id": "Serveurperso/OmniVoice-GGUF",
       "author": "Serveurperso",
       "url": "https://huggingface.co/Serveurperso/OmniVoice-GGUF",
@@ -27560,7 +27630,7 @@
       "lastModified": "2026-04-30T13:39:10.000Z"
     },
     {
-      "rank": 938,
+      "rank": 941,
       "id": "UDream/flux2-dev-turbo-Q4_K_M",
       "author": "UDream",
       "url": "https://huggingface.co/UDream/flux2-dev-turbo-Q4_K_M",
@@ -27584,7 +27654,7 @@
       "lastModified": "2026-05-05T18:35:24.000Z"
     },
     {
-      "rank": 939,
+      "rank": 942,
       "id": "unsloth/Qwen3.6-27B-GGUF-MTP",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF-MTP",
@@ -27612,7 +27682,7 @@
       "lastModified": "2026-05-11T18:23:25.000Z"
     },
     {
-      "rank": 940,
+      "rank": 943,
       "id": "pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
       "author": "pastapaul",
       "url": "https://huggingface.co/pastapaul/DeepSeek-V4-Flash-W4A16-FP8",
@@ -27644,7 +27714,7 @@
       "lastModified": "2026-05-06T19:31:13.000Z"
     },
     {
-      "rank": 941,
+      "rank": 944,
       "id": "RLWRLD/RLDX-1-PT",
       "author": "RLWRLD",
       "url": "https://huggingface.co/RLWRLD/RLDX-1-PT",
@@ -27674,7 +27744,7 @@
       "lastModified": "2026-05-06T03:48:20.000Z"
     },
     {
-      "rank": 942,
+      "rank": 945,
       "id": "AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
       "author": "AngelSlim",
       "url": "https://huggingface.co/AngelSlim/Hy-MT1.5-1.8B-2bit-GGUF",
@@ -27703,7 +27773,7 @@
       "lastModified": "2026-04-29T06:58:03.000Z"
     },
     {
-      "rank": 943,
+      "rank": 946,
       "id": "LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
       "author": "LibertAIDAI",
       "url": "https://huggingface.co/LibertAIDAI/Qwen3.6-27B-NVFP4-GGUF",
@@ -27732,7 +27802,7 @@
       "lastModified": "2026-05-04T12:31:28.000Z"
     },
     {
-      "rank": 944,
+      "rank": 947,
       "id": "byliutao/stable-diffusion-3-medium-turbo",
       "author": "byliutao",
       "url": "https://huggingface.co/byliutao/stable-diffusion-3-medium-turbo",
@@ -27752,7 +27822,7 @@
       "lastModified": "2026-05-08T12:20:11.000Z"
     },
     {
-      "rank": 945,
+      "rank": 948,
       "id": "Jiunsong/supergemma4-26b-abliterated-multimodal",
       "author": "Jiunsong",
       "url": "https://huggingface.co/Jiunsong/supergemma4-26b-abliterated-multimodal",
@@ -27782,7 +27852,7 @@
       "lastModified": "2026-04-18T07:03:07.000Z"
     },
     {
-      "rank": 946,
+      "rank": 949,
       "id": "coder3101/gemma-4-26B-A4B-it-heretic",
       "author": "coder3101",
       "url": "https://huggingface.co/coder3101/gemma-4-26B-A4B-it-heretic",
@@ -27812,7 +27882,7 @@
       "lastModified": "2026-04-14T16:42:01.000Z"
     },
     {
-      "rank": 947,
+      "rank": 950,
       "id": "limuloo1999/RefineAnything",
       "author": "limuloo1999",
       "url": "https://huggingface.co/limuloo1999/RefineAnything",
@@ -27830,7 +27900,7 @@
       "lastModified": "2026-04-14T05:12:22.000Z"
     },
     {
-      "rank": 948,
+      "rank": 951,
       "id": "malcolmrey/ltx",
       "author": "malcolmrey",
       "url": "https://huggingface.co/malcolmrey/ltx",
@@ -27847,7 +27917,7 @@
       "lastModified": "2026-05-07T12:23:51.000Z"
     },
     {
-      "rank": 949,
+      "rank": 952,
       "id": "rednote-hilab/dots.mocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.mocr",
@@ -27883,7 +27953,7 @@
       "lastModified": "2026-04-20T13:01:17.000Z"
     },
     {
-      "rank": 950,
+      "rank": 953,
       "id": "ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
       "author": "ManniX-ITA",
       "url": "https://huggingface.co/ManniX-ITA/Qwen3.6-27B-Omnimerge-v4",
@@ -27914,7 +27984,7 @@
       "lastModified": "2026-05-11T02:49:48.000Z"
     },
     {
-      "rank": 951,
+      "rank": 954,
       "id": "NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
       "author": "NidAll",
       "url": "https://huggingface.co/NidAll/supergemma4-e4b-abliterated-Q4_K_M-GGUF",
@@ -27945,7 +28015,7 @@
       "lastModified": "2026-04-17T15:11:40.000Z"
     },
     {
-      "rank": 952,
+      "rank": 955,
       "id": "cross-encoder/ms-marco-MiniLM-L6-v2",
       "author": "cross-encoder",
       "url": "https://huggingface.co/cross-encoder/ms-marco-MiniLM-L6-v2",
@@ -27978,7 +28048,7 @@
       "lastModified": "2025-08-29T14:36:10.000Z"
     },
     {
-      "rank": 953,
+      "rank": 956,
       "id": "Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
       "author": "Abiray",
       "url": "https://huggingface.co/Abiray/LTX-2.3-22B-DISTILLED-1.1-GGUF",
@@ -28006,7 +28076,7 @@
       "lastModified": "2026-04-14T07:26:50.000Z"
     },
     {
-      "rank": 954,
+      "rank": 957,
       "id": "huggingFresse/Kokoro-82M-ONNX-German-Martin",
       "author": "huggingFresse",
       "url": "https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin",
@@ -28031,7 +28101,7 @@
       "lastModified": "2026-05-14T09:28:56.000Z"
     },
     {
-      "rank": 955,
+      "rank": 958,
       "id": "RomixERR/Pornmaster_v1-Z-Images-Turbo",
       "author": "RomixERR",
       "url": "https://huggingface.co/RomixERR/Pornmaster_v1-Z-Images-Turbo",
@@ -28054,7 +28124,7 @@
       "lastModified": "2025-12-25T12:16:27.000Z"
     },
     {
-      "rank": 956,
+      "rank": 959,
       "id": "Qwen/Qwen3-VL-8B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct-GGUF",
@@ -28082,7 +28152,7 @@
       "lastModified": "2025-11-01T03:21:00.000Z"
     },
     {
-      "rank": 957,
+      "rank": 960,
       "id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2",
@@ -28115,7 +28185,7 @@
       "lastModified": "2026-04-09T15:54:11.000Z"
     },
     {
-      "rank": 958,
+      "rank": 961,
       "id": "Qwen/Qwen2.5-0.5B-Instruct",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
@@ -28145,7 +28215,7 @@
       "lastModified": "2024-09-25T12:32:56.000Z"
     },
     {
-      "rank": 959,
+      "rank": 962,
       "id": "vantagewithai/Sulphur-2-Base-Split",
       "author": "vantagewithai",
       "url": "https://huggingface.co/vantagewithai/Sulphur-2-Base-Split",
@@ -28180,7 +28250,7 @@
       "lastModified": "2026-05-11T07:21:56.000Z"
     },
     {
-      "rank": 960,
+      "rank": 963,
       "id": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
       "author": "mlx-community",
       "url": "https://huggingface.co/mlx-community/Qwen3.5-9B-OptiQ-4bit",
@@ -28212,7 +28282,7 @@
       "lastModified": "2026-05-10T08:05:40.000Z"
     },
     {
-      "rank": 961,
+      "rank": 964,
       "id": "nvidia/RE-USE",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/RE-USE",
@@ -28237,7 +28307,7 @@
       "lastModified": "2026-05-14T21:26:36.000Z"
     },
     {
-      "rank": 962,
+      "rank": 965,
       "id": "Intel/Qwen3.6-27B-int4-AutoRound",
       "author": "Intel",
       "url": "https://huggingface.co/Intel/Qwen3.6-27B-int4-AutoRound",
@@ -28260,7 +28330,7 @@
       "lastModified": "2026-04-24T14:02:05.000Z"
     },
     {
-      "rank": 963,
+      "rank": 966,
       "id": "MiniMaxAI/MiniMax-M2.5",
       "author": "MiniMaxAI",
       "url": "https://huggingface.co/MiniMaxAI/MiniMax-M2.5",
@@ -28287,7 +28357,7 @@
       "lastModified": "2026-03-10T13:42:23.000Z"
     },
     {
-      "rank": 964,
+      "rank": 967,
       "id": "BlackHat404/DefacationAnima",
       "author": "BlackHat404",
       "url": "https://huggingface.co/BlackHat404/DefacationAnima",
@@ -28310,7 +28380,7 @@
       "lastModified": "2026-05-10T20:58:10.000Z"
     },
     {
-      "rank": 965,
+      "rank": 968,
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -28355,7 +28425,7 @@
       "lastModified": "2026-03-15T04:25:53.000Z"
     },
     {
-      "rank": 966,
+      "rank": 969,
       "id": "baidu/Qianfan-OCR",
       "author": "baidu",
       "url": "https://huggingface.co/baidu/Qianfan-OCR",
@@ -28387,7 +28457,7 @@
       "lastModified": "2026-04-29T04:55:52.000Z"
     },
     {
-      "rank": 967,
+      "rank": 970,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-abliterated",
@@ -28414,7 +28484,7 @@
       "lastModified": "2026-05-13T06:29:37.000Z"
     },
     {
-      "rank": 968,
+      "rank": 971,
       "id": "nphSi/Z-Image-Lora",
       "author": "nphSi",
       "url": "https://huggingface.co/nphSi/Z-Image-Lora",
@@ -28440,7 +28510,7 @@
       "lastModified": "2026-05-15T20:36:52.000Z"
     },
     {
-      "rank": 969,
+      "rank": 972,
       "id": "fastino/gliner2-large-v1",
       "author": "fastino",
       "url": "https://huggingface.co/fastino/gliner2-large-v1",
@@ -28472,7 +28542,7 @@
       "lastModified": "2026-05-19T11:13:58.000Z"
     },
     {
-      "rank": 970,
+      "rank": 973,
       "id": "Lucebox/Laguna-XS.2-GGUF",
       "author": "Lucebox",
       "url": "https://huggingface.co/Lucebox/Laguna-XS.2-GGUF",
@@ -28501,12 +28571,12 @@
       "lastModified": "2026-05-08T17:05:30.000Z"
     },
     {
-      "rank": 971,
+      "rank": 974,
       "id": "FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
       "author": "FunAudioLLM",
       "url": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
-      "downloads": 279459,
-      "likes": 545,
+      "downloads": 194650,
+      "likes": 555,
       "trendingScore": 7,
       "pipelineTag": "text-to-speech",
       "libraryName": null,
@@ -28533,7 +28603,7 @@
       "lastModified": "2026-02-03T07:58:17.000Z"
     },
     {
-      "rank": 972,
+      "rank": 975,
       "id": "AtomicChat/gemma-4-E4B-it-assistant-GGUF",
       "author": "AtomicChat",
       "url": "https://huggingface.co/AtomicChat/gemma-4-E4B-it-assistant-GGUF",
@@ -28563,7 +28633,7 @@
       "lastModified": "2026-05-07T09:11:22.000Z"
     },
     {
-      "rank": 973,
+      "rank": 976,
       "id": "xai-org/grok-2",
       "author": "xai-org",
       "url": "https://huggingface.co/xai-org/grok-2",
@@ -28580,7 +28650,7 @@
       "lastModified": "2025-11-05T00:36:25.000Z"
     },
     {
-      "rank": 974,
+      "rank": 977,
       "id": "TheDrummer/Rocinante-X-12B-v1",
       "author": "TheDrummer",
       "url": "https://huggingface.co/TheDrummer/Rocinante-X-12B-v1",
@@ -28600,7 +28670,7 @@
       "lastModified": "2026-01-25T11:55:28.000Z"
     },
     {
-      "rank": 975,
+      "rank": 978,
       "id": "jinaai/jina-embeddings-v5-omni-small-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-small-retrieval",
@@ -28639,7 +28709,7 @@
       "lastModified": "2026-05-17T10:53:03.000Z"
     },
     {
-      "rank": 976,
+      "rank": 979,
       "id": "jinaai/jina-embeddings-v5-omni-nano-retrieval",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v5-omni-nano-retrieval",
@@ -28677,7 +28747,7 @@
       "lastModified": "2026-05-17T10:52:10.000Z"
     },
     {
-      "rank": 977,
+      "rank": 980,
       "id": "answerdotai/ModernBERT-base",
       "author": "answerdotai",
       "url": "https://huggingface.co/answerdotai/ModernBERT-base",
@@ -28705,7 +28775,7 @@
       "lastModified": "2025-01-15T20:11:48.000Z"
     },
     {
-      "rank": 978,
+      "rank": 981,
       "id": "DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
       "author": "DavidAU",
       "url": "https://huggingface.co/DavidAU/Qwen3.6-12B-IQ-Ultra-Heretic-Uncensored-Thinking",
@@ -28750,7 +28820,7 @@
       "lastModified": "2026-05-17T02:12:30.000Z"
     },
     {
-      "rank": 979,
+      "rank": 982,
       "id": "nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
       "author": "nvidia",
       "url": "https://huggingface.co/nvidia/AnyFlow-FAR-Wan2.1-1.3B-Diffusers",
@@ -28780,7 +28850,7 @@
       "lastModified": "2026-05-14T07:08:01.000Z"
     },
     {
-      "rank": 980,
+      "rank": 983,
       "id": "AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
       "author": "AviadDahan",
       "url": "https://huggingface.co/AviadDahan/LTX-2.3-ID-LoRA-CelebVHQ-3K",
@@ -28807,7 +28877,7 @@
       "lastModified": "2026-03-18T20:01:18.000Z"
     },
     {
-      "rank": 981,
+      "rank": 984,
       "id": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
       "author": "cyankiwi",
       "url": "https://huggingface.co/cyankiwi/gemma-4-31B-it-AWQ-4bit",
@@ -28833,7 +28903,7 @@
       "lastModified": "2026-04-30T21:52:07.000Z"
     },
     {
-      "rank": 982,
+      "rank": 985,
       "id": "llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
       "author": "llmfan46",
       "url": "https://huggingface.co/llmfan46/MiniMax-M2.7-ultra-uncensored-heretic-GGUF",
@@ -28862,7 +28932,7 @@
       "lastModified": "2026-05-21T04:18:36.000Z"
     },
     {
-      "rank": 983,
+      "rank": 986,
       "id": "Comfy-Org/z_image",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/z_image",
@@ -28880,7 +28950,7 @@
       "lastModified": "2026-01-27T16:10:00.000Z"
     },
     {
-      "rank": 984,
+      "rank": 987,
       "id": "jinaai/jina-embeddings-v4",
       "author": "jinaai",
       "url": "https://huggingface.co/jinaai/jina-embeddings-v4",
@@ -28912,7 +28982,7 @@
       "lastModified": "2026-04-08T14:29:59.000Z"
     },
     {
-      "rank": 985,
+      "rank": 988,
       "id": "huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
       "author": "huihui-ai",
       "url": "https://huggingface.co/huihui-ai/Huihui-MiniCPM-V-4.6-Thinking-abliterated",
@@ -28939,7 +29009,7 @@
       "lastModified": "2026-05-13T23:35:50.000Z"
     },
     {
-      "rank": 986,
+      "rank": 989,
       "id": "Comfy-Org/gemma-4",
       "author": "Comfy-Org",
       "url": "https://huggingface.co/Comfy-Org/gemma-4",
@@ -28957,7 +29027,7 @@
       "lastModified": "2026-05-06T13:44:48.000Z"
     },
     {
-      "rank": 987,
+      "rank": 990,
       "id": "unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-397B-A17B-MTP-GGUF",
@@ -28984,7 +29054,7 @@
       "lastModified": "2026-05-18T03:34:48.000Z"
     },
     {
-      "rank": 988,
+      "rank": 991,
       "id": "MLXBits/sulphur-2-distill-mlx-q4",
       "author": "MLXBits",
       "url": "https://huggingface.co/MLXBits/sulphur-2-distill-mlx-q4",
@@ -29008,7 +29078,7 @@
       "lastModified": "2026-05-12T20:32:15.000Z"
     },
     {
-      "rank": 989,
+      "rank": 992,
       "id": "mradermacher/Darwin-36B-Opus-i1-GGUF",
       "author": "mradermacher",
       "url": "https://huggingface.co/mradermacher/Darwin-36B-Opus-i1-GGUF",
@@ -29053,7 +29123,7 @@
       "lastModified": "2026-05-16T16:36:57.000Z"
     },
     {
-      "rank": 990,
+      "rank": 993,
       "id": "iapp/ChindaMT-4B",
       "author": "iapp",
       "url": "https://huggingface.co/iapp/ChindaMT-4B",
@@ -29084,7 +29154,7 @@
       "lastModified": "2026-05-15T01:58:40.000Z"
     },
     {
-      "rank": 991,
+      "rank": 994,
       "id": "yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
       "author": "yuvraj108c",
       "url": "https://huggingface.co/yuvraj108c/LTX-2.3-22b-IC-LoRA-Any-Trajectory-Instruction",
@@ -29109,7 +29179,7 @@
       "lastModified": "2026-05-18T07:30:30.000Z"
     },
     {
-      "rank": 992,
+      "rank": 995,
       "id": "rednote-hilab/dots.ocr",
       "author": "rednote-hilab",
       "url": "https://huggingface.co/rednote-hilab/dots.ocr",
@@ -29143,7 +29213,7 @@
       "lastModified": "2025-10-31T08:49:31.000Z"
     },
     {
-      "rank": 993,
+      "rank": 996,
       "id": "ModelsLab/omnivoice-singing",
       "author": "ModelsLab",
       "url": "https://huggingface.co/ModelsLab/omnivoice-singing",
@@ -29184,7 +29254,7 @@
       "lastModified": "2026-04-17T13:12:21.000Z"
     },
     {
-      "rank": 994,
+      "rank": 997,
       "id": "unsloth/Qwen3.5-0.8B-MTP-GGUF",
       "author": "unsloth",
       "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-MTP-GGUF",
@@ -29211,7 +29281,7 @@
       "lastModified": "2026-05-16T12:38:54.000Z"
     },
     {
-      "rank": 995,
+      "rank": 998,
       "id": "resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
       "author": "resect-ai",
       "url": "https://huggingface.co/resect-ai/veritas-8B-fact-checker-non-thinking-1.0",
@@ -29240,7 +29310,7 @@
       "lastModified": "2026-05-21T19:18:06.000Z"
     },
     {
-      "rank": 996,
+      "rank": 999,
       "id": "Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
       "author": "Qwen",
       "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF",
@@ -29272,7 +29342,7 @@
       "lastModified": "2024-11-12T07:59:32.000Z"
     },
     {
-      "rank": 997,
+      "rank": 1000,
       "id": "openbmb/BitCPM4-CANN-8B-gguf",
       "author": "openbmb",
       "url": "https://huggingface.co/openbmb/BitCPM4-CANN-8B-gguf",
@@ -29294,104 +29364,6 @@
       ],
       "createdAt": "2026-05-16T06:18:55.000Z",
       "lastModified": "2026-05-22T10:10:07.000Z"
-    },
-    {
-      "rank": 998,
-      "id": "Qwen/Qwen2.5-0.5B",
-      "author": "Qwen",
-      "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B",
-      "downloads": 2325181,
-      "likes": 411,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "qwen2",
-        "text-generation",
-        "conversational",
-        "en",
-        "arxiv:2407.10671",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "deploy:azure",
-        "region:us"
-      ],
-      "createdAt": "2024-09-15T12:15:39.000Z",
-      "lastModified": "2024-09-25T12:32:36.000Z"
-    },
-    {
-      "rank": 999,
-      "id": "Vortex5/Elysian-Sunrise-12B",
-      "author": "Vortex5",
-      "url": "https://huggingface.co/Vortex5/Elysian-Sunrise-12B",
-      "downloads": 80,
-      "likes": 7,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "transformers",
-      "tags": [
-        "transformers",
-        "safetensors",
-        "mistral",
-        "text-generation",
-        "mergekit",
-        "merge",
-        "roleplay",
-        "conversational",
-        "base_model:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
-        "base_model:merge:ArliAI/Mistral-Nemo-12B-ArliAI-RPMax-v1.2",
-        "base_model:AuriAetherwiing/MN-12B-Starcannon-v3",
-        "base_model:merge:AuriAetherwiing/MN-12B-Starcannon-v3",
-        "base_model:LatitudeGames/Muse-12B",
-        "base_model:merge:LatitudeGames/Muse-12B",
-        "base_model:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
-        "base_model:merge:SuperbEmphasis/MN-12b-RP-Ink-RP-Longform",
-        "base_model:elinas/Chronos-Gold-12B-1.0",
-        "base_model:merge:elinas/Chronos-Gold-12B-1.0",
-        "base_model:yamatazen/EtherealAurora-12B-Lorablated",
-        "base_model:merge:yamatazen/EtherealAurora-12B-Lorablated",
-        "license:apache-2.0",
-        "text-generation-inference",
-        "endpoints_compatible",
-        "region:us"
-      ],
-      "createdAt": "2026-05-17T02:14:17.000Z",
-      "lastModified": "2026-05-17T12:38:01.000Z"
-    },
-    {
-      "rank": 1000,
-      "id": "canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
-      "author": "canada-quant",
-      "url": "https://huggingface.co/canada-quant/DeepSeek-V4-Flash-W4A16-FP8",
-      "downloads": 7644,
-      "likes": 15,
-      "trendingScore": 7,
-      "pipelineTag": "text-generation",
-      "libraryName": "vllm",
-      "tags": [
-        "vllm",
-        "safetensors",
-        "deepseek_v4",
-        "deepseek",
-        "compressed-tensors",
-        "w4a16",
-        "gptq",
-        "fp8",
-        "mixture-of-experts",
-        "moe",
-        "text-generation",
-        "en",
-        "zh",
-        "base_model:deepseek-ai/DeepSeek-V4-Flash",
-        "base_model:quantized:deepseek-ai/DeepSeek-V4-Flash",
-        "license:mit",
-        "region:us"
-      ],
-      "createdAt": "2026-05-04T06:15:20.000Z",
-      "lastModified": "2026-05-25T02:40:36.000Z"
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26708827419

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.