### PR TITLE
fix: use public origin for top10 OG assets

### DIFF
--- a/src/app/api/og/top10/route.tsx
+++ b/src/app/api/og/top10/route.tsx
@@ -30,6 +30,7 @@ import { Dot, StarMark, truncate } from "@/lib/og-primitives";
 import { buildCustomBundleFromSlugs } from "@/lib/top10/build-custom-bundle";
 import { formatDelta, formatStars } from "@/lib/top10/format";
 import { resolveBundle } from "@/lib/top10/resolve-bundle";
+import { SITE_URL } from "@/lib/seo";
 
 // Mirror of CHANNELS in MentionSourcePips.tsx — drives which source logos
 // render as pips on the right of each OG row. Order is intentional (matches
@@ -997,7 +998,7 @@ export async function GET(request: NextRequest) {
 
     // Origin for absolute <img> URLs inside satori — brand SVGs at
     // /brand/sources/*.svg need to resolve to a fully-qualified URL.
-    const origin = new URL(request.url).origin;
+    const origin = SITE_URL;
 
     return new ImageResponse(
       (

--- a/src/lib/__tests__/top10-og-origin.test.ts
+++ b/src/lib/__tests__/top10-og-origin.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "node:test";
+
+test("/api/og/top10 resolves brand assets from SITE_URL, not container origin", () => {
+  const routeSource = readFileSync(
+    resolve(process.cwd(), "src", "app", "api", "og", "top10", "route.tsx"),
+    "utf8",
+  );
+
+  assert.equal(routeSource.includes('import { SITE_URL } from "@/lib/seo"'), true);
+  assert.equal(routeSource.includes("new URL(request.url).origin"), false);
+});


### PR DESCRIPTION
## Summary
- resolve /api/og/top10 brand asset URLs from configured SITE_URL instead of request origin
- add regression coverage so HOSTUP internal origins do not re-enter the OG asset path

## Root cause
The top10 OG route used new URL(request.url).origin for absolute image URLs. On HOSTUP, app-internal requests can arrive as https://0.0.0.0:3023, which ImageResponse/satori cannot fetch, producing production log errors for /brand/sources/*.svg.

## Validation
- npx tsx --test src/lib/__tests__/top10-og-origin.test.ts
- npx tsx --test --require ./tests/setup-server-only-stub.cjs src/lib/__tests__/top10-og-origin.test.ts src/lib/__tests__/star-activity-deltas.test.ts src/lib/pipeline/__tests__/health-availability.test.ts
- npm run lint:guards
- npm run lint
- npm run typecheck -- --pretty false
- npm audit --audit-level=high
- npm run build
- git diff --check