### PR TITLE
chore(data): refresh huggingface dataset signals 2026-05-31T19:45:35Z

### DIFF
--- a/data/_meta/huggingface-datasets.json
+++ b/data/_meta/huggingface-datasets.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-datasets",
   "reason": "ok",
-  "ts": "2026-05-31T14:15:50.072Z",
+  "ts": "2026-05-31T19:45:35.910Z",
   "count": 1,
-  "durationMs": 1933,
+  "durationMs": 2349,
   "extra": {}
 }

--- a/data/huggingface-datasets.json
+++ b/data/huggingface-datasets.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T14:15:48.141Z",
+  "fetchedAt": "2026-05-31T19:45:33.563Z",
   "source": "huggingface.co/api/datasets (default sort = trending)",
   "count": 50,
   "datasets": [
@@ -9,8 +9,8 @@
       "author": "openbmb",
       "url": "https://huggingface.co/datasets/openbmb/UltraData-SFT-2605",
       "downloads": 11036,
-      "likes": 227,
-      "trendingScore": 170,
+      "likes": 229,
+      "trendingScore": 172,
       "tags": [
         "task_categories:text-generation",
         "task_categories:question-answering",
@@ -261,8 +261,8 @@
       "author": "jasperai",
       "url": "https://huggingface.co/datasets/jasperai/monet",
       "downloads": 265463,
-      "likes": 79,
-      "trendingScore": 71,
+      "likes": 81,
+      "trendingScore": 73,
       "tags": [
         "task_categories:text-to-image",
         "task_categories:image-feature-extraction",
@@ -788,8 +788,8 @@
       "author": "stanford-vision-lab",
       "url": "https://huggingface.co/datasets/stanford-vision-lab/gpic",
       "downloads": 15525,
-      "likes": 31,
-      "trendingScore": 26,
+      "likes": 32,
+      "trendingScore": 27,
       "tags": [
         "language:en",
         "license:mit",


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace dataset signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26722606253

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.