### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T15:05:19Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-31T13:01:22.769Z",
+  "ts": "2026-05-31T15:05:19.240Z",
   "count": 1,
-  "durationMs": 3766,
+  "durationMs": 3246,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T13:01:19.019Z",
+  "fetchedAt": "2026-05-31T15:05:16.015Z",
   "windowDays": 7,
-  "scannedStories": 90,
+  "scannedStories": 79,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T13:01:19.019Z",
+  "fetchedAt": "2026-05-31T15:05:16.015Z",
   "windowHours": 72,
-  "scannedTotal": 90,
+  "scannedTotal": 79,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -712,6 +712,24 @@
       "linkedRepos": []
     },
     {
+      "shortId": "2tskyy",
+      "title": "I Put a Datacenter GPU in My Gaming PC for £200",
+      "url": "https://blog.tymscar.com/posts/v100localllm/",
+      "commentsUrl": "https://lobste.rs/s/2tskyy/i_put_datacenter_gpu_my_gaming_pc_for_200",
+      "by": "",
+      "score": 27,
+      "commentCount": 8,
+      "createdUtc": 1780220586,
+      "ageHours": 5.3694444444444445,
+      "trendingScore": 1.3496204192290766,
+      "tags": [
+        "ai",
+        "hardware"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "lwnweu",
       "title": "\"But it happened.\" - Casey Muratori's comment on Eric Schmidt's commencement speech",
       "url": "https://youtu.be/tlQ7EoJDTQY",
@@ -866,25 +884,6 @@
       "trendingScore": 1.2570693447225225,
       "tags": [
         "linux"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "ynxkj6",
-      "title": "Researcher says Microsoft secretly built a backdoor into BitLocker",
-      "url": "https://www.techspot.com/news/112410-security-researcher-microsoft-secretly-built-backdoor-bitlocker-releases.html",
-      "commentsUrl": "https://lobste.rs/s/ynxkj6/researcher_says_microsoft_secretly",
-      "by": "",
-      "score": 38,
-      "commentCount": 4,
-      "createdUtc": 1779073563,
-      "ageHours": 7.7188888888888885,
-      "trendingScore": 1.2541765347097873,
-      "tags": [
-        "programming",
-        "security",
-        "windows"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26716107315

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.