### PR TITLE
Fix scheduled source health checks

### DIFF
--- a/.github/workflows/audit-freshness.yml
+++ b/.github/workflows/audit-freshness.yml
@@ -1,27 +1,12 @@
 name: Audit - source freshness
 
-# Hourly fail-loud gate for collector freshness. Closes audit I2:
-# scripts/collect-twitter-signals.ts depends on the Apify
-# `apidojo~tweet-scraper` actor; cookie-based providers are dead
-# post-2026, so the actor is a single point of failure with no fallback.
-# This workflow surfaces the breakage as a red-X within 1 hour instead of
-# being noticed by a human eyeballing /api/health.
-#
-# How it works: scripts/audit-freshness.mjs reads every data/_meta/*.json
-# sidecar (written by scripts/_data-meta.mjs:writeSourceMeta), classifies
-# each source against a per-source freshness budget, and exits non-zero if
-# ANY source is stale OR a REQUIRED source has no meta file.
-#
-# The workflow only reads the repo — no Redis access, no secrets, no commit
-# back to main. It's intentionally cheap so we can run it hourly.
-#
-# To extend: drop a new source meta file under data/_meta/, optionally add
-# a row to DEFAULT_BUDGETS_MS in audit-freshness.mjs (or set
-# `freshnessBudgetMs` inside the meta file itself for per-source override).
+# Hourly fail-loud gate for live production freshness and worker health.
+# The old gate scanned committed data/_meta/*.json files; those snapshots are
+# no longer the production source of truth after HOSTUP/Redis worker cutover.
 
 on:
   schedule:
-    - cron: "0 * * * *"  # UTC, every hour on the hour
+    - cron: "0 * * * *"
   workflow_dispatch: {}
 
 permissions:
@@ -46,5 +31,7 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Run freshness gate
-        run: node scripts/audit-freshness.mjs
+      - name: Run live freshness gate
+        env:
+          TRENDINGREPO_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
+        run: node scripts/check-live-production-health.mjs

--- a/.github/workflows/health-watch.yml
+++ b/.github/workflows/health-watch.yml
@@ -1,10 +1,10 @@
 name: Source health watch
 
-# Reads data/_meta/<source>.json sidecars and fails the workflow if any
-# source is in a bad state (reason != "ok") or stale beyond its freshness
-# threshold. GitHub Actions emails workflow owners on failure — the
-# "alert" mechanism is the workflow-failure notification, not a separate
-# integration. Tune thresholds in scripts/check-source-health.mjs.
+# Live HOSTUP production health watch. Older versions read committed
+# data/_meta/*.json sidecars, but production truth now lives in Redis and the
+# worker fleet on HOSTUP. This workflow checks the live public health endpoints
+# instead, so GitHub Actions reports real production breakage instead of stale
+# repository snapshots.
 
 on:
   schedule:
@@ -25,12 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "22"
 
-      - name: Check source health
+      - name: Check live production health
         env:
-          REDIS_URL: ${{ secrets.REDIS_URL }}
-        run: node scripts/check-source-health.mjs
+          TRENDINGREPO_URL: ${{ vars.TRENDINGREPO_URL || vars.STARSCREENER_URL || 'https://trendingrepo.com' }}
+        run: node scripts/check-live-production-health.mjs

