### PR TITLE
fix: classify repo metadata not-found graph errors

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/repo-metadata/__tests__/graphql-errors.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/repo-metadata/__tests__/graphql-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeGraphqlErrors } from '../index.js';
+
+describe('repo-metadata GraphQL error classification', () => {
+  it('classifies repository NOT_FOUND errors as expected stale-roster misses', () => {
+    const summary = summarizeGraphqlErrors([
+      {
+        type: 'NOT_FOUND',
+        path: ['r0'],
+        message: "Could not resolve to a Repository with the name 'BAAI/bge-m3'.",
+      },
+      {
+        type: 'NOT_FOUND',
+        path: ['r1'],
+        message:
+          "Could not resolve to a Repository with the name 'deleted/repo'.",
+      },
+    ]);
+
+    expect(summary.notFoundCount).toBe(2);
+    expect(summary.unexpectedCount).toBe(0);
+  });
+
+  it('keeps non-NOT_FOUND GraphQL errors warning-worthy', () => {
+    const summary = summarizeGraphqlErrors([
+      {
+        type: 'RATE_LIMITED',
+        message: 'API rate limit exceeded',
+      },
+    ]);
+
+    expect(summary.notFoundCount).toBe(0);
+    expect(summary.unexpectedCount).toBe(1);
+    expect(summary.unexpectedSamples).toHaveLength(1);
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/repo-metadata/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/repo-metadata/index.ts
@@ -210,6 +210,40 @@ interface GraphqlResponse {
   errors?: unknown[];
 }
 
+interface GraphqlErrorLike {
+  type?: unknown;
+  message?: unknown;
+}
+
+export interface GraphqlErrorSummary {
+  notFoundCount: number;
+  unexpectedCount: number;
+  unexpectedSamples: string[];
+}
+
+export function summarizeGraphqlErrors(errors: unknown[]): GraphqlErrorSummary {
+  let notFoundCount = 0;
+  const unexpectedSamples: string[] = [];
+  for (const error of errors) {
+    const entry = error as GraphqlErrorLike;
+    const type = typeof entry?.type === 'string' ? entry.type : '';
+    const message = typeof entry?.message === 'string' ? entry.message : '';
+    if (
+      type === 'NOT_FOUND' &&
+      message.includes('Could not resolve to a Repository')
+    ) {
+      notFoundCount += 1;
+      continue;
+    }
+    unexpectedSamples.push(message || JSON.stringify(error));
+  }
+  return {
+    notFoundCount,
+    unexpectedCount: unexpectedSamples.length,
+    unexpectedSamples: unexpectedSamples.slice(0, 3),
+  };
+}
+
 function normalizeRepo(
   node: GraphqlRepoNode,
   requestedFullName: string,
@@ -344,10 +378,18 @@ const fetcher: Fetcher = {
         const data = body?.data ?? {};
         const ghErrors = Array.isArray(body?.errors) ? body.errors : [];
         if (ghErrors.length > 0) {
-          ctx.log.warn(
-            { batchNo, batchTotal, errors: ghErrors.length },
-            'graphql errors in batch',
-          );
+          const errorSummary = summarizeGraphqlErrors(ghErrors);
+          if (errorSummary.unexpectedCount > 0) {
+            ctx.log.warn(
+              { batchNo, batchTotal, ...errorSummary },
+              'graphql unexpected errors in batch',
+            );
+          } else {
+            ctx.log.info(
+              { batchNo, batchTotal, notFoundCount: errorSummary.notFoundCount },
+              'graphql not-found repos in batch',
+            );
+          }
         }
         batch.forEach((fullName, i) => {
           const node = data[`r${i}`];


### PR DESCRIPTION
## Summary
- classify GitHub GraphQL repository NOT_FOUND responses as expected stale-roster misses
- keep those misses in the repo-metadata failures payload, but stop logging them as warn every hourly batch
- keep unexpected GraphQL errors warning-level with samples

## Root cause
repo-metadata batches include stale/deleted/non-GitHub owner/name candidates from upstream rosters. GitHub returns GraphQL NOT_FOUND errors for those aliases; the fetcher already preserves previous metadata or records not-found failures, but it logged each batch as warning, hiding real warning signals.

## Validation
- npm --prefix apps/trendingrepo-worker test -- src/fetchers/repo-metadata/__tests__/graphql-errors.test.ts
- npm --prefix apps/trendingrepo-worker test -- src/fetchers/repo-metadata/__tests__/graphql-errors.test.ts src/fetchers/funding-news/__tests__/feed-inventory.test.ts src/fetchers/collection-rankings/__tests__/degraded.test.ts src/fetchers/collection-rankings/__tests__/fallback.test.ts
- npm --prefix apps/trendingrepo-worker run typecheck
- npm --prefix apps/trendingrepo-worker run build
- npm run lint:guards
- npm run typecheck -- --pretty false
- npm --prefix apps/trendingrepo-worker audit --audit-level=high
- git diff --check