### PR TITLE
Zero-tolerance source health hardening

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/__tests__/degraded.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/__tests__/degraded.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FetcherContext } from '../../../lib/types.js';
+
+const readDataStoreMock = vi.hoisted(() => vi.fn());
+const writeDataStoreMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    source: 'redis' as const,
+    writtenAt: '2026-05-31T10:00:00.000Z',
+  })),
+);
+
+vi.mock('../../../lib/redis.js', () => ({
+  readDataStore: readDataStoreMock,
+  writeDataStore: writeDataStoreMock,
+}));
+
+const originalSetTimeout = globalThis.setTimeout;
+
+function makeContext(): FetcherContext {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as FetcherContext['log'];
+  return {
+    db: null as unknown as FetcherContext['db'],
+    redis: null as unknown as FetcherContext['redis'],
+    http: {
+      async json() {
+        throw new Error('OSSInsight 500');
+      },
+      async text() {
+        throw new Error('OSSInsight 500');
+      },
+    },
+    log,
+    dryRun: false,
+    since: new Date('2026-05-31T10:00:00.000Z'),
+    signalRunComplete: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  readDataStoreMock.mockReset();
+  writeDataStoreMock.mockClear();
+  globalThis.setTimeout = ((cb: () => void) => {
+    cb();
+    return 0 as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+describe('collection-rankings degraded writes', () => {
+  it('freshens the slug with cached per-metric rows when OSSInsight fails', async () => {
+    readDataStoreMock.mockResolvedValueOnce({
+      fetchedAt: '2026-05-30T10:00:00.000Z',
+      period: 'past_28_days',
+      collections: {
+        '10139': {
+          stars: [
+            {
+              repoId: 123,
+              repoName: 'alpha/project',
+              currentPeriodGrowth: 10,
+              pastPeriodGrowth: 5,
+              growthPop: 2,
+              rankPop: 1,
+              total: 100,
+              currentPeriodRank: 1,
+              pastPeriodRank: 2,
+            },
+          ],
+          issues: [],
+        },
+      },
+    });
+    const { default: fetcher } = await import('../index.js');
+
+    await fetcher.run(makeContext());
+
+    const writes = writeDataStoreMock.mock.calls as unknown as Array<
+      [string, unknown, unknown?]
+    >;
+    const write = writes.find(
+      ([slug]) => slug === 'collection-rankings',
+    );
+    expect(write).toBeDefined();
+    const payload = write?.[1] as {
+      status?: string;
+      dataAsOf?: string | null;
+      collections?: Record<string, { stars?: unknown[]; issues?: unknown[] }>;
+      errors?: unknown[];
+    };
+
+    expect(payload.status).toBe('degraded');
+    expect(payload.dataAsOf).toBe('2026-05-30T10:00:00.000Z');
+    expect(payload.collections?.['10139']?.stars).toHaveLength(1);
+    expect(payload.errors?.length).toBeGreaterThan(0);
+    expect(write?.[2]).toEqual({ writer: 'worker:collection-rankings:degraded' });
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
@@ -16,7 +16,7 @@
 // fixture in tandem.
 
 import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
-import { writeDataStore } from '../../lib/redis.js';
+import { readDataStore, writeDataStore } from '../../lib/redis.js';
 
 interface CollectionRef {
   id: number;
@@ -95,6 +95,9 @@ export interface CollectionRankingsPayload {
   fetchedAt: string;
   period: string;
   collections: Record<string, Record<Metric, NormalizedRankingRow[]>>;
+  status?: 'ok' | 'degraded';
+  dataAsOf?: string | null;
+  errors?: Array<{ stage: string; message: string }>;
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -148,7 +151,12 @@ const fetcher: Fetcher = {
     const fetchedAt = new Date().toISOString();
     const collections: Record<string, Record<Metric, NormalizedRankingRow[]>> =
       {};
+    const prior =
+      (await readDataStore<CollectionRankingsPayload>('collection-rankings').catch(
+        () => null,
+      )) ?? null;
     let totalRows = 0;
+    let preservedRows = 0;
 
     for (const collection of COLLECTIONS) {
       const metrics: Record<Metric, NormalizedRankingRow[]> = {
@@ -172,11 +180,29 @@ const fetcher: Fetcher = {
           );
         } catch (err) {
           const message = (err as Error).message;
+          const priorRows = prior?.collections?.[String(collection.id)]?.[metric] ?? [];
           ctx.log.error(
-            { collection: collection.id, metric, err: message },
-            'ranking fetch failed',
+            {
+              collection: collection.id,
+              metric,
+              err: message,
+              preservedRows: priorRows.length,
+            },
+            priorRows.length > 0
+              ? 'ranking fetch failed - preserving prior rows for collection metric'
+              : 'ranking fetch failed',
           );
-          errors.push({ stage: label, message });
+          if (priorRows.length > 0) {
+            metrics[metric] = priorRows;
+            preservedRows += priorRows.length;
+            totalRows += priorRows.length;
+            errors.push({
+              stage: label,
+              message: `${message} (preserved ${priorRows.length} cached)`,
+            });
+          } else {
+            errors.push({ stage: label, message });
+          }
         }
         await sleep(PAUSE_MS);
       }
@@ -187,6 +213,9 @@ const fetcher: Fetcher = {
       fetchedAt,
       period: PERIOD,
       collections,
+      status: errors.length > 0 ? 'degraded' : 'ok',
+      dataAsOf: errors.length > 0 ? prior?.dataAsOf ?? prior?.fetchedAt ?? null : fetchedAt,
+      ...(errors.length > 0 ? { errors } : {}),
     };
 
     // Zero-write guard (keep-last-50 rule): when api.ossinsight.io is down,
@@ -195,7 +224,12 @@ const fetcher: Fetcher = {
     // last-known-good slug instead — slightly-stale beats empty.
     let resultSource = 'preserved';
     if (totalRows > 0) {
-      const result = await writeDataStore('collection-rankings', payload);
+      const result = await writeDataStore('collection-rankings', payload, {
+        writer:
+          payload.status === 'degraded'
+            ? 'worker:collection-rankings:degraded'
+            : undefined,
+      });
       resultSource = result.source;
       ctx.log.info(
         {
@@ -208,13 +242,31 @@ const fetcher: Fetcher = {
       );
     } else {
       ctx.log.error(
-        'collection-rankings: all rankings empty (api.ossinsight.io down?) — preserving last-known-good collection-rankings slug',
+        'collection-rankings: all rankings empty (api.ossinsight.io down?) - publishing degraded collection-rankings payload',
       );
       errors.push({
         stage: 'guard',
         message:
-          'all rankings empty; preserved last-known-good collection-rankings slug',
+          'all rankings empty; published degraded collection-rankings payload',
       });
+    }
+
+    if (totalRows === 0) {
+      const result = await writeDataStore('collection-rankings', payload, {
+        writer: 'worker:collection-rankings:degraded',
+      });
+      resultSource = result.source;
+      ctx.log.info(
+        {
+          collections: COLLECTIONS.length,
+          totalRows,
+          preservedRows,
+          status: payload.status,
+          redisSource: result.source,
+          writtenAt: result.writtenAt,
+        },
+        'collection-rankings degraded payload published',
+      );
     }
 
     return done(startedAt, totalRows, resultSource === 'redis', errors);

--- a/apps/trendingrepo-worker/src/fetchers/lobsters/__tests__/mentions-empty.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/lobsters/__tests__/mentions-empty.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FetcherContext } from '../../../lib/types.js';
+
+const readDataStoreMock = vi.hoisted(() => vi.fn());
+const writeDataStoreMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    source: 'redis' as const,
+    writtenAt: '2026-05-31T10:00:00.000Z',
+  })),
+);
+
+vi.mock('../../../lib/redis.js', () => ({
+  readDataStore: readDataStoreMock,
+  writeDataStore: writeDataStoreMock,
+}));
+
+vi.mock('../../../lib/util/tracked-repos.js', () => ({
+  loadTrackedRepos: vi.fn(async () => new Map()),
+}));
+
+const originalSetTimeout = globalThis.setTimeout;
+
+function story() {
+  return {
+    short_id: 'abc123',
+    created_at: '2026-05-31T09:00:00.000Z',
+    title: 'General AI systems discussion',
+    url: 'https://example.com/post',
+    description: 'No tracked repository link in this story.',
+    score: 10,
+    comment_count: 2,
+    tags: ['ai'],
+    user: 'tester',
+  };
+}
+
+function makeContext(): FetcherContext {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as FetcherContext['log'];
+  let calls = 0;
+  return {
+    db: null as unknown as FetcherContext['db'],
+    redis: null as unknown as FetcherContext['redis'],
+    http: {
+      async json<T>() {
+        calls += 1;
+        return { data: (calls === 1 ? [story()] : []) as T, cached: false };
+      },
+      async text() {
+        return { data: '', cached: false };
+      },
+    },
+    log,
+    dryRun: false,
+    since: new Date('2026-05-31T10:00:00.000Z'),
+    signalRunComplete: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  readDataStoreMock.mockReset();
+  writeDataStoreMock.mockClear();
+  globalThis.setTimeout = ((cb: () => void) => {
+    cb();
+    return 0 as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+describe('lobsters empty mentions', () => {
+  it('publishes lobsters-mentions even when no tracked repos were mentioned', async () => {
+    readDataStoreMock.mockResolvedValue(null);
+    const { default: fetcher } = await import('../index.js');
+
+    await fetcher.run(makeContext());
+
+    const writes = writeDataStoreMock.mock.calls as unknown as Array<
+      [string, unknown, unknown?]
+    >;
+    const write = writes.find(
+      ([slug]) => slug === 'lobsters-mentions',
+    );
+    expect(write).toBeDefined();
+    const payload = write?.[1] as {
+      scannedStories?: number;
+      mentions?: Record<string, unknown>;
+      leaderboard?: unknown[];
+    };
+    expect(payload.scannedStories).toBe(1);
+    expect(payload.mentions).toEqual({});
+    expect(payload.leaderboard).toEqual([]);
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/lobsters/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/lobsters/index.ts
@@ -245,10 +245,6 @@ const fetcher: Fetcher = {
     const existingTrending = await readDataStore<{ stories?: unknown[] }>(
       'lobsters-trending',
     ).catch(() => null);
-    const existingMentions = await readDataStore<{ leaderboard?: unknown[] }>(
-      'lobsters-mentions',
-    ).catch(() => null);
-
     let trendingSource = 'preserved';
     let mentionsSource = 'preserved';
     if (
@@ -264,19 +260,11 @@ const fetcher: Fetcher = {
       const r = await writeDataStore('lobsters-trending', trendingPayload);
       trendingSource = r.source;
     }
-    if (
-      shouldPreserveCache<unknown>({
-        fresh: leaderboard,
-        existing: existingMentions?.leaderboard ?? [],
-      })
-    ) {
-      ctx.log.warn(
-        'lobsters: empty mentions scan — preserving last-known-good lobsters-mentions',
-      );
-    } else {
-      const r = await writeDataStore('lobsters-mentions', mentionsPayload);
-      mentionsSource = r.source;
-    }
+    // A successful story scan with zero tracked repo mentions is a valid empty
+    // observation, not an upstream outage. Publish it so the meta sidecar
+    // proves the scan ran.
+    const r = await writeDataStore('lobsters-mentions', mentionsPayload);
+    mentionsSource = r.source;
 
     ctx.log.info(
       {

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/fallback.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/fallback.test.ts
@@ -352,4 +352,28 @@ describe('oss-trending fallback', () => {
     expect(bucket(payload, 'past_week', 'All')[0]?.stars).toBe('31');
     expect(bucket(payload, 'past_month', 'TypeScript')[0]?.stars).toBe('90');
   });
+
+  it('publishes a degraded hot-collections payload when only that endpoint is down', async () => {
+    const { default: fetcher } = await import('../index.js');
+
+    await fetcher.run(makeContext());
+
+    const writes = writeDataStoreMock.mock.calls as unknown as Array<
+      [string, unknown, unknown?]
+    >;
+    const hotWrite = writes.find(([slug]) => slug === 'hot-collections');
+    expect(hotWrite).toBeDefined();
+
+    const payload = hotWrite?.[1] as {
+      status?: string;
+      rows?: unknown[];
+      dataAsOf?: string | null;
+      errors?: Array<{ stage: string; message: string }>;
+    };
+    expect(payload.status).toBe('degraded');
+    expect(payload.rows).toEqual([]);
+    expect(payload.dataAsOf).toBeNull();
+    expect(payload.errors?.[0]?.stage).toBe('hot-collections');
+    expect(hotWrite?.[2]).toEqual({ writer: 'worker:oss-trending:degraded' });
+  });
 });

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
@@ -75,6 +75,9 @@ export interface TrendingPayload {
 export interface HotCollectionsPayload {
   fetchedAt: string;
   rows: NormalizedHotCollectionRow[];
+  status?: 'ok' | 'degraded';
+  dataAsOf?: string | null;
+  errors?: Array<{ stage: string; message: string }>;
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -136,6 +139,10 @@ const fetcher: Fetcher = {
     const priorBuckets =
       (await readDataStore<TrendingPayload>('trending').catch(() => null))
         ?.buckets ?? {};
+    const priorHotCollections =
+      (await readDataStore<HotCollectionsPayload>('hot-collections').catch(
+        () => null,
+      )) ?? null;
 
     for (const period of PERIODS) {
       buckets[period] = {};
@@ -192,7 +199,26 @@ const fetcher: Fetcher = {
     }
 
     const trendsPayload: TrendingPayload = { fetchedAt, buckets };
-    const hotPayload: HotCollectionsPayload = { fetchedAt, rows: hotRows };
+    const hotErrors = errors.filter((err) => err.stage === 'hot-collections');
+    const hotPayload: HotCollectionsPayload =
+      hotRows.length > 0
+        ? { fetchedAt, rows: hotRows, status: 'ok', dataAsOf: fetchedAt }
+        : {
+            fetchedAt,
+            rows: priorHotCollections?.rows ?? [],
+            status: 'degraded',
+            dataAsOf:
+              priorHotCollections?.dataAsOf ?? priorHotCollections?.fetchedAt ?? null,
+            errors:
+              hotErrors.length > 0
+                ? hotErrors
+                : [
+                    {
+                      stage: 'hot-collections',
+                      message: 'empty hot collections response',
+                    },
+                  ],
+          };
 
     // Zero-write guard — root-cause fix for the 2026-05-28 site-wide delta wipe.
     // When api.ossinsight.io is fully down, every bucket fetch fails and comes
@@ -242,8 +268,15 @@ const fetcher: Fetcher = {
       hotSource = res.source;
     } else {
       ctx.log.warn(
-        'oss-trending: no hot collections this run — preserving last-known-good hot-collections slug',
+        'oss-trending: no hot collections this run; publishing degraded hot-collections payload',
       );
+    }
+
+    if (hotRows.length === 0) {
+      const res = await writeDataStore('hot-collections', hotPayload, {
+        writer: 'worker:oss-trending:degraded',
+      });
+      hotSource = res.source;
     }
 
     ctx.log.info(

--- a/src/app/api/health/sources/route.ts
+++ b/src/app/api/health/sources/route.ts
@@ -18,6 +18,7 @@
 import { NextResponse } from "next/server";
 
 import {
+  DISABLED_SOURCES,
   KNOWN_SOURCES,
   sourceHealthTracker,
   type SourceHealthSnapshot,
@@ -47,8 +48,10 @@ interface HealthSourcesBody {
     closed: number;
     open: number;
     halfOpen: number;
+    disabled: number;
     openSources: string[];
     halfOpenSources: string[];
+    disabledSources: string[];
   };
   options: {
     windowSize: number;
@@ -120,8 +123,10 @@ export async function GET(): Promise<NextResponse<HealthSourcesBody>> {
       closed,
       open,
       halfOpen,
+      disabled: DISABLED_SOURCES.length,
       openSources,
       halfOpenSources,
+      disabledSources: [...DISABLED_SOURCES].sort(),
     },
     options: {
       windowSize: opts.windowSize,

--- a/src/app/api/health/sources/route.ts
+++ b/src/app/api/health/sources/route.ts
@@ -90,8 +90,6 @@ export async function GET(): Promise<NextResponse<HealthSourcesBody>> {
   const registerMs = performance.now() - registerStart;
 
   const getAllStart = performance.now();
-  const all = sourceHealthTracker.getAllHealth();
-  const getAllMs = performance.now() - getAllStart;
   const sources: Record<string, SourceBreakerView> = {};
   let closed = 0;
   let open = 0;
@@ -99,7 +97,12 @@ export async function GET(): Promise<NextResponse<HealthSourcesBody>> {
   const openSources: string[] = [];
   const halfOpenSources: string[] = [];
 
-  for (const [id, snap] of Object.entries(all)) {
+  // Only enabled canonical sources participate in the health calculation.
+  // Disabled adapters can still be constructed directly by legacy callers and
+  // auto-register in the tracker via recordFailure(); those snapshots must not
+  // reopen this endpoint after the operator has intentionally switched them off.
+  for (const id of KNOWN_SOURCES) {
+    const snap = sourceHealthTracker.getHealth(id);
     sources[id] = toView(snap);
     if (snap.state === "OPEN") {
       open += 1;
@@ -114,6 +117,7 @@ export async function GET(): Promise<NextResponse<HealthSourcesBody>> {
 
   openSources.sort();
   halfOpenSources.sort();
+  const getAllMs = performance.now() - getAllStart;
 
   const opts = sourceHealthTracker.getOptions();
   const body: HealthSourcesBody = {

--- a/src/app/api/worker/health/route.ts
+++ b/src/app/api/worker/health/route.ts
@@ -1,47 +1,21 @@
 // Worker fleet health probe.
 //
-// Reads the meta sidecar (`ss:meta:v1:<slug>`) for every Redis slug the
-// Railway worker writes, computes age, classifies green / amber / red /
-// missing against the expected cadence, and returns one aggregated JSON
-// envelope. Single hit gives the operator full visibility into worker
-// liveness — no need to load each consumer page to verify a fetcher is
-// firing.
-//
-// Status classification:
-//   green   — age < 2× expected cadence    (fresh)
-//   amber   — age < 6× expected cadence    (stale-but-not-dead)
-//   red     — age >= 6× expected cadence   (worker likely broken for this slug)
-//   missing — no meta key found            (never published, OR Redis miss)
-//
-// HTTP status code:
-//   200 if every slug is green or amber
-//   503 if any slug is red or missing
-//
-// Cache: 30s shared cache (Vercel s-maxage). Hitting the route in a tight
-// loop won't fan out 33× per second to Redis.
-//
-// This complements (not replaces) the existing `/api/worker/pulse`
-// (single-slug hn-pulse liveness) and `/api/health` (a few hand-picked
-// signal slugs with degraded body shape). This route is the COMPLETE
-// worker-fleet view.
+// Reads the meta sidecar (`ss:meta:v1:<slug>`) for every active Redis slug the
+// worker owns, computes age, classifies green / amber / red / missing against
+// expected cadence, and returns one aggregated JSON envelope.
 
-import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
 import { getDataStore } from "@/lib/data-store";
+import {
+  WORKER_HEALTH_DISABLED_SPECS,
+  WORKER_HEALTH_SPECS,
+  type DisabledSlugHealthSpec,
+} from "@/lib/worker-health-specs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-/**
- * Optional bearer-token gate. When `WORKER_HEALTH_BEARER` is unset (the
- * default) this route stays fully public — TOOLBOX cron + the operator
- * dashboard continue to hit `/api/worker/health` with no Authorization
- * header. When the env var IS set, callers MUST present
- * `Authorization: Bearer <value>` and the comparison runs in constant
- * time to avoid leaking the token byte-by-byte.
- *
- * Returns the 401 NextResponse on rejection, or `null` to continue.
- */
 function checkOptionalBearer(request: NextRequest): NextResponse | null {
   const expected = process.env.WORKER_HEALTH_BEARER?.trim();
   if (!expected) return null;
@@ -56,7 +30,6 @@ function checkOptionalBearer(request: NextRequest): NextResponse | null {
   const supplied = header.slice(prefix.length);
   const a = Buffer.from(supplied);
   const b = Buffer.from(expected);
-  // Length must match before timingSafeEqual; otherwise it throws.
   const match = a.length === b.length && timingSafeEqual(a, b);
   if (!match) {
     return NextResponse.json(
@@ -67,83 +40,8 @@ function checkOptionalBearer(request: NextRequest): NextResponse | null {
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Slug → expected cadence map
-// ---------------------------------------------------------------------------
-//
-// Cadence in MINUTES = the expected interval between successful writes for
-// each slug. Drawn directly from each fetcher's cron schedule in
-// apps/trendingrepo-worker/src/fetchers/<name>/index.ts. When a fetcher
-// changes its schedule, update the matching row here in the same commit.
-//
-// `fetcher` is the fetcher name (matches the `name` field on the Fetcher
-// object) — operator can grep by it to find the source.
-
-interface SlugHealthSpec {
-  slug: string;
-  fetcher: string;
-  cadenceMin: number;
-  /** True if this slug is allowed to lag without raising an alert (e.g. weekly). */
-  slowMoving?: boolean;
-  /**
-   * Advisory slugs are useful diagnostics but do not make the fleet unhealthy.
-   * They are either credential-dependent catalogs or GitHub-workflow mirrors,
-   * not core live-feed liveness.
-   */
-  blocking?: boolean;
-}
-
-const SLUG_TABLE: ReadonlyArray<SlugHealthSpec> = [
-  // hourly + faster — these are the freshness-sensitive workhorses
-  { slug: "hn-pulse", fetcher: "hn-pulse", cadenceMin: 10 },
-  { slug: "trending", fetcher: "oss-trending", cadenceMin: 60 },
-  { slug: "hot-collections", fetcher: "oss-trending", cadenceMin: 60, blocking: false },
-  { slug: "recent-repos", fetcher: "recent-repos", cadenceMin: 60 },
-  { slug: "deltas", fetcher: "deltas", cadenceMin: 60 },
-  { slug: "repo-metadata", fetcher: "repo-metadata", cadenceMin: 60, blocking: false },
-  { slug: "repo-profiles", fetcher: "repo-profiles", cadenceMin: 60 },
-  { slug: "trendshift-daily", fetcher: "trendshift-daily", cadenceMin: 60, blocking: false },
-  { slug: "engagement-composite", fetcher: "engagement-composite", cadenceMin: 60 },
-  { slug: "consensus-trending", fetcher: "consensus-trending", cadenceMin: 60 },
-  { slug: "trustmrr-startups", fetcher: "trustmrr", cadenceMin: 60, blocking: false },
-  { slug: "trustmrr-startups:meta", fetcher: "trustmrr", cadenceMin: 60, blocking: false },
-  { slug: "revenue-overlays", fetcher: "trustmrr", cadenceMin: 60, blocking: false },
-  { slug: "hackernews-trending", fetcher: "hackernews", cadenceMin: 60 },
-  { slug: "hackernews-repo-mentions", fetcher: "hackernews", cadenceMin: 60 },
-  { slug: "bluesky-trending", fetcher: "bluesky", cadenceMin: 60 },
-  { slug: "bluesky-mentions", fetcher: "bluesky", cadenceMin: 60 },
-  { slug: "lobsters-trending", fetcher: "lobsters", cadenceMin: 60 },
-  { slug: "lobsters-mentions", fetcher: "lobsters", cadenceMin: 60, blocking: false },
-
-  // few-hours cadence
-  { slug: "trending-skill-sh", fetcher: "skills-sh", cadenceMin: 120, blocking: false },
-  { slug: "huggingface-trending", fetcher: "scrape-huggingface", cadenceMin: 240, blocking: false },
-  { slug: "producthunt-launches", fetcher: "producthunt", cadenceMin: 360, blocking: false },
-  { slug: "trending-skill", fetcher: "claude-skills", cadenceMin: 360, blocking: false },
-  { slug: "trending-mcp", fetcher: "mcp-registry-official+glama+pulsemcp+smithery", cadenceMin: 360, blocking: false },
-  { slug: "funding-news", fetcher: "funding-news", cadenceMin: 360 },
-  { slug: "collection-rankings", fetcher: "collection-rankings", cadenceMin: 360, blocking: false },
-
-  // daily — operator-curated mirrors + once-a-day enrichment
-  { slug: "manual-repos", fetcher: "manual-repos", cadenceMin: 60 * 24 },
-  { slug: "revenue-manual-matches", fetcher: "revenue-manual-matches", cadenceMin: 60 * 24 },
-  { slug: "npm-packages", fetcher: "npm-packages", cadenceMin: 60 * 24 },
-  { slug: "revenue-benchmarks", fetcher: "revenue-benchmarks", cadenceMin: 60 * 24, blocking: false },
-
-  // weekly — slow-moving baselines
-  // Live Reddit collection is paused; baselines remain tracked as a separate
-  // slow-moving snapshot until the OAuth-backed live collector is re-enabled.
-  { slug: "reddit-baselines", fetcher: "reddit-baselines", cadenceMin: 60 * 24 * 7, slowMoving: true },
-
-  // newer skill sources (cadence inherited from each fetcher's schedule)
-  { slug: "trending-skill-skillsmp", fetcher: "skillsmp", cadenceMin: 360, blocking: false },
-  { slug: "trending-skill-smithery", fetcher: "smithery-skills", cadenceMin: 360, blocking: false },
-  { slug: "trending-skill-lobehub", fetcher: "lobehub-skills", cadenceMin: 360, blocking: false },
-];
-
-// ---------------------------------------------------------------------------
-// Status classification
-// ---------------------------------------------------------------------------
+const SLUG_TABLE = WORKER_HEALTH_SPECS;
+const DISABLED_SLUG_TABLE = WORKER_HEALTH_DISABLED_SPECS;
 
 type SlugStatus = "green" | "amber" | "red" | "missing";
 
@@ -159,6 +57,8 @@ interface SlugHealth {
 
 interface HealthSummary {
   total: number;
+  active: number;
+  disabled: number;
   green: number;
   amber: number;
   red: number;
@@ -172,6 +72,7 @@ interface HealthResponse {
   generatedAt: string;
   summary: HealthSummary;
   slugs: SlugHealth[];
+  disabledSlugs: DisabledSlugHealthSpec[];
 }
 
 function classifyAge(
@@ -181,18 +82,12 @@ function classifyAge(
 ): SlugStatus {
   if (ageSec === null) return "missing";
   const cadenceSec = cadenceMin * 60;
-  // Slow-moving slugs (e.g. weekly baselines) get a more forgiving amber
-  // band — they're allowed to be stale for half the cadence before alerting.
   const greenMultiplier = slowMoving ? 1.5 : 2;
   const amberMultiplier = slowMoving ? 3 : 6;
   if (ageSec < cadenceSec * greenMultiplier) return "green";
   if (ageSec < cadenceSec * amberMultiplier) return "amber";
   return "red";
 }
-
-// ---------------------------------------------------------------------------
-// Route handler
-// ---------------------------------------------------------------------------
 
 export async function GET(
   request: NextRequest,
@@ -203,8 +98,6 @@ export async function GET(
   const store = getDataStore();
   const now = Date.now();
 
-  // Read every slug's meta in parallel. data-store's `writtenAt()` is a
-  // single GET on the sidecar key (no payload deserialize) — cheap.
   const probes = await Promise.all(
     SLUG_TABLE.map(async (spec) => {
       const writtenAt = await store.writtenAt(spec.slug).catch(() => null);
@@ -226,7 +119,9 @@ export async function GET(
   );
 
   const summary: HealthSummary = {
-    total: probes.length,
+    total: probes.length + DISABLED_SLUG_TABLE.length,
+    active: probes.length,
+    disabled: DISABLED_SLUG_TABLE.length,
     green: probes.filter((p) => p.status === "green").length,
     amber: probes.filter((p) => p.status === "amber").length,
     red: probes.filter((p) => p.status === "red").length,
@@ -235,7 +130,6 @@ export async function GET(
     blockingMissing: probes.filter((p) => p.blocking && p.status === "missing").length,
   };
 
-  // Sort: red+missing first (caller scans them), then amber, then green.
   const statusRank: Record<SlugStatus, number> = {
     missing: 0,
     red: 1,
@@ -257,12 +151,11 @@ export async function GET(
       generatedAt: new Date().toISOString(),
       summary,
       slugs: probes,
+      disabledSlugs: [...DISABLED_SLUG_TABLE],
     },
     {
       status: ok ? 200 : 503,
       headers: {
-        // 30s edge cache — same window as the route does internally on cache
-        // misses. Vercel SWR returns the stale body for up to 60s after that.
         "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60",
       },
     },

--- a/src/lib/__tests__/reddit-telemetry.test.ts
+++ b/src/lib/__tests__/reddit-telemetry.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { _setRedisForTests } from "../redis";
+import {
+  isUserAgentQuarantined,
+  quarantineUserAgent,
+  recordRedditCall,
+} from "../pool/reddit-telemetry";
+
+class FakeRedis {
+  readonly hashes = new Map<string, Record<string, string>>();
+  readonly strings = new Map<string, string>();
+  readonly expirations = new Map<string, number>();
+  readonly exat = new Map<string, number>();
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+
+  async set(
+    key: string,
+    value: string,
+    mode?: "EX" | "PX" | "EXAT" | "PXAT",
+    ttl?: number,
+  ): Promise<"OK"> {
+    this.strings.set(key, value);
+    if (mode === "EXAT" && typeof ttl === "number") {
+      this.exat.set(key, ttl);
+    }
+    return "OK";
+  }
+
+  async hincrby(key: string, field: string, increment: number): Promise<number> {
+    const hash = this.hashes.get(key) ?? {};
+    const next = Number(hash[field] ?? "0") + increment;
+    hash[field] = String(next);
+    this.hashes.set(key, hash);
+    return next;
+  }
+
+  async hset(key: string, field: string, value: string | number): Promise<number> {
+    const hash = this.hashes.get(key) ?? {};
+    const existed = Object.hasOwn(hash, field);
+    hash[field] = String(value);
+    this.hashes.set(key, hash);
+    return existed ? 0 : 1;
+  }
+
+  async hgetall(key: string): Promise<Record<string, string>> {
+    return { ...(this.hashes.get(key) ?? {}) };
+  }
+
+  async expire(key: string, seconds: number): Promise<number> {
+    this.expirations.set(key, seconds);
+    return 1;
+  }
+}
+
+afterEach(() => {
+  _setRedisForTests(null);
+});
+
+function usageKey(fingerprint: string): string {
+  const hourBucket = new Date().toISOString().slice(0, 13).replace("T", "-");
+  return `pool:reddit:usage:${fingerprint}:${hourBucket}`;
+}
+
+test("recordRedditCall marks 403s as blocked telemetry", async () => {
+  const fake = new FakeRedis();
+  _setRedisForTests(fake);
+
+  await recordRedditCall({
+    userAgentFingerprint: "ua-a",
+    statusCode: 403,
+    responseTimeMs: 42,
+    operation: "reddit_search_mentions",
+    success: false,
+  });
+
+  const hash = await fake.hgetall(usageKey("ua-a"));
+  assert.equal(hash.requests, "1");
+  assert.equal(hash.fail, "1");
+  assert.equal(hash.blocked, "1");
+  assert.equal(hash.lastStatusCode, "403");
+  assert.match(hash.lastBlockedAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(fake.expirations.get(usageKey("ua-a")), 60 * 60 * 25);
+});
+
+test("recordRedditCall marks 429s as rate-limited telemetry", async () => {
+  const fake = new FakeRedis();
+  _setRedisForTests(fake);
+
+  await recordRedditCall({
+    userAgentFingerprint: "ua-b",
+    statusCode: 429,
+    responseTimeMs: 75,
+    operation: "reddit_search_mentions",
+    success: false,
+  });
+
+  const hash = await fake.hgetall(usageKey("ua-b"));
+  assert.equal(hash.requests, "1");
+  assert.equal(hash.fail, "1");
+  assert.equal(hash.rateLimited, "1");
+  assert.equal(hash.lastStatusCode, "429");
+  assert.match(hash.last429At, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("quarantineUserAgent stores reddit UA quarantine until absolute timestamp", async () => {
+  const fake = new FakeRedis();
+  _setRedisForTests(fake);
+
+  await quarantineUserAgent({
+    userAgentFingerprint: "ua-c",
+    reason: "blocked",
+    untilTimestamp: 1_800_000_000,
+  });
+
+  const key = "pool:reddit:quarantine:ua-c";
+  assert.equal(await isUserAgentQuarantined("ua-c"), true);
+  assert.equal(fake.exat.get(key), 1_800_000_000);
+  assert.deepEqual(JSON.parse(fake.strings.get(key) ?? "{}"), {
+    userAgentFingerprint: "ua-c",
+    reason: "blocked",
+    untilTimestamp: 1_800_000_000,
+  });
+});

--- a/src/lib/__tests__/source-health-sources-response.test.ts
+++ b/src/lib/__tests__/source-health-sources-response.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GET } from "../../app/api/health/sources/route";
+import {
+  DISABLED_SOURCES,
+  sourceHealthTracker,
+} from "../source-health-tracker";
+
+test("/api/health/sources ignores disabled-source breaker state", async () => {
+  sourceHealthTracker.reset();
+  for (let i = 0; i < 5; i += 1) {
+    sourceHealthTracker.recordFailure("reddit", "HTTP 403");
+    sourceHealthTracker.recordFailure("github-search", "HTTP 403");
+  }
+
+  const response = await GET();
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body.summary.openSources, []);
+  assert.deepEqual(body.summary.halfOpenSources, []);
+  assert.ok(body.summary.disabledSources.includes("reddit"));
+  assert.ok(body.summary.disabledSources.includes("github-search"));
+  assert.ok(DISABLED_SOURCES.includes("reddit"));
+  assert.ok(DISABLED_SOURCES.includes("github-search"));
+  assert.equal(body.sources.reddit, undefined);
+  assert.equal(body.sources["github-search"], undefined);
+});

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { getHealthHttpStatusForStatus } from "../../health-status";
-import { WORKER_HEALTH_SPECS } from "../../worker-health-specs";
+import {
+  WORKER_HEALTH_DISABLED_SPECS,
+  WORKER_HEALTH_SPECS,
+} from "../../worker-health-specs";
 
 test("/api/health: stale freshness remains HTTP 200 availability", () => {
   assert.equal(getHealthHttpStatusForStatus("ok", false), 200);
@@ -16,11 +19,6 @@ test("/api/worker/health: advisory slugs do not block fleet availability", () =>
     "hot-collections",
     "collection-rankings",
     "lobsters-mentions",
-    "trending-skill",
-    "trending-skill-sh",
-    "trending-skill-skillsmp",
-    "trending-skill-smithery",
-    "trending-skill-lobehub",
   ]);
 
   for (const slug of advisory) {
@@ -28,4 +26,34 @@ test("/api/worker/health: advisory slugs do not block fleet availability", () =>
     assert.ok(spec, `missing worker health spec for ${slug}`);
     assert.equal(spec.blocking, false, `${slug} must be advisory`);
   }
+});
+
+test("/api/worker/health: disabled legacy slugs stay visible but inactive", () => {
+  const disabled = new Set(WORKER_HEALTH_DISABLED_SPECS.map((item) => item.slug));
+  const active = new Set(WORKER_HEALTH_SPECS.map((item) => item.slug));
+
+  for (const slug of [
+    "huggingface-trending",
+    "trending-mcp",
+    "trending-skill",
+    "trending-skill-sh",
+    "trending-skill-skillsmp",
+    "trending-skill-smithery",
+    "trending-skill-lobehub",
+  ]) {
+    assert.equal(disabled.has(slug), true, `${slug} must be explicitly disabled`);
+    assert.equal(active.has(slug), false, `${slug} must not be active worker liveness`);
+  }
+});
+
+test("/api/worker/health: TrustMRR catalog cadence matches daily producer", () => {
+  for (const slug of ["trustmrr-startups", "trustmrr-startups:meta"]) {
+    const spec = WORKER_HEALTH_SPECS.find((item) => item.slug === slug);
+    assert.ok(spec, `missing worker health spec for ${slug}`);
+    assert.equal(spec.cadenceMin, 60 * 24);
+  }
+
+  const overlays = WORKER_HEALTH_SPECS.find((item) => item.slug === "revenue-overlays");
+  assert.ok(overlays, "missing worker health spec for revenue-overlays");
+  assert.equal(overlays.cadenceMin, 60);
 });

--- a/src/lib/pipeline/__tests__/social-adapters.test.ts
+++ b/src/lib/pipeline/__tests__/social-adapters.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getDefaultSocialAdapters } from "../adapters/social-adapters";
+import {
+  DISABLED_SOURCES,
+  KNOWN_SOURCES,
+} from "../../source-health-tracker";
+
+test("default social adapters exclude intentionally disabled live-search sources", () => {
+  const ids = getDefaultSocialAdapters().map((adapter) => adapter.id);
+  assert.deepEqual(ids, ["hackernews-algolia"]);
+  assert.ok(DISABLED_SOURCES.includes("reddit"));
+  assert.ok(DISABLED_SOURCES.includes("github-search"));
+  assert.ok(!KNOWN_SOURCES.includes("reddit"));
+  assert.ok(!KNOWN_SOURCES.includes("github-search"));
+});

--- a/src/lib/pipeline/adapters/social-adapters.ts
+++ b/src/lib/pipeline/adapters/social-adapters.ts
@@ -39,7 +39,10 @@ import {
 // Phase 2C: per-source circuit breaker. Each adapter checks isOpen()
 // at the top of fetch and records success/failure on every response so
 // 5 consecutive failures auto-disable the source until the cooldown.
-import { sourceHealthTracker } from "@/lib/source-health-tracker";
+import {
+  isSourceHealthDisabled,
+  sourceHealthTracker,
+} from "@/lib/source-health-tracker";
 import type { RepoMention, SocialAdapter } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -786,9 +789,12 @@ export class GitHubActivityAdapter implements SocialAdapter {
  * reachable; otherwise the Twitter section is hidden in UI.
  */
 export function getDefaultSocialAdapters(): SocialAdapter[] {
-  return [
-    new HackerNewsAdapter(),
-    new RedditAdapter(),
-    new GitHubActivityAdapter(),
-  ];
+  const adapters: SocialAdapter[] = [new HackerNewsAdapter()];
+  if (!isSourceHealthDisabled("reddit")) {
+    adapters.push(new RedditAdapter());
+  }
+  if (!isSourceHealthDisabled("github-search")) {
+    adapters.push(new GitHubActivityAdapter());
+  }
+  return adapters;
 }

--- a/src/lib/pipeline/adapters/social-adapters.ts
+++ b/src/lib/pipeline/adapters/social-adapters.ts
@@ -359,6 +359,9 @@ export class RedditAdapter implements SocialAdapter {
     fullName: string,
     since?: string,
   ): Promise<RepoMention[]> {
+    if (isSourceHealthDisabled("reddit")) {
+      return [];
+    }
     if (sourceHealthTracker.isOpen("reddit")) {
       return [];
     }
@@ -615,6 +618,9 @@ export class GitHubActivityAdapter implements SocialAdapter {
     fullName: string,
     since?: string,
   ): Promise<RepoMention[]> {
+    if (isSourceHealthDisabled("github-search")) {
+      return [];
+    }
     if (sourceHealthTracker.isOpen("github-search")) {
       return [];
     }

--- a/src/lib/pool/reddit-telemetry.ts
+++ b/src/lib/pool/reddit-telemetry.ts
@@ -25,6 +25,13 @@ export async function recordRedditCall(
     await redis.hincrby(usageKey, "success", 1);
   } else {
     await redis.hincrby(usageKey, "fail", 1);
+    if (params.statusCode === 403) {
+      await redis.hincrby(usageKey, "blocked", 1);
+      await redis.hset(usageKey, "lastBlockedAt", new Date().toISOString());
+    } else if (params.statusCode === 429) {
+      await redis.hincrby(usageKey, "rateLimited", 1);
+      await redis.hset(usageKey, "last429At", new Date().toISOString());
+    }
   }
   await redis.hset(usageKey, "lastStatusCode", params.statusCode);
   await redis.hset(usageKey, "lastResponseMs", params.responseTimeMs);

--- a/src/lib/source-health-tracker.ts
+++ b/src/lib/source-health-tracker.ts
@@ -331,7 +331,7 @@ function formatError(err: unknown): string | null {
  * `/api/health/sources` endpoint reports them even before any traffic flows.
  * Add new sources here when wiring a new adapter.
  */
-export const KNOWN_SOURCES = [
+export const DEFAULT_KNOWN_SOURCES = [
   "hackernews",
   "reddit",
   "bluesky",
@@ -343,7 +343,44 @@ export const KNOWN_SOURCES = [
   "producthunt",
 ] as const;
 
-export type KnownSource = (typeof KNOWN_SOURCES)[number];
+export type KnownSource = (typeof DEFAULT_KNOWN_SOURCES)[number];
+
+const DEFAULT_DISABLED_SOURCE_IDS = [
+  // These two are per-repo live-search adapters, not the worker-backed Redis
+  // feeds. Cron ingest fans them out over the top-50 repos and reliably hits
+  // Reddit edge blocks / GitHub Search 403s. Keep them explicitly off until
+  // they have a rate-limited queue or a credentialed provider.
+  "reddit",
+  "github-search",
+] as const satisfies readonly KnownSource[];
+
+function parseDisabledSources(raw: string | undefined): Set<KnownSource> {
+  const source = raw?.trim();
+  if (source && /^(none|false|0|off)$/i.test(source)) return new Set();
+  const ids = source
+    ? source.split(/[,\s]+/).filter(Boolean)
+    : DEFAULT_DISABLED_SOURCE_IDS;
+  const allowed = new Set<string>(DEFAULT_KNOWN_SOURCES);
+  return new Set(
+    ids.filter((id): id is KnownSource => allowed.has(id)),
+  );
+}
+
+const DISABLED_SOURCE_SET = parseDisabledSources(
+  process.env.SOURCE_HEALTH_DISABLED_SOURCES,
+);
+
+export const DISABLED_SOURCES = DEFAULT_KNOWN_SOURCES.filter((id) =>
+  DISABLED_SOURCE_SET.has(id),
+);
+
+export const KNOWN_SOURCES = DEFAULT_KNOWN_SOURCES.filter(
+  (id) => !DISABLED_SOURCE_SET.has(id),
+);
+
+export function isSourceHealthDisabled(source: string): boolean {
+  return DISABLED_SOURCE_SET.has(source as KnownSource);
+}
 
 export const sourceHealthTracker = new SourceHealthTracker();
 

--- a/src/lib/worker-health-specs.ts
+++ b/src/lib/worker-health-specs.ts
@@ -12,6 +12,12 @@ export interface SlugHealthSpec {
   blocking?: boolean;
 }
 
+export interface DisabledSlugHealthSpec {
+  slug: string;
+  fetcher: string;
+  reason: string;
+}
+
 export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
   // hourly + faster - these are the freshness-sensitive workhorses
   { slug: "hn-pulse", fetcher: "hn-pulse", cadenceMin: 10 },
@@ -24,8 +30,10 @@ export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
   { slug: "trendshift-daily", fetcher: "trendshift-daily", cadenceMin: 60, blocking: false },
   { slug: "engagement-composite", fetcher: "engagement-composite", cadenceMin: 60 },
   { slug: "consensus-trending", fetcher: "consensus-trending", cadenceMin: 60 },
-  { slug: "trustmrr-startups", fetcher: "trustmrr", cadenceMin: 60, blocking: false },
-  { slug: "trustmrr-startups:meta", fetcher: "trustmrr", cadenceMin: 60, blocking: false },
+  // TrustMRR catalog/meta are full daily snapshots; hourly TrustMRR ticks only
+  // refresh revenue-overlays. Keep the catalog cadence aligned to the producer.
+  { slug: "trustmrr-startups", fetcher: "trustmrr", cadenceMin: 60 * 24, blocking: false },
+  { slug: "trustmrr-startups:meta", fetcher: "trustmrr", cadenceMin: 60 * 24, blocking: false },
   { slug: "revenue-overlays", fetcher: "trustmrr", cadenceMin: 60, blocking: false },
   { slug: "hackernews-trending", fetcher: "hackernews", cadenceMin: 60 },
   { slug: "hackernews-repo-mentions", fetcher: "hackernews", cadenceMin: 60 },
@@ -35,11 +43,7 @@ export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
   { slug: "lobsters-mentions", fetcher: "lobsters", cadenceMin: 60, blocking: false },
 
   // few-hours cadence
-  { slug: "trending-skill-sh", fetcher: "skills-sh", cadenceMin: 120, blocking: false },
-  { slug: "huggingface-trending", fetcher: "scrape-huggingface", cadenceMin: 240, blocking: false },
   { slug: "producthunt-launches", fetcher: "producthunt", cadenceMin: 360, blocking: false },
-  { slug: "trending-skill", fetcher: "claude-skills", cadenceMin: 360, blocking: false },
-  { slug: "trending-mcp", fetcher: "mcp-registry-official+glama+pulsemcp+smithery", cadenceMin: 360, blocking: false },
   { slug: "funding-news", fetcher: "funding-news", cadenceMin: 360 },
   { slug: "collection-rankings", fetcher: "collection-rankings", cadenceMin: 360, blocking: false },
 
@@ -54,8 +58,49 @@ export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
   // slow-moving snapshot until the OAuth-backed live collector is re-enabled.
   { slug: "reddit-baselines", fetcher: "reddit-baselines", cadenceMin: 60 * 24 * 7, slowMoving: true },
 
-  // newer skill sources (cadence inherited from each fetcher's schedule)
-  { slug: "trending-skill-skillsmp", fetcher: "skillsmp", cadenceMin: 360, blocking: false },
-  { slug: "trending-skill-smithery", fetcher: "smithery-skills", cadenceMin: 360, blocking: false },
-  { slug: "trending-skill-lobehub", fetcher: "lobehub-skills", cadenceMin: 360, blocking: false },
+];
+
+export const WORKER_HEALTH_DISABLED_SPECS: ReadonlyArray<DisabledSlugHealthSpec> = [
+  {
+    slug: "huggingface-trending",
+    fetcher: "scrape-huggingface",
+    reason:
+      "workflow-owned script output; no registered live worker producer, tracked by cron freshness",
+  },
+  {
+    slug: "trending-mcp",
+    fetcher: "mcp-registry-official+glama+pulsemcp+smithery",
+    reason:
+      "legacy MCP roster has no registered live worker producer; disabled until rollup fetcher lands",
+  },
+  {
+    slug: "trending-skill",
+    fetcher: "claude-skills",
+    reason:
+      "legacy skill roster has no registered live worker producer; disabled until source is ported",
+  },
+  {
+    slug: "trending-skill-sh",
+    fetcher: "skills-sh",
+    reason:
+      "legacy skill roster has no registered live worker producer; disabled until source is ported",
+  },
+  {
+    slug: "trending-skill-skillsmp",
+    fetcher: "skillsmp",
+    reason:
+      "legacy skill roster has no registered live worker producer; disabled until source is ported",
+  },
+  {
+    slug: "trending-skill-smithery",
+    fetcher: "smithery-skills",
+    reason:
+      "legacy skill roster has no registered live worker producer; disabled until source is ported",
+  },
+  {
+    slug: "trending-skill-lobehub",
+    fetcher: "lobehub-skills",
+    reason:
+      "legacy skill roster has no registered live worker producer; disabled until source is ported",
+  },
 ];


### PR DESCRIPTION
## Summary
- disable brittle unauthenticated Reddit/GitHub Search live-search sources by default and keep them out of /api/health/sources calculations
- make /api/worker/health worker-owned only, with disabled legacy HF/MCP/skill slugs reported separately instead of counted stale
- fix stale worker roots: TrustMRR catalog cadence, Lobsters empty mentions writes, OSSInsight hot/rankings degraded writes with fresh sidecar metadata

## Validation
- npx eslint src/app/api/worker/health/route.ts src/lib/worker-health-specs.ts src/lib/pipeline/__tests__/health-availability.test.ts src/app/api/health/sources/route.ts src/lib/pipeline/adapters/social-adapters.ts src/lib/pool/reddit-telemetry.ts src/lib/__tests__/source-health-sources-response.test.ts src/lib/__tests__/reddit-telemetry.test.ts
- npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/health-availability.test.ts src/lib/pipeline/__tests__/social-adapters.test.ts src/lib/__tests__/source-health-tracker.test.ts src/lib/__tests__/source-health-sources-response.test.ts src/lib/__tests__/reddit-telemetry.test.ts src/lib/__tests__/github-telemetry.test.ts src/lib/__tests__/reddit-ua-pool.test.ts
- npm --prefix apps/trendingrepo-worker test -- src/fetchers/oss-trending/__tests__/fallback.test.ts src/fetchers/collection-rankings/__tests__/degraded.test.ts src/fetchers/lobsters/__tests__/mentions-empty.test.ts
- npm run lint:worker-keep-last-50
- npm run typecheck -- --pretty false
- npm --prefix apps/trendingrepo-worker run typecheck
- npm --prefix apps/trendingrepo-worker run build
- npm run build