### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T18:48:33Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-31T16:43:53.803Z",
+  "ts": "2026-05-31T18:48:33.517Z",
   "count": 1,
-  "durationMs": 4315,
+  "durationMs": 11024,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T16:43:49.510Z",
+  "fetchedAt": "2026-05-31T18:48:22.512Z",
   "windowDays": 7,
-  "scannedStories": 78,
+  "scannedStories": 77,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T16:43:49.510Z",
+  "fetchedAt": "2026-05-31T18:48:22.512Z",
   "windowHours": 72,
-  "scannedTotal": 78,
+  "scannedTotal": 77,
   "stories": [
     {
       "shortId": "t1spjc",
@@ -492,6 +492,23 @@
       "linkedRepos": []
     },
     {
+      "shortId": "2balua",
+      "title": "Unlawful by design: Exposing the human rights costs of generative AI",
+      "url": "https://www.amnesty.org/en/documents/pol40/0996/2026/en/",
+      "commentsUrl": "https://lobste.rs/s/2balua/unlawful_by_design_exposing_human_rights",
+      "by": "",
+      "score": 11,
+      "commentCount": 2,
+      "createdUtc": 1780247917,
+      "ageHours": 1.4958333333333333,
+      "trendingScore": 1.6829321476916759,
+      "tags": [
+        "vibecoding"
+      ],
+      "description": "",
+      "linkedRepos": []
+    },
+    {
       "shortId": "4jgpkn",
       "title": "Announcing Rust 1.96.0",
       "url": "https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/",
@@ -865,24 +882,6 @@
       "trendingScore": 1.269406930280126,
       "tags": [
         "concatenative",
-        "web"
-      ],
-      "description": "",
-      "linkedRepos": []
-    },
-    {
-      "shortId": "nkrgmr",
-      "title": "JS Crossword - a crossword where the clue = eval(answer)",
-      "url": "https://lyra.horse/fun/jscrossword/",
-      "commentsUrl": "https://lobste.rs/s/nkrgmr/js_crossword_crossword_where_clue_eval",
-      "by": "",
-      "score": 10,
-      "commentCount": 1,
-      "createdUtc": 1779665892,
-      "ageHours": 1.9725,
-      "trendingScore": 1.2630022992716048,
-      "tags": [
-        "javascript",
         "web"
       ],
       "description": "",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26721276361

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.