### PR TITLE
fix(health): allow cold source breakers in prod audit

### DIFF
--- a/scripts/__tests__/check-live-production-health.test.mjs
+++ b/scripts/__tests__/check-live-production-health.test.mjs
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import {
   validateAppHealthBody,
   validateSourceHealthBody,
+  validateSourceHealthSummary,
 } from "../check-live-production-health.mjs";
 
 test("validateAppHealthBody rejects legacy app health without workerStatus", () => {
@@ -111,4 +112,29 @@ test("validateSourceHealthBody accepts proven active source breakers", () => {
     }),
     [],
   );
+});
+
+test("validateSourceHealthSummary accepts cold but closed source breakers", () => {
+  assert.deepEqual(
+    validateSourceHealthSummary({
+      open: 0,
+      halfOpen: 0,
+      neverAttempted: 4,
+      neverAttemptedSources: ["bluesky", "devto", "github", "hackernews"],
+    }),
+    [],
+  );
+});
+
+test("validateSourceHealthSummary rejects open or half-open breakers", () => {
+  const errors = validateSourceHealthSummary({
+    open: 1,
+    halfOpen: 1,
+    neverAttempted: 0,
+    openSources: ["github"],
+    halfOpenSources: ["devto"],
+  });
+
+  assert.match(errors.join("\n"), /open source breaker/);
+  assert.match(errors.join("\n"), /half-open source breaker/);
 });

--- a/scripts/check-live-production-health.mjs
+++ b/scripts/check-live-production-health.mjs
@@ -66,6 +66,21 @@ export function validateSourceHealthBody(body) {
   return errors;
 }
 
+export function validateSourceHealthSummary(summary) {
+  const errors = [];
+  if ((summary?.open ?? 0) > 0) {
+    errors.push(
+      `open source breaker(s): ${summary.openSources?.join(", ") || summary.open}`,
+    );
+  }
+  if ((summary?.halfOpen ?? 0) > 0) {
+    errors.push(
+      `half-open source breaker(s): ${summary.halfOpenSources?.join(", ") || summary.halfOpen}`,
+    );
+  }
+  return errors;
+}
+
 async function fetchJson(path, okStatuses = [200]) {
   const url = `${BASE_URL}${path}`;
   let res;
@@ -322,12 +337,14 @@ async function main() {
       errors: sourceHealthProofErrors,
       summary: sourceSummary,
     });
-  } else if (
-    (sourceSummary.open ?? 0) > 0 ||
-    (sourceSummary.halfOpen ?? 0) > 0 ||
-    sourceSummary.neverAttempted > 0
-  ) {
-    fail("/api/health/sources has degraded or unproven sources", sourceSummary);
+  } else {
+    const sourceSummaryErrors = validateSourceHealthSummary(sourceSummary);
+    if (sourceSummaryErrors.length > 0) {
+      fail("/api/health/sources has degraded sources", {
+        errors: sourceSummaryErrors,
+        summary: sourceSummary,
+      });
+    }
   }
 
   if (


### PR DESCRIPTION
## Summary
- removes the remaining live audit failure on closed-but-neverAttempted in-memory source breakers
- adds summary-level validation so open and half-open source breakers still fail production health

## Validation
- npx tsx --test scripts/__tests__/check-live-production-health.test.mjs
- npm run lint -- scripts/check-live-production-health.mjs scripts/__tests__/check-live-production-health.test.mjs
- npm run test:scraper-shared
- npm run health:prod
- git diff --check