### PR TITLE
Accept degraded source health in deploy smoke

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -58,7 +58,10 @@ jobs:
             "/drop|200"
             "/api/health?soft=1|200"
             "/api/worker/health|200"
-            "/api/health/sources|200"
+            # 207 means the health endpoint is serving but one or more
+            # upstream source breakers are open. That is source-health signal,
+            # not a failed app deploy.
+            "/api/health/sources|200,207"
           )
 
           failures=0


### PR DESCRIPTION
## Summary
- allow /api/health/sources to return 207 in post-deploy smoke
- keep page and core health route expectations strict at 200
- document that source breaker degradation belongs to source-health monitoring, not app deploy smoke

## Root cause
The HOSTUP smoke workflow was checking endpoint availability, but /api/health/sources intentionally returns 207 Multi-Status when upstream source breakers are open. The endpoint was alive and returning JSON; the smoke expectation was too strict for this route.

## Validation
- git diff --check
- npm run lint (passes, existing 47 warnings)
- live /api/health/sources probe returned 207 and matches the updated expected statuses

No Vercel deploy/promote/reconnect commands were run.