### PR TITLE
chore(data): refresh profile-completion queue 2026-05-31T21:51:09Z

### DIFF
--- a/data/_meta/profile-completion-check.json
+++ b/data/_meta/profile-completion-check.json
@@ -1,9 +1,9 @@
 {
   "source": "profile-completion-check",
   "reason": "ok",
-  "ts": "2026-05-31T20:36:06.969Z",
+  "ts": "2026-05-31T21:51:09.531Z",
   "count": 63,
-  "durationMs": 906,
+  "durationMs": 900,
   "extra": {
     "mode": "top",
     "totalChecked": 100,

--- a/data/profile-completion-queue.json
+++ b/data/profile-completion-queue.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-31T20:36:06.967Z",
+  "generatedAt": "2026-05-31T21:51:09.528Z",
   "version": 1,
   "mode": "top",
   "totalChecked": 100,


### PR DESCRIPTION
Automated data refresh from `Profile completion check`.

- Files changed: 2
- Run: https://github.com/0motionguy/starscreener/actions/runs/26725479597

The `auto-merge` label is set; `auto-merge-bot.yml` enables
auto-merge asynchronously, which avoids the `gh pr merge --auto`
hang surface that timed out Twitter collectors at 90 min (see
`docs/forensic/twitter-cancellation-2026-05-17.md`). PR merges once
required status checks pass.