### PR TITLE
chore(data): refresh arxiv signals 2026-05-31T19:57:56Z

### DIFF
--- a/data/_meta/arxiv.json
+++ b/data/_meta/arxiv.json
@@ -1,8 +1,8 @@
 {
   "source": "arxiv",
   "reason": "ok",
-  "ts": "2026-05-31T14:24:13.522Z",
+  "ts": "2026-05-31T19:54:11.472Z",
   "count": 1,
-  "durationMs": 60746,
+  "durationMs": 60675,
   "extra": {}
 }

--- a/data/arxiv-enriched.json
+++ b/data/arxiv-enriched.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T14:24:13.574Z",
+  "fetchedAt": "2026-05-31T19:54:11.524Z",
   "source": "api.semanticscholar.org/graph/v1/paper/arXiv:* + HN + Reddit",
   "socialSources": [
     "hackernews",
@@ -7,6 +7,13 @@
   ],
   "count": 145,
   "papers": [
+    {
+      "arxivId": "2605.30353v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
     {
       "arxivId": "2605.30351v1",
       "citationCount": 0,
@@ -50,6 +57,13 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30339v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30337v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -90,6 +104,27 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30328v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30327v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30326v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30325v1",
@@ -155,6 +190,20 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30288v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30284v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30280v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -167,6 +216,27 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30269v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30268v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30263v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30260v1",
@@ -253,6 +323,13 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30231v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30230v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -260,11 +337,25 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30227v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30226v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30225v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30220v1",
@@ -288,6 +379,13 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30215v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30214v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -307,6 +405,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30201v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30198v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30195v1",
@@ -351,6 +463,20 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30174v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30170v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30169v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -363,6 +489,13 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30167v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30166v1",
@@ -379,6 +512,20 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30159v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30154v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30153v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -391,6 +538,20 @@
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30131v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30126v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30123v1",
@@ -421,6 +582,13 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30093v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30085v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -428,11 +596,39 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
+      "arxivId": "2605.30076v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
       "arxivId": "2605.30073v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
+    },
+    {
+      "arxivId": "2605.30051v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30036v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.30022v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30018v1",
@@ -449,7 +645,21 @@
       "lastEnrichedAt": "2026-05-31T05:11:11.376Z"
     },
     {
-      "arxivId": "2605.30353v1",
+      "arxivId": "2605.29987v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.29971v1",
+      "citationCount": 0,
+      "citationVelocity": 0,
+      "socialMentions": 0,
+      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+    },
+    {
+      "arxivId": "2605.29951v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
@@ -460,35 +670,35 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30348v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30349v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30346v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30344v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30343v1",
@@ -498,60 +708,32 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30339v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30336v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30335v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30333v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30328v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30327v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30326v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30324v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30323v1",
@@ -572,63 +754,49 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30307v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30290v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30289v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30288v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30284v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30283v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30277v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30274v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30273v1",
@@ -638,39 +806,18 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30269v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30268v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30265v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30263v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30257v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30251v1",
@@ -694,39 +841,11 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30231v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30229v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30227v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30225v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30215v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30213v1",
@@ -740,7 +859,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30202v1",
@@ -750,25 +869,11 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30201v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30200v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30198v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30189v1",
@@ -785,27 +890,6 @@
       "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
     },
     {
-      "arxivId": "2605.30174v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30170v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30167v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30161v1",
       "citationCount": 0,
       "citationVelocity": 0,
@@ -817,28 +901,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30159v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30155v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30154v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30152v1",
@@ -873,21 +943,7 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T21:03:42.757Z"
-    },
-    {
-      "arxivId": "2605.30131v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.30126v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30116v1",
@@ -901,28 +957,21 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30111v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T10:39:55.424Z"
-    },
-    {
-      "arxivId": "2605.30093v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30090v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30083v1",
@@ -936,21 +985,14 @@
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.30076v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30058v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     },
     {
       "arxivId": "2605.30052v1",
@@ -960,25 +1002,11 @@
       "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
     },
     {
-      "arxivId": "2605.30051v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30040v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
-    },
-    {
-      "arxivId": "2605.30036v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
     },
     {
       "arxivId": "2605.30031v1",
@@ -988,39 +1016,11 @@
       "lastEnrichedAt": "2026-05-29T05:03:23.689Z"
     },
     {
-      "arxivId": "2605.30022v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
       "arxivId": "2605.30021v1",
       "citationCount": 0,
       "citationVelocity": 0,
       "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-30T09:05:59.931Z"
-    },
-    {
-      "arxivId": "2605.29987v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.29971v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
-    },
-    {
-      "arxivId": "2605.29951v1",
-      "citationCount": 0,
-      "citationVelocity": 0,
-      "socialMentions": 0,
-      "lastEnrichedAt": "2026-05-31T14:24:13.574Z"
+      "lastEnrichedAt": "2026-05-31T19:54:11.524Z"
     }
   ]
 }

--- a/data/arxiv-recent.json
+++ b/data/arxiv-recent.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-05-31T14:23:12.796Z",
+  "fetchedAt": "2026-05-31T19:53:10.818Z",
   "source": "export.arxiv.org/api/query (cs.AI, cs.CL, cs.LG, cs.CV)",
   "fetchedCategories": [
     "cs.AI",


### PR DESCRIPTION
Automated data refresh from `Refresh arXiv signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26722778883

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.