### PR TITLE
Fix cron freshness live health gate

### DIFF
--- a/.github/workflows/cron-freshness-check.yml
+++ b/.github/workflows/cron-freshness-check.yml
@@ -1,26 +1,23 @@
 name: Cron - freshness check
 
-# Cheap GET /api/health probe every 15 min UTC to detect cold-start
-# regressions and freshness drops between ingest runs. No auth needed:
-# the route is an unauthenticated uptime probe. If `status` is anything
-# other than "ok" the step fails so Actions email/ops dashboards light
-# up before a user notices stale data.
+# Cheap live production health probe every 15 min UTC to detect cold-start
+# regressions and blocking source/worker failures between ingest runs. No auth
+# needed: the checked routes are unauthenticated uptime probes. Older versions
+# failed whenever /api/health.status was "stale"; production now distinguishes
+# blocking availability from advisory/stale sources, so this workflow uses the
+# same live HOSTUP gate as health-watch.yml and audit-freshness.yml.
 #
 # Required repo config:
-#   vars.TRENDINGREPO_URL  — optional; defaults to prod URL (legacy: vars.STARSCREENER_URL)
-#   secrets.OPS_ALERT_WEBHOOK — optional Discord/Slack webhook URL.
+#   vars.TRENDINGREPO_URL - optional; defaults to prod URL (legacy: vars.STARSCREENER_URL)
+#   secrets.OPS_ALERT_WEBHOOK - optional Discord/Slack webhook URL.
 #     When set, the workflow POSTs a one-line JSON message on state changes
-#     (healthy → stale and stale → healthy). Email-on-fail is too quiet,
-#     ops were missing alerts for days. State-change-only keeps it from
-#     becoming a 96-message/day spam-channel.
+#     (healthy to unhealthy and unhealthy to healthy). Email-on-fail is too
+#     quiet, and state-change-only keeps it from becoming a spam channel.
 #
-# State persistence: a single-line file `data/.cron-health-status` is
-# committed back to main on every transition. Picked over `actions/cache`
-# + artifacts because:
-#   1. The repo is already the source of truth for collector state.
-#   2. Cache keys can race / evict; a committed file cannot.
-#   3. One file vs. configuring artifact upload+download steps. K2/K3.
-# The file holds exactly one of: ok | stale | error  (no trailing newline).
+# State persistence: a single-line file `data/.cron-health-status` is committed
+# back to main on every transition. The file holds exactly one of: ok | error.
+# A legacy stale value is accepted as a previous value and will transition to
+# ok/error on the next run.
 
 on:
   schedule:
@@ -49,57 +46,34 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: GET /api/health
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Check live production health
         id: probe
-        # Probe outputs:
-        #   status: "ok" | "stale" | "error"
-        #   message: short human description for the alert payload
+        env:
+          TRENDINGREPO_URL: ${{ env.BASE_URL }}
         run: |
           set +e
-          # ?soft=1 — /api/health returns 503 when ANY source is stale by
-          # default, which trips this workflow on normal hourly drift. Soft
-          # mode returns 200 with status="stale" in the body; the parser
-          # below already inspects body.status, so we still alert correctly
-          # without false-positive page failures.
-          code=$(curl -sS -o /tmp/out -w "%{http_code}" \
-            "$BASE_URL/api/health?soft=1")
-          curl_rc=$?
+          node scripts/check-live-production-health.mjs > /tmp/live-health.log 2>&1
+          probe_rc=$?
           set -e
-          echo "HTTP $code (curl_rc=$curl_rc)"
-          if command -v jq >/dev/null 2>&1 && jq . /tmp/out >/dev/null 2>&1; then
-            jq . /tmp/out | head -c 2000
-          else
-            head -c 2000 /tmp/out
-          fi
-          echo
 
-          if [ "$curl_rc" != "0" ] || [ "$code" != "200" ]; then
-            echo "status=error" >> "$GITHUB_OUTPUT"
-            echo "message=health probe failed (HTTP $code, curl_rc=$curl_rc)" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if command -v jq >/dev/null 2>&1; then
-            body_status=$(jq -r '.status // "missing"' /tmp/out)
-            echo "body_status=$body_status"
-            if [ "$body_status" = "ok" ]; then
-              echo "status=ok" >> "$GITHUB_OUTPUT"
-              echo "message=health ok" >> "$GITHUB_OUTPUT"
-            else
-              echo "status=stale" >> "$GITHUB_OUTPUT"
-              echo "message=health status='$body_status' (expected 'ok')" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            # No jq available — assume ok if HTTP 200, since the body parse
-            # would also have failed and we don't want to spam on infra blips.
+          cat /tmp/live-health.log
+          if [ "$probe_rc" = "0" ]; then
             echo "status=ok" >> "$GITHUB_OUTPUT"
