### PR TITLE
feat(home): surface FreshnessBadge + fail-closed staleness gate (F4)

### DIFF
--- a/src/components/home/LiveTopTable.tsx
+++ b/src/components/home/LiveTopTable.tsx
@@ -42,6 +42,7 @@ import type { NewsSource } from "@/lib/news/freshness";
 import { repoLogoUrl } from "@/lib/logos";
 import { useViewportPrefetch } from "@/hooks/useViewportPrefetch";
 import { MAX_COMPARE_REPOS } from "@/lib/constants";
+import { classifyPublicStaleness } from "@/lib/public-staleness";
 
 type SortKey = "rank" | "stars" | "d24" | "d7" | "d30" | "forks" | "mentions";
 type SortDir = "asc" | "desc";
@@ -366,6 +367,41 @@ export function LiveTopTable({
     );
     return sorted;
   }, [rows, sortKey, sortDir, activeCat]);
+
+  // "No publicly stale batches" gate — drop rows entirely when the data is
+  // past `MAX_PUBLIC_STALENESS_MIN`. Render a "data refreshing" banner
+  // instead of a stale ranking table so readers can't act on cold rows.
+  const stalenessVerdict = classifyPublicStaleness(lastUpdatedAt, freshnessNowMs);
+
+  if (!stalenessVerdict.isFresh && rows.length > 0) {
+    return (
+      <div className="live-top">
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            padding: "16px 20px",
+            border: "1px solid var(--v4-amber, #f59e0b)",
+            background: "var(--v4-bg-050)",
+            borderRadius: "var(--v4-radius-md, 8px)",
+            color: "var(--v4-amber, #f59e0b)",
+            fontFamily: "var(--font-geist-mono), monospace",
+            fontSize: 13,
+            lineHeight: 1.6,
+          }}
+        >
+          <strong>Data refreshing.</strong> The latest batch is older than the
+          public freshness window ({Math.round(stalenessVerdict.thresholdMs / 60000)}min).
+          Rankings will reappear once the next worker tick lands.
+          <FreshnessBadge
+            source={freshnessSource}
+            lastUpdatedAt={lastUpdatedAt}
+            nowMs={freshnessNowMs}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="live-top">

--- a/src/components/shared/FreshnessBadge.tsx
+++ b/src/components/shared/FreshnessBadge.tsx
@@ -11,13 +11,13 @@
 
 import { classifyFreshness, type NewsSource } from "@/lib/news/freshness";
 
