### PR TITLE
chore(data): refresh huggingface space signals 2026-05-31T19:51:26Z

### DIFF
--- a/data/_meta/huggingface-spaces.json
+++ b/data/_meta/huggingface-spaces.json
@@ -1,8 +1,8 @@
 {
   "source": "huggingface-spaces",
   "reason": "ok",
-  "ts": "2026-05-31T14:22:09.942Z",
+  "ts": "2026-05-31T19:51:26.774Z",
   "count": 1,
-  "durationMs": 4487,
+  "durationMs": 4376,
   "extra": {}
 }

--- a/data/huggingface-spaces.json
+++ b/data/huggingface-spaces.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T14:22:05.457Z",
+  "fetchedAt": "2026-05-31T19:51:22.400Z",
   "source": "huggingface.co/api/spaces (default sort = trending)",
   "count": 50,
   "spaces": [
@@ -111,8 +111,8 @@
       "id": "webml-community/bonsai-image-webgpu",
       "author": "webml-community",
       "url": "https://huggingface.co/spaces/webml-community/bonsai-image-webgpu",
-      "likes": 133,
-      "trendingScore": 126,
+      "likes": 137,
+      "trendingScore": 130,
       "sdk": "static",
       "tags": [
         "static",
@@ -163,8 +163,8 @@
       "id": "nvidia/LocateAnything",
       "author": "nvidia",
       "url": "https://huggingface.co/spaces/nvidia/LocateAnything",
-      "likes": 91,
-      "trendingScore": 90,
+      "likes": 97,
+      "trendingScore": 96,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -427,8 +427,8 @@
       "id": "selfit-camera/Omni-Image-Editor",
       "author": "selfit-camera",
       "url": "https://huggingface.co/spaces/selfit-camera/Omni-Image-Editor",
-      "likes": 1793,
-      "trendingScore": 52,
+      "likes": 1805,
+      "trendingScore": 54,
       "sdk": "gradio",
       "tags": [
         "gradio",
@@ -619,6 +619,22 @@
     },
     {
       "rank": 38,
+      "id": "facebook/vggt-omega",
+      "author": "facebook",
+      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
+      "likes": 49,
+      "trendingScore": 33,
+      "sdk": "gradio",
+      "tags": [
+        "gradio",
+        "region:us"
+      ],
+      "createdAt": "2026-05-16T23:39:56.000Z",
+      "lastModified": "2026-05-18T21:46:03.000Z",
+      "models": []
+    },
+    {
+      "rank": 39,
       "id": "HiDream-ai/HiDream-O1-Image-Dev",
       "author": "HiDream-ai",
       "url": "https://huggingface.co/spaces/HiDream-ai/HiDream-O1-Image-Dev",
@@ -634,7 +650,23 @@
       "models": []
     },
     {
-      "rank": 39,
+      "rank": 40,
+      "id": "prism-ml/Bonsai-Image-Demo",
+      "author": "prism-ml",
+      "url": "https://huggingface.co/spaces/prism-ml/Bonsai-Image-Demo",
+      "likes": 33,
+      "trendingScore": 33,
+      "sdk": "docker",
+      "tags": [
+        "docker",
+        "region:us"
+      ],
+      "createdAt": "2026-05-13T23:49:03.000Z",
+      "lastModified": "2026-05-27T09:27:24.000Z",
+      "models": []
+    },
+    {
+      "rank": 41,
       "id": "mteb/leaderboard",
       "author": "mteb",
       "url": "https://huggingface.co/spaces/mteb/leaderboard",
@@ -651,7 +683,7 @@
       "models": []
     },
     {
-      "rank": 40,
+      "rank": 42,
       "id": "Imosu/image_audio_to_video_NSFW",
       "author": "Imosu",
       "url": "https://huggingface.co/spaces/Imosu/image_audio_to_video_NSFW",
@@ -668,43 +700,11 @@
       "models": []
     },
     {
-      "rank": 41,
-      "id": "facebook/vggt-omega",
-      "author": "facebook",
-      "url": "https://huggingface.co/spaces/facebook/vggt-omega",
-      "likes": 48,
-      "trendingScore": 32,
-      "sdk": "gradio",
-      "tags": [
-        "gradio",
-        "region:us"
-      ],
-      "createdAt": "2026-05-16T23:39:56.000Z",
-      "lastModified": "2026-05-18T21:46:03.000Z",
-      "models": []
-    },
-    {
-      "rank": 42,
-      "id": "prism-ml/Bonsai-Image-Demo",
-      "author": "prism-ml",
-      "url": "https://huggingface.co/spaces/prism-ml/Bonsai-Image-Demo",
-      "likes": 32,
-      "trendingScore": 32,
-      "sdk": "docker",
-      "tags": [
-        "docker",
-        "region:us"
-      ],
-      "createdAt": "2026-05-13T23:49:03.000Z",
-      "lastModified": "2026-05-27T09:27:24.000Z",
-      "models": []
-    },
-    {
       "rank": 43,
       "id": "AimeeBingmouQu/ProtectBirds",
       "author": "AimeeBingmouQu",
       "url": "https://huggingface.co/spaces/AimeeBingmouQu/ProtectBirds",
-      "likes": 332,
+      "likes": 335,
       "trendingScore": 31.5,
       "sdk": "docker",
       "tags": [


### PR DESCRIPTION
Automated data refresh from `Refresh HuggingFace space signals`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26722734382

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.