-            echo "message=health ok (jq unavailable, HTTP 200 only)" >> "$GITHUB_OUTPUT"
+            echo "message=live production health ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=error" >> "$GITHUB_OUTPUT"
+            echo "message=live production health gate failed (exit $probe_rc)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Read previous status
         id: previous
-        # Defaults to 'unknown' so the very first run after this workflow
-        # ships emits exactly one alert (unknown → whatever the current state is).
+        # Defaults to 'unknown' so the first run after this workflow ships emits
+        # exactly one alert.
         run: |
           if [ -f "$STATUS_FILE" ]; then
             prev=$(cat "$STATUS_FILE" | tr -d '[:space:]')
@@ -119,18 +93,13 @@ jobs:
           DETAIL: ${{ steps.probe.outputs.message }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         # Discord-compatible / Slack-compatible-enough single-field payload.
-        # No-op (with a warning) if the webhook secret isn't configured —
-        # the workflow still updates the status file so future transitions
-        # won't be skipped.
+        # No-op with a warning if the webhook secret is not configured.
         run: |
           if [ -z "${OPS_ALERT_WEBHOOK:-}" ]; then
-            echo "::warning::OPS_ALERT_WEBHOOK secret not set — skipping notification (state $PREV -> $NEXT)"
+            echo "::warning::OPS_ALERT_WEBHOOK secret not set - skipping notification (state $PREV -> $NEXT)"
             exit 0
           fi
-          # Minimal Discord-shaped payload. Slack + Mattermost also accept
-          # a top-level `content` field for plain-text webhooks.
-          msg="[trendingrepo cron] $PREV -> $NEXT — $DETAIL ($RUN_URL)"
-          # Escape backslashes + double-quotes for safe JSON embedding.
+          msg="[trendingrepo cron] $PREV -> $NEXT - $DETAIL ($RUN_URL)"
           esc=$(printf '%s' "$msg" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
           curl -sS -X POST -H "Content-Type: application/json" \
             -d "{\"content\": $esc}" \
@@ -146,13 +115,8 @@ jobs:
 
       - name: Persist status
         if: ${{ steps.previous.outputs.prev != steps.probe.outputs.status }}
-        # Commit the flip-file so the *next* run sees the new state.
-        # Skipped (by the if: above) when state didn't change — avoids an
-        # empty-commit per cycle.
-        # Step-level timeout — git-commit-data invokes `gh pr merge --auto`
-        # which can block indefinitely waiting for required checks. Cap at
-        # 5 min so the rest of the job (which may run other workloads) isn't
-        # starved. Pattern source: #1529 (collect-twitter.yml).
+        # Commit the flip-file so the next run sees the new state. Skipped when
+        # state did not change to avoid an empty commit every cycle.
         timeout-minutes: 5
         uses: ./.github/actions/git-commit-data
         with:
@@ -162,9 +126,9 @@ jobs:
           paths: |
             data/.cron-health-status
 
-      - name: Fail loud on stale/error
-        # Keep the existing red-X behavior so anyone watching the workflow
-        # tab still sees the failure. Webhook is additive, not replacement.
+      - name: Fail loud on error
+        # Keep red-X behavior for real blocking failures. Advisory stale source
+        # rows remain visible in script output but do not fail this workflow.
         if: ${{ steps.probe.outputs.status != 'ok' }}
         run: |
           echo "::error::health status is '${{ steps.probe.outputs.status }}': ${{ steps.probe.outputs.message }}"


### PR DESCRIPTION
## Summary
- switch the scheduled freshness state-change workflow to the live production health gate
- preserve OPS_ALERT_WEBHOOK notifications and status-file transition commits
- stop failing the cron on advisory stale source rows when blocking health is green

## Validation
- git diff --check
- node --check scripts/check-live-production-health.mjs
- node scripts/check-live-production-health.mjs
- npm run lint (passes, existing 47 warnings)

No Vercel deploy/promote/reconnect commands were run.