### PR TITLE
chore(data): refresh huggingface space signals 2026-05-31T09:36:57Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-31T05:08:40.987Z",
+  "ts": "2026-05-31T09:36:57.575Z",
   "count": 1,
-  "durationMs": 6432,
+  "durationMs": 6054,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T05:08:34.557Z",
+  "fetchedAt": "2026-05-31T09:36:51.523Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -25,7 +25,7 @@
       "id": "victor/LongCat-Video-Avatar-1.5",
       "author": "victor",
       "url": "https://huggingface.co/spaces/victor/LongCat-Video-Avatar-1.5",
-      "likes": 175,
+      "likes": 176,
       "trendingScore": 165,
       "sdk": "gradio",
       "tags": [
@@ -111,8 +111,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 129,
-      "trendingScore": 122,
+      "likes": 131,
+      "trendingScore": 124,
       "sdk": "static",
       "tags": [
         "static",
@@ -196,8 +196,8 @@
       "id": "nvidia/LocateAnything",
       "author": "nvidia",
       "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 82,
-      "trendingScore": 82,
+      "likes": 84,
+      "trendingScore": 83,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -717,6 +717,22 @@
     },
     {
       "rank": 44,
+      "id": "facebook/vggt-omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
+      "likes": 47,
+      "trendingScore": 31,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T23:39:56.000Z",
+      "lastModified": "2026-05-18T21:46:03.000Z",
+      "models": []
+    },
+    {
+      "rank": 45,
       "id": "systms/ACTION-HF",
       "author": "systms",
       "url": "https://huggingface.co/spaces/systms/ACTION-HF",
@@ -732,7 +748,7 @@
       "models": []
     },
     {
-      "rank": 45,
+      "rank": 46,
       "id": "Lakonik/AsymFLUX.2-klein",
       "author": "Lakonik",
       "url": "https://huggingface.co/spaces/Lakonik/AsymFLUX.2-klein",
@@ -748,7 +764,7 @@
       "models": []
     },
     {
-      "rank": 46,
+      "rank": 47,
       "id": "openbmb/VoxCPM-Demo",
       "author": "openbmb",
       "url": "https://huggingface.co/spaces/openbmb/VoxCPM-Demo",
@@ -761,22 +777,6 @@
       ],
       "createdAt": "2025-09-16T14:53:41.000Z",
       "lastModified": "2026-05-23T09:59:35.000Z",
-      "models": []
-    },
-    {
-      "rank": 47,
-      "id": "facebook/vggt-omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
-      "likes": 46,
-      "trendingScore": 30,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T23:39:56.000Z",
-      "lastModified": "2026-05-18T21:46:03.000Z",
       "models": []
     },
     {


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26709043395

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.