-// Operator decision (2026-05-15): cold/stale chrome reads as honesty
-// theatre, not as useful signal. Hide the indicators by default but
-// keep the classifier intact so a future flip via env can bring them
-// back without touching call sites. Set
-// `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=false` to render.
+// Operator decision (2026-06-15, ULTRA plan §F4): visible recency stamp
+// is part of the "no publicly stale batches" rule. Show by default so
+// readers can tell a fresh batch from a 4h-old one without opening the
+// route. The hide flag stays available — set
+// `NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=true` to opt out.
 function isFreshnessBadgeHidden(): boolean {
-  return process.env.NEXT_PUBLIC_HIDE_FRESHNESS_BADGES !== "false";
+  return process.env.NEXT_PUBLIC_HIDE_FRESHNESS_BADGES === "true";
 }
 
 interface FreshnessBadgeProps {

--- a/src/lib/public-staleness.ts
+++ b/src/lib/public-staleness.ts
@@ -1,0 +1,54 @@
+/**
+ * Public-staleness gate — "no publicly stale batches" rule.
+ *
+ * Any homepage-rendered dataset older than `MAX_PUBLIC_STALENESS_MIN`
+ * (default 30min) should NOT be rendered as a normal row. The component
+ * renders a "data refreshing" banner or an empty/degraded state instead.
+ *
+ * The threshold defaults are conservative — most fetchers publish hourly,
+ * so 30min is the "we missed at most one tick" line. Override per-deploy
+ * with `NEXT_PUBLIC_MAX_PUBLIC_STALENESS_MIN` (still client-readable since
+ * stale UI is visible to anyone).
+ */
+
+const DEFAULT_MAX_PUBLIC_STALENESS_MIN = 30;
+
+function maxPublicStalenessMin(): number {
+  const raw = process.env.NEXT_PUBLIC_MAX_PUBLIC_STALENESS_MIN;
+  if (!raw) return DEFAULT_MAX_PUBLIC_STALENESS_MIN;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_PUBLIC_STALENESS_MIN;
+  return parsed;
+}
+
+export interface PublicStalenessVerdict {
+  /** True when the data is within the publicly-acceptable freshness window. */
+  isFresh: boolean;
+  /** Age in milliseconds. Infinity when timestamp is missing/invalid. */
+  ageMs: number;
+  /** Configured freshness threshold in milliseconds. */
+  thresholdMs: number;
+}
+
+export function classifyPublicStaleness(
+  lastUpdatedAt: string | number | Date | null | undefined,
+  nowMs: number = Date.now(),
+): PublicStalenessVerdict {
+  const thresholdMs = maxPublicStalenessMin() * 60 * 1000;
+  if (lastUpdatedAt === null || lastUpdatedAt === undefined) {
+    return { isFresh: false, ageMs: Number.POSITIVE_INFINITY, thresholdMs };
+  }
+  let ts: number;
+  if (lastUpdatedAt instanceof Date) {
+    ts = lastUpdatedAt.getTime();
+  } else if (typeof lastUpdatedAt === "number") {
+    ts = lastUpdatedAt;
+  } else {
+    ts = Date.parse(lastUpdatedAt);
+  }
+  if (!Number.isFinite(ts)) {
+    return { isFresh: false, ageMs: Number.POSITIVE_INFINITY, thresholdMs };
+  }
+  const ageMs = Math.max(0, nowMs - ts);
+  return { isFresh: ageMs <= thresholdMs, ageMs, thresholdMs };
+}


### PR DESCRIPTION
## Summary

- Flip ``FreshnessBadge`` default from hidden to visible — readers can tell fresh from stale at a glance. Opt-out via ``NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=true``.
- Add fail-closed staleness gate on the homepage ``LiveTopTable``: when data is past ``MAX_PUBLIC_STALENESS_MIN`` (default 30min), render a "data refreshing" banner instead of the rankings. **No publicly stale batches reach users.**
- Implements the user-added hard rule from the ULTRA improvement plan: stale batches do not get rendered as if they were live.

## Files

- ``src/lib/public-staleness.ts`` (new) — ``classifyPublicStaleness()`` helper returning ``{ isFresh, ageMs, thresholdMs }``.
- ``src/components/shared/FreshnessBadge.tsx`` — flip default visibility.
- ``src/components/home/LiveTopTable.tsx`` — guard rankings render on ``classifyPublicStaleness()``; show banner when stale.

## Why now

ULTRA improvement plan Phase 4.1 always-ship row F4. Independent of deep-crawl deltas — the ``FreshnessBadge`` component is already implemented behind an env flag, and the staleness gate is the user's "no publicly stale batches" rule.

## Test plan

- [ ] ``pnpm tsc --noEmit`` clean (existing ``.next/types`` errors unrelated)
- [ ] Visit ``/`` after worker ticks — ``FreshnessBadge`` renders next to "showing X / Y" toolbar with current age label.
- [ ] Force stale data (set ``NEXT_PUBLIC_MAX_PUBLIC_STALENESS_MIN=0`` or pass a ``lastUpdatedAt`` more than 30min old) → rankings table is replaced by "Data refreshing." banner.
- [ ] Verify the badge can still be hidden with ``NEXT_PUBLIC_HIDE_FRESHNESS_BADGES=true`` (opt-out kept).

## Evidence

Phase 4.1 always-ship row from the ULTRA improvement plan. Companion to L1 PR #3172 (consensus stale-hide). Together they enforce: no stale row visible publicly anywhere on the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)