### PR TITLE
fix(worker): make source health zero tolerance on prod branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
 
       - name: Build (production)
         if: needs.classify.outputs.data_only != 'true'
+        timeout-minutes: 12
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
         run: npm run build
 
       - name: Bundle size check (T3.3 — warn at >300 KB per client chunk)

--- a/apps/trendingrepo-worker/src/__tests__/run-contract.test.ts
+++ b/apps/trendingrepo-worker/src/__tests__/run-contract.test.ts
@@ -36,6 +36,14 @@ function emptyResult(name: string): RunResult {
   };
 }
 
+function warningResult(name: string): RunResult {
+  const result = emptyResult(name);
+  return {
+    ...result,
+    errors: [{ stage: 'test', message: 'soft failure' }],
+  };
+}
+
 function makeMock(name: string): {
   fetcher: Fetcher;
   captured: { contract: FetcherContext['contract'] | undefined };
@@ -52,6 +60,16 @@ function makeMock(name: string): {
     },
   };
   return { fetcher, captured };
+}
+
+function makeWarnMock(name: string): Fetcher {
+  return {
+    name,
+    schedule: '0 * * * *',
+    async run() {
+      return warningResult(name);
+    },
+  };
 }
 
 describe('runFetcher → SourceContract binding (Move 1, Phase 3)', () => {
@@ -107,6 +125,18 @@ describe('runFetcher → SourceContract binding (Move 1, Phase 3)', () => {
     expect(summary).toContain(
       `contract_freshness_budget_ms=${known!.freshness_budget_ms}`,
     );
+  });
+
+  it('emits status=warn when the fetcher returns soft errors', async () => {
+    const known = SOURCE_CONTRACTS[0];
+    expect(known).toBeDefined();
+
+    await runFetcher(makeWarnMock(known!.id), { dryRun: true });
+
+    const lines = logSpy.mock.calls.map((c) => String(c[0] ?? ''));
+    const summary = lines.find((l) => l.startsWith('[run-summary]'));
+    expect(summary).toBeDefined();
+    expect(summary).toContain('status=warn');
   });
 
   it('emits contract_freshness_budget_ms=missing when no contract is found', async () => {

--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/__tests__/fallback.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/__tests__/fallback.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGithubCollectionRankingsFallback,
+  buildHotCollectionsFromRankings,
+  countRankingRows,
+} from '../fallback.js';
+
+describe('collection rankings github fallback', () => {
+  it('builds fresh rowful rankings from live repo metadata and star deltas', () => {
+    const payload = buildGithubCollectionRankingsFallback(
+      {
+        repoMetadata: {
+          fetchedAt: '2026-06-01T00:00:00.000Z',
+          items: [
+            {
+              githubId: 155220641,
+              fullName: 'huggingface/transformers',
+              stars: 152000,
+              openIssues: 950,
+            },
+          ],
+        },
+        starActivityDeltas: {
+          computedAt: '2026-06-01T00:00:00.000Z',
+          repos: {
+            'huggingface/transformers': {
+              stars_now: 152000,
+              delta_30d: { value: 321, basis: 'exact' },
+            },
+          },
+        },
+      },
+      '2026-06-01T00:00:00.000Z',
+    );
+
+    expect(payload?.status).toBe('ok');
+    expect(payload?.source).toBe('github-metadata-fallback');
+    expect(payload?.dataAsOf).toBe('2026-06-01T00:00:00.000Z');
+    expect(countRankingRows(payload)).toBeGreaterThan(0);
+    expect(payload?.collections['10010']?.stars[0]).toMatchObject({
+      repoId: 155220641,
+      repoName: 'huggingface/transformers',
+      currentPeriodGrowth: 321,
+      total: 152000,
+      currentPeriodRank: 1,
+    });
+    expect(payload?.collections['10010']?.issues[0]).toMatchObject({
+      repoName: 'huggingface/transformers',
+      currentPeriodGrowth: 950,
+      total: 950,
+    });
+  });
+
+  it('derives non-empty hot collections from fallback rankings', () => {
+    const rankings = buildGithubCollectionRankingsFallback(
+      {
+        repoMetadata: {
+          items: [
+            {
+              githubId: 155220641,
+              fullName: 'huggingface/transformers',
+              stars: 152000,
+              openIssues: 950,
+            },
+          ],
+        },
+        starActivityDeltas: null,
+      },
+      '2026-06-01T00:00:00.000Z',
+    );
+
+    const hotRows = buildHotCollectionsFromRankings(rankings);
+
+    expect(hotRows.length).toBeGreaterThan(0);
+    expect(hotRows[0]).toMatchObject({
+      id: 10010,
+      name: 'Artificial Intelligence',
+      repoId: 155220641,
+      repoName: 'huggingface/transformers',
+    });
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/fallback.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/fallback.ts
@@ -1,0 +1,338 @@
+import { readDataStore } from '../../lib/redis.js';
+import seedRankings from './seed.json' with { type: 'json' };
+
+export interface CollectionRef {
+  id: number;
+  slug: string;
+}
+
+export const COLLECTIONS: CollectionRef[] = [
+  { id: 10139, slug: 'a2a-protocol' },
+  { id: 10141, slug: 'agent-harness' },
+  { id: 10124, slug: 'agent-skills' },
+  { id: 10098, slug: 'ai-agent-frameworks' },
+  { id: 10114, slug: 'ai-agent-memory' },
+  { id: 10113, slug: 'ai-browser-agents' },
+  { id: 10136, slug: 'ai-code-review' },
+  { id: 10112, slug: 'ai-coding-assistants' },
+  { id: 10130, slug: 'ai-finops' },
+  { id: 10127, slug: 'ai-governance' },
+  { id: 10125, slug: 'ai-infrastructure' },
+  { id: 10135, slug: 'ai-observability' },
+  { id: 10116, slug: 'ai-safety-alignment' },
+  { id: 10122, slug: 'ai-video-generation' },
+  { id: 10010, slug: 'artificial-intelligence' },
+  { id: 10075, slug: 'chatgpt-alternatives' },
+  { id: 10078, slug: 'chatgpt-apps' },
+  { id: 10106, slug: 'coding-agents' },
+  { id: 10126, slug: 'edge-ai' },
+  { id: 10134, slug: 'knowledge-graphs-for-ai' },
+  { id: 10110, slug: 'llm-finetuning' },
+  { id: 10109, slug: 'llm-inference-engines' },
+  { id: 10076, slug: 'llm-tools' },
+  { id: 10105, slug: 'mcp-servers' },
+  { id: 10121, slug: 'model-compression' },
+  { id: 10118, slug: 'multimodal-ai' },
+  { id: 10108, slug: 'rag-frameworks' },
+  { id: 10117, slug: 'vector-databases' },
+];
+
+export const METRICS = ['stars', 'issues'] as const;
+export type Metric = (typeof METRICS)[number];
+
+export interface NormalizedRankingRow {
+  repoId: number | null;
+  repoName: string;
+  currentPeriodGrowth: number | null;
+  pastPeriodGrowth: number | null;
+  growthPop: number | null;
+  rankPop: number | null;
+  total: number | null;
+  currentPeriodRank: number | null;
+  pastPeriodRank: number | null;
+}
+
+export interface CollectionRankingsPayload {
+  fetchedAt: string;
+  period: string;
+  collections: Record<string, Record<Metric, NormalizedRankingRow[]>>;
+  status?: 'ok' | 'degraded';
+  dataAsOf?: string | null;
+  errors?: Array<{ stage: string; message: string }>;
+  source?: string;
+}
+
+interface RepoMetadataItem {
+  githubId?: number | null;
+  fullName?: string;
+  stars?: number;
+  forks?: number;
+  openIssues?: number;
+}
+
+interface RepoMetadataPayload {
+  fetchedAt?: string;
+  items?: RepoMetadataItem[];
+}
+
+interface StarActivityDeltaValue {
+  value?: number | null;
+  basis?: string;
+}
+
+interface StarActivityDeltaEntry {
+  stars_now?: number;
+  delta_30d?: StarActivityDeltaValue;
+}
+
+interface StarActivityDeltasPayload {
+  computedAt?: string;
+  repos?: Record<string, StarActivityDeltaEntry>;
+}
+
+export interface GithubCollectionFallbackSources {
+  repoMetadata: RepoMetadataPayload | null;
+  starActivityDeltas: StarActivityDeltasPayload | null;
+}
+
+export const SEED_COLLECTION_RANKINGS =
+  seedRankings as unknown as CollectionRankingsPayload;
+
+function finiteNumber(value: unknown): number {
+  const parsed =
+    typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function positiveDelta(value: StarActivityDeltaValue | undefined): number {
+  const parsed = finiteNumber(value?.value);
+  return parsed > 0 ? parsed : 0;
+}
+
+function lowerFullName(value: unknown): string {
+  const fullName = String(value ?? '').trim().toLowerCase();
+  return fullName.includes('/') ? fullName : '';
+}
+
+function titleizeCollection(slug: string): string {
+  const acronyms = new Map([
+    ['a2a', 'A2A'],
+    ['ai', 'AI'],
+    ['llm', 'LLM'],
+    ['mcp', 'MCP'],
+    ['rag', 'RAG'],
+  ]);
+  return slug
+    .split('-')
+    .map((part) => acronyms.get(part) ?? part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function previousRank(
+  seedRows: NormalizedRankingRow[],
+  repoName: string,
+): number | null {
+  return (
+    seedRows.find(
+      (row) => row.repoName.toLowerCase() === repoName.toLowerCase(),
+    )?.currentPeriodRank ?? null
+  );
+}
+
+function withRanks(
+  rows: NormalizedRankingRow[],
+  seedRows: NormalizedRankingRow[],
+): NormalizedRankingRow[] {
+  return rows
+    .sort((a, b) => {
+      const growthDelta =
+        (b.currentPeriodGrowth ?? 0) - (a.currentPeriodGrowth ?? 0);
+      if (growthDelta !== 0) return growthDelta;
+      const totalDelta = (b.total ?? 0) - (a.total ?? 0);
+      if (totalDelta !== 0) return totalDelta;
+      return a.repoName.localeCompare(b.repoName);
+    })
+    .slice(0, 50)
+    .map((row, index) => {
+      const currentRank = index + 1;
+      const priorRank = previousRank(seedRows, row.repoName);
+      return {
+        ...row,
+        currentPeriodRank: currentRank,
+        pastPeriodRank: priorRank,
+        rankPop: priorRank === null ? null : priorRank - currentRank,
+      };
+    });
+}
+
+export function rankingRows(
+  payload: CollectionRankingsPayload | null | undefined,
+  collectionId: string,
+  metric: Metric,
+): NormalizedRankingRow[] {
+  return payload?.collections?.[collectionId]?.[metric] ?? [];
+}
+
+export function countRankingRows(
+  payload: CollectionRankingsPayload | null | undefined,
+): number {
+  if (!payload?.collections) return 0;
+  let count = 0;
+  for (const collection of Object.values(payload.collections)) {
+    for (const metric of METRICS) {
+      count += collection[metric]?.length ?? 0;
+    }
+  }
+  return count;
+}
+
+export function buildGithubCollectionRankingsFallback(
+  sources: GithubCollectionFallbackSources,
+  fetchedAt: string,
+): CollectionRankingsPayload | null {
+  const metadataByName = new Map<string, RepoMetadataItem>();
+  for (const item of sources.repoMetadata?.items ?? []) {
+    const key = lowerFullName(item.fullName);
+    if (key) metadataByName.set(key, item);
+  }
+  const deltas = sources.starActivityDeltas?.repos ?? {};
+
+  if (metadataByName.size === 0 && Object.keys(deltas).length === 0) {
+    return null;
+  }
+
+  const collections = {} as Record<string, Record<Metric, NormalizedRankingRow[]>>;
+  for (const collection of COLLECTIONS) {
+    const id = String(collection.id);
+    const starsSeed = rankingRows(SEED_COLLECTION_RANKINGS, id, 'stars');
+    const issuesSeed = rankingRows(SEED_COLLECTION_RANKINGS, id, 'issues');
+    const seedByName = new Map<string, NormalizedRankingRow>();
+    for (const row of [...starsSeed, ...issuesSeed]) {
+      const key = lowerFullName(row.repoName);
+      if (key && !seedByName.has(key)) seedByName.set(key, row);
+    }
+
+    const starsRows: NormalizedRankingRow[] = [];
+    const issuesRows: NormalizedRankingRow[] = [];
+    for (const [key, seed] of seedByName.entries()) {
+      const meta = metadataByName.get(key);
+      const delta = deltas[key];
+      if (!meta && !delta) continue;
+
+      const starsNow = finiteNumber(delta?.stars_now ?? meta?.stars ?? seed.total);
+      const starGrowth = positiveDelta(delta?.delta_30d);
+      const openIssues = finiteNumber(meta?.openIssues);
+      const repoId = meta?.githubId ?? seed.repoId ?? null;
+      const repoName = meta?.fullName ?? seed.repoName;
+
+      starsRows.push({
+        repoId,
+        repoName,
+        currentPeriodGrowth: starGrowth > 0 ? starGrowth : starsNow,
+        pastPeriodGrowth: seed.pastPeriodGrowth,
+        growthPop: null,
+        rankPop: null,
+        total: starsNow,
+        currentPeriodRank: null,
+        pastPeriodRank: null,
+      });
+      issuesRows.push({
+        repoId,
+        repoName,
+        currentPeriodGrowth: openIssues,
+        pastPeriodGrowth: seed.pastPeriodGrowth,
+        growthPop: null,
+        rankPop: null,
+        total: openIssues,
+        currentPeriodRank: null,
+        pastPeriodRank: null,
+      });
+    }
+
+    collections[id] = {
+      stars: withRanks(starsRows, starsSeed),
+      issues: withRanks(issuesRows, issuesSeed),
+    };
+  }
+
+  const payload: CollectionRankingsPayload = {
+    fetchedAt,
+    period: SEED_COLLECTION_RANKINGS.period,
+    collections,
+    status: 'ok',
+    dataAsOf: fetchedAt,
+    source: 'github-metadata-fallback',
+  };
+  return countRankingRows(payload) > 0 ? payload : null;
+}
+
+export function buildHotCollectionsFromRankings(
+  payload: CollectionRankingsPayload | null | undefined,
+  maxReposPerCollection = 3,
+): Array<{
+  id: number | null;
+  name: string;
+  repos: number | null;
+  repoId: number | null;
+  repoName: string;
+  repoCurrentPeriodRank: number | null;
+  repoPastPeriodRank: number | null;
+  repoRankChanges: number | null;
+}> {
+  if (!payload) return [];
+  const rows: Array<{
+    id: number | null;
+    name: string;
+    repos: number | null;
+    repoId: number | null;
+    repoName: string;
+    repoCurrentPeriodRank: number | null;
+    repoPastPeriodRank: number | null;
+    repoRankChanges: number | null;
+  }> = [];
+
+  for (const collection of COLLECTIONS) {
+    const stars = rankingRows(payload, String(collection.id), 'stars')
+      .slice()
+      .sort((a, b) => {
+        const rankDelta =
+          (a.currentPeriodRank ?? Number.MAX_SAFE_INTEGER) -
+          (b.currentPeriodRank ?? Number.MAX_SAFE_INTEGER);
+        if (rankDelta !== 0) return rankDelta;
+        return a.repoName.localeCompare(b.repoName);
+      });
+    for (const row of stars.slice(0, maxReposPerCollection)) {
+      rows.push({
+        id: collection.id,
+        name: titleizeCollection(collection.slug),
+        repos: stars.length,
+        repoId: row.repoId,
+        repoName: row.repoName,
+        repoCurrentPeriodRank: row.currentPeriodRank,
+        repoPastPeriodRank: row.pastPeriodRank,
+        repoRankChanges:
+          row.rankPop === null || row.rankPop === undefined
+            ? null
+            : row.rankPop,
+      });
+    }
+  }
+
+  return rows;
+}
+
+async function safeReadDataStore<T>(slug: string): Promise<T | null> {
+  try {
+    return (await readDataStore<T>(slug)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readGithubCollectionFallbackSources(): Promise<GithubCollectionFallbackSources> {
+  const [repoMetadata, starActivityDeltas] = await Promise.all([
+    safeReadDataStore<RepoMetadataPayload>('repo-metadata'),
+    safeReadDataStore<StarActivityDeltasPayload>('star-activity-deltas'),
+  ]);
+  return { repoMetadata, starActivityDeltas };
+}

--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
@@ -17,52 +17,21 @@
 
 import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
 import { readDataStore, writeDataStore } from '../../lib/redis.js';
-import seedRankings from './seed.json' with { type: 'json' };
-
-interface CollectionRef {
-  id: number;
-  slug: string;
-}
-
-// Source: data/collections/*.yml (id + filename without .yml). Must stay
-// in lockstep with that directory; cross-check with `head -2 *.yml` if
-// adding a new collection.
-const COLLECTIONS: CollectionRef[] = [
-  { id: 10139, slug: 'a2a-protocol' },
-  { id: 10141, slug: 'agent-harness' },
-  { id: 10124, slug: 'agent-skills' },
-  { id: 10098, slug: 'ai-agent-frameworks' },
-  { id: 10114, slug: 'ai-agent-memory' },
-  { id: 10113, slug: 'ai-browser-agents' },
-  { id: 10136, slug: 'ai-code-review' },
-  { id: 10112, slug: 'ai-coding-assistants' },
-  { id: 10130, slug: 'ai-finops' },
-  { id: 10127, slug: 'ai-governance' },
-  { id: 10125, slug: 'ai-infrastructure' },
-  { id: 10135, slug: 'ai-observability' },
-  { id: 10116, slug: 'ai-safety-alignment' },
-  { id: 10122, slug: 'ai-video-generation' },
-  { id: 10010, slug: 'artificial-intelligence' },
-  { id: 10075, slug: 'chatgpt-alternatives' },
-  { id: 10078, slug: 'chatgpt-apps' },
-  { id: 10106, slug: 'coding-agents' },
-  { id: 10126, slug: 'edge-ai' },
-  { id: 10134, slug: 'knowledge-graphs-for-ai' },
-  { id: 10110, slug: 'llm-finetuning' },
-  { id: 10109, slug: 'llm-inference-engines' },
-  { id: 10076, slug: 'llm-tools' },
-  { id: 10105, slug: 'mcp-servers' },
-  { id: 10121, slug: 'model-compression' },
-  { id: 10118, slug: 'multimodal-ai' },
-  { id: 10108, slug: 'rag-frameworks' },
-  { id: 10117, slug: 'vector-databases' },
-];
+import {
+  COLLECTIONS,
+  METRICS,
+  SEED_COLLECTION_RANKINGS,
+  buildGithubCollectionRankingsFallback,
+  countRankingRows,
+  rankingRows,
+  readGithubCollectionFallbackSources,
+  type CollectionRankingsPayload,
+  type Metric,
+  type NormalizedRankingRow,
+} from './fallback.js';
 
 const PERIOD = 'past_28_days';
-const METRICS = ['stars', 'issues'] as const;
 const PAUSE_MS = 400;
-
-type Metric = (typeof METRICS)[number];
 
 interface RankingRow {
   repo_id?: string | number;
@@ -76,36 +45,12 @@ interface RankingRow {
   past_period_rank?: string | number;
 }
 
-interface NormalizedRankingRow {
-  repoId: number | null;
-  repoName: string;
-  currentPeriodGrowth: number | null;
-  pastPeriodGrowth: number | null;
-  growthPop: number | null;
-  rankPop: number | null;
-  total: number | null;
-  currentPeriodRank: number | null;
-  pastPeriodRank: number | null;
-}
-
 interface OssEnvelope<T> {
   data?: { rows?: T[] };
 }
 
-export interface CollectionRankingsPayload {
-  fetchedAt: string;
-  period: string;
-  collections: Record<string, Record<Metric, NormalizedRankingRow[]>>;
-  status?: 'ok' | 'degraded';
-  dataAsOf?: string | null;
-  errors?: Array<{ stage: string; message: string }>;
-}
-
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
-
-const SEED_COLLECTION_RANKINGS =
-  seedRankings as unknown as CollectionRankingsPayload;
 
 function toNumber(value: unknown): number | null {
   const parsed = Number.parseInt(String(value ?? ''), 10);
@@ -139,27 +84,6 @@ function normalize(row: RankingRow): NormalizedRankingRow {
   };
 }
 
-function rankingRows(
-  payload: CollectionRankingsPayload | null | undefined,
-  collectionId: string,
-  metric: Metric,
-): NormalizedRankingRow[] {
-  return payload?.collections?.[collectionId]?.[metric] ?? [];
-}
-
-function countRankingRows(
-  payload: CollectionRankingsPayload | null | undefined,
-): number {
-  if (!payload?.collections) return 0;
-  let count = 0;
-  for (const collection of Object.values(payload.collections)) {
-    for (const metric of METRICS) {
-      count += collection[metric]?.length ?? 0;
-    }
-  }
-  return count;
-}
-
 const fetcher: Fetcher = {
   name: 'collection-rankings',
   // Every 6h at :17 - matches refresh-collection-rankings.yml.
@@ -180,8 +104,14 @@ const fetcher: Fetcher = {
       (await readDataStore<CollectionRankingsPayload>('collection-rankings').catch(
         () => null,
       )) ?? null;
+    const githubFallback = buildGithubCollectionRankingsFallback(
+      await readGithubCollectionFallbackSources(),
+      fetchedAt,
+    );
     let totalRows = 0;
     let preservedRows = 0;
+    let githubFallbackRows = 0;
+    const payloadErrors: RunResult['errors'] = [];
 
     for (const collection of COLLECTIONS) {
       const metrics: Record<Metric, NormalizedRankingRow[]> = {
@@ -206,6 +136,7 @@ const fetcher: Fetcher = {
         } catch (err) {
           const message = (err as Error).message;
           const collectionId = String(collection.id);
+          const githubRows = rankingRows(githubFallback, collectionId, metric);
           const priorRows = rankingRows(prior, collectionId, metric);
           const seedRows = rankingRows(
             SEED_COLLECTION_RANKINGS,
@@ -213,13 +144,17 @@ const fetcher: Fetcher = {
             metric,
           );
           const fallbackRows =
-            priorRows.length > 0
+            githubRows.length > 0
+              ? githubRows
+              : priorRows.length > 0
               ? priorRows
               : seedRows.length > 0
                 ? seedRows
                 : [];
           const fallbackSource =
-            priorRows.length > 0
+            githubRows.length > 0
+              ? 'github-metadata'
+              : priorRows.length > 0
               ? 'cached'
               : seedRows.length > 0
                 ? 'seed'
@@ -238,7 +173,15 @@ const fetcher: Fetcher = {
           );
           if (fallbackRows.length > 0 && fallbackSource) {
             metrics[metric] = fallbackRows;
-            preservedRows += fallbackRows.length;
+            if (fallbackSource === 'github-metadata') {
+              githubFallbackRows += fallbackRows.length;
+            } else {
+              preservedRows += fallbackRows.length;
+              payloadErrors.push({
+                stage: label,
+                message: `${message} (preserved ${fallbackRows.length} ${fallbackSource})`,
+              });
+            }
             totalRows += fallbackRows.length;
             errors.push({
               stage: label,
@@ -246,6 +189,7 @@ const fetcher: Fetcher = {
             });
           } else {
             errors.push({ stage: label, message });
+            payloadErrors.push({ stage: label, message });
           }
         }
         await sleep(PAUSE_MS);
@@ -262,15 +206,18 @@ const fetcher: Fetcher = {
       fetchedAt,
       period: PERIOD,
       collections,
-      status: errors.length > 0 ? 'degraded' : 'ok',
+      status: payloadErrors.length > 0 ? 'degraded' : 'ok',
+      ...(githubFallbackRows > 0 && payloadErrors.length === 0
+        ? { source: 'github-metadata-fallback' }
+        : {}),
       dataAsOf:
-        errors.length > 0
+        payloadErrors.length > 0
           ? rowfulPrior?.dataAsOf ??
             rowfulPrior?.fetchedAt ??
             rowfulSeed?.fetchedAt ??
             null
           : fetchedAt,
-      ...(errors.length > 0 ? { errors } : {}),
+      ...(payloadErrors.length > 0 ? { errors: payloadErrors } : {}),
     };
 
     // Zero-write guard (keep-last-50 rule): when api.ossinsight.io is down,
@@ -291,6 +238,7 @@ const fetcher: Fetcher = {
           collections: COLLECTIONS.length,
           totalRows,
           preservedRows,
+          githubFallbackRows,
           redisSource: result.source,
           writtenAt: result.writtenAt,
         },
@@ -301,6 +249,11 @@ const fetcher: Fetcher = {
         'collection-rankings: all rankings empty (api.ossinsight.io down?) - skipping empty degraded publish',
       );
       errors.push({
+        stage: 'guard',
+        message:
+          'all rankings empty; skipped empty collection-rankings publish',
+      });
+      payloadErrors.push({
         stage: 'guard',
         message:
           'all rankings empty; skipped empty collection-rankings publish',

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/degraded.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/degraded.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FetcherContext } from '../../../lib/types.js';
+
+const readDataStoreMock = vi.hoisted(() => vi.fn());
+const writeDataStoreMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    source: 'redis' as const,
+    writtenAt: '2026-06-01T00:00:00.000Z',
+  })),
+);
+
+vi.mock('../../../lib/redis.js', () => ({
+  readDataStore: readDataStoreMock,
+  writeDataStore: writeDataStoreMock,
+}));
+
+const originalSetTimeout = globalThis.setTimeout;
+
+const PERIODS = ['past_24_hours', 'past_week', 'past_month'] as const;
+const LANGUAGES = [
+  'All',
+  'Python',
+  'TypeScript',
+  'Rust',
+  'Go',
+  'JavaScript',
+  'Java',
+  'C++',
+  'C#',
+  'Kotlin',
+] as const;
+
+function makeContext(
+  handler: FetcherContext['http']['json'],
+): FetcherContext {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as FetcherContext['log'];
+  return {
+    db: null as unknown as FetcherContext['db'],
+    redis: null as unknown as FetcherContext['redis'],
+    http: {
+      json: handler,
+      async text() {
+        throw new Error('not used');
+      },
+    },
+    log,
+    dryRun: false,
+    since: new Date('2026-06-01T00:00:00.000Z'),
+    signalRunComplete: vi.fn(),
+  };
+}
+
+function makePriorTrending() {
+  const buckets: Record<string, Record<string, unknown[]>> = {};
+  for (const period of PERIODS) {
+    buckets[period] = {};
+    for (const language of LANGUAGES) {
+      buckets[period][language] = [
+        {
+          repo_id: `${period}:${language}`,
+          repo_name: `cached/${language.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+          primary_language: language,
+          description: 'cached row',
+          stars: '100',
+          forks: '10',
+          pull_requests: '1',
+          pushes: '2',
+          total_score: '3',
+          contributor_logins: '',
+          collection_names: '',
+        },
+      ];
+    }
+  }
+  return {
+    fetchedAt: '2026-05-31T20:00:00.000Z',
+    buckets,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  readDataStoreMock.mockReset();
+  writeDataStoreMock.mockClear();
+  globalThis.setTimeout = ((cb: () => void) => {
+    cb();
+    return 0 as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+});
+
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+describe('oss-trending degraded writes', () => {
+  it('does not publish fresh empty trending or hot-collections payloads on total OSSInsight failure', async () => {
+    readDataStoreMock.mockResolvedValue(null);
+    const { default: fetcher } = await import('../index.js');
+
+    const result = await fetcher.run(
+      makeContext(async () => {
+        throw new Error('OSSInsight 500');
+      }),
+    );
+
+    expect(result.redisPublished).toBe(false);
+    expect(writeDataStoreMock).not.toHaveBeenCalled();
+    expect(
+      result.errors.some((entry) =>
+        entry.message.includes('skipped empty trending publish'),
+      ),
+    ).toBe(true);
+    expect(
+      result.errors.some((entry) =>
+        entry.message.includes('skipped empty hot-collections publish'),
+      ),
+    ).toBe(true);
+  });
+
+  it('freshens degraded payloads only when every failed leaf has cached rows', async () => {
+    readDataStoreMock
+      .mockResolvedValueOnce(makePriorTrending())
+      .mockResolvedValueOnce({
+        fetchedAt: '2026-05-31T20:05:00.000Z',
+        rows: [
+          {
+            id: 10098,
+            name: 'AI Agent Frameworks',
+            repos: 17,
+            repoId: 1,
+            repoName: 'cached/project',
+            repoCurrentPeriodRank: 1,
+            repoPastPeriodRank: 2,
+            repoRankChanges: 1,
+          },
+        ],
+      });
+    const { default: fetcher } = await import('../index.js');
+
+    const result = await fetcher.run(
+      makeContext(async () => {
+        throw new Error('OSSInsight 500');
+      }),
+    );
+
+    expect(result.redisPublished).toBe(true);
+    const writes = writeDataStoreMock.mock.calls as unknown as Array<
+      [string, unknown, unknown?]
+    >;
+    const trendingWrite = writes.find(([slug]) => slug === 'trending');
+    const hotWrite = writes.find(([slug]) => slug === 'hot-collections');
+
+    expect(trendingWrite?.[2]).toEqual({ writer: 'worker:oss-trending:degraded' });
+    expect(hotWrite?.[2]).toEqual({ writer: 'worker:oss-trending:degraded' });
+    expect((trendingWrite?.[1] as { status?: string }).status).toBe('degraded');
+    expect((hotWrite?.[1] as { status?: string }).status).toBe('degraded');
+    expect(
+      (trendingWrite?.[1] as { buckets?: Record<string, Record<string, unknown[]>> })
+        .buckets?.past_24_hours?.All,
+    ).toHaveLength(1);
+    expect((hotWrite?.[1] as { rows?: unknown[] }).rows).toHaveLength(1);
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/fallback.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/fallback.test.ts
@@ -353,7 +353,7 @@ describe('oss-trending fallback', () => {
     expect(bucket(payload, 'past_month', 'TypeScript')[0]?.stars).toBe('90');
   });
 
-  it('publishes a degraded hot-collections payload when only that endpoint is down', async () => {
+  it('does not publish an empty hot-collections payload when the endpoint is down without cache', async () => {
     const { default: fetcher } = await import('../index.js');
 
     await fetcher.run(makeContext());
@@ -362,18 +362,6 @@ describe('oss-trending fallback', () => {
       [string, unknown, unknown?]
     >;
     const hotWrite = writes.find(([slug]) => slug === 'hot-collections');
-    expect(hotWrite).toBeDefined();
-
-    const payload = hotWrite?.[1] as {
-      status?: string;
-      rows?: unknown[];
-      dataAsOf?: string | null;
-      errors?: Array<{ stage: string; message: string }>;
-    };
-    expect(payload.status).toBe('degraded');
-    expect(payload.rows).toEqual([]);
-    expect(payload.dataAsOf).toBeNull();
-    expect(payload.errors?.[0]?.stage).toBe('hot-collections');
-    expect(hotWrite?.[2]).toEqual({ writer: 'worker:oss-trending:degraded' });
+    expect(hotWrite).toBeUndefined();
   });
 });

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/fallback.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/__tests__/fallback.test.ts
@@ -364,4 +364,52 @@ describe('oss-trending fallback', () => {
     const hotWrite = writes.find(([slug]) => slug === 'hot-collections');
     expect(hotWrite).toBeUndefined();
   });
+
+  it('publishes hot-collections from github metadata fallback when OSSInsight hot endpoint is down cold', async () => {
+    readDataStoreMock.mockImplementation(async (slug: string) => {
+      if (slug === 'trending') return emptyTrendingPayload();
+      if (slug === 'hot-collections') return null;
+      if (slug === 'repo-metadata') {
+        return {
+          fetchedAt: '2026-06-01T00:00:00.000Z',
+          items: [
+            {
+              githubId: 155220641,
+              fullName: 'huggingface/transformers',
+              stars: 152000,
+              openIssues: 950,
+            },
+          ],
+        };
+      }
+      if (slug === 'star-activity-deltas') {
+        return {
+          computedAt: '2026-06-01T00:00:00.000Z',
+          repos: {
+            'huggingface/transformers': {
+              stars_now: 152000,
+              delta_30d: { value: 321, basis: 'exact' },
+            },
+          },
+        };
+      }
+      return null;
+    });
+    const { default: fetcher } = await import('../index.js');
+
+    await fetcher.run(makeContext());
+
+    const writes = writeDataStoreMock.mock.calls as unknown as Array<
+      [string, unknown, unknown?]
+    >;
+    const hotWrite = writes.find(([slug]) => slug === 'hot-collections');
+    expect(hotWrite).toBeDefined();
+    expect((hotWrite?.[1] as { status?: string }).status).toBe('ok');
+    expect((hotWrite?.[1] as { source?: string }).source).toBe(
+      'github-metadata-fallback',
+    );
+    expect((hotWrite?.[1] as { rows?: unknown[] }).rows?.length).toBeGreaterThan(
+      0,
+    );
+  });
 });

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/fallback.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/fallback.ts
@@ -357,13 +357,21 @@ export function buildFallbackTrendingPayload(
   return countTrendingRows(payload) > 0 ? payload : null;
 }
 
+async function safeReadDataStore<T>(slug: string): Promise<T | null> {
+  try {
+    return (await readDataStore<T>(slug)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function readFallbackSources(): Promise<FallbackSources> {
   const [registry, metadata, consensus, recent, starActivityDeltas] = await Promise.all([
-    readDataStore<RegistryPayload>('repo-registry').catch(() => null),
-    readDataStore<RepoMetadataPayload>('repo-metadata').catch(() => null),
-    readDataStore<ConsensusPayload>('consensus-trending').catch(() => null),
-    readDataStore<RecentReposPayload>('recent-repos').catch(() => null),
-    readDataStore<StarActivityDeltasPayload>('star-activity-deltas').catch(() => null),
+    safeReadDataStore<RegistryPayload>('repo-registry'),
+    safeReadDataStore<RepoMetadataPayload>('repo-metadata'),
+    safeReadDataStore<ConsensusPayload>('consensus-trending'),
+    safeReadDataStore<RecentReposPayload>('recent-repos'),
+    safeReadDataStore<StarActivityDeltasPayload>('star-activity-deltas'),
   ]);
   return { registry, metadata, consensus, recent, starActivityDeltas };
 }

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
@@ -16,6 +16,11 @@ import {
   countTrendingRows,
   readFallbackSources,
 } from './fallback.js';
+import {
+  buildGithubCollectionRankingsFallback,
+  buildHotCollectionsFromRankings,
+  readGithubCollectionFallbackSources,
+} from '../collection-rankings/fallback.js';
 
 const PERIODS = ['past_24_hours', 'past_week', 'past_month'] as const;
 const LANGUAGES = ['All', 'Python', 'TypeScript', 'Rust', 'Go'] as const;
@@ -78,6 +83,7 @@ export interface HotCollectionsPayload {
   status?: 'ok' | 'degraded';
   dataAsOf?: string | null;
   errors?: Array<{ stage: string; message: string }>;
+  source?: string;
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -197,8 +203,9 @@ const fetcher: Fetcher = {
 
     let hotRows: NormalizedHotCollectionRow[] = [];
     let preservedHotRows = 0;
+    let githubHotRows = 0;
     let missingHotFallback = false;
-    const hotErrors: Array<{ stage: string; message: string }> = [];
+    const hotPayloadErrors: Array<{ stage: string; message: string }> = [];
     try {
       const { data } = await ctx.http.json<OssEnvelope<HotCollectionRow>>(
         HOT_COLLECTIONS_URL,
@@ -211,7 +218,23 @@ const fetcher: Fetcher = {
     } catch (err) {
       const message = (err as Error).message;
       const priorRows = hotRowsFromPayload(priorHotCollections);
-      if (priorRows.length > 0) {
+      const githubFallback = buildGithubCollectionRankingsFallback(
+        await readGithubCollectionFallbackSources(),
+        fetchedAt,
+      );
+      const fallbackRows = buildHotCollectionsFromRankings(githubFallback);
+      if (fallbackRows.length > 0) {
+        hotRows = fallbackRows;
+        githubHotRows = hotRows.length;
+        ctx.log.warn(
+          { err: message, rows: hotRows.length },
+          'hot collections fetch failed - serving github-metadata fallback rows',
+        );
+        errors.push({
+          stage: 'hot-collections',
+          message: `${message} (served ${hotRows.length} github-metadata fallback)`,
+        });
+      } else if (priorRows.length > 0) {
         hotRows = priorRows;
         preservedHotRows = priorRows.length;
         ctx.log.warn(
@@ -223,12 +246,12 @@ const fetcher: Fetcher = {
           message: `${message} (preserved ${priorRows.length} cached)`,
         };
         errors.push(preserved);
-        hotErrors.push(preserved);
+        hotPayloadErrors.push(preserved);
       } else {
         ctx.log.error({ err: message }, 'hot collections fetch failed');
         const failed = { stage: 'hot-collections', message };
         errors.push(failed);
-        hotErrors.push(failed);
+        hotPayloadErrors.push(failed);
         missingHotFallback = true;
       }
     }
@@ -237,7 +260,7 @@ const fetcher: Fetcher = {
       error.stage.startsWith('bucket:'),
     );
     const trendStatus = trendErrors.length > 0 ? 'degraded' : 'ok';
-    const hotStatus = hotErrors.length > 0 ? 'degraded' : 'ok';
+    const hotStatus = hotPayloadErrors.length > 0 ? 'degraded' : 'ok';
     const trendsPayload: TrendingPayload = {
       fetchedAt,
       buckets,
@@ -252,13 +275,16 @@ const fetcher: Fetcher = {
       fetchedAt,
       rows: hotRows,
       status: hotStatus,
+      ...(githubHotRows > 0 && hotPayloadErrors.length === 0
+        ? { source: 'github-metadata-fallback' }
+        : {}),
       dataAsOf:
         hotStatus === 'degraded'
           ? priorHotCollections?.dataAsOf ??
             priorHotCollections?.fetchedAt ??
             null
           : fetchedAt,
-      ...(hotErrors.length > 0 ? { errors: hotErrors } : {}),
+      ...(hotPayloadErrors.length > 0 ? { errors: hotPayloadErrors } : {}),
     };
 
     let trendsSource: 'redis' | 'preserved' = 'preserved';
@@ -335,6 +361,7 @@ const fetcher: Fetcher = {
         hotCollections: hotRows.length,
         preservedTrendRows,
         preservedHotRows,
+        githubHotRows,
         trendingRedis: trendsSource,
         hotRedis: hotSource,
       },

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
@@ -75,6 +75,7 @@ export interface TrendingPayload {
   status?: 'ok' | 'degraded';
   dataAsOf?: string | null;
   errors?: Array<{ stage: string; message: string }>;
+  source?: string;
 }
 
 export interface HotCollectionsPayload {
@@ -152,9 +153,15 @@ const fetcher: Fetcher = {
       (await readDataStore<HotCollectionsPayload>('hot-collections').catch(
         () => null,
       )) ?? null;
+    const internalTrendingFallback = buildFallbackTrendingPayload(
+      await readFallbackSources(),
+      fetchedAt,
+    );
     let totalRows = 0;
     let preservedTrendRows = 0;
+    let internalTrendRows = 0;
     let missingTrendFallbacks = 0;
+    const trendPayloadErrors: Array<{ stage: string; message: string }> = [];
 
     for (const period of PERIODS) {
       buckets[period] = {};
@@ -172,29 +179,60 @@ const fetcher: Fetcher = {
           ctx.log.info({ period, language, rows: rows.length }, 'bucket fetched');
         } catch (err) {
           const message = (err as Error).message;
+          const internalRows = trendingRows(
+            internalTrendingFallback,
+            period,
+            language,
+          );
           const priorRows = trendingRows(priorTrending, period, language);
-          if (priorRows.length > 0) {
-            buckets[period]![language] = priorRows;
-            preservedTrendRows += priorRows.length;
-            totalRows += priorRows.length;
+          if (internalTrendingFallback) {
+            const fallbackRows = internalRows;
+            buckets[period]![language] = fallbackRows;
+            internalTrendRows += fallbackRows.length;
+            totalRows += fallbackRows.length;
             ctx.log.warn(
               {
                 period,
                 language,
                 err: message,
-                preservedRows: priorRows.length,
+                preservedRows: fallbackRows.length,
+                fallbackSource: 'internal-github',
               },
-              'bucket fetch failed - preserving cached rows',
+              'bucket fetch failed - serving fallback rows',
             );
             errors.push({
               stage: `bucket:${label}`,
-              message: `${message} (preserved ${priorRows.length} cached)`,
+              message: `${message} (served ${fallbackRows.length} internal-github)`,
+            });
+          } else if (priorRows.length > 0) {
+            const fallbackRows = priorRows;
+            buckets[period]![language] = fallbackRows;
+            preservedTrendRows += fallbackRows.length;
+            trendPayloadErrors.push({
+              stage: `bucket:${label}`,
+              message: `${message} (preserved ${fallbackRows.length} cached)`,
+            });
+            totalRows += fallbackRows.length;
+            ctx.log.warn(
+              {
+                period,
+                language,
+                err: message,
+                preservedRows: fallbackRows.length,
+                fallbackSource: 'cached',
+              },
+              'bucket fetch failed - serving fallback rows',
+            );
+            errors.push({
+              stage: `bucket:${label}`,
+              message: `${message} (served ${fallbackRows.length} cached)`,
             });
           } else {
             ctx.log.error({ period, language, err: message }, 'bucket fetch failed');
             errors.push({ stage: `bucket:${label}`, message });
             buckets[period]![language] = [];
             missingTrendFallbacks += 1;
+            trendPayloadErrors.push({ stage: `bucket:${label}`, message });
           }
         }
         await sleep(TRENDS_PAUSE_MS);
@@ -256,20 +294,20 @@ const fetcher: Fetcher = {
       }
     }
 
-    const trendErrors = errors.filter((error) =>
-      error.stage.startsWith('bucket:'),
-    );
-    const trendStatus = trendErrors.length > 0 ? 'degraded' : 'ok';
+    const trendStatus = trendPayloadErrors.length > 0 ? 'degraded' : 'ok';
     const hotStatus = hotPayloadErrors.length > 0 ? 'degraded' : 'ok';
     const trendsPayload: TrendingPayload = {
       fetchedAt,
       buckets,
       status: trendStatus,
+      ...(internalTrendRows > 0 && trendPayloadErrors.length === 0
+        ? { source: 'internal-github-fallback' }
+        : {}),
       dataAsOf:
         trendStatus === 'degraded'
           ? priorTrending?.dataAsOf ?? priorTrending?.fetchedAt ?? null
           : fetchedAt,
-      ...(trendErrors.length > 0 ? { errors: trendErrors } : {}),
+      ...(trendPayloadErrors.length > 0 ? { errors: trendPayloadErrors } : {}),
     };
     const hotPayload: HotCollectionsPayload = {
       fetchedAt,
@@ -299,10 +337,7 @@ const fetcher: Fetcher = {
       );
       trendsSource = trendsRes.source === 'redis' ? 'redis' : 'preserved';
     } else if (totalRows === 0) {
-      const fallbackPayload = buildFallbackTrendingPayload(
-        await readFallbackSources(),
-        fetchedAt,
-      );
+      const fallbackPayload = internalTrendingFallback;
       if (fallbackPayload) {
         const fallbackRows = countTrendingRows(fallbackPayload);
         const message = `all OSSInsight buckets empty; published ${fallbackRows} internal fallback rows`;
@@ -360,6 +395,7 @@ const fetcher: Fetcher = {
         totalRows,
         hotCollections: hotRows.length,
         preservedTrendRows,
+        internalTrendRows,
         preservedHotRows,
         githubHotRows,
         trendingRedis: trendsSource,

--- a/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/oss-trending/index.ts
@@ -1,16 +1,13 @@
 // OSS Insight trending + hot collections fetcher.
 //
-// Ports `scripts/scrape-trending.mjs` (the `--skip-collection-rankings`
-// path) into the worker. Pulls 3 periods x 5 languages from
-// /v1/trends/repos/, plus /v1/collections/hot/, then publishes two
-// data-store slugs:
-//   - `trending`         (ss:data:v1:trending)         buckets payload
-//   - `hot-collections`  (ss:data:v1:hot-collections)  hot-collections payload
+// Pulls 3 periods x 5 languages from /v1/trends/repos/, plus
+// /v1/collections/hot/, then publishes two data-store slugs:
+//   - `trending`
+//   - `hot-collections`
 //
-// Cadence: hourly at :27 (matches .github/workflows/scrape-trending.yml).
-// OSS Insight allows ~600 req/hr per IP; we throttle 1.5s between bucket
-// requests to stay polite. Endpoints don't emit ETag, so we disable the
-// HTTP client's ETag cache to keep redis namespace tidy.
+// The producer never publishes empty upstream failures over last-known-good
+// data. Partial failures preserve cached leaf rows; total failures can publish
+// an internal degraded fallback built from other fresh worker outputs.
 
 import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
 import { readDataStore, writeDataStore } from '../../lib/redis.js';
@@ -70,6 +67,9 @@ export interface NormalizedHotCollectionRow {
 export interface TrendingPayload {
   fetchedAt: string;
   buckets: Record<string, Record<string, OssRow[]>>;
+  status?: 'ok' | 'degraded';
+  dataAsOf?: string | null;
+  errors?: Array<{ stage: string; message: string }>;
 }
 
 export interface HotCollectionsPayload {
@@ -111,12 +111,22 @@ function normalizeHotCollectionRow(
   };
 }
 
+function trendingRows(
+  payload: TrendingPayload | null | undefined,
+  period: string,
+  language: string,
+): OssRow[] {
+  return payload?.buckets?.[period]?.[language] ?? [];
+}
+
+function hotRowsFromPayload(
+  payload: HotCollectionsPayload | null | undefined,
+): NormalizedHotCollectionRow[] {
+  return Array.isArray(payload?.rows) ? payload.rows : [];
+}
+
 const fetcher: Fetcher = {
   name: 'oss-trending',
-  // Staggered to :22 (was :27 — clustered with 3 others). Runs first in
-  // the cluster so deltas (:40) sees a fresh `trending` payload. Cron-tick
-  // budget is generous: 22s of bucket fetches comfortably finish before
-  // recent-repos starts at :25.
   schedule: '22 * * * *',
   async run(ctx: FetcherContext): Promise<RunResult> {
     const startedAt = new Date().toISOString();
@@ -129,20 +139,16 @@ const fetcher: Fetcher = {
 
     const fetchedAt = new Date().toISOString();
     const buckets: Record<string, Record<string, OssRow[]>> = {};
-    let totalRows = 0;
-
-    // Read the last-known-good payload so a per-bucket fetch failure can
-    // preserve that bucket instead of replacing it with [] (partial-outage
-    // protection — OSSInsight's CDN flakes per-PoP, so one language/window can
-    // 500 while the rest 200). The total-failure guard below still handles a
-    // full outage.
-    const priorBuckets =
-      (await readDataStore<TrendingPayload>('trending').catch(() => null))
-        ?.buckets ?? {};
+    const priorTrending =
+      (await readDataStore<TrendingPayload>('trending').catch(() => null)) ??
+      null;
     const priorHotCollections =
       (await readDataStore<HotCollectionsPayload>('hot-collections').catch(
         () => null,
       )) ?? null;
+    let totalRows = 0;
+    let preservedTrendRows = 0;
+    let missingTrendFallbacks = 0;
 
     for (const period of PERIODS) {
       buckets[period] = {};
@@ -160,22 +166,29 @@ const fetcher: Fetcher = {
           ctx.log.info({ period, language, rows: rows.length }, 'bucket fetched');
         } catch (err) {
           const message = (err as Error).message;
-          const prior = priorBuckets[period]?.[language] ?? [];
-          if (prior.length > 0) {
+          const priorRows = trendingRows(priorTrending, period, language);
+          if (priorRows.length > 0) {
+            buckets[period]![language] = priorRows;
+            preservedTrendRows += priorRows.length;
+            totalRows += priorRows.length;
             ctx.log.warn(
-              { period, language, err: message, preserved: prior.length },
-              'bucket fetch failed — preserving last-known-good bucket',
+              {
+                period,
+                language,
+                err: message,
+                preservedRows: priorRows.length,
+              },
+              'bucket fetch failed - preserving cached rows',
             );
             errors.push({
               stage: `bucket:${label}`,
-              message: `${message} (preserved ${prior.length} cached)`,
+              message: `${message} (preserved ${priorRows.length} cached)`,
             });
-            buckets[period]![language] = prior;
-            totalRows += prior.length;
           } else {
             ctx.log.error({ period, language, err: message }, 'bucket fetch failed');
             errors.push({ stage: `bucket:${label}`, message });
             buckets[period]![language] = [];
+            missingTrendFallbacks += 1;
           }
         }
         await sleep(TRENDS_PAUSE_MS);
@@ -183,6 +196,9 @@ const fetcher: Fetcher = {
     }
 
     let hotRows: NormalizedHotCollectionRow[] = [];
+    let preservedHotRows = 0;
+    let missingHotFallback = false;
+    const hotErrors: Array<{ stage: string; message: string }> = [];
     try {
       const { data } = await ctx.http.json<OssEnvelope<HotCollectionRow>>(
         HOT_COLLECTIONS_URL,
@@ -194,95 +210,131 @@ const fetcher: Fetcher = {
       ctx.log.info({ rows: hotRows.length }, 'hot collections fetched');
     } catch (err) {
       const message = (err as Error).message;
-      ctx.log.error({ err: message }, 'hot collections fetch failed');
-      errors.push({ stage: 'hot-collections', message });
+      const priorRows = hotRowsFromPayload(priorHotCollections);
+      if (priorRows.length > 0) {
+        hotRows = priorRows;
+        preservedHotRows = priorRows.length;
+        ctx.log.warn(
+          { err: message, preservedRows: priorRows.length },
+          'hot collections fetch failed - preserving cached rows',
+        );
+        const preserved = {
+          stage: 'hot-collections',
+          message: `${message} (preserved ${priorRows.length} cached)`,
+        };
+        errors.push(preserved);
+        hotErrors.push(preserved);
+      } else {
+        ctx.log.error({ err: message }, 'hot collections fetch failed');
+        const failed = { stage: 'hot-collections', message };
+        errors.push(failed);
+        hotErrors.push(failed);
+        missingHotFallback = true;
+      }
     }
 
-    const trendsPayload: TrendingPayload = { fetchedAt, buckets };
-    const hotErrors = errors.filter((err) => err.stage === 'hot-collections');
-    const hotPayload: HotCollectionsPayload =
-      hotRows.length > 0
-        ? { fetchedAt, rows: hotRows, status: 'ok', dataAsOf: fetchedAt }
-        : {
-            fetchedAt,
-            rows: priorHotCollections?.rows ?? [],
-            status: 'degraded',
-            dataAsOf:
-              priorHotCollections?.dataAsOf ?? priorHotCollections?.fetchedAt ?? null,
-            errors:
-              hotErrors.length > 0
-                ? hotErrors
-                : [
-                    {
-                      stage: 'hot-collections',
-                      message: 'empty hot collections response',
-                    },
-                  ],
-          };
+    const trendErrors = errors.filter((error) =>
+      error.stage.startsWith('bucket:'),
+    );
+    const trendStatus = trendErrors.length > 0 ? 'degraded' : 'ok';
+    const hotStatus = hotErrors.length > 0 ? 'degraded' : 'ok';
+    const trendsPayload: TrendingPayload = {
+      fetchedAt,
+      buckets,
+      status: trendStatus,
+      dataAsOf:
+        trendStatus === 'degraded'
+          ? priorTrending?.dataAsOf ?? priorTrending?.fetchedAt ?? null
+          : fetchedAt,
+      ...(trendErrors.length > 0 ? { errors: trendErrors } : {}),
+    };
+    const hotPayload: HotCollectionsPayload = {
+      fetchedAt,
+      rows: hotRows,
+      status: hotStatus,
+      dataAsOf:
+        hotStatus === 'degraded'
+          ? priorHotCollections?.dataAsOf ??
+            priorHotCollections?.fetchedAt ??
+            null
+          : fetchedAt,
+      ...(hotErrors.length > 0 ? { errors: hotErrors } : {}),
+    };
 
-    // Zero-write guard — root-cause fix for the 2026-05-28 site-wide delta wipe.
-    // When api.ossinsight.io is fully down, every bucket fetch fails and comes
-    // back empty. Writing that empty payload OVERWRITES the last-known-good
-    // `trending` slug, which zeroes every repo's star-delta site-wide and forces
-    // the deltaless registry fallback ("—" + monogram everywhere). Preserve the
-    // existing slug instead — slightly-stale beats empty, same contract as the
-    // keep-last-50 collector rule. Only a TOTAL failure (totalRows === 0)
-    // triggers preservation; partial buckets still publish.
-    let trendsSource = 'preserved';
-    let hotSource = 'preserved';
-    if (totalRows > 0) {
-      const res = await writeDataStore('trending', trendsPayload);
-      trendsSource = res.source;
-    } else {
+    let trendsSource: 'redis' | 'preserved' = 'preserved';
+    let hotSource: 'redis' | 'preserved' = 'preserved';
+    if (totalRows > 0 && missingTrendFallbacks === 0) {
+      const trendsRes = await writeDataStore(
+        'trending',
+        trendsPayload,
+        trendStatus === 'degraded'
+          ? { writer: 'worker:oss-trending:degraded' }
+          : {},
+      );
+      trendsSource = trendsRes.source === 'redis' ? 'redis' : 'preserved';
+    } else if (totalRows === 0) {
       const fallbackPayload = buildFallbackTrendingPayload(
         await readFallbackSources(),
         fetchedAt,
       );
       if (fallbackPayload) {
         const fallbackRows = countTrendingRows(fallbackPayload);
-        const res = await writeDataStore('trending', fallbackPayload, {
-          writer: 'worker:oss-trending:fallback',
-        });
+        const message = `all OSSInsight buckets empty; published ${fallbackRows} internal fallback rows`;
+        const trendsRes = await writeDataStore(
+          'trending',
+          {
+            ...fallbackPayload,
+            status: 'degraded',
+            dataAsOf: fetchedAt,
+            errors: [{ stage: 'fallback-trending', message }],
+          } satisfies TrendingPayload,
+          { writer: 'worker:oss-trending:fallback' },
+        );
         totalRows = fallbackRows;
-        trendsSource = res.source;
-        ctx.log.warn(
-          { fallbackRows },
-          'oss-trending: ALL buckets empty; published internal fallback trending payload',
-        );
-        errors.push({
-          stage: 'fallback-trending',
-          message: `all OSSInsight buckets empty; published ${fallbackRows} internal fallback rows`,
-        });
+        trendsSource = trendsRes.source === 'redis' ? 'redis' : 'preserved';
+        errors.push({ stage: 'fallback-trending', message });
+        ctx.log.warn({ fallbackRows }, message);
       } else {
-        ctx.log.error(
-          'oss-trending: ALL buckets empty (api.ossinsight.io down?) — preserving last-known-good `trending` slug instead of overwriting with empty',
-        );
-        errors.push({
-          stage: 'guard-trending',
-          message: 'all buckets empty; preserved last-known-good trending slug',
-        });
+        const message = 'all trend buckets empty; skipped empty trending publish';
+        errors.push({ stage: 'guard:trending', message });
+        ctx.log.error({ totalRows, preservedTrendRows }, message);
       }
-    }
-    if (hotRows.length > 0) {
-      const res = await writeDataStore('hot-collections', hotPayload);
-      hotSource = res.source;
     } else {
-      ctx.log.warn(
-        'oss-trending: no hot collections this run; publishing degraded hot-collections payload',
+      const message = `missing cached rows for ${missingTrendFallbacks} failed trend bucket(s); skipped empty trending publish`;
+      errors.push({ stage: 'guard:trending', message });
+      ctx.log.error(
+        {
+          totalRows,
+          preservedTrendRows,
+          missingTrendFallbacks,
+        },
+        message,
       );
     }
 
-    if (hotRows.length === 0) {
-      const res = await writeDataStore('hot-collections', hotPayload, {
-        writer: 'worker:oss-trending:degraded',
-      });
-      hotSource = res.source;
+    if (hotRows.length > 0 && !missingHotFallback) {
+      const hotRes = await writeDataStore(
+        'hot-collections',
+        hotPayload,
+        hotStatus === 'degraded'
+          ? { writer: 'worker:oss-trending:degraded' }
+          : {},
+      );
+      hotSource = hotRes.source === 'redis' ? 'redis' : 'preserved';
+    } else {
+      const message = missingHotFallback
+        ? 'no cached hot collection rows after upstream failure; skipped empty hot-collections publish'
+        : 'hot collections empty; skipped empty hot-collections publish';
+      errors.push({ stage: 'guard:hot-collections', message });
+      ctx.log.error({ hotCollections: hotRows.length }, message);
     }
 
     ctx.log.info(
       {
         totalRows,
         hotCollections: hotRows.length,
+        preservedTrendRows,
+        preservedHotRows,
         trendingRedis: trendsSource,
         hotRedis: hotSource,
       },

--- a/apps/trendingrepo-worker/src/fetchers/repo-metadata/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/repo-metadata/index.ts
@@ -20,6 +20,10 @@ import {
   pickGithubToken,
   recordRateLimit,
 } from '../../lib/util/github-token-pool.js';
+import {
+  METRICS,
+  SEED_COLLECTION_RANKINGS,
+} from '../collection-rankings/fallback.js';
 
 const GRAPHQL_URL = 'https://api.github.com/graphql';
 const API_VERSION = '2022-11-28';
@@ -87,6 +91,16 @@ interface RegistryPayloadLite {
   repos?: Record<string, { fullName?: string; lastSeenAt?: string }>;
 }
 
+function addCollectionSeedRepos(out: Map<string, string>): void {
+  for (const collection of Object.values(SEED_COLLECTION_RANKINGS.collections)) {
+    for (const metric of METRICS) {
+      for (const row of collection[metric] ?? []) {
+        addFullName(out, row.repoName);
+      }
+    }
+  }
+}
+
 function collectFullNames(
   trending: TrendingPayload | null,
   recentRepos: RecentReposPayload | null,
@@ -112,6 +126,10 @@ function collectFullNames(
     (b.lastSeenAt ?? '') < (a.lastSeenAt ?? '') ? -1 : (b.lastSeenAt ?? '') > (a.lastSeenAt ?? '') ? 1 : 0,
   );
   for (const entry of registryEntries) addFullName(names, entry?.fullName);
+  // The collection-ranking fallback is now GitHub-backed during OSSInsight
+  // outages. Hydrate that curated roster here so collection health does not
+  // depend on stale OSSInsight rows being present in the trending feed.
+  addCollectionSeedRepos(names);
   return Array.from(names.values()).sort((a, b) =>
     a.toLowerCase().localeCompare(b.toLowerCase()),
   );

--- a/apps/trendingrepo-worker/src/platform/run-summary.ts
+++ b/apps/trendingrepo-worker/src/platform/run-summary.ts
@@ -6,7 +6,7 @@
  * a future log scraper / freshness dashboard can ingest without parsing
  * pino's full JSON envelope. The line is intentionally human-greppable:
  *
- *   [run-summary] source=<id> status=<ok|err> duration_ms=<N>
+ *   [run-summary] source=<id> status=<ok|warn|err> duration_ms=<N>
  *                 records_in=<N> records_out=<N>
  *                 contract_freshness_budget_ms=<N|missing>
  *
@@ -26,7 +26,7 @@
 
 import type { SourceContract } from './source-contract.js';
 
-export type RunSummaryStatus = 'ok' | 'err';
+export type RunSummaryStatus = 'ok' | 'warn' | 'err';
 
 export interface RunSummary {
   sourceId: string;

--- a/apps/trendingrepo-worker/src/run.ts
+++ b/apps/trendingrepo-worker/src/run.ts
@@ -145,7 +145,7 @@ export async function runFetcher(
     recordRun();
     emitRunSummary({
       sourceId: fetcher.name,
-      status: 'ok',
+      status: result.errors.length > 0 ? 'warn' : 'ok',
       durationMs: Date.now() - t0,
       recordsIn: result.itemsSeen,
       recordsOut: result.itemsUpserted,

--- a/apps/trendingrepo-worker/src/server.ts
+++ b/apps/trendingrepo-worker/src/server.ts
@@ -10,8 +10,10 @@ interface HealthState {
   ok: boolean;
   db: boolean;
   redis: boolean;
+  scheduler: boolean;
   lastCheckAt: string;
   lastRunAt: string | null;
+  schedulerIdleSec: number | null;
   /**
    * Override source_ids that no longer correspond to any registered fetcher
    * AND no longer correspond to a static contract row. Empty in the green
@@ -21,14 +23,59 @@ interface HealthState {
 }
 
 let cached: HealthState | null = null;
+let cachedEnforcesScheduler = false;
 let inFlight: Promise<HealthState> | null = null;
 const TTL_MS = 30_000;
+const PROCESS_STARTED_AT_MS = Date.now();
+let lastRunAtMs: number | null = null;
 
-export function recordRun(at: Date = new Date()): void {
-  if (cached) cached.lastRunAt = at.toISOString();
+function envNumber(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
-async function refreshHealth(): Promise<HealthState> {
+export function recordRun(at: Date = new Date()): void {
+  lastRunAtMs = at.getTime();
+  if (cached) {
+    cached.lastRunAt = at.toISOString();
+    cached.schedulerIdleSec = 0;
+  }
+}
+
+function schedulerHealth(enforceScheduler: boolean): {
+  ok: boolean;
+  idleSec: number | null;
+} {
+  const forceScheduler = process.env.WORKER_HEALTH_FORCE_SCHEDULER === '1';
+  if (
+    !enforceScheduler ||
+    (process.env.NODE_ENV !== 'production' && !forceScheduler)
+  ) {
+    return { ok: true, idleSec: null };
+  }
+
+  const nowMs = Date.now();
+  const startupGraceMs = envNumber(
+    'WORKER_HEALTH_STARTUP_GRACE_MS',
+    10 * 60 * 1000,
+  );
+  if (nowMs - PROCESS_STARTED_AT_MS < startupGraceMs) {
+    return { ok: true, idleSec: null };
+  }
+
+  if (lastRunAtMs === null) {
+    return { ok: false, idleSec: null };
+  }
+
+  const idleMs = Math.max(0, nowMs - lastRunAtMs);
+  const maxIdleMs = envNumber('WORKER_HEALTH_MAX_IDLE_MS', 15 * 60 * 1000);
+  return {
+    ok: idleMs <= maxIdleMs,
+    idleSec: Math.floor(idleMs / 1000),
+  };
+}
+
+async function refreshHealth(enforceScheduler = false): Promise<HealthState> {
   const log = getLogger();
   const env = loadEnv();
   let dbOk = false;
@@ -53,25 +100,33 @@ async function refreshHealth(): Promise<HealthState> {
   } catch (err) {
     log.warn(`healthcheck redis: ${(err as Error).message}`);
   }
+  const scheduler = schedulerHealth(enforceScheduler);
   const ghostOverrides = findGhostOverrides(FETCHERS, getCachedOverrides(), SOURCE_CONTRACTS);
   const state: HealthState = {
-    ok: dbOk && redisOk,
+    ok: dbOk && redisOk && scheduler.ok,
     db: dbOk,
     redis: redisOk,
+    scheduler: scheduler.ok,
     lastCheckAt: new Date().toISOString(),
-    lastRunAt: cached?.lastRunAt ?? null,
+    lastRunAt: lastRunAtMs === null ? null : new Date(lastRunAtMs).toISOString(),
+    schedulerIdleSec: scheduler.idleSec,
     ghost_overrides: ghostOverrides,
   };
   cached = state;
+  cachedEnforcesScheduler = enforceScheduler;
   return state;
 }
 
-async function getHealth(): Promise<HealthState> {
-  if (cached && Date.now() - Date.parse(cached.lastCheckAt) < TTL_MS) {
+async function getHealth(enforceScheduler = true): Promise<HealthState> {
+  if (
+    cached &&
+    cachedEnforcesScheduler === enforceScheduler &&
+    Date.now() - Date.parse(cached.lastCheckAt) < TTL_MS
+  ) {
     return cached;
   }
   if (inFlight) return inFlight;
-  inFlight = refreshHealth().finally(() => {
+  inFlight = refreshHealth(enforceScheduler).finally(() => {
     inFlight = null;
   });
   return inFlight;
@@ -81,7 +136,7 @@ export function startHealthServer(port = loadEnv().PORT): http.Server {
   const log = getLogger();
   const server = http.createServer((req, res) => {
     if (req.url === '/healthz' || req.url === '/health') {
-      void getHealth().then((state) => {
+      void getHealth(true).then((state) => {
         res.writeHead(state.ok ? 200 : 503, { 'content-type': 'application/json' });
         res.end(JSON.stringify(state));
       });
@@ -96,8 +151,10 @@ export function startHealthServer(port = loadEnv().PORT): http.Server {
   return server;
 }
 
-export async function oneShotHealthcheck(): Promise<number> {
-  const state = await refreshHealth();
+export async function oneShotHealthcheck(
+  opts: { enforceScheduler?: boolean } = {},
+): Promise<number> {
+  const state = await refreshHealth(opts.enforceScheduler === true);
   // eslint-disable-next-line no-console
   console.log(JSON.stringify(state, null, 2));
   return state.ok ? 0 : 1;

--- a/apps/trendingrepo-worker/tests/server-health.test.ts
+++ b/apps/trendingrepo-worker/tests/server-health.test.ts
@@ -8,6 +8,9 @@ const ENV_KEYS = [
   'UPSTASH_REDIS_REST_TOKEN',
   'SUPABASE_URL',
   'SUPABASE_SERVICE_ROLE',
+  'WORKER_HEALTH_FORCE_SCHEDULER',
+  'WORKER_HEALTH_STARTUP_GRACE_MS',
+  'WORKER_HEALTH_MAX_IDLE_MS',
 ] as const;
 
 const previousEnv = new Map<string, string | undefined>();
@@ -45,5 +48,33 @@ describe('worker healthcheck', () => {
     const { oneShotHealthcheck } = await import('../src/server.js');
 
     await expect(oneShotHealthcheck()).resolves.toBe(1);
+  });
+
+  it('fails enforced health when cron has not reported progress after startup grace', async () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.DATA_STORE_DISABLE = '1';
+    process.env.WORKER_HEALTH_FORCE_SCHEDULER = '1';
+    process.env.WORKER_HEALTH_STARTUP_GRACE_MS = '0';
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { oneShotHealthcheck } = await import('../src/server.js');
+
+    await expect(oneShotHealthcheck({ enforceScheduler: true })).resolves.toBe(1);
+  });
+
+  it('passes enforced health after recordRun marks scheduler progress', async () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    process.env.DATA_STORE_DISABLE = '1';
+    process.env.WORKER_HEALTH_FORCE_SCHEDULER = '1';
+    process.env.WORKER_HEALTH_STARTUP_GRACE_MS = '0';
+    process.env.WORKER_HEALTH_MAX_IDLE_MS = '60000';
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { oneShotHealthcheck, recordRun } = await import('../src/server.js');
+    recordRun(new Date());
+
+    await expect(oneShotHealthcheck({ enforceScheduler: true })).resolves.toBe(0);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,13 +372,13 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.33.3",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.3.tgz",
-      "integrity": "sha512-cgkFVEYFG2nZn4QDuYBhiAwPtMdo8Yj7DAtq/SBQ5C/ainh3uxNRDgUj4bFn52qJkWLiCkraYJIw1b8dEUbUBg==",
+      "version": "2.33.5",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.5.tgz",
+      "integrity": "sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.5",
-        "@clerk/types": "^4.101.23",
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -387,12 +387,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.6",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.6.tgz",
-      "integrity": "sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==",
+      "version": "5.61.8",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.8.tgz",
+      "integrity": "sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.5",
+        "@clerk/shared": "^3.47.7",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -404,15 +404,15 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.39.3",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.3.tgz",
-      "integrity": "sha512-a64lJ1IlV1uA7eEe8DOx+v2bkNOhnTsNlB5THP/xkHvynHqZhc74Yt05sm1vTniWwhJpJspAZ95pCWUX/RVZ2Q==",
+      "version": "6.39.5",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.5.tgz",
+      "integrity": "sha512-hvdvpiuHXPhlx3iaNfoXO1joZkNP4Lzw83teUNPrzsbOX0rT9QE0uSxS2J/UEAeqoPK6JhNK7dZGvZ9knsB/mg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.33.3",
-        "@clerk/clerk-react": "^5.61.6",
-        "@clerk/shared": "^3.47.5",
-        "@clerk/types": "^4.101.23",
+        "@clerk/backend": "^2.33.5",
+        "@clerk/clerk-react": "^5.61.8",
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -426,16 +426,16 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.5",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
-      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
+      "version": "3.47.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.7.tgz",
+      "integrity": "sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
+        "js-cookie": "3.0.7",
         "std-env": "^3.9.0",
         "swr": "2.3.4"
       },
@@ -456,12 +456,12 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.101.23",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.23.tgz",
-      "integrity": "sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA==",
+      "version": "4.101.25",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.25.tgz",
+      "integrity": "sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.5"
+        "@clerk/shared": "^3.47.7"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -11103,12 +11103,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {

--- a/src/app/api/worker/health/route.ts
+++ b/src/app/api/worker/health/route.ts
@@ -12,6 +12,12 @@ import {
   WORKER_HEALTH_SPECS,
   type DisabledSlugHealthSpec,
 } from "@/lib/worker-health-specs";
+import {
+  applyPayloadHealthToSlugStatus,
+  decodeWorkerPayloadFromStore,
+  summarizeWorkerPayloadHealth,
+  type WorkerPayloadHealth,
+} from "@/lib/worker-health-payload";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -43,6 +49,12 @@ function checkOptionalBearer(request: NextRequest): NextResponse | null {
 const SLUG_TABLE = WORKER_HEALTH_SPECS;
 const DISABLED_SLUG_TABLE = WORKER_HEALTH_DISABLED_SPECS;
 const DATA_STORE_META_NAMESPACE = "ss:meta:v1";
+const DATA_STORE_PAYLOAD_NAMESPACE = "ss:data:v1";
+const PAYLOAD_HEALTH_SLUGS = new Set([
+  "trending",
+  "hot-collections",
+  "collection-rankings",
+]);
 
 type SlugStatus = "green" | "amber" | "red" | "missing";
 
@@ -54,6 +66,10 @@ interface SlugHealth {
   status: SlugStatus;
   writtenAt: string | null;
   ageSec: number | null;
+  payloadStatus: WorkerPayloadHealth["payloadStatus"];
+  payloadDataAsOf: string | null;
+  payloadErrorCount: number | null;
+  payloadRowCount: number | null;
 }
 
 interface HealthSummary {
@@ -66,6 +82,8 @@ interface HealthSummary {
   missing: number;
   blockingRed: number;
   blockingMissing: number;
+  degradedPayload: number;
+  emptyPayload: number;
 }
 
 interface HealthResponse {
@@ -78,6 +96,10 @@ interface HealthResponse {
 
 function dataStoreMetaKey(slug: string): string {
   return `${DATA_STORE_META_NAMESPACE}:${slug}`;
+}
+
+function dataStorePayloadKey(slug: string): string {
+  return `${DATA_STORE_PAYLOAD_NAMESPACE}:${slug}`;
 }
 
 function parseRedisWrittenAt(raw: unknown): string | null {
@@ -119,6 +141,28 @@ async function readRedisMetaWrittenAt(
   }
 }
 
+async function readRedisPayloadHealth(
+  redis: RedisClientLike | null,
+  slug: string,
+): Promise<WorkerPayloadHealth | null> {
+  if (!redis || !PAYLOAD_HEALTH_SLUGS.has(slug)) return null;
+  try {
+    const raw = await redis.get(dataStorePayloadKey(slug));
+    if (!raw) return null;
+    return summarizeWorkerPayloadHealth(
+      slug,
+      decodeWorkerPayloadFromStore(raw),
+    );
+  } catch {
+    return {
+      payloadStatus: null,
+      dataAsOf: null,
+      errorCount: null,
+      rowCount: 0,
+    };
+  }
+}
+
 function classifyAge(
   ageSec: number | null,
   cadenceMin: number,
@@ -145,12 +189,16 @@ export async function GET(
 
   const probes = await Promise.all(
     SLUG_TABLE.map(async (spec) => {
-      const writtenAt = await readRedisMetaWrittenAt(redis, spec.slug);
+      const [writtenAt, payloadHealth] = await Promise.all([
+        readRedisMetaWrittenAt(redis, spec.slug),
+        readRedisPayloadHealth(redis, spec.slug),
+      ]);
       const ageSec =
         writtenAt !== null
           ? Math.max(0, Math.floor((now - new Date(writtenAt).getTime()) / 1000))
           : null;
-      const status = classifyAge(ageSec, spec.cadenceMin, spec.slowMoving === true);
+      const ageStatus = classifyAge(ageSec, spec.cadenceMin, spec.slowMoving === true);
+      const status = applyPayloadHealthToSlugStatus(ageStatus, payloadHealth);
       return {
         slug: spec.slug,
         fetcher: spec.fetcher,
@@ -159,6 +207,10 @@ export async function GET(
         status,
         writtenAt,
         ageSec,
+        payloadStatus: payloadHealth?.payloadStatus ?? null,
+        payloadDataAsOf: payloadHealth?.dataAsOf ?? null,
+        payloadErrorCount: payloadHealth?.errorCount ?? null,
+        payloadRowCount: payloadHealth?.rowCount ?? null,
       } satisfies SlugHealth;
     }),
   );
@@ -173,6 +225,8 @@ export async function GET(
     missing: probes.filter((p) => p.status === "missing").length,
     blockingRed: probes.filter((p) => p.blocking && p.status === "red").length,
     blockingMissing: probes.filter((p) => p.blocking && p.status === "missing").length,
+    degradedPayload: probes.filter((p) => p.payloadStatus === "degraded").length,
+    emptyPayload: probes.filter((p) => p.payloadRowCount === 0).length,
   };
 
   const statusRank: Record<SlugStatus, number> = {

--- a/src/lib/collection-rankings.ts
+++ b/src/lib/collection-rankings.ts
@@ -143,6 +143,21 @@ export function getCollectionRankingsCoverage(
   };
 }
 
+export function countCollectionRankingRows(file: CollectionRankingsFile): number {
+  let count = 0;
+  for (const ranking of Object.values(file.collections ?? {})) {
+    count += ranking.stars?.length ?? 0;
+    count += ranking.issues?.length ?? 0;
+  }
+  return count;
+}
+
+export function isUsableCollectionRankingsPayload(
+  file: CollectionRankingsFile,
+): boolean {
+  return countCollectionRankingRows(file) > 0;
+}
+
 // ---------------------------------------------------------------------------
 // Refresh hook — pulls fresh collection-rankings from the data-store.
 // ---------------------------------------------------------------------------
@@ -174,7 +189,11 @@ export async function refreshCollectionRankingsFromStore(): Promise<RefreshResul
       const result = await getDataStore().read<CollectionRankingsFile>(
         "collection-rankings",
       );
-      if (result.data && result.source !== "missing") {
+      if (
+        result.data &&
+        result.source !== "missing" &&
+        isUsableCollectionRankingsPayload(result.data)
+      ) {
         data = result.data;
       }
       lastRefreshMs = Date.now();

--- a/src/lib/devto-trending.ts
+++ b/src/lib/devto-trending.ts
@@ -31,6 +31,15 @@ export interface DevtoTrendingFile {
 // refreshDevtoTrendingFromStore().
 let trendingFile: DevtoTrendingFile = devtoTrendingData as unknown as DevtoTrendingFile;
 
+export function isUsableDevtoTrendingPayload(file: DevtoTrendingFile): boolean {
+  return (
+    !!file.fetchedAt &&
+    !file.fetchedAt.startsWith("1970-") &&
+    file.scannedArticles > 0 &&
+    (file.articles?.length ?? 0) > 0
+  );
+}
+
 export function getDevtoTrendingFile(): DevtoTrendingFile {
   return trendingFile;
 }
@@ -65,7 +74,11 @@ export async function refreshDevtoTrendingFromStore(): Promise<{
     const result = await getDataStore().read<DevtoTrendingFile>(
       "devto-trending",
     );
-    if (result.data && result.source !== "missing") {
+    if (
+      result.data &&
+      result.source !== "missing" &&
+      isUsableDevtoTrendingPayload(result.data)
+    ) {
       trendingFile = result.data;
     }
     lastRefreshMs = Date.now();

--- a/src/lib/devto.ts
+++ b/src/lib/devto.ts
@@ -116,6 +116,22 @@ export interface DevtoMentionsFile {
 let mentionsFile: DevtoMentionsFile = devtoMentionsData as unknown as DevtoMentionsFile;
 enrichDevtoWindowedCounts(mentionsFile);
 
+export function isDevtoMentionsColdPayload(file: DevtoMentionsFile): boolean {
+  return (
+    !file.fetchedAt ||
+    file.fetchedAt.startsWith("1970-") ||
+    file.scannedArticles === 0
+  );
+}
+
+export function isUsableDevtoMentionsPayload(file: DevtoMentionsFile): boolean {
+  return (
+    !isDevtoMentionsColdPayload(file) &&
+    (Object.keys(file.mentions ?? {}).length > 0 ||
+      (file.leaderboard?.length ?? 0) > 0)
+  );
+}
+
 /**
  * Backfill `count24h` / `count30d` on each repo mention from the raw
  * `articles` array. dev.to articles carry `publishedAt` (ISO); we map
@@ -142,20 +158,14 @@ export const devtoBodyFetchMode: DevtoBodyFetchMode = mentionsFile.bodyFetchMode
 // suppresses the freshness gate while cold; once a real run lands the
 // daily-cron staleness threshold kicks in.
 export const devtoCold: boolean =
-  !mentionsFile.fetchedAt ||
-  mentionsFile.fetchedAt.startsWith("1970-") ||
-  mentionsFile.scannedArticles === 0;
+  isDevtoMentionsColdPayload(mentionsFile);
 
 export function getDevtoFetchedAt(): string {
   return mentionsFile.fetchedAt;
 }
 
 export function isDevtoCold(): boolean {
-  return (
-    !mentionsFile.fetchedAt ||
-    mentionsFile.fetchedAt.startsWith("1970-") ||
-    mentionsFile.scannedArticles === 0
-  );
+  return isDevtoMentionsColdPayload(mentionsFile);
 }
 
 function buildDevtoMentionsByLowerName(file: DevtoMentionsFile): Map<string, DevtoRepoMention> {
@@ -278,7 +288,11 @@ export async function refreshDevtoMentionsFromStore(): Promise<{
     const result = await getDataStore().read<DevtoMentionsFile>(
       "devto-mentions",
     );
-    if (result.data && result.source !== "missing") {
+    if (
+      result.data &&
+      result.source !== "missing" &&
+      isUsableDevtoMentionsPayload(result.data)
+    ) {
       mentionsFile = result.data;
       enrichDevtoWindowedCounts(mentionsFile);
       mentionsByLowerName = buildDevtoMentionsByLowerName(mentionsFile);

--- a/src/lib/hot-collections.ts
+++ b/src/lib/hot-collections.ts
@@ -30,6 +30,9 @@ interface HotCollectionRow {
 interface HotCollectionsFile {
   fetchedAt: string;
   rows: HotCollectionRow[];
+  status?: "ok" | "degraded";
+  dataAsOf?: string | null;
+  errors?: Array<{ stage: string; message: string }>;
 }
 
 // Mutable in-memory cache. Seeded from the bundled JSON; replaced by Redis
@@ -89,6 +92,14 @@ export function getHotAiCollections(
   );
 }
 
+export function countHotCollectionRows(file: HotCollectionsFile): number {
+  return Array.isArray(file.rows) ? file.rows.length : 0;
+}
+
+export function isUsableHotCollectionsPayload(file: HotCollectionsFile): boolean {
+  return countHotCollectionRows(file) > 0;
+}
+
 // ---------------------------------------------------------------------------
 // Refresh hook — pulls fresh hot-collections from the data-store.
 // ---------------------------------------------------------------------------
@@ -118,7 +129,11 @@ export async function refreshHotCollectionsFromStore(): Promise<RefreshResult> {
     try {
       const { getDataStore } = await import("./data-store");
       const result = await getDataStore().read<HotCollectionsFile>("hot-collections");
-      if (result.data && result.source !== "missing") {
+      if (
+        result.data &&
+        result.source !== "missing" &&
+        isUsableHotCollectionsPayload(result.data)
+      ) {
         data = result.data;
       }
       lastRefreshMs = Date.now();
@@ -140,4 +155,3 @@ export function _resetHotCollectionsCacheForTests(): void {
   lastRefreshMs = 0;
   inflight = null;
 }
-

--- a/src/lib/pipeline/__tests__/collection-rankings.test.ts
+++ b/src/lib/pipeline/__tests__/collection-rankings.test.ts
@@ -3,7 +3,9 @@ import { strict as assert } from "node:assert";
 
 import {
   buildCollectionRankingEntries,
+  countCollectionRankingRows,
   getCollectionRankingsCoverage,
+  isUsableCollectionRankingsPayload,
 } from "../../collection-rankings";
 
 test("buildCollectionRankingEntries maps slugs and sorts ranking rows by current rank", () => {
@@ -98,4 +100,32 @@ test("getCollectionRankingsCoverage counts collections with star and issue ranki
     withIssues: 1,
     withAnyRanking: 2,
   });
+});
+
+test("collection rankings payload quality rejects fresh empty collection shells", () => {
+  const empty = {
+    fetchedAt: "2026-06-01T00:00:00.000Z",
+    period: "past_28_days",
+    collections: {
+      "10098": {
+        stars: [],
+        issues: [],
+      },
+    },
+  };
+
+  assert.equal(countCollectionRankingRows(empty), 0);
+  assert.equal(isUsableCollectionRankingsPayload(empty), false);
+  assert.equal(
+    isUsableCollectionRankingsPayload({
+      ...empty,
+      collections: {
+        "10098": {
+          stars: [{ repoId: 1, repoName: "a/b", currentPeriodGrowth: 10, pastPeriodGrowth: 5, growthPop: 100, rankPop: 0, total: 50, currentPeriodRank: 1, pastPeriodRank: 1 }],
+          issues: [],
+        },
+      },
+    }),
+    true,
+  );
 });

--- a/src/lib/pipeline/__tests__/devto-payload.test.ts
+++ b/src/lib/pipeline/__tests__/devto-payload.test.ts
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { isUsableDevtoMentionsPayload } from "../../devto";
+import { isUsableDevtoTrendingPayload } from "../../devto-trending";
+
+test("dev.to mentions payload quality rejects cold or empty Redis payloads", () => {
+  assert.equal(
+    isUsableDevtoMentionsPayload({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      windowDays: 7,
+      scannedArticles: 0,
+      bodyFetchMode: "description-only",
+      mentions: {},
+      leaderboard: [],
+    }),
+    false,
+  );
+  assert.equal(
+    isUsableDevtoMentionsPayload({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      windowDays: 7,
+      scannedArticles: 42,
+      bodyFetchMode: "full",
+      mentions: {
+        "cached/project": {
+          count7d: 1,
+          reactionsSum7d: 10,
+          commentsSum7d: 2,
+          topArticle: null,
+          articles: [],
+        },
+      },
+      leaderboard: [{ fullName: "cached/project", count7d: 1, reactionsSum7d: 10 }],
+    }),
+    true,
+  );
+});
+
+test("dev.to trending payload quality rejects cold article lists", () => {
+  assert.equal(
+    isUsableDevtoTrendingPayload({
+      fetchedAt: "1970-01-01T00:00:00.000Z",
+      windowDays: 7,
+      scannedArticles: 0,
+      bodyFetchMode: "description-only",
+      articles: [],
+    }),
+    false,
+  );
+  assert.equal(
+    isUsableDevtoTrendingPayload({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      windowDays: 7,
+      scannedArticles: 42,
+      bodyFetchMode: "full",
+      articles: [
+        {
+          id: 1,
+          title: "Agent writeup",
+          description: "cached article",
+          url: "https://dev.to/example/agent-writeup",
+          author: { username: "example", name: "Example", profileImage: "" },
+          reactionsCount: 10,
+          commentsCount: 1,
+          readingTime: 4,
+          publishedAt: "2026-06-01T00:00:00.000Z",
+          tags: ["ai"],
+          trendingScore: 10,
+          linkedRepos: [],
+        },
+      ],
+    }),
+    true,
+  );
+});

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -6,6 +6,10 @@ import {
   WORKER_HEALTH_DISABLED_SPECS,
   WORKER_HEALTH_SPECS,
 } from "../../worker-health-specs";
+import {
+  applyPayloadHealthToSlugStatus,
+  summarizeWorkerPayloadHealth,
+} from "../../worker-health-payload";
 
 test("/api/health: stale freshness remains HTTP 200 availability", () => {
   assert.equal(getHealthHttpStatusForStatus("ok", false), 200);
@@ -59,4 +63,58 @@ test("/api/worker/health: TrustMRR catalog cadence matches daily producer", () =
   const overlays = WORKER_HEALTH_SPECS.find((item) => item.slug === "revenue-overlays");
   assert.ok(overlays, "missing worker health spec for revenue-overlays");
   assert.equal(overlays.cadenceMin, 60);
+});
+
+test("/api/worker/health: degraded payloads are not reported as pure green", () => {
+  assert.equal(
+    applyPayloadHealthToSlugStatus("green", {
+      payloadStatus: "degraded",
+      dataAsOf: "2026-05-31T20:00:00.000Z",
+      errorCount: 1,
+      rowCount: 10,
+    }),
+    "amber",
+  );
+  assert.equal(
+    applyPayloadHealthToSlugStatus("green", {
+      payloadStatus: "ok",
+      dataAsOf: null,
+      errorCount: null,
+      rowCount: 0,
+    }),
+    "red",
+  );
+});
+
+test("/api/worker/health: payload row-quality summary covers OSSInsight slugs", () => {
+  assert.deepEqual(
+    summarizeWorkerPayloadHealth("trending", {
+      status: "degraded",
+      dataAsOf: "2026-05-31T20:00:00.000Z",
+      errors: [{ stage: "bucket:past_week/Rust", message: "500" }],
+      buckets: {
+        past_week: {
+          Rust: [{ repo_name: "cached/project" }],
+          Go: [{ repo_name: "cached/go" }],
+        },
+      },
+    }),
+    {
+      payloadStatus: "degraded",
+      dataAsOf: "2026-05-31T20:00:00.000Z",
+      errorCount: 1,
+      rowCount: 2,
+    },
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("collection-rankings", {
+      collections: {
+        "10139": {
+          stars: [{ repoName: "cached/project" }],
+          issues: [],
+        },
+      },
+    }).rowCount,
+    1,
+  );
 });

--- a/src/lib/pipeline/__tests__/hot-collections.test.ts
+++ b/src/lib/pipeline/__tests__/hot-collections.test.ts
@@ -1,7 +1,10 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
 
-import { groupHotCollectionRows } from "../../hot-collections";
+import {
+  groupHotCollectionRows,
+  isUsableHotCollectionsPayload,
+} from "../../hot-collections";
 
 test("groupHotCollectionRows groups rows into ordered collections and maps slugs", () => {
   const groups = groupHotCollectionRows(
@@ -58,4 +61,32 @@ test("groupHotCollectionRows groups rows into ordered collections and maps slugs
   assert.equal(groups[0].topRepos.length, 2);
   assert.equal(groups[0].topRepos[0].repoName, "openai/openai-agents-python");
   assert.equal(groups[1].slug, "coding-agents");
+});
+
+test("hot collections payload quality rejects fresh empty rows", () => {
+  assert.equal(
+    isUsableHotCollectionsPayload({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      rows: [],
+    }),
+    false,
+  );
+  assert.equal(
+    isUsableHotCollectionsPayload({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      rows: [
+        {
+          id: 10098,
+          name: "AI Agent Frameworks",
+          repos: 17,
+          repoId: 1,
+          repoName: "cached/project",
+          repoCurrentPeriodRank: 1,
+          repoPastPeriodRank: 2,
+          repoRankChanges: 1,
+        },
+      ],
+    }),
+    true,
+  );
 });

--- a/src/lib/pipeline/__tests__/trending-payload.test.ts
+++ b/src/lib/pipeline/__tests__/trending-payload.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import {
+  countTrendingPayloadRows,
+  isUsableTrendingPayload,
+} from "../../trending";
+
+test("trending payload quality rejects fresh empty bucket payloads", () => {
+  assert.equal(
+    isUsableTrendingPayload({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      buckets: {
+        past_24_hours: {
+          All: [],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    countTrendingPayloadRows({
+      fetchedAt: "2026-06-01T00:00:00.000Z",
+      buckets: {
+        past_24_hours: {
+          All: [
+            {
+              repo_id: "1",
+              repo_name: "cached/project",
+              primary_language: "TypeScript",
+              description: "cached row",
+              stars: "10",
+              forks: "1",
+              pull_requests: "1",
+              pushes: "1",
+              total_score: "1",
+              contributor_logins: "",
+              collection_names: "",
+            },
+          ],
+        },
+      },
+    }),
+    1,
+  );
+});

--- a/src/lib/trending.ts
+++ b/src/lib/trending.ts
@@ -42,7 +42,10 @@ export interface TrendingRow {
 
 interface TrendingFile {
   fetchedAt: string;
-  buckets: Record<TrendingPeriod, Record<TrendingLanguage, TrendingRow[]>>;
+  buckets: Partial<Record<TrendingPeriod, Partial<Record<TrendingLanguage, TrendingRow[]>>>>;
+  status?: "ok" | "degraded";
+  dataAsOf?: string | null;
+  errors?: Array<{ stage: string; message: string }>;
 }
 
 // Mutable in-memory cache. Seeded from the bundled JSON; replaced by Redis
@@ -87,6 +90,20 @@ export function getAllFullNames(): string[] {
     }
   }
   return out;
+}
+
+export function countTrendingPayloadRows(file: TrendingFile): number {
+  let count = 0;
+  for (const langMap of Object.values(file.buckets ?? {})) {
+    for (const rows of Object.values(langMap)) {
+      if (Array.isArray(rows)) count += rows.length;
+    }
+  }
+  return count;
+}
+
+export function isUsableTrendingPayload(file: TrendingFile): boolean {
+  return countTrendingPayloadRows(file) > 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +251,11 @@ export async function refreshTrendingFromStore(): Promise<RefreshResult> {
         readDeltasWithToolboxFallback(store),
       ]);
 
-      if (trendingResult.data && trendingResult.source !== "missing") {
+      if (
+        trendingResult.data &&
+        trendingResult.source !== "missing" &&
+        isUsableTrendingPayload(trendingResult.data)
+      ) {
         data = trendingResult.data;
         _fullNameToRepoId = null;
       }

--- a/src/lib/worker-health-payload.ts
+++ b/src/lib/worker-health-payload.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { gunzipSync } from "node:zlib";
 
 const GZIP_MAGIC_PREFIX = "gz1:";

--- a/src/lib/worker-health-payload.ts
+++ b/src/lib/worker-health-payload.ts
@@ -1,0 +1,99 @@
+import { gunzipSync } from "node:zlib";
+
+const GZIP_MAGIC_PREFIX = "gz1:";
+
+export type WorkerPayloadStatus = "ok" | "degraded" | null;
+export type WorkerSlugStatus = "green" | "amber" | "red" | "missing";
+
+export interface WorkerPayloadHealth {
+  payloadStatus: WorkerPayloadStatus;
+  dataAsOf: string | null;
+  errorCount: number | null;
+  rowCount: number | null;
+}
+
+export function decodeWorkerPayloadFromStore(raw: unknown): unknown {
+  if (typeof raw === "object" && raw !== null) return raw;
+  if (typeof raw !== "string") {
+    throw new Error("worker payload is not a string or object");
+  }
+  const payload = raw.startsWith(GZIP_MAGIC_PREFIX)
+    ? gunzipSync(Buffer.from(raw.slice(GZIP_MAGIC_PREFIX.length), "base64")).toString(
+        "utf8",
+      )
+    : raw;
+  return JSON.parse(payload) as unknown;
+}
+
+function countArrayRows(value: unknown): number | null {
+  return Array.isArray(value) ? value.length : null;
+}
+
+function countTrendingRows(payload: unknown): number | null {
+  const buckets = (payload as { buckets?: unknown })?.buckets;
+  if (!buckets || typeof buckets !== "object") return null;
+  let count = 0;
+  for (const langMap of Object.values(buckets)) {
+    if (!langMap || typeof langMap !== "object") continue;
+    for (const rows of Object.values(langMap)) {
+      if (Array.isArray(rows)) count += rows.length;
+    }
+  }
+  return count;
+}
+
+function countCollectionRankingRows(payload: unknown): number | null {
+  const collections = (payload as { collections?: unknown })?.collections;
+  if (!collections || typeof collections !== "object") return null;
+  let count = 0;
+  for (const collection of Object.values(collections)) {
+    if (!collection || typeof collection !== "object") continue;
+    for (const rows of Object.values(collection)) {
+      if (Array.isArray(rows)) count += rows.length;
+    }
+  }
+  return count;
+}
+
+function countRows(slug: string, payload: unknown): number | null {
+  if (slug === "trending") return countTrendingRows(payload);
+  if (slug === "hot-collections") {
+    return countArrayRows((payload as { rows?: unknown })?.rows);
+  }
+  if (slug === "collection-rankings") {
+    return countCollectionRankingRows(payload);
+  }
+  return null;
+}
+
+export function summarizeWorkerPayloadHealth(
+  slug: string,
+  payload: unknown,
+): WorkerPayloadHealth {
+  const envelope = payload as {
+    status?: unknown;
+    dataAsOf?: unknown;
+    errors?: unknown;
+  };
+  return {
+    payloadStatus:
+      envelope.status === "ok" || envelope.status === "degraded"
+        ? envelope.status
+        : null,
+    dataAsOf: typeof envelope.dataAsOf === "string" ? envelope.dataAsOf : null,
+    errorCount: Array.isArray(envelope.errors) ? envelope.errors.length : null,
+    rowCount: countRows(slug, payload),
+  };
+}
+
+export function applyPayloadHealthToSlugStatus(
+  status: WorkerSlugStatus,
+  payloadHealth: WorkerPayloadHealth | null,
+): WorkerSlugStatus {
+  if (!payloadHealth) return status;
+  if (payloadHealth.rowCount === 0) return "red";
+  if (payloadHealth.payloadStatus === "degraded" && status === "green") {
+    return "amber";
+  }
+  return status;
+}


### PR DESCRIPTION
## Summary
- make worker/app health inspect Redis payload quality instead of false-green age checks
- reject empty/stale Redis payloads in app readers so bundled/LKG data is not poisoned
- replace OSSInsight collection/trending outage behavior with GitHub metadata/star-activity fallbacks
- hydrate collection seed repos in repo-metadata so fallback rows stay current
- keep Reddit live collection disabled while reddit-baselines remains tracked

## Live HOSTUP verification
- deployed worker image: toolbox-trendingrepo-worker:vps-20260531174953-be728c2fd3
- /api/health: 200 status=ok sourceStatus=ok
- /api/pipeline/status: 200 healthStatus=ok sourceStatus=ok
- /api/worker/health: ok=true green=27 amber=0 red=0 degradedPayload=0 emptyPayload=0
- /api/health/sources: open=0 halfOpen=0 disabled=[github-search, reddit]
- root headers: Server: cloudflare, no Vercel headers observed

## Validation
- npm --prefix apps/trendingrepo-worker run typecheck
- npm --prefix apps/trendingrepo-worker run build
- npm --prefix apps/trendingrepo-worker test -- src/fetchers/oss-trending/__tests__/fallback.test.ts src/fetchers/oss-trending/__tests__/degraded.test.ts src/fetchers/collection-rankings/__tests__/fallback.test.ts src/fetchers/collection-rankings/__tests__/degraded.test.ts tests/registry.test.ts
- npm run typecheck -- --pretty false
- npm run lint:guards
- npm audit --audit-level=high
- npm run build