--- a/scripts/check-live-production-health.mjs
+++ b/scripts/check-live-production-health.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Live production health gate for HOSTUP/Cloudflare deployments.
+//
+// This replaces the old GitHub-side data/_meta freshness gates for scheduled
+// monitoring. Production truth now lives in Redis/worker health on HOSTUP, so
+// failing a workflow because committed JSON snapshots are stale is noise.
+
+const BASE_URL = (
+  process.env.TRENDINGREPO_URL ||
+  process.env.STARSCREENER_URL ||
+  "https://trendingrepo.com"
+).replace(/\/+$/, "");
+
+async function fetchJson(path, okStatuses = [200]) {
+  const url = `${BASE_URL}${path}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { parseError: true, raw: text.slice(0, 500) };
+  }
+  return {
+    url,
+    status: res.status,
+    okStatus: okStatuses.includes(res.status),
+    body,
+  };
+}
+
+function fail(message, context = {}) {
+  console.error(`FAIL: ${message}`);
+  if (Object.keys(context).length > 0) {
+    console.error(JSON.stringify(context, null, 2));
+  }
+  process.exitCode = 1;
+}
+
+function summarizeWorker(body) {
+  const summary = body?.summary ?? {};
+  const blocking = Array.isArray(body?.slugs)
+    ? body.slugs.filter(
+        (s) => s?.blocking === true && (s.status === "red" || s.status === "missing"),
+      )
+    : [];
+  const advisory = Array.isArray(body?.slugs)
+    ? body.slugs.filter(
+        (s) => s?.blocking === false && (s.status === "red" || s.status === "missing"),
+      )
+    : [];
+  return {
+    ok: body?.ok,
+    summary,
+    blockingProblems: blocking.map((s) => ({
+      slug: s.slug,
+      fetcher: s.fetcher,
+      status: s.status,
+      ageSec: s.ageSec,
+      writtenAt: s.writtenAt,
+    })),
+    advisoryRedCount: advisory.length,
+    advisoryRedSlugs: advisory.map((s) => s.slug).sort(),
+  };
+}
+
+async function main() {
+  console.log(`# Live production health - ${new Date().toISOString()}`);
+  console.log(`base=${BASE_URL}`);
+
+  const [appHealth, workerHealth, sourceHealth] = await Promise.all([
+    fetchJson("/api/health"),
+    fetchJson("/api/worker/health"),
+    fetchJson("/api/health/sources", [200, 207]),
+  ]);
+
+  console.log("\n/api/health");
+  console.log(
+    JSON.stringify(
+      {
+        http: appHealth.status,
+        status: appHealth.body?.status,
+        sourceStatus: appHealth.body?.sourceStatus,
+        lastFetchedAt: appHealth.body?.lastFetchedAt,
+        computedAt: appHealth.body?.computedAt,
+        warning: appHealth.body?.warning ?? null,
+        error: appHealth.body?.error ?? null,
+      },
+      null,
+      2,
+    ),
+  );
+
+  console.log("\n/api/worker/health");
+  const workerSummary = summarizeWorker(workerHealth.body);
+  console.log(JSON.stringify({ http: workerHealth.status, ...workerSummary }, null, 2));
+
+  console.log("\n/api/health/sources");
+  console.log(
+    JSON.stringify(
+      {
+        http: sourceHealth.status,
+        summary: sourceHealth.body?.summary,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!appHealth.okStatus) {
+    fail("/api/health returned non-200", {
+      http: appHealth.status,
+      body: appHealth.body,
+    });
+  }
+  if (appHealth.body?.status === "error" || appHealth.body?.error) {
+    fail("/api/health reports hard error", appHealth.body);
+  }
+
+  if (!workerHealth.okStatus || workerHealth.body?.ok !== true) {
+    fail("/api/worker/health is not ok", {
+      http: workerHealth.status,
+      ...workerSummary,
+    });
+  }
+
+  const sourceSummary = sourceHealth.body?.summary;
+  if (!sourceHealth.okStatus || !sourceSummary) {
+    fail("/api/health/sources returned invalid response", {
+      http: sourceHealth.status,
+      body: sourceHealth.body,
+    });
+  } else if ((sourceSummary.open ?? 0) > 0 || (sourceSummary.halfOpen ?? 0) > 0) {
+    fail("/api/health/sources has open circuit breakers", sourceSummary);
+  }
+
+  if (process.exitCode) return;
+  console.log("\nPASS - live production health is green for blocking checks.");
+}
+
+main().catch((err) => {
+  fail("live health check threw", {
+    message: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+  });
+});

--- a/src/lib/twitter/__tests__/service.test.ts
+++ b/src/lib/twitter/__tests__/service.test.ts
@@ -1,4 +1,4 @@
-import { test, beforeEach, afterEach } from "node:test";
+import { test, beforeEach, afterEach, mock } from "node:test";
 import assert from "node:assert/strict";
 import {
   getTwitterAdminReview,
@@ -165,10 +165,13 @@ function makeAgentRequest(
 beforeEach(() => {
   process.env.STARSCREENER_PERSIST = "false";
   delete process.env.STARSCREENER_DATA_DIR;
+  mock.method(Date, "now", () => Date.parse("2026-04-23T00:00:00.000Z"));
   __resetTwitterStoreForTests();
 });
 
 afterEach(() => {
+  mock.restoreAll();
+
   if (PRIOR_ENV.STARSCREENER_PERSIST === undefined) {
     delete process.env.STARSCREENER_PERSIST;
   } else {


### PR DESCRIPTION
## Summary
- switch Source health watch and Audit - source freshness to live HOSTUP production checks
- add scripts/check-live-production-health.mjs for /api/health, /api/worker/health, and /api/health/sources
- keep advisory/nonblocking source reds visible without failing scheduled production checks

## Validation
- node --check scripts/check-live-production-health.mjs
- node scripts/check-live-production-health.mjs
- npm run lint (passes with existing warnings)
- git diff --check HEAD~1..HEAD

No Vercel commands, deploys, promotes, or Git reconnects were run.