### PR TITLE
fix: align health coverage with star activity deltas

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -127,6 +127,7 @@ type HealthDeps = {
   recentRepos: typeof import("@/lib/recent-repos");
   sourceHealth: typeof import("@/lib/source-health");
   sourceHealthTracker: typeof import("@/lib/source-health-tracker");
+  starActivityDeltas: typeof import("@/lib/star-activity-deltas");
   trending: typeof import("@/lib/trending");
 };
 
@@ -222,6 +223,7 @@ async function loadHealthDeps(): Promise<HealthDeps> {
     recentRepos,
     sourceHealth,
     sourceHealthTracker,
+    starActivityDeltas,
     trending,
   ] = await Promise.all([
     import("@/lib/collection-rankings"),
@@ -230,6 +232,7 @@ async function loadHealthDeps(): Promise<HealthDeps> {
     import("@/lib/recent-repos"),
     import("@/lib/source-health"),
     import("@/lib/source-health-tracker"),
+    import("@/lib/star-activity-deltas"),
     import("@/lib/trending"),
   ]);
 
@@ -240,8 +243,18 @@ async function loadHealthDeps(): Promise<HealthDeps> {
     recentRepos,
     sourceHealth,
     sourceHealthTracker,
+    starActivityDeltas,
     trending,
   };
+}
+
+function bestCoverageQuality(
+  primary: DeltaCoverageQuality,
+  secondary: DeltaCoverageQuality,
+): DeltaCoverageQuality {
+  if (primary === "full" || secondary === "full") return "full";
+  if (primary === "partial" || secondary === "partial") return "partial";
+  return "cold";
 }
 
 async function canViewDetail(request: NextRequest): Promise<boolean> {
@@ -395,6 +408,10 @@ function createRefreshTasks(deps: HealthDeps): RefreshTask[] {
       label: "scannerSourceHealth",
       run: deps.sourceHealth.refreshScannerSourceHealthFromStore,
     },
+    {
+      label: "starActivityDeltas",
+      run: deps.starActivityDeltas.refreshStarActivityDeltasFromStore,
+    },
   ];
 }
 
@@ -537,9 +554,15 @@ export async function GET(
       (lobsters?.stale ?? false) ||
       (npm?.stale ?? false);
 
-    const coverage = deps.trending.deltasCoveragePct();
+    const snapshotCoverage = deps.trending.deltasCoveragePct();
+    const starActivityCoverage =
+      deps.starActivityDeltas.getStarActivityDeltasCoveragePct();
+    const coverage = Math.max(snapshotCoverage, starActivityCoverage);
     const coverageLow = coverage < COVERAGE_WARN_PCT;
-    const quality = deps.trending.deltasCoverageQuality();
+    const quality = bestCoverageQuality(
+      deps.trending.deltasCoverageQuality(),
+      deps.starActivityDeltas.getStarActivityDeltasCoverageQuality(),
+    );
     const collectionCoverage =
       deps.collectionRankings.getCollectionRankingsCoverage();
 

--- a/src/lib/__tests__/star-activity-deltas.test.ts
+++ b/src/lib/__tests__/star-activity-deltas.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  _resetStarActivityDeltasCacheForTests,
+  _seedStarActivityDeltasForTests,
+  getStarActivityDeltasCoveragePct,
+  getStarActivityDeltasCoverageQuality,
+  type StarActivityDeltasFile,
+} from "../star-activity-deltas";
+
+afterEach(() => {
+  _resetStarActivityDeltasCacheForTests();
+});
+
+function seedWithCoverage(
+  coverage: StarActivityDeltasFile["coverage"],
+): void {
+  _seedStarActivityDeltasForTests({
+    computedAt: "2026-06-01T00:00:00.000Z",
+    coverage,
+    repos: {},
+  });
+}
+
+test("star-activity-deltas coverage quality is full when exact/nearest dominate", () => {
+  seedWithCoverage({
+    exact: 5154,
+    nearest: 32,
+    "cold-start": 10,
+    "no-history": 0,
+  });
+
+  assert.equal(getStarActivityDeltasCoverageQuality(), "full");
+  assert.equal(Math.round(getStarActivityDeltasCoveragePct() * 10) / 10, 99.8);
+});
+
+test("star-activity-deltas coverage quality remains partial when cold-start dominates", () => {
+  seedWithCoverage({
+    exact: 10,
+    nearest: 0,
+    "cold-start": 90,
+    "no-history": 0,
+  });
+
+  assert.equal(getStarActivityDeltasCoverageQuality(), "partial");
+});
+
+test("star-activity-deltas coverage quality is cold before the worker publishes", () => {
+  assert.equal(getStarActivityDeltasCoverageQuality(), "cold");
+  assert.equal(getStarActivityDeltasCoveragePct(), 0);
+});

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -56,6 +56,24 @@ test("/api/health: paused reddit is not exposed as a cold active source", () => 
   assert.equal(routeSource.includes("reddit: reddit"), false);
 });
 
