### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T09:36:19Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-31T06:01:18.725Z",
+  "ts": "2026-05-31T09:36:19.861Z",
   "count": 1,
-  "durationMs": 2511,
+  "durationMs": 4247,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T06:01:16.235Z",
+  "fetchedAt": "2026-05-31T09:36:15.635Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T06:01:16.235Z",
+  "fetchedAt": "2026-05-31T09:36:15.635Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26709032243

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.