### PR TITLE
chore(data): refresh ProductHunt launches 2026-05-31T16:22:10Z

### DIFF
--- a/data/_meta/producthunt.json
+++ b/data/_meta/producthunt.json
@@ -1,8 +1,8 @@
 {
   "source": "producthunt",
   "reason": "ok",
-  "ts": "2026-05-31T12:19:32.618Z",
+  "ts": "2026-05-31T16:22:10.429Z",
   "count": 1,
-  "durationMs": 10771,
+  "durationMs": 16314,
   "extra": {}
 }

--- a/data/producthunt-launches.json
+++ b/data/producthunt-launches.json
@@ -1,5 +1,5 @@
 {
-  "lastFetchedAt": "2026-05-31T12:19:30.848Z",
+  "lastFetchedAt": "2026-05-31T16:22:05.424Z",
   "windowDays": 7,
   "launches": [
     {
@@ -2125,6 +2125,42 @@
       "aiAdjacent": true
     },
     {
+      "id": "1133330",
+      "name": "Clipto",
+      "tagline": "Fully local, natural language search over terabytes of media",
+      "description": "Like Google Photos, but fully local. Turn the terabytes of video, audio, meetings, and files you work with into searchable memories, without uploading anything to the cloud. Clipto automatically tags people, dialogue, and scenes, so you can instantly find any moment buried in your media just by describing what you're looking for. It's fast too: on a MacBook Pro M5, Clipto indexed 2TB of videos in just 24 hours.",
+      "url": "https://www.producthunt.com/products/clipto-ai?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
+      "website": "https://www.producthunt.com/r/Y5E7U6HB2KB5NG",
+      "votesCount": 265,
+      "commentsCount": 70,
+      "createdAt": "2026-05-31T07:01:00Z",
+      "thumbnail": "https://ph-files.imgix.net/307c181c-9d5c-4825-b49b-a2ccf4f23c2a.png?auto=format",
+      "topics": [
+        "mac",
+        "productivity",
+        "artificial-intelligence"
+      ],
+      "makers": [
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        },
+        {
+          "name": "[REDACTED]",
+          "username": "[REDACTED]",
+          "twitterUsername": null,
+          "websiteUrl": null
+        }
+      ],
+      "githubUrl": null,
+      "xUrl": null,
+      "linkedRepo": null,
+      "daysSinceLaunch": 0,
+      "aiAdjacent": true
+    },
+    {
       "id": "1148000",
       "name": "Mintlify Workflows",
       "tagline": "Self-updating knowledge bases",
@@ -2375,47 +2411,6 @@
       "linkedRepo": null,
       "daysSinceLaunch": 0,
       "aiAdjacent": false
-    },
-    {
-      "id": "1113430",
-      "name": "Mantle Chat",
-      "tagline": "Collaboration platform where teams work with AI together",
-      "description": "Mantle Chat helps teams boost productivity and adopt AI faster by bringing real-time messaging, AI model chats, autonomous agents, and tool integrations into one shared workspace. Communicate in Discord/Slack-style channels, mention AI agents and models (GPT, Claude, Gemini, Grok, Deepseek) with @ whenever you need help directly in conversations with teammates, build agents, run autonomous tasks together, and connect 30+ tools (Notion, Linear, Gmail and more) your team already uses.",
-      "url": "https://www.producthunt.com/products/mantle-chat?utm_campaign=producthunt-api&utm_medium=api-v2&utm_source=Application%3A+visitportal+%28ID%3A+283275%29",
-      "website": "https://www.producthunt.com/r/HNOJTU2EDLNEGN",
-      "votesCount": 254,
-      "commentsCount": 34,
-      "createdAt": "2026-05-19T07:01:00Z",
-      "thumbnail": "https://ph-files.imgix.net/977f6301-b044-4702-893f-4e3419e560cd.png?auto=format",
-      "topics": [
-        "productivity",
-        "messaging"
-      ],
-      "makers": [
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        },
-        {
-          "name": "[REDACTED]",
-          "username": "[REDACTED]",
-          "twitterUsername": null,
-          "websiteUrl": null
-        }
-      ],
-      "githubUrl": null,
-      "xUrl": null,
-      "linkedRepo": null,
-      "daysSinceLaunch": 0,
-      "aiAdjacent": true
     }
   ]
 }


### PR DESCRIPTION
Automated data refresh from `Refresh ProductHunt launches`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26717881947

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.