### PR TITLE
fix: close stale source health leaks

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/__tests__/degraded.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/__tests__/degraded.test.ts
@@ -15,8 +15,10 @@ vi.mock('../../../lib/redis.js', () => ({
 }));
 
 const originalSetTimeout = globalThis.setTimeout;
+const originalOssInsightCollectionRankingsEnabled =
+  process.env.OSSINSIGHT_COLLECTION_RANKINGS_ENABLED;
 
-function makeContext(): FetcherContext {
+function makeContext(jsonMock?: FetcherContext['http']['json']): FetcherContext {
   const log = {
     info: vi.fn(),
     warn: vi.fn(),
@@ -27,9 +29,9 @@ function makeContext(): FetcherContext {
     db: null as unknown as FetcherContext['db'],
     redis: null as unknown as FetcherContext['redis'],
     http: {
-      async json() {
+      json: jsonMock ?? (async () => {
         throw new Error('OSSInsight 500');
-      },
+      }),
       async text() {
         throw new Error('OSSInsight 500');
       },
@@ -43,6 +45,7 @@ function makeContext(): FetcherContext {
 
 beforeEach(() => {
   vi.resetModules();
+  process.env.OSSINSIGHT_COLLECTION_RANKINGS_ENABLED = '1';
   readDataStoreMock.mockReset();
   writeDataStoreMock.mockClear();
   globalThis.setTimeout = ((cb: () => void) => {
@@ -53,9 +56,61 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.setTimeout = originalSetTimeout;
+  if (originalOssInsightCollectionRankingsEnabled === undefined) {
+    delete process.env.OSSINSIGHT_COLLECTION_RANKINGS_ENABLED;
+  } else {
+    process.env.OSSINSIGHT_COLLECTION_RANKINGS_ENABLED =
+      originalOssInsightCollectionRankingsEnabled;
+  }
 });
 
 describe('collection-rankings degraded writes', () => {
+  it('uses the internal github fallback by default without calling OSSInsight', async () => {
+    delete process.env.OSSINSIGHT_COLLECTION_RANKINGS_ENABLED;
+    vi.resetModules();
+    const httpJson: FetcherContext['http']['json'] = vi.fn(async () => {
+      throw new Error('should not call OSSInsight by default');
+    });
+    readDataStoreMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        fetchedAt: '2026-06-01T00:00:00.000Z',
+        items: [
+          {
+            githubId: 155220641,
+            fullName: 'huggingface/transformers',
+            stars: 152000,
+            openIssues: 950,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        computedAt: '2026-06-01T00:00:00.000Z',
+        repos: {
+          'huggingface/transformers': {
+            stars_now: 152000,
+            delta_30d: { value: 321, basis: 'exact' },
+          },
+        },
+      });
+    const { default: fetcher } = await import('../index.js');
+
+    const result = await fetcher.run(makeContext(httpJson));
+
+    expect(httpJson).not.toHaveBeenCalled();
+    expect(result.redisPublished).toBe(true);
+    const write = (writeDataStoreMock.mock.calls as unknown as Array<
+      [string, unknown, unknown?]
+    >).find(([slug]) => slug === 'collection-rankings');
+    expect(write).toBeDefined();
+    const payload = write?.[1] as { status?: string; source?: string };
+    expect(payload.status).toBe('ok');
+    expect(payload.source).toBe('github-metadata-fallback');
+    expect(write?.[2]).toEqual({
+      writer: 'worker:collection-rankings:github-metadata',
+    });
+  });
+
   it('freshens the slug with cached per-metric rows when OSSInsight fails', async () => {
     readDataStoreMock.mockResolvedValueOnce({
       fetchedAt: '2026-05-30T10:00:00.000Z',

--- a/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/collection-rankings/index.ts
@@ -1,10 +1,9 @@
-// OSS Insight per-collection ranking fetcher.
+// Per-collection ranking fetcher.
 //
-// Ports the `--only-collection-rankings` path of
-// `scripts/scrape-trending.mjs`. For each curated collection (~28 of
-// them, hardcoded below), pull /v1/collections/{id}/ranking_by_stars and
-// /v1/collections/{id}/ranking_by_issues for the past 28 days, normalize
-// rows, and publish the aggregate to `ss:data:v1:collection-rankings`.
+// Production defaults to the HOSTUP-owned GitHub metadata/star-activity
+// fallback because api.ossinsight.io frequently returns 500s from the VPS.
+// The older OSS Insight path is still available for explicit diagnostics via
+// OSSINSIGHT_COLLECTION_RANKINGS_ENABLED=1.
 //
 // Cadence: every 6 hours at :17 (matches
 // `.github/workflows/refresh-collection-rankings.yml`).
@@ -32,6 +31,10 @@ import {
 
 const PERIOD = 'past_28_days';
 const PAUSE_MS = 400;
+
+function isOssInsightCollectionRankingsEnabled(): boolean {
+  return process.env.OSSINSIGHT_COLLECTION_RANKINGS_ENABLED === '1';
+}
 
 interface RankingRow {
   repo_id?: string | number;
@@ -108,6 +111,58 @@ const fetcher: Fetcher = {
       await readGithubCollectionFallbackSources(),
       fetchedAt,
     );
+    const rowfulPrior = countRankingRows(prior) > 0 ? prior : null;
+    const rowfulSeed =
+      countRankingRows(SEED_COLLECTION_RANKINGS) > 0
+        ? SEED_COLLECTION_RANKINGS
+        : null;
+
+    if (!isOssInsightCollectionRankingsEnabled()) {
+      const payload = githubFallback ?? rowfulPrior ?? rowfulSeed;
+      const totalRows = countRankingRows(payload);
+      if (!payload || totalRows === 0) {
+        const message =
+          'internal github metadata fallback produced no rows; skipped collection-rankings publish';
+        ctx.log.error(message);
+        return done(startedAt, 0, false, [{ stage: 'internal-fallback', message }]);
+      }
+
+      const usingLiveGithubFallback = payload === githubFallback;
+      const result = await writeDataStore(
+        'collection-rankings',
+        usingLiveGithubFallback
+          ? payload
+          : {
+              ...payload,
+              fetchedAt,
+              status: 'degraded',
+              dataAsOf: payload.dataAsOf ?? payload.fetchedAt ?? null,
+              errors: [
+                {
+                  stage: 'internal-fallback',
+                  message:
+                    'github metadata fallback unavailable; preserved previous or seed collection rankings',
+                },
+              ],
+            },
+        {
+          writer: usingLiveGithubFallback
+            ? 'worker:collection-rankings:github-metadata'
+            : 'worker:collection-rankings:degraded',
+        },
+      );
+      ctx.log.info(
+        {
+          totalRows,
+          source: usingLiveGithubFallback ? 'github-metadata-fallback' : 'preserved',
+          redisSource: result.source,
+          writtenAt: result.writtenAt,
+        },
+        'collection-rankings published from internal fallback',
+      );
+      return done(startedAt, totalRows, result.source === 'redis', []);
+    }
+
     let totalRows = 0;
     let preservedRows = 0;
     let githubFallbackRows = 0;
@@ -197,11 +252,6 @@ const fetcher: Fetcher = {
       collections[String(collection.id)] = metrics;
     }
 
-    const rowfulPrior = countRankingRows(prior) > 0 ? prior : null;
-    const rowfulSeed =
-      countRankingRows(SEED_COLLECTION_RANKINGS) > 0
-        ? SEED_COLLECTION_RANKINGS
-        : null;
     const payload: CollectionRankingsPayload = {
       fetchedAt,
       period: PERIOD,

--- a/apps/trendingrepo-worker/src/platform/sources.json
+++ b/apps/trendingrepo-worker/src/platform/sources.json
@@ -163,7 +163,7 @@
       "scope": "ip"
     },
     "owner": "UNASSIGNED",
-    "upstream_url": "https://api.ossinsight.io/v1/collections/{id}/ranking_by_{metric}/",
+    "upstream_url": "internal:data-store:repo-metadata+star-activity-deltas; optional:https://api.ossinsight.io/v1/collections/{id}/ranking_by_{metric}/",
     "auth_required": false,
     "auth_scheme": "none",
     "primary_output_keys": [
@@ -174,10 +174,11 @@
       "src/lib/collection-rankings.ts"
     ],
     "depends_on": [
-      "oss-trending"
+      "repo-metadata",
+      "star-activity-deltas"
     ],
     "supports_backfill": false,
-    "fallback_strategy": "cache",
+    "fallback_strategy": "internal-github-metadata",
     "writes_canonical_entity_kind": [
       "repo"
     ]

--- a/src/app/api/cron/freshness/state/route.ts
+++ b/src/app/api/cron/freshness/state/route.ts
@@ -206,9 +206,14 @@ const SOURCE_SPECS: ReadonlyArray<SourceSpec> = [
     ...hours(24),
   },
   {
+    // Workflow/file-owned script output. Keep disabled until HuggingFace is
+    // ported to a HOSTUP worker producer; otherwise stale legacy Redis writes
+    // can make freshness look owned by the live worker fleet.
     name: "huggingface",
     metaSource: "huggingface",
     redisSlugs: ["huggingface-trending"],
+    blocking: false,
+    enabled: false,
     ...hours(24),
   },
   {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -44,8 +44,6 @@ interface HealthBody {
   collectionRankingsStatus?: "ok" | "degraded";
   collectionRankingsDataAsOf?: string | null;
   collectionRankingsErrorCount?: number;
-  redditFetchedAt: string | null;
-  redditCold: boolean;
   blueskyFetchedAt: string | null;
   blueskyCold: boolean;
   hnFetchedAt: string | null;
@@ -65,7 +63,6 @@ interface HealthBody {
     recentRepos: number | null;
     repoMetadata: number | null;
     collectionRankings: number | null;
-    reddit: number | null;
     bluesky: number | null;
     hn: number | null;
     producthunt: number | null;
@@ -87,7 +84,6 @@ interface HealthBody {
     recentRepos: boolean;
     repoMetadata: boolean;
     collectionRankings: boolean;
-    reddit: boolean;
     bluesky: boolean;
     hn: boolean;
     producthunt: boolean;
@@ -497,7 +493,6 @@ export async function GET(
     const sourceById = new Map<ScannerSourceHealth["id"], ScannerSourceHealth>(
       sources.map((source) => [source.id, source]),
     );
-    const reddit = sourceById.get("reddit");
     const bluesky = sourceById.get("bluesky");
     const hn = sourceById.get("hackernews");
     const producthunt = sourceById.get("producthunt");
@@ -535,7 +530,6 @@ export async function GET(
       recentReposStale ||
       repoMetadataStale ||
       collectionRankingsStale ||
-      (reddit?.stale ?? false) ||
       (bluesky?.stale ?? false) ||
       (hn?.stale ?? false) ||
       (producthunt?.stale ?? false) ||
@@ -561,8 +555,6 @@ export async function GET(
       collectionRankingsStatus,
       collectionRankingsDataAsOf,
       collectionRankingsErrorCount,
-      redditFetchedAt: reddit?.fetchedAt ?? null,
-      redditCold: reddit?.cold ?? true,
       blueskyFetchedAt: bluesky?.fetchedAt ?? null,
       blueskyCold: bluesky?.cold ?? true,
       hnFetchedAt: hn?.fetchedAt ?? null,
@@ -590,7 +582,6 @@ export async function GET(
           collectionRankingsAge === null
             ? null
             : Math.floor(collectionRankingsAge / 1000),
-        reddit: reddit?.ageSeconds ?? null,
         bluesky: bluesky?.ageSeconds ?? null,
         hn: hn?.ageSeconds ?? null,
         producthunt: producthunt?.ageSeconds ?? null,
@@ -612,7 +603,6 @@ export async function GET(
         recentRepos: recentReposStale,
         repoMetadata: repoMetadataStale,
         collectionRankings: collectionRankingsStale,
-        reddit: reddit?.stale ?? false,
         bluesky: bluesky?.stale ?? false,
         hn: hn?.stale ?? false,
         producthunt: producthunt?.stale ?? false,
@@ -712,8 +702,6 @@ export async function GET(
         recentReposFetchedAt: fallbackRecentReposFetchedAt,
         repoMetadataFetchedAt: fallbackRepoMetadataFetchedAt,
         collectionRankingsFetchedAt: fallbackCollectionRankingsFetchedAt,
-        redditFetchedAt: null,
-        redditCold: true,
         blueskyFetchedAt: null,
         blueskyCold: true,
         hnFetchedAt: null,
@@ -733,7 +721,6 @@ export async function GET(
           recentRepos: null,
           repoMetadata: null,
           collectionRankings: null,
-          reddit: null,
           bluesky: null,
           hn: null,
           producthunt: null,
@@ -755,7 +742,6 @@ export async function GET(
           recentRepos: true,
           repoMetadata: true,
           collectionRankings: true,
-          reddit: false,
           bluesky: false,
           hn: false,
           producthunt: false,

--- a/src/app/api/repos/[owner]/[name]/mentions/route.ts
+++ b/src/app/api/repos/[owner]/[name]/mentions/route.ts
@@ -39,7 +39,11 @@ const MENTIONS_CACHE_HEADERS = {
 
 const PAGE_DEFAULT_LIMIT = 50;
 const PAGE_MAX_LIMIT = 200;
-const PAUSED_MENTION_SOURCES: readonly SocialPlatform[] = ["reddit"];
+const PAUSED_MENTION_SOURCES: readonly SocialPlatform[] = [
+  "reddit",
+  "huggingface",
+  "arxiv",
+];
 
 // Must stay in sync with the SocialPlatform union in src/lib/types.ts.
 // Keeping it as an explicit runtime set rather than deriving from the type
@@ -53,8 +57,6 @@ const ALLOWED_SOURCES: ReadonlySet<SocialPlatform> = new Set<SocialPlatform>([
   "producthunt",
   "lobsters",
   "npm",
-  "huggingface",
-  "arxiv",
 ]);
 
 interface ErrorEnvelope {

--- a/src/lib/api/repo-profile.ts
+++ b/src/lib/api/repo-profile.ts
@@ -76,7 +76,11 @@ import type { RepoMention, RepoScore } from "@/lib/pipeline/types";
 
 /** Upper bound on mentions returned inline with the canonical profile. */
 const PROFILE_MENTIONS_LIMIT = 50;
-const PAUSED_MENTION_SOURCES: readonly SocialPlatform[] = ["reddit"];
+const PAUSED_MENTION_SOURCES: readonly SocialPlatform[] = [
+  "reddit",
+  "huggingface",
+  "arxiv",
+];
 
 export interface CanonicalRepoProfileMentions {
   /**

--- a/src/lib/pipeline/__tests__/freshness-state-route.test.ts
+++ b/src/lib/pipeline/__tests__/freshness-state-route.test.ts
@@ -28,7 +28,7 @@ test("freshness state route exposes expanded inventory with advisory blocking fl
     };
     const byName = new Map(body.sources.map((source) => [source.name, source]));
 
-    assert.ok(body.sources.length >= 28, `expected active inventory, got ${body.sources.length}`);
+    assert.ok(body.sources.length >= 27, `expected active inventory, got ${body.sources.length}`);
     assert.equal(byName.get("trending-repos")?.blocking, true);
     assert.ok(byName.has("twitter"), "worker-owned twitter-repo-signals should remain tracked");
     assert.equal(byName.has("reddit"), false, "live reddit collector should be disabled");
@@ -38,6 +38,7 @@ test("freshness state route exposes expanded inventory with advisory blocking fl
       "arxiv",
       "awesome-skills",
       "claude-rss",
+      "huggingface",
       "huggingface-datasets",
       "huggingface-spaces",
       "hotness-snapshots",

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -45,6 +45,17 @@ test("/api/health: stale freshness remains HTTP 200 availability", () => {
   assert.equal(getHealthHttpStatusForStatus("error", true), 200);
 });
 
+test("/api/health: paused reddit is not exposed as a cold active source", () => {
+  const routeSource = readFileSync(
+    resolve(process.cwd(), "src", "app", "api", "health", "route.ts"),
+    "utf8",
+  );
+
+  assert.equal(routeSource.includes("redditFetchedAt"), false);
+  assert.equal(routeSource.includes("redditCold"), false);
+  assert.equal(routeSource.includes("reddit: reddit"), false);
+});
+
 test("/api/worker/health: advisory slugs remain labelled for triage", () => {
   const advisory = new Set([
     "hot-collections",

--- a/src/lib/pipeline/__tests__/mentions-endpoint.test.ts
+++ b/src/lib/pipeline/__tests__/mentions-endpoint.test.ts
@@ -179,6 +179,20 @@ test("400 on paused reddit source value", async () => {
   assert.equal(body.code, "invalid_source");
 });
 
+test("400 on disabled legacy research source values", async () => {
+  for (const source of ["huggingface", "arxiv"]) {
+    const res = await invokeRoute(
+      FIXTURE_OWNER,
+      FIXTURE_NAME,
+      `?source=${source}`,
+    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { ok: boolean; code?: string };
+    assert.equal(body.ok, false);
+    assert.equal(body.code, "invalid_source");
+  }
+});
+
 test("400 on limit > 200", async () => {
   const res = await invokeRoute(
     FIXTURE_OWNER,

--- a/src/lib/worker-health-specs.ts
+++ b/src/lib/worker-health-specs.ts
@@ -124,7 +124,7 @@ export const WORKER_HEALTH_DISABLED_SPECS: ReadonlyArray<DisabledSlugHealthSpec>
     slug: "huggingface-trending",
     fetcher: "scrape-huggingface",
     reason:
-      "workflow-owned script output; no registered live worker producer, tracked by cron freshness",
+      "workflow-owned script output; no registered live worker producer, disabled from live worker and cron freshness until ported to HOSTUP",
   },
   {
     slug: "trending-mcp",


### PR DESCRIPTION
## Summary
- disable workflow-owned HuggingFace from active cron freshness until it has a HOSTUP worker producer
- keep paused/legacy research mention sources (Reddit, HuggingFace, arXiv) out of repo profile and mentions API responses
- remove paused Reddit cold-source fields from `/api/health`
- make `collection-rankings` default to HOSTUP-owned GitHub metadata/star-activity fallback and make OSS Insight collection rankings opt-in via `OSSINSIGHT_COLLECTION_RANKINGS_ENABLED=1`
- update source registry provenance for `collection-rankings`

## Validation
- `npx tsx --test --require .\tests\setup-server-only-stub.cjs src\lib\pipeline\__tests__\freshness-state-route.test.ts src\lib\pipeline\__tests__\mentions-endpoint.test.ts src\lib\pipeline\__tests__\health-availability.test.ts`
- `npm --prefix apps/trendingrepo-worker test -- src/fetchers/collection-rankings/__tests__/degraded.test.ts src/fetchers/collection-rankings/__tests__/fallback.test.ts`
- `npm run lint:guards`
- `npm run lint`
- `npm run typecheck -- --pretty false`
- `npm --prefix apps/trendingrepo-worker run typecheck`
- `npm --prefix apps/trendingrepo-worker run build`
- `npm run build`
- `npm audit --audit-level=high`
- `npm --prefix apps/trendingrepo-worker audit --audit-level=high`

## Live evidence
- HOSTUP worker `/healthz` is 200 with Redis/db/scheduler true and no skipped jobs.
- `/api/worker/health` currently green on prod: 44 active, 17 disabled, 0 amber/red/missing/degraded/empty.
- OSS Insight `trends/repos` still returns 500 externally; production `collection-rankings` currently has 536 rows via `github-metadata-fallback`.
