### PR TITLE
chore(data): refresh arxiv signals 2026-05-31T09:45:16Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-31T05:11:11.323Z",
+  "ts": "2026-05-31T09:39:06.260Z",
   "count": 1,
-  "durationMs": 60810,
+  "durationMs": 60875,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T05:11:11.376Z",
+  "fetchedAt": "2026-05-31T09:39:06.310Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -7,223 +7,6 @@
   ],
   "count": 145,
   "papers": [
-    {
-      "arxivId": "2605.30348v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30343v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30335v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30324v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30311v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30310v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30290v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30274v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30273v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30268v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30265v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30251v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30232v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30202v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30189v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30167v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30133v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30131v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30126v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30080v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30076v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30058v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30052v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30051v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30022v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30021v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.29987v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.29971v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.29951v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30353v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30352v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
     {
       "arxivId": "2605.30351v1",
       "citationCount": 0,
@@ -239,13 +22,6 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30349v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30347v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -253,25 +29,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30346v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30345v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30344v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30342v1",
@@ -288,13 +50,6 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30339v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30337v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -309,25 +64,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30336v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30334v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30333v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30332v1",
@@ -351,39 +92,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30328v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30327v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30326v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30325v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30323v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30322v1",
@@ -428,13 +141,6 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30307v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30295v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -449,46 +155,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30289v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30288v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30284v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30283v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30280v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30277v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30275v1",
@@ -498,32 +169,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30269v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30263v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30260v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30257v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30256v1",
@@ -568,13 +218,6 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30244v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30241v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -610,13 +253,6 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30231v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
       "arxivId": "2605.30230v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -624,32 +260,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30229v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30227v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30226v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30225v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30220v1",
@@ -673,25 +288,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30215v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
       "arxivId": "2605.30214v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30213v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30211v1",
@@ -706,34 +307,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30207v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30201v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30200v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30198v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
       "arxivId": "2605.30195v1",
@@ -757,13 +330,6 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30187v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30184v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -783,20 +349,6 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30174v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30170v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
       "arxivId": "2605.30169v1",
@@ -827,67 +379,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30161v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30160v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30159v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30155v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30154v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30153v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30152v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30148v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30140v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30135v1",
@@ -897,39 +393,11 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30132v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
       "arxivId": "2605.30123v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
-      "arxivId": "2605.30116v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30115v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30111v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
       "arxivId": "2605.30107v1",
@@ -953,11 +421,501 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30093v1",
+      "arxivId": "2605.30085v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30073v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30018v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.29992v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30353v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30352v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30348v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30349v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30346v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30344v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30343v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30339v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30336v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30335v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30333v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30328v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30327v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30326v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30324v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30323v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30311v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30310v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30307v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30290v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30289v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30288v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30284v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30283v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30277v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30274v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30273v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30269v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30268v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30265v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30263v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30257v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30251v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30244v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30232v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30231v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30229v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30227v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30225v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30215v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30213v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30207v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30202v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30201v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30200v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30198v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30189v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30187v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30174v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30170v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+    },
+    {
+      "arxivId": "2605.30167v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30161v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30160v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30159v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30155v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30154v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30152v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30148v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+    },
+    {
+      "arxivId": "2605.30140v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30133v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30132v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30131v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30126v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30116v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30115v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30111v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+    },
+    {
+      "arxivId": "2605.30093v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
     },
     {
       "arxivId": "2605.30090v1",
@@ -967,13 +925,6 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
-      "arxivId": "2605.30085v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
-    },
-    {
       "arxivId": "2605.30083v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -981,11 +932,39 @@
       "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
     },
     {
-      "arxivId": "2605.30073v1",
+      "arxivId": "2605.30080v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.30076v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30058v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30052v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.30051v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
       "arxivId": "2605.30040v1",
@@ -1006,21 +985,42 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
     },
     {
-      "arxivId": "2605.30018v1",
+      "arxivId": "2605.30022v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
     },
     {
-      "arxivId": "2605.29992v1",
+      "arxivId": "2605.30021v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.29987v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+    },
+    {
+      "arxivId": "2605.29971v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
+    },
+    {
+      "arxivId": "2605.29951v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T09:39:06.310Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T05:10:10.536Z",
+  "fetchedAt": "2026-05-31T09:38:05.405Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26709070254

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.