### PR TITLE
fix(health): treat cold source breakers as unknown

### DIFF
--- a/scripts/__tests__/check-live-production-health.test.mjs
+++ b/scripts/__tests__/check-live-production-health.test.mjs
@@ -45,7 +45,7 @@ test("operator freshness audit script uses the live production health gate", () 
   );
 });
 
-test("validateSourceHealthBody rejects legacy source-health schema without attempt proof", () => {
+test("validateSourceHealthBody rejects legacy source-health schema without attempt fields", () => {
   const errors = validateSourceHealthBody({
     summary: {
       total: 1,
@@ -64,10 +64,9 @@ test("validateSourceHealthBody rejects legacy source-health schema without attem
 
   assert.match(errors.join("\n"), /summary\.neverAttempted is missing/);
   assert.match(errors.join("\n"), /hackernews: attempted flag is missing/);
-  assert.match(errors.join("\n"), /hackernews: source breaker has no runtime attempt proof/);
 });
 
-test("validateSourceHealthBody rejects unattempted active source breakers", () => {
+test("validateSourceHealthBody accepts unattempted cold source breakers", () => {
   const errors = validateSourceHealthBody({
     summary: {
       total: 1,
@@ -87,8 +86,7 @@ test("validateSourceHealthBody rejects unattempted active source breakers", () =
     },
   });
 
-  assert.match(errors.join("\n"), /unproven source breaker/);
-  assert.match(errors.join("\n"), /bluesky: source breaker has no runtime attempt proof/);
+  assert.deepEqual(errors, []);
 });
 
 test("validateSourceHealthBody accepts proven active source breakers", () => {

--- a/scripts/check-live-production-health.mjs
+++ b/scripts/check-live-production-health.mjs
@@ -44,12 +44,6 @@ export function validateSourceHealthBody(body) {
     errors.push("summary.neverAttemptedSources is missing");
   }
 
-  if (typeof summary.neverAttempted === "number" && summary.neverAttempted > 0) {
-    errors.push(
-      `unproven source breaker(s): ${summary.neverAttemptedSources?.join(", ") || summary.neverAttempted}`,
-    );
-  }
-
   const sources = body?.sources;
   if (!sources || typeof sources !== "object" || Array.isArray(sources)) {
     errors.push("sources map is missing");
@@ -66,9 +60,6 @@ export function validateSourceHealthBody(body) {
     }
     if (typeof source.totalAttempts !== "number") {
       errors.push(`${id}: totalAttempts is missing`);
-    }
-    if (source.attempted === false || source.totalAttempts === 0) {
-      errors.push(`${id}: source breaker has no runtime attempt proof`);
     }
   }
 

--- a/src/app/api/health/sources/route.ts
+++ b/src/app/api/health/sources/route.ts
@@ -162,8 +162,9 @@ export async function GET(): Promise<NextResponse<HealthSourcesBody>> {
   };
 
   // 207 Multi-Status when degraded so monitors can split "down" from
-  // "degraded but serving". Zero-attempt sources are unknown, not green.
-  const status = open + halfOpen + neverAttempted > 0 ? 207 : 200;
+  // "degraded but serving". Zero-attempt sources remain visible as unknown,
+  // but a healthy process restart must not fail production availability.
+  const status = open + halfOpen > 0 ? 207 : 200;
   if (trace) {
     const totalMs = performance.now() - startedAt;
     console.info(

--- a/src/lib/__tests__/source-health-sources-response.test.ts
+++ b/src/lib/__tests__/source-health-sources-response.test.ts
@@ -19,7 +19,7 @@ test("/api/health/sources ignores disabled-source breaker state", async () => {
   const response = await GET();
   const body = await response.json();
 
-  assert.equal(response.status, 207);
+  assert.equal(response.status, 200);
   assert.equal(response.headers.get("cache-control"), "private, no-store");
   assert.deepEqual(body.summary.openSources, []);
   assert.deepEqual(body.summary.halfOpenSources, []);
@@ -46,4 +46,24 @@ test("/api/health/sources ignores disabled-source breaker state", async () => {
   assert.equal(body.sources.nitter, undefined);
   assert.equal(body.sources.lobsters, undefined);
   assert.equal(body.sources.producthunt, undefined);
+});
+
+test("/api/health/sources keeps cold breaker sources visible without degrading availability", async () => {
+  sourceHealthTracker.reset();
+
+  const response = await GET();
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.summary.neverAttempted, 4);
+  assert.deepEqual(body.summary.neverAttemptedSources, [
+    "bluesky",
+    "devto",
+    "github",
+    "hackernews",
+  ]);
+  assert.equal(body.sources.hackernews.attempted, false);
+  assert.equal(body.sources.bluesky.attempted, false);
+  assert.equal(body.sources.devto.attempted, false);
+  assert.equal(body.sources.github.attempted, false);
 });


### PR DESCRIPTION
## Summary
- keep /api/health/sources neverAttempted source breakers visible but no longer return 207 solely for process-cold state after deploy
- keep the live production health gate strict for open/half-open breaker state while accepting cold in-memory breakers
- add regression coverage for disabled-source handling and cold breaker availability

## Validation
- npm run lint -- src/app/api/health/sources/route.ts src/lib/__tests__/source-health-sources-response.test.ts scripts/check-live-production-health.mjs scripts/__tests__/check-live-production-health.test.mjs
- npm run typecheck
- npm run test:scraper-shared
- npm run test
- npm run build
- git diff --check
- npm audit --audit-level=high

## Ops note
HOSTUP worker Redis was also bootstrapped with one-shot runs for the newly strict worker health slugs. /api/worker/health is green after seeding.