### PR TITLE
fix: keep paused sources out of runtime hydration

### DIFF
--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -182,6 +182,19 @@ test("/api/worker/health: disabled slugs stay visible but inactive", () => {
   }
 });
 
+test("paused Reddit source is not hydrated by the global mention refresher", () => {
+  const source = readFileSync(
+    resolve(process.cwd(), "src", "lib", "refresh-mentions.ts"),
+    "utf8",
+  );
+
+  assert.equal(
+    source.includes("refreshRedditMentionsFromStore"),
+    false,
+    "refreshAllMentionStores must not hydrate stale reddit-mentions while Reddit is paused",
+  );
+});
+
 test("/api/worker/health: TrustMRR catalog cadence matches daily producer", () => {
   const contract = SOURCE_CONTRACTS.find((source) => source.id === "trustmrr");
 

--- a/src/lib/refresh-mentions.ts
+++ b/src/lib/refresh-mentions.ts
@@ -15,7 +15,6 @@ import { refreshHackernewsMentionsFromStore } from "./hackernews";
 import { refreshBlueskyMentionsFromStore } from "./bluesky";
 import { refreshDevtoMentionsFromStore } from "./devto";
 import { refreshLobstersMentionsFromStore } from "./lobsters";
-import { refreshRedditMentionsFromStore } from "./reddit-data";
 import { refreshNpmFromStore } from "./npm";
 import { refreshProducthuntLaunchesFromStore } from "./producthunt";
 import { refreshArxivFromStore } from "./arxiv";
@@ -25,8 +24,9 @@ import { refreshMentionsLedgerFromStore } from "./mentions-ledger";
 /**
  * Refresh all mention/cross-source stores in parallel. Never throws — each
  * refresh swallows its own error (the data-store reader already preserves the
- * last-known cache on a miss). Twitter is intentionally absent: it reads its
- * bundled signal file synchronously and needs no async refresh.
+ * last-known cache on a miss). Reddit is intentionally absent while paused:
+ * the stale historical redis slug must not hydrate active request caches.
+ * Twitter reads its bundled signal file synchronously and needs no async refresh.
  */
 export async function refreshAllMentionStores(): Promise<void> {
   await Promise.all([
@@ -34,7 +34,6 @@ export async function refreshAllMentionStores(): Promise<void> {
     refreshBlueskyMentionsFromStore().catch(() => undefined),
     refreshDevtoMentionsFromStore().catch(() => undefined),
     refreshLobstersMentionsFromStore().catch(() => undefined),
-    refreshRedditMentionsFromStore().catch(() => undefined),
     refreshNpmFromStore().catch(() => undefined),
     refreshProducthuntLaunchesFromStore().catch(() => undefined),
     refreshArxivFromStore().catch(() => undefined),


### PR DESCRIPTION
## Summary
- remove paused Reddit mention hydration from the global mention refresher
- add a regression guard so Reddit cannot silently re-enter active request caches

## Production evidence
- deployed clean HOSTUP image: trendingrepo-app:vps-clean-202606010010-757effa9e
- /api/worker/health: 61 total, 44 active, 17 disabled, 44 green, 0 amber/red/missing/degraded/empty
- /api/health, /api/worker/pulse, /api/health/sources all green behind Cloudflare

## Validation
- npm run lint:guards
- npm run lint
- npm run typecheck -- --pretty false
- npx tsx --test --require .\\tests\\setup-server-only-stub.cjs src\\lib\\pipeline\\__tests__\\health-availability.test.ts