### PR TITLE
fix: derive worker payload health coverage

### DIFF
--- a/src/app/api/worker/health/route.ts
+++ b/src/app/api/worker/health/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDataStore, type RedisClientLike } from "@/lib/data-store";
 import {
   WORKER_HEALTH_DISABLED_SPECS,
+  WORKER_PAYLOAD_HEALTH_SLUGS,
   WORKER_HEALTH_SPECS,
   type DisabledSlugHealthSpec,
 } from "@/lib/worker-health-specs";
@@ -51,50 +52,6 @@ const SLUG_TABLE = WORKER_HEALTH_SPECS;
 const DISABLED_SLUG_TABLE = WORKER_HEALTH_DISABLED_SPECS;
 const DATA_STORE_META_NAMESPACE = "ss:meta:v1";
 const DATA_STORE_PAYLOAD_NAMESPACE = "ss:data:v1";
-const PAYLOAD_HEALTH_SLUGS = new Set([
-  "hn-pulse",
-  "trending",
-  "hot-collections",
-  "recent-repos",
-  "deltas",
-  "repo-metadata",
-  "repo-profiles",
-  "trendshift-daily",
-  "engagement-composite",
-  "consensus-trending",
-  "trustmrr-startups",
-  "revenue-overlays",
-  "hackernews-trending",
-  "hackernews-repo-mentions",
-  "bluesky-trending",
-  "bluesky-mentions",
-  "lobsters-trending",
-  "lobsters-mentions",
-  "producthunt-launches",
-  "collection-rankings",
-  "funding-news",
-  "funding-news-crunchbase",
-  "consensus-verdicts",
-  "devto-mentions",
-  "devto-trending",
-  "twitter-repo-signals",
-  "aa-llms",
-  "openrouter-models",
-  "openrouter-usage",
-  "repo-registry",
-  "mentions-ledger",
-  "repo-mentions-detail-rollup",
-  "star-activity-deltas",
-  "editorial-best",
-  "editorial-categories",
-  "editorial-compare",
-  "editorial-alternatives",
-  "manual-repos",
-  "npm-packages",
-  "revenue-benchmarks",
-  "stars-by-category-daily",
-  "lmarena-text",
-]);
 
 type SlugStatus = "green" | "amber" | "red" | "missing";
 
@@ -185,7 +142,7 @@ async function readRedisPayloadHealth(
   redis: RedisClientLike | null,
   slug: string,
 ): Promise<WorkerPayloadHealth | null> {
-  if (!redis || !PAYLOAD_HEALTH_SLUGS.has(slug)) return null;
+  if (!redis || !WORKER_PAYLOAD_HEALTH_SLUGS.has(slug)) return null;
   try {
     const raw = await redis.get(dataStorePayloadKey(slug));
     if (!raw) {

--- a/src/lib/pipeline/__tests__/health-availability.test.ts
+++ b/src/lib/pipeline/__tests__/health-availability.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import { getHealthHttpStatusForStatus } from "../../health-status";
 import {
   WORKER_HEALTH_DISABLED_SPECS,
+  WORKER_PAYLOAD_HEALTH_SLUGS,
   WORKER_HEALTH_SPECS,
 } from "../../worker-health-specs";
 import sourcesData from "../../../../apps/trendingrepo-worker/src/platform/sources.json";
@@ -179,6 +180,14 @@ test("/api/worker/health: every active worker concrete output is tracked", () =>
       if (!tracked.has(key)) missing.push(`${source.id}:${key}`);
     }
   }
+
+  assert.deepEqual(missing.sort(), []);
+});
+
+test("/api/worker/health: every active tracked slug receives payload quality checks", () => {
+  const missing = WORKER_HEALTH_SPECS.map((item) => item.slug).filter(
+    (slug) => !WORKER_PAYLOAD_HEALTH_SLUGS.has(slug),
+  );
 
   assert.deepEqual(missing.sort(), []);
 });
@@ -376,6 +385,26 @@ test("/api/worker/health: payload row-quality summary covers tracked slugs", () 
   assert.equal(
     summarizeWorkerPayloadHealth("trustmrr-startups", {
       startups: [{ slug: "acme" }],
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("trustmrr-startups:meta", {
+      startupCount: 412,
+      totalReported: 512,
+      totalSize: 1024,
+    }).rowCount,
+    412,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("revenue-manual-matches", {
+      _comment: "manual overrides are optional",
+    }).rowCount,
+    1,
+  );
+  assert.equal(
+    summarizeWorkerPayloadHealth("revenue-manual-matches", {
+      "owner/repo": "trustmrr-slug",
     }).rowCount,
     1,
   );

--- a/src/lib/worker-health-payload.ts
+++ b/src/lib/worker-health-payload.ts
@@ -107,6 +107,22 @@ function countRows(slug: string, payload: unknown): number | null {
   if (slug === "trustmrr-startups") {
     return countArrayRows((payload as { startups?: unknown })?.startups);
   }
+  if (slug === "trustmrr-startups:meta") {
+    return (
+      countPositiveNumberRows((payload as { startupCount?: unknown })?.startupCount) ??
+      countPositiveNumberRows((payload as { totalReported?: unknown })?.totalReported) ??
+      countPositiveNumberRows((payload as { totalSize?: unknown })?.totalSize)
+    );
+  }
+  if (slug === "revenue-manual-matches") {
+    const mappings = Object.entries(
+      payload && typeof payload === "object" && !Array.isArray(payload)
+        ? (payload as Record<string, unknown>)
+        : {},
+    ).filter(([key, value]) => !key.startsWith("_") && typeof value === "string").length;
+    if (mappings > 0) return mappings;
+    return typeof (payload as { _comment?: unknown })._comment === "string" ? 1 : 0;
+  }
   if (slug === "revenue-overlays") {
     return countObjectRows((payload as { overlays?: unknown })?.overlays);
   }

--- a/src/lib/worker-health-specs.ts
+++ b/src/lib/worker-health-specs.ts
@@ -77,6 +77,10 @@ export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
 
 ];
 
+export const WORKER_PAYLOAD_HEALTH_SLUGS: ReadonlySet<string> = new Set(
+  WORKER_HEALTH_SPECS.map((spec) => spec.slug),
+);
+
 export const WORKER_HEALTH_DISABLED_SPECS: ReadonlyArray<DisabledSlugHealthSpec> = [
   {
     slug: "reddit-mentions",


### PR DESCRIPTION
## Summary
- Derives `WORKER_PAYLOAD_HEALTH_SLUGS` from `WORKER_HEALTH_SPECS` so active worker-health slugs cannot be added without payload row-quality checks.
- Removes the duplicated hard-coded payload-health slug allowlist from `/api/worker/health`.
- Adds payload row counters for the two active tracked slugs that were previously metadata-only: `trustmrr-startups:meta` and `revenue-manual-matches`.

## Validation
- npx tsx --test --require .\tests\setup-server-only-stub.cjs src\lib\pipeline\__tests__\health-availability.test.ts
- npm --prefix apps/trendingrepo-worker run test -- tests/registry.test.ts src/__tests__/run-contract.test.ts
- npm run typecheck -- --pretty false
- npm --prefix apps/trendingrepo-worker run typecheck
- npm run lint
- npm run lint:guards
- npm audit --audit-level=high
- npm run build
- git diff --check

## Live evidence
Current prod still shows `trustmrr-startups:meta` and `revenue-manual-matches` as green from metadata only; this patch makes future deploys inspect their payload rows too.