### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T13:01:22Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-31T11:20:04.487Z",
+  "ts": "2026-05-31T13:01:22.769Z",
   "count": 1,
-  "durationMs": 4096,
+  "durationMs": 3766,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T11:20:00.410Z",
+  "fetchedAt": "2026-05-31T13:01:19.019Z",
   "windowDays": 7,
-  "scannedStories": 81,
+  "scannedStories": 90,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T11:20:00.410Z",
+  "fetchedAt": "2026-05-31T13:01:19.019Z",
   "windowHours": 72,
-  "scannedTotal": 81,
+  "scannedTotal": 90,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -748,6 +748,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "giktao",
+      "title": "My Accessibility Stack and the future on Wayland",
+      "url": "https://nocoffei.com/?p=451",
+      "commentsUrl": "https://lobste.rs/s/giktao/my_accessibility_stack_future_on_wayland",
+      "by": "",
+      "score": 62,
+      "commentCount": 19,
+      "createdUtc": 1780193074,
+      "ageHours": 10.945833333333333,
+      "trendingScore": 1.3310570566083157,
+      "tags": [
+        "a11y",
+        "linux"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "auxtwd",
       "title": "Steering Zig Fmt",
       "url": "https://matklad.github.io/2026/05/08/steering-zig-fmt.html",
@@ -867,24 +885,6 @@
         "programming",
         "security",
         "windows"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "iuv7kw",
-      "title": "Raft Consensus with a Minority of Nodes",
-      "url": "https://padhye.org/raft-minority/",
-      "commentsUrl": "https://lobste.rs/s/iuv7kw/raft_consensus_with_minority_nodes",
-      "by": "",
-      "score": 7,
-      "commentCount": 0,
-      "createdUtc": 1779888710,
-      "ageHours": 1.18,
-      "trendingScore": 1.2344041127812295,
-      "tags": [
-        "distributed",
-        "math"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26713294886

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.