### PR TITLE
chore(data): refresh lobsters signals 2026-05-31T20:39:52Z

### DIFF
--- a/data/_meta/lobsters.json
+++ b/data/_meta/lobsters.json
@@ -1,8 +1,8 @@
 {
   "source": "lobsters",
   "reason": "ok",
-  "ts": "2026-05-31T18:48:33.517Z",
+  "ts": "2026-05-31T20:39:51.955Z",
   "count": 1,
-  "durationMs": 11024,
+  "durationMs": 2950,
   "extra": {}
 }

--- a/data/lobsters-mentions.json
+++ b/data/lobsters-mentions.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T18:48:22.512Z",
+  "fetchedAt": "2026-05-31T20:39:49.027Z",
   "windowDays": 7,
-  "scannedStories": 77,
+  "scannedStories": 80,
   "mentions": {
     "0xdeadbeefnetwork/ssh-keysign-pwn": {
       "count7d": 1,

--- a/data/lobsters-trending.json
+++ b/data/lobsters-trending.json
@@ -1,7 +1,7 @@
 {
-  "fetchedAt": "2026-05-31T18:48:22.512Z",
+  "fetchedAt": "2026-05-31T20:39:49.027Z",
   "windowHours": 72,
-  "scannedTotal": 77,
+  "scannedTotal": 80,
   "stories": [
     {
       "shortId": "t1spjc",


### PR DESCRIPTION
Automated data refresh from `Refresh Lobsters signals`.

- Files changed: 4
- Run: https://github.com/0motionguy/starscreener/actions/runs/26723847940

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.