### PR TITLE
Harden runtime health gates

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Wait for deploy propagation
         run: sleep 30
 
-      - name: Synthetic curl checks (29 critical routes)
+      - name: Synthetic curl checks (critical routes)
         id: smoke
         shell: bash
         run: |
@@ -75,6 +75,8 @@ jobs:
             "/npm"
             "/breakouts"
             "/categories"
+            "/collections"
+            "/collections/ai-agent-frameworks"
             "/methodology"
             "/research"
             "/tools/revenue-estimate"
@@ -86,6 +88,12 @@ jobs:
             "/repo/anthropics/anthropic-cookbook"
             # health probe
             "/api/health?soft=1"
+            # API surfaces that have historically lacked page-route coverage
+            "/api/collections"
+            "/api/collections/ai-agent-frameworks"
+            "/api/model-usage/overview"
+            "/api/model-usage/models"
+            "/api/model-usage/rankings"
           )
 
           # Pass 1: probe every route, collect page-route failures into

--- a/scripts/check-live-production-health.mjs
+++ b/scripts/check-live-production-health.mjs
@@ -32,6 +32,21 @@ async function fetchJson(path, okStatuses = [200]) {
   };
 }
 
+async function fetchRoute(path, okStatuses = [200]) {
+  const url = `${BASE_URL}${path}`;
+  const res = await fetch(url, {
+    headers: { Accept: "text/html,application/json" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  return {
+    path,
+    url,
+    status: res.status,
+    okStatus: okStatuses.includes(res.status),
+    contentType: res.headers.get("content-type") ?? null,
+  };
+}
+
 function fail(message, context = {}) {
   console.error(`FAIL: ${message}`);
   if (Object.keys(context).length > 0) {
@@ -77,11 +92,22 @@ async function main() {
   console.log(`# Live production health - ${new Date().toISOString()}`);
   console.log(`base=${BASE_URL}`);
 
-  const [appHealth, workerHealth, sourceHealth, adminOverview] = await Promise.all([
+  const [appHealth, workerHealth, workerPulse, sourceHealth, adminOverview] = await Promise.all([
     fetchJson("/api/health"),
     fetchJson("/api/worker/health"),
+    fetchJson("/api/worker/pulse"),
     fetchJson("/api/health/sources", [200, 207]),
     fetchJson("/api/admin/overview", [401]),
+  ]);
+  const criticalRoutes = await Promise.all([
+    fetchRoute("/collections"),
+    fetchRoute("/collections/ai-agent-frameworks"),
+    fetchRoute("/api/collections"),
+    fetchRoute("/api/collections/ai-agent-frameworks"),
+    fetchRoute("/api/model-usage/overview"),
+    fetchRoute("/api/model-usage/models"),
+    fetchRoute("/api/model-usage/rankings"),
+    fetchRoute("/api/model-usage/features", [401]),
   ]);
 
   console.log("\n/api/health");
@@ -104,6 +130,23 @@ async function main() {
   console.log("\n/api/worker/health");
   const workerSummary = summarizeWorker(workerHealth.body);
   console.log(JSON.stringify({ http: workerHealth.status, ...workerSummary }, null, 2));
+
+  console.log("\n/api/worker/pulse");
+  console.log(
+    JSON.stringify(
+      {
+        http: workerPulse.status,
+        ok: workerPulse.body?.ok,
+        source: workerPulse.body?.source,
+        fresh: workerPulse.body?.fresh,
+        writtenAt: workerPulse.body?.writtenAt,
+        ageSeconds: workerPulse.body?.ageSeconds,
+        stories: workerPulse.body?.stories,
+      },
+      null,
+      2,
+    ),
+  );
 
   console.log("\n/api/health/sources");
   console.log(
@@ -129,6 +172,19 @@ async function main() {
     ),
   );
 
+  console.log("\ncritical route coverage");
+  console.log(
+    JSON.stringify(
+      criticalRoutes.map((route) => ({
+        path: route.path,
+        http: route.status,
+        contentType: route.contentType,
+      })),
+      null,
+      2,
+    ),
+  );
+
   if (!appHealth.okStatus) {
     fail("/api/health returned non-200", {
       http: appHealth.status,
@@ -137,6 +193,9 @@ async function main() {
   }
   if (appHealth.body?.status !== "ok" || appHealth.body?.error) {
     fail("/api/health is not fresh", appHealth.body);
+  }
+  if (appHealth.body?.sourceStatus && appHealth.body.sourceStatus !== "ok") {
+    fail("/api/health reports degraded source status", appHealth.body);
   }
 
   if (
@@ -148,6 +207,20 @@ async function main() {
     fail("/api/worker/health is not zero-tolerance green", {
       http: workerHealth.status,
       ...workerSummary,
+    });
+  }
+
+  if (
+    !workerPulse.okStatus ||
+    workerPulse.body?.ok !== true ||
+    workerPulse.body?.source !== "redis" ||
+    workerPulse.body?.fresh !== true ||
+    !(workerPulse.body?.stories > 0)
+  ) {
+    fail("/api/worker/pulse is not proving Redis-backed scheduler freshness", {
+      http: workerPulse.status,
+      body: workerPulse.body,
+      expected: "200 ok with source=redis, fresh=true, stories>0",
     });
   }
 
@@ -170,6 +243,17 @@ async function main() {
       body: adminOverview.body,
       expected:
         "401 unauthorized. 503 means ADMIN_TOKEN is missing; 200 means admin is public.",
+    });
+  }
+
+  const failedCriticalRoutes = criticalRoutes.filter((route) => !route.okStatus);
+  if (failedCriticalRoutes.length > 0) {
+    fail("critical route coverage failed", {
+      routes: failedCriticalRoutes.map((route) => ({
+        path: route.path,
+        http: route.status,
+        expected: route.path === "/api/model-usage/features" ? [401] : [200],
+      })),
     });
   }
 

--- a/src/app/agent-commerce/page.tsx
+++ b/src/app/agent-commerce/page.tsx
@@ -1,7 +1,7 @@
 // /agent-commerce — Agent Commerce M2M cockpit (Phase 2C).
 //
 // Reads:
-//   - getAgentCommerceItems() + getAgentCommerceStats() — items + counts
+//   - getAgentCommerceStats() — item counts
 //   - getBaseX402Onchain() / getSolanaX402Onchain() — facilitator + tx counts
 //   - getDuneX402Volume() — historical USD volume per facilitator/day
 //   - getAgentCommerceFetchedAt() — freshness pill
@@ -12,7 +12,6 @@
 
 import {
   refreshAgentCommerceFromStore,
-  getAgentCommerceItems,
   getAgentCommerceStats,
   getAgentCommerceFetchedAt,
 } from "@/lib/agent-commerce";
@@ -149,7 +148,6 @@ export default async function AgentCommercePage({ searchParams }: Props) {
     })),
   ]);
 
-  const items = safe(() => getAgentCommerceItems(), []);
   const stats = safe(() => getAgentCommerceStats(), {
     totalItems: 0,
     byKind: {} as Record<string, number>,
@@ -204,8 +202,6 @@ export default async function AgentCommercePage({ searchParams }: Props) {
   // degraded — show 0 degraded and let the operator see the honest signal.
   const mcpHealthy = mcpServers;
   const mcpDegraded = 0;
-  const a2aCount = stats.byProtocol["a2a"] ?? 0;
-
   // Token tables are now driven by live CoinGecko data (no SEED_TOKENS).
   const gainers = getTokenRows(agentTokens, "gainers", 5);
   const losers = getTokenRows(agentTokens, "losers", 3);

--- a/src/app/api/build/timeline/route.ts
+++ b/src/app/api/build/timeline/route.ts
@@ -7,7 +7,7 @@
 // let the idea claimer publish a build-event row attached to a claimed
 // idea. Backed by a new src/lib/build-timeline.ts JSONL store.
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
 import { requireUser } from "@/lib/auth/server";
 
@@ -20,9 +20,7 @@ interface NotImplementedResponse {
   code: "NOT_IMPLEMENTED";
 }
 
-export async function GET(
-  _request: NextRequest,
-): Promise<NextResponse<NotImplementedResponse>> {
+export async function GET(): Promise<NextResponse<NotImplementedResponse>> {
   return NextResponse.json(
     {
       ok: false,
@@ -33,9 +31,7 @@ export async function GET(
   );
 }
 
-export async function POST(
-  _request: NextRequest,
-): Promise<NextResponse<NotImplementedResponse>> {
+export async function POST(): Promise<NextResponse<NotImplementedResponse>> {
   await requireUser();
 
   return NextResponse.json(

--- a/src/app/api/og/top10/route.tsx
+++ b/src/app/api/og/top10/route.tsx
@@ -122,24 +122,6 @@ function hexToRgba(hex: string, alpha: number): string {
 // and the OG card share one source of truth (round 1 ate a "49k vs 49.5k"
 // regression because they had drifted inline copies).
 
-// SVG card returned when no snapshot exists for the requested past date.
-// Renders as the same dimensions as the live PNG so the X unfurl crop is
-// consistent; tells the receiver honestly that history isn't filled yet.
-function buildEmptySvg(
-  width: number,
-  height: number,
-  theme: Theme,
-  date: string,
-): string {
-  const c = THEMES[theme];
-  const padX = Math.round(width * 0.06);
-  const titleSize = Math.round(height * 0.06);
-  const bodySize = Math.round(height * 0.025);
-  const eyebrowSize = Math.round(height * 0.020);
-  const titleY = height * 0.4;
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"><rect width="${width}" height="${height}" fill="${c.bg}"/><text x="${padX}" y="${height * 0.18}" font-family="ui-monospace,monospace" font-size="${eyebrowSize}" fill="${c.textTertiary}" letter-spacing="2">// TRENDINGREPO · TOP 10 · NO SNAPSHOT</text><text x="${padX}" y="${titleY}" font-family="ui-sans-serif,system-ui,sans-serif" font-size="${titleSize}" fill="${c.textPrimary}" font-weight="700">No top 10 for ${escapeXml(date)}</text><text x="${padX}" y="${titleY + titleSize * 1.5}" font-family="ui-monospace,monospace" font-size="${bodySize}" fill="${c.textTertiary}">The daily snapshot cron starts baking at 23:55 UTC.</text><text x="${padX}" y="${titleY + titleSize * 1.5 + bodySize * 1.6}" font-family="ui-monospace,monospace" font-size="${bodySize}" fill="${c.textTertiary}">Pick a more recent date — or today's live top 10.</text><rect x="0" y="${height - 6}" width="${width}" height="6" fill="${c.accentStrip}"/></svg>`;
-}
-
 // Build a normalized polyline points string for an inline sparkline SVG.
 // Returns "" for series < 2 points so the caller can skip rendering.
 function sparklinePolyline(

--- a/src/app/api/worker/health/route.ts
+++ b/src/app/api/worker/health/route.ts
@@ -52,8 +52,25 @@ const DISABLED_SLUG_TABLE = WORKER_HEALTH_DISABLED_SPECS;
 const DATA_STORE_META_NAMESPACE = "ss:meta:v1";
 const DATA_STORE_PAYLOAD_NAMESPACE = "ss:data:v1";
 const PAYLOAD_HEALTH_SLUGS = new Set([
+  "hn-pulse",
   "trending",
   "hot-collections",
+  "recent-repos",
+  "deltas",
+  "repo-metadata",
+  "repo-profiles",
+  "trendshift-daily",
+  "engagement-composite",
+  "consensus-trending",
+  "trustmrr-startups",
+  "revenue-overlays",
+  "hackernews-trending",
+  "hackernews-repo-mentions",
+  "bluesky-trending",
+  "bluesky-mentions",
+  "lobsters-trending",
+  "lobsters-mentions",
+  "producthunt-launches",
   "collection-rankings",
   "funding-news",
   "funding-news-crunchbase",
@@ -68,6 +85,10 @@ const PAYLOAD_HEALTH_SLUGS = new Set([
   "editorial-categories",
   "editorial-compare",
   "editorial-alternatives",
+  "manual-repos",
+  "npm-packages",
+  "reddit-baselines",
+  "revenue-benchmarks",
 ]);
 
 type SlugStatus = "green" | "amber" | "red" | "missing";

--- a/src/app/api/worker/pulse/route.ts
+++ b/src/app/api/worker/pulse/route.ts
@@ -46,14 +46,19 @@ export async function GET() {
 
   const ageSeconds = Math.round(result.ageMs / 1000);
   const stale = ageSeconds > STALE_AFTER_SECONDS;
+  const redisFresh = result.source === "redis" && result.fresh === true;
+  const hasStories =
+    result.data.windowItems > 0 && Array.isArray(result.data.stories) && result.data.stories.length > 0;
+  const ok = !stale && redisFresh && hasStories;
 
   return NextResponse.json(
     {
-      ok: !stale,
+      ok,
       source: result.source,
       fresh: result.fresh,
       writtenAt: result.writtenAt ?? null,
       ageSeconds,
+      stale,
       stories: result.data.windowItems,
       sample: result.data.stories.slice(0, 3).map((s) => ({
         id: s.id,
@@ -62,6 +67,6 @@ export async function GET() {
         score: s.score,
       })),
     },
-    { status: stale ? 503 : 200 },
+    { status: ok ? 200 : 503 },
   );
 }

--- a/src/app/ideas/page.tsx
+++ b/src/app/ideas/page.tsx
@@ -392,7 +392,6 @@ export default async function IdeasBoardPage({ searchParams }: Props) {
       <IdeaBriefModal />
       <script
         type="application/ld+json"
-        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({
             "@context": "https://schema.org",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 import { refreshTrendingFromStore, getLastFetchedAt } from "@/lib/trending";
 import { refreshRecentDropsFromStore, getNewFullNameSet } from "@/lib/recent-drops";
 import { refreshAllMentionStores } from "@/lib/refresh-mentions";
@@ -422,69 +420,4 @@ function orModelDesc(m: {
   if (m.priceInPerM === 0) parts.push("free");
   else if (m.priceInPerM !== null) parts.push(`$${m.priceInPerM}/1M input`);
   return parts.join(" · ");
-}
-
-function cleanQueryPage(input: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(input).filter(
-      ([key, v]) =>
-        v !== "" &&
-        v !== "all" &&
-        !(key === "rank" && v === "top") &&
-        !(key === "sort" && v === "momentum") &&
-        !(key === "window" && v === "24h") &&
-        !(key === "cat" && v === "repos"),
-    ),
-  );
-}
-
-interface UnifiedTab {
-  id: string;
-  label: string;
-  cat: CategoryId;
-  rank: RankerId;
-  active: boolean;
-  count: number | null;
-}
-
-function buildUnifiedTabs(
-  category: CategoryId,
-  ranker: RankerId,
-  counts: Partial<Record<CategoryId, number>>,
-): UnifiedTab[] {
-  const repoCount = counts.repos ?? null;
-  return [
-    {
-      id: "repos-top",
-      label: "Top",
-      cat: "repos",
-      rank: "top",
-      active: category === "repos" && ranker === "top",
-      count: repoCount,
-    },
-    {
-      id: "repos-gainer",
-      label: "Gainer",
-      cat: "repos",
-      rank: "gainer",
-      active: category === "repos" && ranker === "gainer",
-      count: repoCount,
-    },
-    {
-      id: "repos-trend",
-      label: "Trend",
-      cat: "repos",
-      rank: "trend",
-      active: category === "repos" && ranker === "trend",
-      count: repoCount,
-    },
-    ...CATEGORIES.filter((c) => c.id !== "repos").map((c) => ({
-      id: c.id,
-      label: c.label,
-      cat: c.id as CategoryId,
-      rank: "top" as RankerId,
-      active: category === c.id,
-      count: counts[c.id] ?? null,
-    })),
-  ];
 }

--- a/src/app/revenue/page.tsx
+++ b/src/app/revenue/page.tsx
@@ -17,8 +17,6 @@ import {
   refreshRevenueStartupsFromStore,
   getLeaderboard,
   LEADERBOARD_CATEGORIES,
-  getTrustMrrMeta,
-  type VerifiedStartup,
 } from "@/lib/revenue-startups";
 import { listRevenueSubmissions } from "@/lib/revenue-submissions";
 import { getDerivedRepos } from "@/lib/derived-repos";
@@ -219,38 +217,6 @@ const LEADERBOARD_PILL_IDS = [
 
 /** Categories surfaced in the hero segmented control. */
 const HERO_FILTER_IDS = CATEGORY_FILTERS.map((c) => c.id);
-const MIN_VISIBLE_STARTUPS = 6323;
-
-const CATEGORY_LABELS: Record<string, string> = {
-  all: "All",
-  "dev-tools": "Dev Tools",
-  ai: "AI",
-  saas: "SaaS",
-  "e-commerce": "E-commerce",
-  content: "Content Creation",
-  analytics: "Analytics",
-  fintech: "Fintech",
-  education: "Education",
-};
-
-const SEEDED_TRACKED_CARDS: Array<{
-  displayName: string;
-  fullName: string;
-  mrrCents: number;
-  growthMrr30d: number;
-  paymentProvider: string;
-  category: string;
-  trustmrrSlug: string;
-}> = [
-  { displayName: "Cursor", fullName: "getcursor/cursor", mrrCents: 240_000_000, growthMrr30d: 18, paymentProvider: "stripe", category: "Developer Tools", trustmrrSlug: "cursor" },
-  { displayName: "Lovable", fullName: "lovable-dev/lovable", mrrCents: 120_000_000, growthMrr30d: 412, paymentProvider: "stripe", category: "Artificial Intelligence", trustmrrSlug: "lovable" },
-  { displayName: "Vercel", fullName: "vercel/next.js", mrrCents: 1_480_000_000, growthMrr30d: 12, paymentProvider: "stripe", category: "Developer Tools", trustmrrSlug: "vercel" },
-  { displayName: "Replicate", fullName: "replicate/cog", mrrCents: 84_000_000, growthMrr30d: 24, paymentProvider: "stripe", category: "Artificial Intelligence", trustmrrSlug: "replicate" },
-  { displayName: "Mintlify", fullName: "mintlify/writer", mrrCents: 62_000_000, growthMrr30d: 34, paymentProvider: "stripe", category: "Developer Tools", trustmrrSlug: "mintlify" },
-  { displayName: "Plausible", fullName: "plausible/analytics", mrrCents: 48_500_000, growthMrr30d: 5.2, paymentProvider: "paddle", category: "Analytics", trustmrrSlug: "plausible" },
-  { displayName: "Pieces", fullName: "pieces-app/pieces", mrrCents: 31_200_000, growthMrr30d: 62, paymentProvider: "lemonsqueezy", category: "Developer Tools", trustmrrSlug: "pieces" },
-  { displayName: "Mercury", fullName: "mercury/mercury-sdk", mrrCents: 180_000_000, growthMrr30d: 8, paymentProvider: "stripe", category: "Fintech", trustmrrSlug: "mercury" },
-];
 
 function inferProviderFromOverlay(overlay: RevenueOverlay): string | null {
   return overlay.paymentProvider;

--- a/src/components/agent-commerce/LiveX402Stream.tsx
+++ b/src/components/agent-commerce/LiveX402Stream.tsx
@@ -34,10 +34,10 @@ function formatCount(n: number): string {
   return Math.round(n).toLocaleString();
 }
 
-function relativeAge(iso: string): string {
+function relativeAge(iso: string, nowMs = Date.now()): string {
   const t = Date.parse(iso);
   if (!Number.isFinite(t)) return "—";
-  const seconds = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  const seconds = Math.max(0, Math.floor((nowMs - t) / 1000));
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m`;
@@ -57,7 +57,7 @@ export function LiveX402Stream({ initial }: LiveX402StreamProps) {
   const [deltaSignedAt, setDeltaSignedAt] = useState<number>(0);
   const [pollCount, setPollCount] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
-  const [tick, setTick] = useState<number>(0); // forces re-renders for relative-age labels
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
   const poll = useCallback(async () => {
     try {
@@ -93,13 +93,12 @@ export function LiveX402Stream({ initial }: LiveX402StreamProps) {
 
   // Tick every second to keep relative-time labels fresh
   useEffect(() => {
-    const id = window.setInterval(() => setTick((t) => t + 1), 1000);
+    const id = window.setInterval(() => setNowMs(Date.now()), 1000);
     return () => window.clearInterval(id);
   }, []);
 
   const showDelta = delta !== 0 && Date.now() - deltaSignedAt < 5000;
-  const lastUpdated = snapshot ? relativeAge(snapshot.fetchedAt) : "—";
-  const _ = tick; // referenced for stale-closure dep
+  const lastUpdated = snapshot ? relativeAge(snapshot.fetchedAt, nowMs) : "—";
 
   return (
     <section className="lx-stream card">
@@ -181,7 +180,7 @@ export function LiveX402Stream({ initial }: LiveX402StreamProps) {
                   >
                     <span className="lx-tx-hash">{shortHash(tx.hash)}</span>
                     <span className="lx-tx-fac">{tx.facilitator}</span>
-                    <span className="lx-tx-age">{relativeAge(tx.timestamp)} ago</span>
+                    <span className="lx-tx-age">{relativeAge(tx.timestamp, nowMs)} ago</span>
                   </a>
                 ))
               )}

--- a/src/components/breakout/BreakoutVelocityLadder.tsx
+++ b/src/components/breakout/BreakoutVelocityLadder.tsx
@@ -115,14 +115,6 @@ function langDotColor(language: string | null | undefined): string {
   return LANG_DOT[language] ?? "var(--fg-subtle)";
 }
 
-function formatStars(value: number): string {
-  if (value >= 1000) {
-    const k = value / 1000;
-    return `${k >= 10 ? k.toFixed(0) : k.toFixed(1)}k`;
-  }
-  return value.toLocaleString();
-}
-
 function formatPct(pct: number): string {
   if (!Number.isFinite(pct) || pct <= 0) return "+0%";
   return `+${pct.toFixed(0)}%`;

--- a/src/components/ideas/IdeaDetailSummary.tsx
+++ b/src/components/ideas/IdeaDetailSummary.tsx
@@ -9,7 +9,6 @@
 import Link from "next/link";
 
 import type { IdeaRecord } from "@/lib/ideas";
-import { ideaEvidenceLabel } from "@/lib/ideas/display-data";
 import type {
   ReactionCounts,
   UserReactionState,

--- a/src/components/ideas/IdeaSideStack.tsx
+++ b/src/components/ideas/IdeaSideStack.tsx
@@ -18,7 +18,6 @@ import type {
   IdeaMvpEstimate,
   IdeaRecord,
 } from "@/lib/ideas";
-import { ideaEvidenceLabel } from "@/lib/ideas/display-data";
 import type { ReactionCounts } from "@/lib/reactions-shape";
 
 import { IdeaClaimedBox } from "./IdeaClaimedBox";

--- a/src/components/layout/HeaderAccount.tsx
+++ b/src/components/layout/HeaderAccount.tsx
@@ -63,5 +63,5 @@ export function HeaderAccount({ authEnabled }: HeaderAccountProps) {
     return <SignedOutAccountLink />;
   }
 
-  return <HeaderAccountLoaded fallback={<SignedOutAccountLink />} />;
+  return <HeaderAccountLoaded />;
 }

--- a/src/components/layout/HeaderAccountLoaded.tsx
+++ b/src/components/layout/HeaderAccountLoaded.tsx
@@ -14,13 +14,9 @@
 
 import { useUser } from "@clerk/nextjs";
 import { SignInButton, UserButton } from "@clerk/nextjs";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 
-interface HeaderAccountLoadedProps {
-  fallback: ReactNode;
-}
-
-export function HeaderAccountLoaded({ fallback }: HeaderAccountLoadedProps) {
+export function HeaderAccountLoaded() {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -31,7 +27,7 @@ export function HeaderAccountLoaded({ fallback }: HeaderAccountLoadedProps) {
     return <HeaderAccountLoading />;
   }
 
-  return <HeaderAccountClerkState fallback={fallback} />;
+  return <HeaderAccountClerkState />;
 }
 
 function HeaderAccountLoading() {
@@ -46,7 +42,7 @@ function HeaderAccountLoading() {
   );
 }
 
-function HeaderAccountClerkState({ fallback: _fallback }: HeaderAccountLoadedProps) {
+function HeaderAccountClerkState() {
   const { isLoaded, isSignedIn, user } = useUser();
 
   if (!isLoaded) {

--- a/src/components/repo/RepoCommentsComposer.tsx
+++ b/src/components/repo/RepoCommentsComposer.tsx
@@ -97,7 +97,6 @@ function tempId(): string {
 export function RepoCommentsComposer({
   repoFullName,
   signedIn,
-  signInUrl,
   repoNameShort,
   parentId,
   isGlobalListener,
@@ -232,7 +231,6 @@ export function RepoCommentsComposer({
     onPosted,
     parentId,
     repoFullName,
-    signInUrl,
     signedIn,
     trimmed,
   ]);

--- a/src/components/repo/RepoHeroCard.tsx
+++ b/src/components/repo/RepoHeroCard.tsx
@@ -102,7 +102,6 @@ function buildHeroTagFacets(repo: Repo): string[] {
 
 export function RepoHeroCard({
   repo,
-  profile: _profile,
   likeCount,
   liked,
   unicornStatus,

--- a/src/components/revenue/TrackedOssCards.tsx
+++ b/src/components/revenue/TrackedOssCards.tsx
@@ -46,10 +46,6 @@ function fmtGrowth(pct: number | null): string {
   return pct >= 0 ? `+${pct.toFixed(0)}%` : `${pct.toFixed(0)}%`;
 }
 
-function logoLetter(name: string): string {
-  return name.trim().slice(0, 1).toUpperCase() || "?";
-}
-
 export function TrackedOssCards({ cards }: TrackedOssCardsProps) {
   return (
     <div className="panel fade-up" style={{ margin: "18px 0 14px" }}>

--- a/src/components/share/SharePanel.tsx
+++ b/src/components/share/SharePanel.tsx
@@ -25,7 +25,7 @@
 //
 // See docs/DESIGN-SYSTEM.md §7 (Component primitives), §8 (Icon system).
 
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { Icon, SourceLogo } from "@/lib/icons";
 import { absoluteUrl } from "@/lib/seo";

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -11,7 +11,6 @@ import { NavLink } from "./NavLink";
 import {
   TrendingUp,
   Sparkles,
-  Activity,
   CircleDollarSign,
   User,
   Download,

--- a/src/components/shell/Topbar.tsx
+++ b/src/components/shell/Topbar.tsx
@@ -255,8 +255,10 @@ export function Topbar({ crumbs, authEnabled = false }: TopbarProps) {
           onKeyDown={onInputKeyDown}
           placeholder="Search repos, mentions, owners, models…"
           autoComplete="off"
+          role="combobox"
           aria-label="Search"
           aria-autocomplete="list"
+          aria-controls="global-search-dropdown"
           aria-expanded={showDropdown}
         />
         <kbd>⌘K</kbd>
@@ -270,7 +272,6 @@ export function Topbar({ crumbs, authEnabled = false }: TopbarProps) {
             panelRef={dropdownRef}
             onHover={setActiveIdx}
             onPick={navigateToHit}
-            hits={hits}
           />
         )}
       </div>
@@ -316,7 +317,6 @@ export function Topbar({ crumbs, authEnabled = false }: TopbarProps) {
 interface SearchDropdownProps {
   loading: boolean;
   results: SearchResponse | null;
-  hits: Hit[];
   activeIdx: number;
   anchorRect: DOMRect | null;
   panelRef: React.RefObject<HTMLDivElement | null>;
@@ -324,12 +324,12 @@ interface SearchDropdownProps {
   onPick: (hit: Hit) => void;
 }
 
-function SearchDropdown({ loading, results, hits, activeIdx, anchorRect, panelRef, onHover, onPick }: SearchDropdownProps) {
+function SearchDropdown({ loading, results, activeIdx, anchorRect, panelRef, onHover, onPick }: SearchDropdownProps) {
   if (typeof document === "undefined" || !anchorRect) return null;
 
   if (loading && !results) {
     return createPortal(
-      <div ref={panelRef} className="search-dropdown" role="listbox">
+      <div id="global-search-dropdown" ref={panelRef} className="search-dropdown" role="listbox">
         <div className="search-empty">Searching…</div>
       </div>,
       document.body,
@@ -338,7 +338,7 @@ function SearchDropdown({ loading, results, hits, activeIdx, anchorRect, panelRe
 
   if (results && results.repos.length === 0 && results.llms.length === 0) {
     return createPortal(
-      <div ref={panelRef} className="search-dropdown" role="listbox">
+      <div id="global-search-dropdown" ref={panelRef} className="search-dropdown" role="listbox">
         <div className="search-empty">
           No results for <b>{results.query}</b>
         </div>
@@ -351,7 +351,7 @@ function SearchDropdown({ loading, results, hits, activeIdx, anchorRect, panelRe
 
   let runningIdx = 0;
   return createPortal(
-    <div ref={panelRef} className="search-dropdown" role="listbox">
+    <div id="global-search-dropdown" ref={panelRef} className="search-dropdown" role="listbox">
       {results.repos.length > 0 && (
         <>
           <SectionHeader label="Repos" count={results.totals?.repos ?? results.repos.length} />

--- a/src/components/tools/top-10/Top10Board.tsx
+++ b/src/components/tools/top-10/Top10Board.tsx
@@ -7,7 +7,6 @@
 import Image from "next/image";
 
 import { Icon } from "@/components/icon/Icon";
-import { MentionCell } from "@/components/trending/MentionSourcePips";
 import { RepoSparkline } from "@/components/trending/RepoSparkline";
 import { formatDelta, formatStars } from "@/lib/top10/format";
 import type { Top10Bundle } from "@/lib/top10/types";

--- a/src/components/trending/TrendingHubHero.tsx
+++ b/src/components/trending/TrendingHubHero.tsx
@@ -9,7 +9,6 @@ import { getLastFetchedAt } from "@/lib/trending";
 // from getTrackedRepoCount, which under-reported once the persistent registry
 // shipped (732 vs the canonical 838+).
 import { getDerivedRepoCount } from "@/lib/derived-repos";
-import Link from "next/link";
 
 const CATEGORIES = [
   { id: "repos", label: "Repos", glyph: "R" },

--- a/src/lib/api/repo-profile.ts
+++ b/src/lib/api/repo-profile.ts
@@ -322,11 +322,7 @@ function synthesizeNpmMentions(
  * stripped per operator refocus. Function kept as a no-op shim so callers
  * keep compiling; always returns an empty array.
  */
-function synthesizeHuggingFaceMentions(
-  _modelIds: string[] | undefined,
-  _repoId: string,
-  _discoveredAt: string,
-): RepoMention[] {
+function synthesizeHuggingFaceMentions(): RepoMention[] {
   return [];
 }
 
@@ -524,11 +520,7 @@ export async function buildCanonicalRepoProfile(
     fetchedAtIso,
   );
   const npmSynth = synthesizeNpmMentions(npmPackages, repo.id, fetchedAtIso);
-  const hfSynth = synthesizeHuggingFaceMentions(
-    repo.linkedHfModels,
-    repo.id,
-    fetchedAtIso,
-  );
+  const hfSynth = synthesizeHuggingFaceMentions();
   const arxivPapers = getArxivRecentFile().papers ?? [];
   const arxivSynth = synthesizeArxivMentions(
     repo.linkedArxivIds,

--- a/src/lib/category-adapters.ts
+++ b/src/lib/category-adapters.ts
@@ -11,7 +11,8 @@ import { decorateWithMentionsRollup } from "@/lib/derived-repos/decorators/menti
 import type { CategoryId } from "@/components/trending/TrendingHubHero";
 import type { Repo } from "@/lib/types";
 
-export async function refreshCategoryFromStore(_category: CategoryId): Promise<void> {
+export async function refreshCategoryFromStore(category: CategoryId): Promise<void> {
+  void category;
   // No-ops for repos / agents / llms — repos + agents derive from
   // getDerivedRepos() which is refreshed by refreshTrendingFromStore() at the
   // top of the page handler. llms gets its own AA refresh hook in Wave 4.

--- a/src/lib/derived-repos/decorators/mentions-rollup.ts
+++ b/src/lib/derived-repos/decorators/mentions-rollup.ts
@@ -99,7 +99,6 @@ interface LifetimeIndex {
 }
 
 let _npmLifetime: { token: unknown; index: LifetimeIndex } | null = null;
-let _hfLifetime: { token: unknown; index: LifetimeIndex } | null = null;
 let _arxivLifetime: { token: unknown; index: LifetimeIndex } | null = null;
 let _phLifetime: { token: unknown; index: LifetimeIndex } | null = null;
 
@@ -287,7 +286,6 @@ function buildNameOnlyFallback(
 // ---------------------------------------------------------------------------
 
 let _npmIndex: { token: unknown; index: BucketIndex } | null = null;
-let _hfIndex: { token: unknown; index: BucketIndex } | null = null;
 let _arxivIndex: { token: unknown; index: BucketIndex } | null = null;
 let _phIndex: { token: unknown; index: BucketIndex } | null = null;
 
@@ -304,7 +302,7 @@ function npmIndex(nowMs: number): BucketIndex {
   return index;
 }
 
-function hfIndex(_nowMs: number): BucketIndex {
+function hfIndex(): BucketIndex {
   // HuggingFace data source stripped 2026-05-24 per operator refocus. Stub
   // returns an empty bucket so consumers downstream still resolve to
   // count24h=0 / count7d=0 / count=0 without a TypeError.
@@ -371,7 +369,7 @@ export function decorateWithMentionsRollup(
 ): Repo[] {
   const nowMs = Date.now();
   const npm = npmIndex(nowMs);
-  const hf = hfIndex(nowMs);
+  const hf = hfIndex();
   const arxiv = arxivIndex(nowMs);
   const ph = phIndex(nowMs);
   const npmLife = npmLifetimeIndex();
@@ -582,11 +580,9 @@ export function decorateWithMentionsRollup(
 // Test-only memo reset.
 export function __resetMentionsRollupMemoForTests(): void {
   _npmIndex = null;
-  _hfIndex = null;
   _arxivIndex = null;
   _phIndex = null;
   _npmLifetime = null;
-  _hfLifetime = null;
   _arxivLifetime = null;
   _phLifetime = null;
 }

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -54,6 +54,23 @@ test("/api/worker/health: critical concrete worker outputs are tracked", () => {
   const active = new Set(WORKER_HEALTH_SPECS.map((item) => item.slug));
 
   for (const slug of [
+    "hn-pulse",
+    "recent-repos",
+    "deltas",
+    "repo-metadata",
+    "repo-profiles",
+    "trendshift-daily",
+    "engagement-composite",
+    "consensus-trending",
+    "trustmrr-startups",
+    "revenue-overlays",
+    "hackernews-trending",
+    "hackernews-repo-mentions",
+    "bluesky-trending",
+    "bluesky-mentions",
+    "lobsters-trending",
+    "lobsters-mentions",
+    "producthunt-launches",
     "funding-news-crunchbase",
     "consensus-verdicts",
     "devto-mentions",
@@ -66,6 +83,10 @@ test("/api/worker/health: critical concrete worker outputs are tracked", () => {
     "editorial-categories",
     "editorial-compare",
     "editorial-alternatives",
+    "manual-repos",
+    "npm-packages",
+    "reddit-baselines",
+    "revenue-benchmarks",
   ]) {
     assert.equal(active.has(slug), true, `${slug} must be worker-health tracked`);
   }
@@ -167,6 +188,102 @@ test("/api/worker/health: payload row-quality summary covers tracked slugs", () 
     1,
   );
   assert.equal(
+    summarizeWorkerPayloadHealth("hn-pulse", {
+      stories: [{ id: 1 }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("recent-repos", {
+      items: [{ fullName: "owner/repo" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("deltas", {
+      repos: { "owner/repo": { d7: 1 } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("repo-metadata", {
+      items: [{ fullName: "owner/repo" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("repo-profiles", {
+      profiles: { "owner/repo": { websiteUrl: "https://example.com" } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("engagement-composite", {
+      items: [{ fullName: "owner/repo" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("consensus-trending", {
+      items: [{ slug: "owner/repo" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("trustmrr-startups", {
+      startups: [{ slug: "acme" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("revenue-overlays", {
+      overlays: { "owner/repo": { mrrCents: 1000 } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("hackernews-trending", {
+      stories: [{ title: "Story" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("hackernews-repo-mentions", {
+      mentions: { "owner/repo": [{ title: "Story" }] },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("bluesky-trending", {
+      posts: [{ text: "Post" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("bluesky-mentions", {
+      mentions: { "owner/repo": [{ text: "Post" }] },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("lobsters-trending", {
+      stories: [{ title: "Story" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("lobsters-mentions", {
+      mentions: { "owner/repo": [{ title: "Story" }] },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("producthunt-launches", {
+      launches: [{ name: "Launch" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
     summarizeWorkerPayloadHealth("funding-news-crunchbase", {
       fetchedAt: "2026-05-31T20:00:00.000Z",
       signals: [{ company: "Acme" }],
@@ -213,6 +330,30 @@ test("/api/worker/health: payload row-quality summary covers tracked slugs", () 
   assert.equal(
     summarizeWorkerPayloadHealth("editorial-compare", {
       items: { "a__vs__b": { summary: "A vs B" } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("manual-repos", {
+      items: [{ fullName: "owner/repo" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("npm-packages", {
+      packages: [{ name: "pkg" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("reddit-baselines", {
+      baselines: { "r/opensource": { posts: 1 } },
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("revenue-benchmarks", {
+      buckets: [{ category: "ai" }],
     }).rowCount,
     1,
   );

--- a/src/lib/repo-intelligence.ts
+++ b/src/lib/repo-intelligence.ts
@@ -111,7 +111,6 @@ export function computeVerdicts(args: {
   const nowMs = Date.now();
   const lastCommitDays = daysSince(repo.lastCommitAt, nowMs);
   const lastReleaseDays = daysSince(repo.lastReleaseAt, nowMs);
-  const ageDays = daysSince(repo.createdAt, nowMs);
   const channels = repo.channelsFiring ?? 0;
   const momentum = repo.momentumScore ?? 0;
   const stars = repo.stars ?? 0;

--- a/src/lib/star-activity.ts
+++ b/src/lib/star-activity.ts
@@ -152,7 +152,8 @@ export function _seedStarActivityForTests(
  * in `safeAsync()` anyway, but we double-belt this one because /tools is a
  * public ISR route that must NEVER 500 on a missing metric.
  */
-export async function countStarPlotRequests(_date: string): Promise<number> {
+export async function countStarPlotRequests(date: string): Promise<number> {
+  void date;
   try {
     // Intentionally a no-op until the instrumentation lands. Keeping the
     // body small + side-effect-free so future implementers can swap in a

--- a/src/lib/worker-health-payload.ts
+++ b/src/lib/worker-health-payload.ts
@@ -72,9 +72,54 @@ function countCollectionRankingRows(payload: unknown): number | null {
 }
 
 function countRows(slug: string, payload: unknown): number | null {
+  if (slug === "hn-pulse") {
+    return countArrayRows((payload as { stories?: unknown })?.stories);
+  }
   if (slug === "trending") return countTrendingRows(payload);
   if (slug === "hot-collections") {
     return countArrayRows((payload as { rows?: unknown })?.rows);
+  }
+  if (slug === "recent-repos" || slug === "trendshift-daily" || slug === "manual-repos") {
+    return countArrayRows((payload as { items?: unknown })?.items);
+  }
+  if (slug === "deltas") {
+    return countObjectRows((payload as { repos?: unknown })?.repos);
+  }
+  if (slug === "repo-metadata" || slug === "consensus-trending") {
+    return countArrayRows((payload as { items?: unknown })?.items);
+  }
+  if (slug === "repo-profiles") {
+    return countObjectRows((payload as { profiles?: unknown })?.profiles);
+  }
+  if (slug === "engagement-composite") {
+    return countArrayRows((payload as { items?: unknown })?.items);
+  }
+  if (slug === "trustmrr-startups") {
+    return countArrayRows((payload as { startups?: unknown })?.startups);
+  }
+  if (slug === "revenue-overlays") {
+    return countObjectRows((payload as { overlays?: unknown })?.overlays);
+  }
+  if (slug === "hackernews-trending" || slug === "lobsters-trending") {
+    return countArrayRows((payload as { stories?: unknown })?.stories);
+  }
+  if (slug === "hackernews-repo-mentions" || slug === "bluesky-mentions" || slug === "lobsters-mentions") {
+    return countObjectRows((payload as { mentions?: unknown })?.mentions);
+  }
+  if (slug === "bluesky-trending") {
+    return countArrayRows((payload as { posts?: unknown })?.posts);
+  }
+  if (slug === "producthunt-launches") {
+    return countArrayRows((payload as { launches?: unknown })?.launches);
+  }
+  if (slug === "npm-packages") {
+    return countArrayRows((payload as { packages?: unknown })?.packages);
+  }
+  if (slug === "reddit-baselines") {
+    return countObjectRows((payload as { baselines?: unknown })?.baselines);
+  }
+  if (slug === "revenue-benchmarks") {
+    return countArrayRows((payload as { buckets?: unknown })?.buckets);
   }
   if (slug === "collection-rankings") {
     return countCollectionRankingRows(payload);

--- a/tests/e2e/v6-routes.spec.ts
+++ b/tests/e2e/v6-routes.spec.ts
@@ -21,6 +21,8 @@ const PUBLIC_ROUTES: Array<{ path: string; sentinel: RegExp }> = [
   { path: "/market-signals", sentinel: /market|signals/i },
   { path: "/funding", sentinel: /funding/i },
   { path: "/revenue", sentinel: /revenue/i },
+  { path: "/collections", sentinel: /collections/i },
+  { path: "/collections/ai-agent-frameworks", sentinel: /AI Agent Frameworks/i },
   { path: "/agent-commerce", sentinel: /agent[- ]?commerce/i },
   { path: "/tools", sentinel: /tools/i },
   { path: "/ideas", sentinel: /ideas/i },
@@ -107,7 +109,15 @@ test("v6 unknown repo GET /repo/totally-fake/nonexistent returns 404", async ({
 // unpublished/missing id; both are valid.
 // ---------------------------------------------------------------------------
 
-const API_OK_ROUTES = ["/api/healthz", "/api/repos"];
+const API_OK_ROUTES = [
+  "/api/healthz",
+  "/api/repos",
+  "/api/collections",
+  "/api/collections/ai-agent-frameworks",
+  "/api/model-usage/overview",
+  "/api/model-usage/models",
+  "/api/model-usage/rankings",
+];
 
 for (const path of API_OK_ROUTES) {
   test(`v6 api ${path} returns 200`, async ({ request }) => {


### PR DESCRIPTION
## Summary
- require /api/worker/pulse to prove Redis-backed fresh scheduler output with non-empty stories
- expand /api/worker/health payload row-quality checks across active source slugs
- add production live-health and post-deploy smoke coverage for collections and model-usage routes
- clear build/lint warnings touched during the audit so runtime signal stays readable

## Validation
- npx eslint <targeted changed files>
- git diff --check
- node --check scripts/check-live-production-health.mjs
- npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/pipeline/__tests__/health-availability.test.ts
- node scripts/check-live-production-health.mjs
- npm run lint
- npm run typecheck -- --pretty false
- npm run build