+test("/api/health: coverage warning considers star-activity delta backbone", () => {
+  const routeSource = readFileSync(
+    resolve(process.cwd(), "src", "app", "api", "health", "route.ts"),
+    "utf8",
+  );
+
+  assert.equal(routeSource.includes("starActivityDeltas"), true);
+  assert.equal(
+    routeSource.includes("getStarActivityDeltasCoveragePct"),
+    true,
+  );
+  assert.equal(
+    routeSource.includes("getStarActivityDeltasCoverageQuality"),
+    true,
+  );
+  assert.equal(routeSource.includes("bestCoverageQuality"), true);
+});
+
 test("/api/worker/health: advisory slugs remain labelled for triage", () => {
   const advisory = new Set([
     "hot-collections",

--- a/src/lib/star-activity-deltas.ts
+++ b/src/lib/star-activity-deltas.ts
@@ -43,6 +43,8 @@ export interface StarActivityDeltasFile {
   repos: Record<string, SADeltaEntry>;
 }
 
+export type StarActivityDeltasCoverageQuality = "full" | "partial" | "cold";
+
 const EMPTY: StarActivityDeltasFile = { computedAt: "", repos: {} };
 const SLUG = "star-activity-deltas";
 const MIN_REFRESH_INTERVAL_MS = 30_000;
@@ -79,12 +81,60 @@ export function getStarActivityDeltasDataVersion(): string {
   return cache.computedAt || "empty";
 }
 
+export function getStarActivityDeltasCoveragePct(): number {
+  const coverage = getCoverageSummary();
+  const total =
+    coverage.exact +
+    coverage.nearest +
+    coverage["cold-start"] +
+    coverage["no-history"];
+  if (total === 0) return 0;
+  return ((coverage.exact + coverage.nearest) * 100) / total;
+}
+
+export function getStarActivityDeltasCoverageQuality(): StarActivityDeltasCoverageQuality {
+  const coverage = getCoverageSummary();
+  const total =
+    coverage.exact +
+    coverage.nearest +
+    coverage["cold-start"] +
+    coverage["no-history"];
+  if (total === 0) return "cold";
+  const good = coverage.exact + coverage.nearest;
+  if (good / total > 0.5) return "full";
+  if (coverage["cold-start"] > 0) return "partial";
+  return "cold";
+}
+
 /**
  * Convenience lookup of one repo's delta entry by fullName (case-insensitive).
  * Returns null when the repo has no GitHub-direct delta yet.
  */
 export function getStarActivityDelta(fullName: string): SADeltaEntry | null {
   return cache.repos[fullName.toLowerCase()] ?? null;
+}
+
+function getCoverageSummary(): Record<SADeltaBasis, number> {
+  const empty: Record<SADeltaBasis, number> = {
+    exact: 0,
+    nearest: 0,
+    "cold-start": 0,
+    "no-history": 0,
+  };
+  if (cache.coverage) {
+    return {
+      exact: cache.coverage.exact ?? 0,
+      nearest: cache.coverage.nearest ?? 0,
+      "cold-start": cache.coverage["cold-start"] ?? 0,
+      "no-history": cache.coverage["no-history"] ?? 0,
+    };
+  }
+  for (const entry of Object.values(cache.repos)) {
+    empty[entry.delta_24h.basis] += 1;
+    empty[entry.delta_7d.basis] += 1;
+    empty[entry.delta_30d.basis] += 1;
+  }
+  return empty;
 }
 
 /**


### PR DESCRIPTION
## Summary
- include star-activity-deltas in /api/health refresh dependencies
- combine legacy snapshot delta coverage with the GitHub-direct star-activity delta backbone
- add regression coverage for star-activity coverage quality and route wiring

## Root cause
/api/health still judged coverage from the older deltas snapshot ring only. That ring can remain partial while the active homepage delta backbone, star-activity-deltas, is fresh and mostly exact/nearest. The result was a misleading public warning even though the live GitHub-direct delta source was healthy.

## Validation
- npx tsx --test src/lib/__tests__/star-activity-deltas.test.ts
- npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/star-activity-deltas.test.ts src/lib/pipeline/__tests__/health-availability.test.ts
- npm run lint:guards
- npm run lint
- npm run typecheck -- --pretty false
- npm audit --audit-level=high
- npm run build
- git diff --check

Live evidence before patch: star-activity-deltas coverage exact+nearest was 5186/5196 slots while /api/health still reported coverageQuality=partial from the legacy deltas ring.