### PR TITLE
fix(worker): enforce strict source health contracts

### DIFF
--- a/apps/trendingrepo-worker/package-lock.json
+++ b/apps/trendingrepo-worker/package-lock.json
@@ -2229,6 +2229,18 @@
         "acorn": "^8"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2267,13 +2279,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2910,6 +2923,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iceberg-js": {
@@ -4375,9 +4401,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/apps/trendingrepo-worker/src/fetchers/_editorial/__tests__/run.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/_editorial/__tests__/run.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FetcherContext } from '../../../lib/types.js';
+
+const readDataStore = vi.fn();
+const writeDataStore = vi.fn();
+
+vi.mock('../../../lib/redis.js', () => ({
+  readDataStore,
+  writeDataStore,
+}));
+
+vi.mock('../../../lib/llm/router.js', () => ({
+  callLlm: vi.fn(),
+  getLlmProvider: () => 'template',
+  isLlmConfigured: () => true,
+}));
+
+const { runEditorial } = await import('../run.js');
+
+function ctx(): FetcherContext {
+  return {
+    db: {} as FetcherContext['db'],
+    redis: {} as FetcherContext['redis'],
+    http: {} as FetcherContext['http'],
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as FetcherContext['log'],
+    dryRun: false,
+    since: new Date('2026-05-31T00:00:00.000Z'),
+    signalRunComplete: vi.fn(),
+  };
+}
+
+describe('runEditorial', () => {
+  beforeEach(() => {
+    readDataStore.mockReset();
+    writeDataStore.mockReset();
+  });
+
+  it('refreshes the data-store heartbeat when there are no new candidates', async () => {
+    readDataStore.mockResolvedValue({
+      computedAt: '2026-05-28T12:00:00.000Z',
+      generator: 'template',
+      items: {
+        'a__vs__b': {
+          slug: 'a__vs__b',
+          title: 'A vs B',
+          overview: 'Existing overview that should be retained without another LLM call.',
+        },
+      },
+    });
+    writeDataStore.mockResolvedValue({
+      source: 'redis',
+      writtenAt: '2026-05-31T12:00:00.000Z',
+    });
+
+    const result = await runEditorial(ctx(), {
+      slug: 'editorial-compare',
+      fetcherName: 'editorial-compare',
+      systemPrompt: 'system',
+      buildWorkItems: async () => [],
+      skipExisting: true,
+    });
+
+    expect(result.redisPublished).toBe(true);
+    expect(result.itemsSeen).toBe(1);
+    expect(writeDataStore).toHaveBeenCalledOnce();
+    expect(writeDataStore.mock.calls[0]?.[0]).toBe('editorial-compare');
+    expect(writeDataStore.mock.calls[0]?.[1]).toMatchObject({
+      generator: 'template',
+      items: {
+        'a__vs__b': {
+          slug: 'a__vs__b',
+          title: 'A vs B',
+        },
+      },
+    });
+    expect(writeDataStore.mock.calls[0]?.[1].computedAt).not.toBe(
+      '2026-05-28T12:00:00.000Z',
+    );
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/_editorial/run.ts
+++ b/apps/trendingrepo-worker/src/fetchers/_editorial/run.ts
@@ -89,7 +89,8 @@ export async function runEditorial(
     return done(opts.fetcherName, startedAt, 0, false);
   }
 
-  const existing = await loadExistingItems(opts.slug);
+  const existingPayload = await loadExistingPayload(opts.slug);
+  const existing = existingPayload.items;
 
   if (!isLlmConfigured()) {
     const retained = Object.keys(existing).length;
@@ -110,8 +111,22 @@ export async function runEditorial(
 
   if (candidates.length === 0) {
     const retained = Object.keys(existing).length;
-    ctx.log.info({ retainedItems: retained }, `${opts.fetcherName}: no new candidates this run`);
-    return done(opts.fetcherName, startedAt, retained, false);
+    if (retained === 0) {
+      ctx.log.info({ retainedItems: retained }, `${opts.fetcherName}: no new candidates this run`);
+      return done(opts.fetcherName, startedAt, retained, false);
+    }
+    const heartbeat: EditorialPayload = {
+      computedAt: new Date().toISOString(),
+      generator: existingPayload.generator,
+      ...(existingPayload.model ? { model: existingPayload.model } : {}),
+      items: existing,
+    };
+    const result = await writeDataStore(opts.slug, heartbeat);
+    ctx.log.info(
+      { retainedItems: retained, slug: opts.slug, redis: result.source },
+      `${opts.fetcherName}: no new candidates this run - heartbeat refreshed`,
+    );
+    return done(opts.fetcherName, startedAt, retained, result.source === 'redis');
   }
 
   const fresh: Record<string, EditorialItem> = {};
@@ -210,16 +225,20 @@ async function safeBuild(
   }
 }
 
-async function loadExistingItems(slug: string): Promise<Record<string, EditorialItem>> {
+async function loadExistingPayload(slug: string): Promise<EditorialPayload> {
   try {
     const existing = await readDataStore<EditorialPayload>(slug);
     if (existing && existing.items && typeof existing.items === 'object') {
-      return existing.items;
+      return existing;
     }
   } catch {
     /* fall through to empty */
   }
-  return {};
+  return {
+    computedAt: new Date(0).toISOString(),
+    generator: 'template',
+    items: {},
+  };
 }
 
 /** Strip a single pair of wrapping straight/smart quotes the model sometimes adds. */

--- a/apps/trendingrepo-worker/src/fetchers/x-funding/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/x-funding/index.ts
@@ -353,22 +353,12 @@ const fetcher: Fetcher = {
     const token = process.env.APIFY_API_TOKEN?.trim();
 
     if (!token) {
-      // No Apify credentials → publish an empty payload so the slug exists
-      // and downstream readers see a fresh `fetchedAt` without falling back
-      // to the "missing" tier.
-      const payload: FundingNewsXPayload = {
-        fetchedAt: discoveredAt,
-        source: 'x-funding-hashtags',
-        windowDays: WINDOW_DAYS,
-        signals: [],
-        requiresApifyToken: true,
-      };
-      const result = await writeDataStore('funding-news-x', payload);
+      // No Apify credentials: skip the collector.
+      // Do not publish a fresh empty payload; stale/missing data must stay visible.
       ctx.log.warn(
-        { redisSource: result.source },
-        'x-funding skipped: APIFY_API_TOKEN unset (slug published empty)',
+        'x-funding skipped: APIFY_API_TOKEN unset (no empty payload published)',
       );
-      return done(startedAt, 0, result.source === 'redis');
+      return done(startedAt, 0, false);
     }
 
     const allSignals: FundingSignal[] = [];

--- a/apps/trendingrepo-worker/src/platform/source-contract.ts
+++ b/apps/trendingrepo-worker/src/platform/source-contract.ts
@@ -76,13 +76,15 @@ export type CardinalitySource = 'watchlist' | 'static' | 'enum';
  * (e.g. {pattern: 'mcp-downloads:<package>', cardinality_source: 'watchlist'}).
  * One row per slug family — concrete-slug enumeration is a Move 3 concern.
  */
-export type PrimaryOutputKeys =
-  | string[]
-  | {
-      pattern: string;
-      index_key?: string;
-      cardinality_source: CardinalitySource;
-    };
+export interface PrimaryOutputPattern {
+  pattern: string;
+  index_key?: string;
+  cardinality_source: CardinalitySource;
+}
+
+export type PrimaryOutputKey = string | PrimaryOutputPattern;
+
+export type PrimaryOutputKeys = PrimaryOutputKey[] | PrimaryOutputPattern;
 
 export type OutputRecordShape =
   | 'ranked_list'

--- a/apps/trendingrepo-worker/src/platform/sources.json
+++ b/apps/trendingrepo-worker/src/platform/sources.json
@@ -395,7 +395,7 @@
     "id": "x-funding",
     "category": "funding",
     "kind": "collector",
-    "state": "active",
+    "state": "paused",
     "freshness_budget_ms": 86400000,
     "cost_signal_metric": {
       "type": "apify_units",
@@ -418,7 +418,8 @@
     "writes_canonical_entity_kind": [
       "company",
       "mention"
-    ]
+    ],
+    "decision_pending": "Paused on HOSTUP because the only producer path uses Apify, which is disabled by policy. Re-enable only with an approved non-empty producer and APIFY_API_TOKEN budget."
   },
   {
     "id": "trustmrr",
@@ -1726,6 +1727,10 @@
     "auth_required": true,
     "auth_scheme": "github_pat_pool",
     "primary_output_keys": [
+      {
+        "pattern": "star-activity:<owner>__<name>",
+        "cardinality_source": "watchlist"
+      },
       "star-activity-deltas"
     ],
     "output_record_shape": "metric_snapshot",
@@ -1777,6 +1782,366 @@
     "fallback_strategy": "cache",
     "writes_canonical_entity_kind": [
       "repo"
+    ]
+  },
+  {
+    "id": "star-activity-deltas",
+    "category": "repo-derived",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 86400000,
+    "cost_signal_metric": {
+      "type": "pat_quota_pct",
+      "scope": "hour"
+    },
+    "rate_limit": {
+      "per_hour": 5000,
+      "scope": "token"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "multiple",
+    "auth_required": true,
+    "auth_scheme": "github_pat_pool",
+    "primary_output_keys": [
+      "star-activity-deltas"
+    ],
+    "output_record_shape": "metric_snapshot",
+    "consumer_surfaces": [
+      "src/lib/star-activity-deltas.ts",
+      "src/app/page.tsx"
+    ],
+    "depends_on": [
+      "repo-registry",
+      "star-activity"
+    ],
+    "supports_backfill": true,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "repo"
+    ]
+  },
+  {
+    "id": "velocity-refresh",
+    "category": "repo-derived",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 3600000,
+    "cost_signal_metric": {
+      "type": "pat_quota_pct",
+      "scope": "hour"
+    },
+    "rate_limit": {
+      "per_hour": 5000,
+      "scope": "token"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://api.github.com/repos/{owner}/{repo}",
+    "auth_required": true,
+    "auth_scheme": "github_pat_pool",
+    "primary_output_keys": [
+      {
+        "pattern": "star-activity:<owner>__<name>",
+        "cardinality_source": "watchlist"
+      },
+      "star-activity-deltas"
+    ],
+    "output_record_shape": "metric_snapshot",
+    "consumer_surfaces": [
+      "src/lib/star-activity-deltas.ts",
+      "src/app/page.tsx"
+    ],
+    "depends_on": [
+      "repo-registry",
+      "star-activity-deltas"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "repo"
+    ]
+  },
+  {
+    "id": "velocity-seed",
+    "category": "repo-derived",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 86400000,
+    "cost_signal_metric": {
+      "type": "pat_quota_pct",
+      "scope": "day"
+    },
+    "rate_limit": {
+      "per_hour": 5000,
+      "scope": "token"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://api.github.com/graphql",
+    "auth_required": true,
+    "auth_scheme": "github_pat_pool",
+    "primary_output_keys": {
+      "pattern": "star-activity:<owner>__<name>",
+      "cardinality_source": "watchlist"
+    },
+    "output_record_shape": "metric_snapshot",
+    "consumer_surfaces": [
+      "src/lib/star-activity.ts",
+      "src/components/repo/RepoStarChart.tsx"
+    ],
+    "depends_on": [
+      "repo-registry"
+    ],
+    "supports_backfill": true,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "repo"
+    ]
+  },
+  {
+    "id": "stars-by-category",
+    "category": "repo-derived",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 86400000,
+    "cost_signal_metric": {
+      "type": "none"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "multiple",
+    "auth_required": false,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "stars-by-category-daily"
+    ],
+    "output_record_shape": "metric_snapshot",
+    "consumer_surfaces": [
+      "src/lib/stars-by-category.ts",
+      "src/app/page.tsx"
+    ],
+    "depends_on": [
+      "repo-registry",
+      "star-activity"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "repo"
+    ]
+  },
+  {
+    "id": "consensus-analyst-tail",
+    "category": "repo-derived",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 86400000,
+    "cost_signal_metric": {
+      "type": "usd",
+      "scope": "day"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "multiple",
+    "auth_required": true,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "consensus-verdicts"
+    ],
+    "output_record_shape": "extracted_signal",
+    "consumer_surfaces": [
+      "src/lib/consensus-verdicts.ts"
+    ],
+    "depends_on": [
+      "consensus-trending",
+      "repo-metadata",
+      "consensus-analyst"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "repo"
+    ]
+  },
+  {
+    "id": "cross-source-sweep",
+    "category": "social",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 86400000,
+    "cost_signal_metric": {
+      "type": "rate_limit_pct",
+      "scope": "day"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "multiple",
+    "auth_required": false,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "repo-mentions-detail-rollup"
+    ],
+    "output_record_shape": "mention_feed",
+    "consumer_surfaces": [
+      "src/lib/derived-repos/decorators/mentions-rollup.ts",
+      "src/lib/mentions-ledger.ts"
+    ],
+    "depends_on": [
+      "consensus-trending",
+      "repo-registry",
+      "mentions-ledger"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "mention"
+    ]
+  },
+  {
+    "id": "drop-deep-enrich-drain",
+    "category": "user-input",
+    "kind": "enrichment",
+    "state": "active",
+    "freshness_budget_ms": 600000,
+    "cost_signal_metric": {
+      "type": "none"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://trendingrepo.com/api/repo-submissions/[id]/enrich",
+    "auth_required": true,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      {
+        "pattern": "repo-community:<owner>__<name>",
+        "cardinality_source": "watchlist"
+      },
+      {
+        "pattern": "repo-editorial:<owner>__<name>",
+        "cardinality_source": "watchlist"
+      }
+    ],
+    "output_record_shape": "extracted_signal",
+    "consumer_surfaces": [
+      "apps/trendingrepo-worker/src/fetchers/drop-deep-enrich-drain/index.ts",
+      "src/app/api/repo-submissions/[id]/enrich/route.ts"
+    ],
+    "depends_on": [
+      "drop-intake-drain"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "none",
+    "writes_canonical_entity_kind": [
+      "repo",
+      "mention"
+    ]
+  },
+  {
+    "id": "artificialanalysis",
+    "category": "model",
+    "kind": "collector",
+    "state": "active",
+    "freshness_budget_ms": 21600000,
+    "cost_signal_metric": {
+      "type": "rate_limit_pct",
+      "scope": "hour"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://artificialanalysis.ai",
+    "auth_required": false,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "aa-llms"
+    ],
+    "output_record_shape": "ranked_list",
+    "consumer_surfaces": [
+      "src/lib/aa-llms.ts"
+    ],
+    "depends_on": [],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "model"
+    ]
+  },
+  {
+    "id": "lmarena",
+    "category": "model",
+    "kind": "collector",
+    "state": "active",
+    "freshness_budget_ms": 604800000,
+    "cost_signal_metric": {
+      "type": "none",
+      "scope": "day"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://lmarena.ai",
+    "auth_required": false,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "lmarena-text"
+    ],
+    "output_record_shape": "ranked_list",
+    "consumer_surfaces": [
+      "src/lib/aa-llms.ts"
+    ],
+    "depends_on": [],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "model"
+    ]
+  },
+  {
+    "id": "openrouter-models",
+    "category": "model",
+    "kind": "collector",
+    "state": "active",
+    "freshness_budget_ms": 21600000,
+    "cost_signal_metric": {
+      "type": "rate_limit_pct",
+      "scope": "hour"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://openrouter.ai/api/v1/models",
+    "auth_required": false,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "openrouter-models"
+    ],
+    "output_record_shape": "ranked_list",
+    "consumer_surfaces": [
+      "src/lib/openrouter-models.ts"
+    ],
+    "depends_on": [],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "model"
+    ]
+  },
+  {
+    "id": "openrouter-usage",
+    "category": "model",
+    "kind": "collector",
+    "state": "active",
+    "freshness_budget_ms": 21600000,
+    "cost_signal_metric": {
+      "type": "rate_limit_pct",
+      "scope": "hour"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://openrouter.ai/rankings",
+    "auth_required": false,
+    "auth_scheme": "none",
+    "primary_output_keys": [
+      "openrouter-usage"
+    ],
+    "output_record_shape": "metric_snapshot",
+    "consumer_surfaces": [
+      "src/lib/openrouter-usage.ts"
+    ],
+    "depends_on": [
+      "openrouter-models"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "cache",
+    "writes_canonical_entity_kind": [
+      "model"
     ]
   },
   {

--- a/apps/trendingrepo-worker/src/registry.ts
+++ b/apps/trendingrepo-worker/src/registry.ts
@@ -16,7 +16,6 @@ import repoMetadata from './fetchers/repo-metadata/index.js';
 import npmPackages from './fetchers/npm-packages/index.js';
 import crunchbase from './fetchers/crunchbase/index.js';
 import fundingNews from './fetchers/funding-news/index.js';
-import xFunding from './fetchers/x-funding/index.js';
 import trustmrr from './fetchers/trustmrr/index.js';
 import revenueBenchmarks from './fetchers/revenue-benchmarks/index.js';
 // Live Reddit collection is intentionally paused until the operator provisions
@@ -167,7 +166,6 @@ export const FETCHERS: Fetcher[] = [
   npmPackages,
   fundingNews,
   crunchbase,
-  xFunding,
   trustmrr,
   revenueBenchmarks,
   redditBaselines,

--- a/apps/trendingrepo-worker/tests/registry.test.ts
+++ b/apps/trendingrepo-worker/tests/registry.test.ts
@@ -1,7 +1,54 @@
 import { describe, expect, it } from 'vitest';
 import { SOURCE_CONTRACTS, getFetcher, listFetcherNames } from '../src/registry.js';
+import type { PrimaryOutputKey, SourceContract } from '../src/platform/source-contract.js';
+
+function primaryOutputKeys(source: SourceContract): string[] {
+  const raw = source.primary_output_keys;
+  const items: PrimaryOutputKey[] = Array.isArray(raw) ? raw : [raw];
+  return items.map((item) => (typeof item === 'string' ? item : item.pattern));
+}
 
 describe('worker registry', () => {
+  it('has unique SourceContract ids', () => {
+    const ids = SOURCE_CONTRACTS.map((source) => source.id);
+    const duplicateIds = ids
+      .filter((id, index) => ids.indexOf(id) !== index)
+      .sort();
+
+    expect(duplicateIds).toEqual([]);
+  });
+
+  it('has a SourceContract for every registered fetcher', () => {
+    const contracts = new Set(SOURCE_CONTRACTS.map((source) => source.id));
+    const missing = listFetcherNames().filter((name) => !contracts.has(name)).sort();
+
+    expect(missing).toEqual([]);
+  });
+
+  it('records dynamic output families for multi-output fetchers', () => {
+    const velocityBackfill = SOURCE_CONTRACTS.find((source) => source.id === 'velocity-backfill');
+    const velocityRefresh = SOURCE_CONTRACTS.find((source) => source.id === 'velocity-refresh');
+    const dropDeepEnrich = SOURCE_CONTRACTS.find(
+      (source) => source.id === 'drop-deep-enrich-drain',
+    );
+
+    expect(velocityBackfill).toBeTruthy();
+    expect(primaryOutputKeys(velocityBackfill!)).toEqual([
+      'star-activity:<owner>__<name>',
+      'star-activity-deltas',
+    ]);
+    expect(velocityRefresh).toBeTruthy();
+    expect(primaryOutputKeys(velocityRefresh!)).toEqual([
+      'star-activity:<owner>__<name>',
+      'star-activity-deltas',
+    ]);
+    expect(dropDeepEnrich).toBeTruthy();
+    expect(primaryOutputKeys(dropDeepEnrich!)).toEqual([
+      'repo-community:<owner>__<name>',
+      'repo-editorial:<owner>__<name>',
+    ]);
+  });
+
   it('schedules the engagement-composite fetcher consumed by the public API', () => {
     expect(listFetcherNames()).toContain('engagement-composite');
     expect(getFetcher('engagement-composite')?.schedule).toBe('45 * * * *');
@@ -25,6 +72,17 @@ describe('worker registry', () => {
       auth_required: true,
       auth_scheme: 'reddit_oauth_client_credentials',
       primary_output_keys: ['reddit-mentions', 'reddit-all-posts'],
+    });
+  });
+
+  it('keeps Apify-only x-funding paused until an approved non-empty producer exists', () => {
+    expect(listFetcherNames()).not.toContain('x-funding');
+    expect(getFetcher('x-funding')).toBeUndefined();
+    expect(SOURCE_CONTRACTS.find((source) => source.id === 'x-funding')).toMatchObject({
+      state: 'paused',
+      auth_required: true,
+      auth_scheme: 'apify_token',
+      primary_output_keys: ['funding-news-x'],
     });
   });
 });

--- a/scripts/check-live-production-health.mjs
+++ b/scripts/check-live-production-health.mjs
@@ -42,28 +42,34 @@ function fail(message, context = {}) {
 
 function summarizeWorker(body) {
   const summary = body?.summary ?? {};
-  const blocking = Array.isArray(body?.slugs)
+  const nonGreen = Array.isArray(body?.slugs)
     ? body.slugs.filter(
-        (s) => s?.blocking === true && (s.status === "red" || s.status === "missing"),
+        (s) => s?.status && s.status !== "green",
       )
     : [];
-  const advisory = Array.isArray(body?.slugs)
+  const degraded = Array.isArray(body?.slugs)
     ? body.slugs.filter(
-        (s) => s?.blocking === false && (s.status === "red" || s.status === "missing"),
+        (s) => s?.payloadStatus === "degraded" || s?.payloadRowCount === 0,
       )
     : [];
   return {
     ok: body?.ok,
     summary,
-    blockingProblems: blocking.map((s) => ({
+    nonGreenSlugs: nonGreen.map((s) => ({
       slug: s.slug,
       fetcher: s.fetcher,
       status: s.status,
+      blocking: s.blocking,
       ageSec: s.ageSec,
       writtenAt: s.writtenAt,
+      payloadStatus: s.payloadStatus ?? null,
+      payloadRowCount: s.payloadRowCount ?? null,
     })),
-    advisoryRedCount: advisory.length,
-    advisoryRedSlugs: advisory.map((s) => s.slug).sort(),
+    degradedPayloadSlugs: degraded.map((s) => ({
+      slug: s.slug,
+      payloadStatus: s.payloadStatus ?? null,
+      payloadRowCount: s.payloadRowCount ?? null,
+    })),
   };
 }
 
@@ -120,8 +126,13 @@ async function main() {
     fail("/api/health is not fresh", appHealth.body);
   }
 
-  if (!workerHealth.okStatus || workerHealth.body?.ok !== true) {
-    fail("/api/worker/health is not ok", {
+  if (
+    !workerHealth.okStatus ||
+    workerHealth.body?.ok !== true ||
+    workerSummary.nonGreenSlugs.length > 0 ||
+    workerSummary.degradedPayloadSlugs.length > 0
+  ) {
+    fail("/api/worker/health is not zero-tolerance green", {
       http: workerHealth.status,
       ...workerSummary,
     });
@@ -138,7 +149,7 @@ async function main() {
   }
 
   if (process.exitCode) return;
-  console.log("\nPASS - live production health is green for blocking checks.");
+  console.log("\nPASS - live production health is zero-tolerance green.");
 }
 
 main().catch((err) => {

--- a/src/app/api/worker/health/route.ts
+++ b/src/app/api/worker/health/route.ts
@@ -15,6 +15,7 @@ import {
 import {
   applyPayloadHealthToSlugStatus,
   decodeWorkerPayloadFromStore,
+  isWorkerHealthStrictlyOk,
   summarizeWorkerPayloadHealth,
   type WorkerPayloadHealth,
 } from "@/lib/worker-health-payload";
@@ -54,6 +55,19 @@ const PAYLOAD_HEALTH_SLUGS = new Set([
   "trending",
   "hot-collections",
   "collection-rankings",
+  "funding-news",
+  "funding-news-crunchbase",
+  "consensus-verdicts",
+  "devto-mentions",
+  "devto-trending",
+  "twitter-repo-signals",
+  "repo-registry",
+  "mentions-ledger",
+  "star-activity-deltas",
+  "editorial-best",
+  "editorial-categories",
+  "editorial-compare",
+  "editorial-alternatives",
 ]);
 
 type SlugStatus = "green" | "amber" | "red" | "missing";
@@ -148,7 +162,14 @@ async function readRedisPayloadHealth(
   if (!redis || !PAYLOAD_HEALTH_SLUGS.has(slug)) return null;
   try {
     const raw = await redis.get(dataStorePayloadKey(slug));
-    if (!raw) return null;
+    if (!raw) {
+      return {
+        payloadStatus: null,
+        dataAsOf: null,
+        errorCount: null,
+        rowCount: 0,
+      };
+    }
     return summarizeWorkerPayloadHealth(
       slug,
       decodeWorkerPayloadFromStore(raw),
@@ -242,7 +263,7 @@ export async function GET(
     return a.slug.localeCompare(b.slug);
   });
 
-  const ok = summary.blockingRed === 0 && summary.blockingMissing === 0;
+  const ok = isWorkerHealthStrictlyOk(summary);
 
   return NextResponse.json(
     {

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../worker-health-specs";
 import {
   applyPayloadHealthToSlugStatus,
+  isWorkerHealthStrictlyOk,
   summarizeWorkerPayloadHealth,
 } from "../../worker-health-payload";
 
@@ -18,7 +19,7 @@ test("/api/health: stale freshness remains HTTP 200 availability", () => {
   assert.equal(getHealthHttpStatusForStatus("error", true), 200);
 });
 
-test("/api/worker/health: advisory slugs do not block fleet availability", () => {
+test("/api/worker/health: advisory slugs remain labelled for triage", () => {
   const advisory = new Set([
     "hot-collections",
     "collection-rankings",
@@ -32,13 +33,52 @@ test("/api/worker/health: advisory slugs do not block fleet availability", () =>
   }
 });
 
-test("/api/worker/health: disabled legacy slugs stay visible but inactive", () => {
+test("/api/worker/health: fleet ok is zero-tolerance across active tracked slugs", () => {
+  const green = {
+    amber: 0,
+    red: 0,
+    missing: 0,
+    degradedPayload: 0,
+    emptyPayload: 0,
+  };
+
+  assert.equal(isWorkerHealthStrictlyOk(green), true);
+  assert.equal(isWorkerHealthStrictlyOk({ ...green, amber: 1 }), false);
+  assert.equal(isWorkerHealthStrictlyOk({ ...green, red: 1 }), false);
+  assert.equal(isWorkerHealthStrictlyOk({ ...green, missing: 1 }), false);
+  assert.equal(isWorkerHealthStrictlyOk({ ...green, degradedPayload: 1 }), false);
+  assert.equal(isWorkerHealthStrictlyOk({ ...green, emptyPayload: 1 }), false);
+});
+
+test("/api/worker/health: critical concrete worker outputs are tracked", () => {
+  const active = new Set(WORKER_HEALTH_SPECS.map((item) => item.slug));
+
+  for (const slug of [
+    "funding-news-crunchbase",
+    "consensus-verdicts",
+    "devto-mentions",
+    "devto-trending",
+    "twitter-repo-signals",
+    "repo-registry",
+    "mentions-ledger",
+    "star-activity-deltas",
+    "editorial-best",
+    "editorial-categories",
+    "editorial-compare",
+    "editorial-alternatives",
+  ]) {
+    assert.equal(active.has(slug), true, `${slug} must be worker-health tracked`);
+  }
+});
+
+test("/api/worker/health: disabled slugs stay visible but inactive", () => {
   const disabled = new Set(WORKER_HEALTH_DISABLED_SPECS.map((item) => item.slug));
   const active = new Set(WORKER_HEALTH_SPECS.map((item) => item.slug));
 
   for (const slug of [
     "reddit-mentions",
     "reddit-all-posts",
+    "funding-news-x",
     "github-events:_index",
     "huggingface-trending",
     "trending-mcp",
@@ -84,9 +124,18 @@ test("/api/worker/health: degraded payloads are not reported as pure green", () 
     }),
     "red",
   );
+  assert.equal(
+    applyPayloadHealthToSlugStatus("green", {
+      payloadStatus: "ok",
+      dataAsOf: null,
+      errorCount: null,
+      rowCount: null,
+    }),
+    "red",
+  );
 });
 
-test("/api/worker/health: payload row-quality summary covers OSSInsight slugs", () => {
+test("/api/worker/health: payload row-quality summary covers tracked slugs", () => {
   assert.deepEqual(
     summarizeWorkerPayloadHealth("trending", {
       status: "degraded",
@@ -116,5 +165,61 @@ test("/api/worker/health: payload row-quality summary covers OSSInsight slugs", 
       },
     }).rowCount,
     1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("funding-news-crunchbase", {
+      fetchedAt: "2026-05-31T20:00:00.000Z",
+      signals: [{ company: "Acme" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("consensus-verdicts", {
+      computedAt: "2026-05-31T20:00:00.000Z",
+      items: { "owner/repo": { verdict: "up" } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("devto-mentions", {
+      mentions: { "owner/repo": [{ title: "Post" }] },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("devto-trending", {
+      articles: [{ title: "Post" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("twitter-repo-signals", {
+      posts: [{ id: "1" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("repo-registry", {
+      repos: { "owner/repo": { stars: 1 } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("mentions-ledger", {
+      entries: [{ repoFullName: "owner/repo" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("editorial-compare", {
+      items: { "a__vs__b": { summary: "A vs B" } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("devto-trending", {
+      wrongShape: [],
+    }).rowCount,
+    null,
   );
 });

--- a/src/lib/worker-health-payload.ts
+++ b/src/lib/worker-health-payload.ts
@@ -7,6 +7,14 @@ const GZIP_MAGIC_PREFIX = "gz1:";
 export type WorkerPayloadStatus = "ok" | "degraded" | null;
 export type WorkerSlugStatus = "green" | "amber" | "red" | "missing";
 
+export interface WorkerHealthStrictSummary {
+  amber: number;
+  red: number;
+  missing: number;
+  degradedPayload: number;
+  emptyPayload: number;
+}
+
 export interface WorkerPayloadHealth {
   payloadStatus: WorkerPayloadStatus;
   dataAsOf: string | null;
@@ -29,6 +37,12 @@ export function decodeWorkerPayloadFromStore(raw: unknown): unknown {
 
 function countArrayRows(value: unknown): number | null {
   return Array.isArray(value) ? value.length : null;
+}
+
+function countObjectRows(value: unknown): number | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? Object.keys(value).length
+    : null;
 }
 
 function countTrendingRows(payload: unknown): number | null {
@@ -65,6 +79,35 @@ function countRows(slug: string, payload: unknown): number | null {
   if (slug === "collection-rankings") {
     return countCollectionRankingRows(payload);
   }
+  if (slug === "funding-news" || slug === "funding-news-crunchbase") {
+    return countArrayRows((payload as { signals?: unknown })?.signals);
+  }
+  if (slug === "consensus-verdicts") {
+    return countObjectRows((payload as { items?: unknown })?.items);
+  }
+  if (slug === "devto-mentions") {
+    return countObjectRows((payload as { mentions?: unknown })?.mentions);
+  }
+  if (slug === "devto-trending") {
+    return countArrayRows((payload as { articles?: unknown })?.articles);
+  }
+  if (slug === "twitter-repo-signals") {
+    return countArrayRows((payload as { posts?: unknown })?.posts);
+  }
+  if (slug === "repo-registry" || slug === "star-activity-deltas") {
+    return countObjectRows((payload as { repos?: unknown })?.repos);
+  }
+  if (slug === "mentions-ledger") {
+    return countArrayRows((payload as { entries?: unknown })?.entries);
+  }
+  if (
+    slug === "editorial-best" ||
+    slug === "editorial-categories" ||
+    slug === "editorial-compare" ||
+    slug === "editorial-alternatives"
+  ) {
+    return countObjectRows((payload as { items?: unknown })?.items);
+  }
   return null;
 }
 
@@ -82,7 +125,16 @@ export function summarizeWorkerPayloadHealth(
       envelope.status === "ok" || envelope.status === "degraded"
         ? envelope.status
         : null,
-    dataAsOf: typeof envelope.dataAsOf === "string" ? envelope.dataAsOf : null,
+    dataAsOf:
+      typeof envelope.dataAsOf === "string"
+        ? envelope.dataAsOf
+        : typeof (payload as { fetchedAt?: unknown }).fetchedAt === "string"
+          ? (payload as { fetchedAt: string }).fetchedAt
+          : typeof (payload as { computedAt?: unknown }).computedAt === "string"
+            ? (payload as { computedAt: string }).computedAt
+            : typeof (payload as { writtenAt?: unknown }).writtenAt === "string"
+              ? (payload as { writtenAt: string }).writtenAt
+              : null,
     errorCount: Array.isArray(envelope.errors) ? envelope.errors.length : null,
     rowCount: countRows(slug, payload),
   };
@@ -93,9 +145,21 @@ export function applyPayloadHealthToSlugStatus(
   payloadHealth: WorkerPayloadHealth | null,
 ): WorkerSlugStatus {
   if (!payloadHealth) return status;
-  if (payloadHealth.rowCount === 0) return "red";
+  if (payloadHealth.rowCount === null || payloadHealth.rowCount === 0) return "red";
   if (payloadHealth.payloadStatus === "degraded" && status === "green") {
     return "amber";
   }
   return status;
+}
+
+export function isWorkerHealthStrictlyOk(
+  summary: WorkerHealthStrictSummary,
+): boolean {
+  return (
+    summary.amber === 0 &&
+    summary.red === 0 &&
+    summary.missing === 0 &&
+    summary.degradedPayload === 0 &&
+    summary.emptyPayload === 0
+  );
 }

--- a/src/lib/worker-health-specs.ts
+++ b/src/lib/worker-health-specs.ts
@@ -5,9 +5,9 @@ export interface SlugHealthSpec {
   /** True if this slug is allowed to lag without raising an alert (e.g. weekly). */
   slowMoving?: boolean;
   /**
-   * Advisory slugs are useful diagnostics but do not make the fleet unhealthy.
-   * They are either credential-dependent catalogs, third-party mirrors, or
-   * non-critical enrichment feeds.
+   * Triage label retained in the response for operator context. The fleet
+   * health result is zero-tolerance across every active tracked slug; optional
+   * or intentionally paused producers belong in WORKER_HEALTH_DISABLED_SPECS.
    */
   blocking?: boolean;
 }
@@ -44,8 +44,20 @@ export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
 
   // few-hours cadence
   { slug: "producthunt-launches", fetcher: "producthunt", cadenceMin: 360, blocking: false },
-  { slug: "funding-news", fetcher: "funding-news", cadenceMin: 360 },
+  { slug: "funding-news", fetcher: "funding-news", cadenceMin: 720 },
   { slug: "collection-rankings", fetcher: "collection-rankings", cadenceMin: 360, blocking: false },
+  { slug: "funding-news-crunchbase", fetcher: "crunchbase", cadenceMin: 720 },
+  { slug: "consensus-verdicts", fetcher: "consensus-analyst", cadenceMin: 60 },
+  { slug: "devto-mentions", fetcher: "devto", cadenceMin: 720 },
+  { slug: "devto-trending", fetcher: "devto", cadenceMin: 720 },
+  { slug: "twitter-repo-signals", fetcher: "twitter", cadenceMin: 60 },
+  { slug: "repo-registry", fetcher: "repo-registry", cadenceMin: 60 },
+  { slug: "mentions-ledger", fetcher: "mentions-ledger", cadenceMin: 30 },
+  { slug: "star-activity-deltas", fetcher: "star-activity-deltas", cadenceMin: 180 },
+  { slug: "editorial-best", fetcher: "editorial-writer", cadenceMin: 60 * 24 },
+  { slug: "editorial-categories", fetcher: "editorial-categories", cadenceMin: 60 * 24 },
+  { slug: "editorial-compare", fetcher: "editorial-compare", cadenceMin: 60 * 24 },
+  { slug: "editorial-alternatives", fetcher: "editorial-alternatives", cadenceMin: 60 * 24 },
 
   // daily - operator-curated mirrors + once-a-day enrichment
   { slug: "manual-repos", fetcher: "manual-repos", cadenceMin: 60 * 24 },
@@ -72,6 +84,12 @@ export const WORKER_HEALTH_DISABLED_SPECS: ReadonlyArray<DisabledSlugHealthSpec>
     fetcher: "reddit",
     reason:
       "live Reddit collector is intentionally paused on HOSTUP; do not treat the stale historical all-posts slug as worker-owned",
+  },
+  {
+    slug: "funding-news-x",
+    fetcher: "x-funding",
+    reason:
+      "x-funding is intentionally paused on HOSTUP because the only producer path uses Apify and must not publish empty freshness payloads",
   },
   {
     slug: "github-events:_index",


### PR DESCRIPTION
## Summary
- makes `/api/worker/health` zero-tolerance for every active tracked slug, including amber, red, missing, degraded payload, empty payload, missing payload, and malformed row shape
- expands active worker health coverage to the Redis outputs that were previously invisible, while keeping Reddit and Apify-only `funding-news-x` explicitly disabled
- adds source contracts for registered fetchers, dynamic output-family contracts, and registry tests so worker fetchers cannot silently ship without a contract
- refreshes editorial payload heartbeats when daily LLM editorial runs skip existing work, so unchanged-but-valid editorial outputs do not drift stale
- updates the worker lockfile to clear high-severity audit findings; remaining worker audit findings are moderate Vitest/Vite/esbuild and require a breaking upgrade

## Validation
- `npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/health-availability.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint:guards`
- `npm run build`
- `npm test`
- `npm --prefix apps/trendingrepo-worker run typecheck -- --pretty false`
- `npm --prefix apps/trendingrepo-worker run build`
- `npm --prefix apps/trendingrepo-worker run test`
- `npm audit --audit-level=high`
- `npm --prefix apps/trendingrepo-worker audit --audit-level=high`
- `git diff --cached --check`