### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T16:43:53Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-31T15:05:19.240Z",
+  "ts": "2026-05-31T16:43:53.803Z",
   "count": 1,
-  "durationMs": 3246,
+  "durationMs": 4315,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T15:05:16.015Z",
+  "fetchedAt": "2026-05-31T16:43:49.510Z",
   "windowDays": 7,
-  "scannedStories": 79,
+  "scannedStories": 78,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T15:05:16.015Z",
+  "fetchedAt": "2026-05-31T16:43:49.510Z",
   "windowHours": 72,
-  "scannedTotal": 79,
+  "scannedTotal": 78,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -818,6 +818,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "ls3ris",
+      "title": "Cloudflare Turnstile requiring fingerprintable WebGL",
+      "url": "https://hacktivis.me/articles/cloudflare-turnstile-webgl-fingerprinting",
+      "commentsUrl": "https://lobste.rs/s/ls3ris/cloudflare_turnstile_requiring",
+      "by": "",
+      "score": 16,
+      "commentCount": 2,
+      "createdUtc": 1780233642,
+      "ageHours": 3.3852777777777776,
+      "trendingScore": 1.2802884228464848,
+      "tags": [
+        "privacy"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "e7lsqn",
       "title": "Chromium publishes fixed exploit 4 years later, turns out it's actually unfixed",
       "url": "https://infosec.exchange/@rebane2001/116606719764376414",
@@ -867,23 +884,6 @@
       "tags": [
         "javascript",
         "web"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "jp3nva",
-      "title": "You probably don't need Yocto, and that's fine",
-      "url": "https://sigma-star.at/blog/2026/05/you-probably-dont-need-yocto-and-thats-fine/",
-      "commentsUrl": "https://lobste.rs/s/jp3nva/you_probably_don_t_need_yocto_s_fine",
-      "by": "",
-      "score": 16,
-      "commentCount": 3,
-      "createdUtc": 1780045692,
-      "ageHours": 3.451388888888889,
-      "trendingScore": 1.2570693447225225,
-      "tags": [
-        "linux"
       ],
       "description": "",
       "linkedRepos": []


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26718394626

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.