### PR TITLE
feat(video-mentions): YouTube-v1 fetcher for top-200 consensus repos (Tier B.3)

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/video-mentions/__tests__/video-mentions.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/video-mentions/__tests__/video-mentions.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeItems,
+  pickRunSlice,
+  topTierFullNames,
+} from '../index.js';
+import {
+  searchVideos,
+  sevenDaysAgo,
+  YouTubeQuotaExceededError,
+  YouTubeApiError,
+} from '../youtube-client.js';
+import type { VideoMentionsEntry } from '../types.js';
+
+describe('topTierFullNames', () => {
+  it('returns up to tierSize fullNames in input order, filtering malformed rows', () => {
+    const payload = {
+      items: [
+        { fullName: 'vercel/next.js', rank: 1 },
+        { fullName: 'facebook/react', rank: 2 },
+        { fullName: 'invalid-no-slash', rank: 3 },
+        { fullName: '', rank: 4 },
+        { fullName: 'huggingface/transformers', rank: 5 },
+      ],
+    };
+    expect(topTierFullNames(payload, 3)).toEqual([
+      'vercel/next.js',
+      'facebook/react',
+      'huggingface/transformers',
+    ]);
+  });
+
+  it('returns empty array for null/empty payloads', () => {
+    expect(topTierFullNames(null)).toEqual([]);
+    expect(topTierFullNames(undefined)).toEqual([]);
+    expect(topTierFullNames({})).toEqual([]);
+    expect(topTierFullNames({ items: [] })).toEqual([]);
+  });
+
+  it('respects the tierSize cap when input is larger', () => {
+    const items = Array.from({ length: 250 }, (_, i) => ({
+      fullName: `owner${i}/repo${i}`,
+      rank: i + 1,
+    }));
+    const out = topTierFullNames({ items }, 200);
+    expect(out).toHaveLength(200);
+    expect(out[0]).toBe('owner0/repo0');
+    expect(out[199]).toBe('owner199/repo199');
+  });
+});
+
+describe('pickRunSlice', () => {
+  const tier = Array.from({ length: 200 }, (_, i) => `o/${i}`);
+
+  it('returns the first reposPerRun starting at cursor 0', () => {
+    const { picked, nextCursor } = pickRunSlice(tier, 0, 100);
+    expect(picked).toHaveLength(100);
+    expect(picked[0]).toBe('o/0');
+    expect(picked[99]).toBe('o/99');
+    expect(nextCursor).toBe(100);
+  });
+
+  it('returns the second half starting at cursor 100', () => {
+    const { picked, nextCursor } = pickRunSlice(tier, 100, 100);
+    expect(picked).toHaveLength(100);
+    expect(picked[0]).toBe('o/100');
+    expect(picked[99]).toBe('o/199');
+    expect(nextCursor).toBe(0);
+  });
+
+  it('wraps around when the slice spans the tier end', () => {
+    const { picked, nextCursor } = pickRunSlice(tier, 150, 100);
+    expect(picked).toHaveLength(100);
+    expect(picked[0]).toBe('o/150');
+    expect(picked[49]).toBe('o/199');
+    expect(picked[50]).toBe('o/0');
+    expect(picked[99]).toBe('o/49');
+    expect(nextCursor).toBe(50);
+  });
+
+  it('normalizes a cursor beyond the tier size with modulo', () => {
+    const { picked, nextCursor } = pickRunSlice(tier, 200, 100);
+    expect(picked[0]).toBe('o/0');
+    expect(nextCursor).toBe(100);
+  });
+
+  it('handles negative cursor input safely (floors at 0 mod)', () => {
+    const { picked } = pickRunSlice(tier, -50, 10);
+    expect(picked[0]).toBe('o/150');
+  });
+
+  it('returns empty + cursor 0 for an empty tier', () => {
+    expect(pickRunSlice([], 5, 10)).toEqual({ picked: [], nextCursor: 0 });
+  });
+
+  it('caps reposPerRun at the effective tier size', () => {
+    const small = ['a/b', 'c/d', 'e/f'];
+    const { picked, nextCursor } = pickRunSlice(small, 0, 100);
+    expect(picked).toHaveLength(3);
+    expect(nextCursor).toBe(0);
+  });
+});
+
+describe('mergeItems', () => {
+  const e = (count: number): VideoMentionsEntry => ({
+    count7d: count,
+    topVideos: [],
+    fetchedAt: '2026-06-15T00:00:00Z',
+  });
+
+  it('overlays fresh entries on top of existing, preserving non-overlapping repos', () => {
+    const merged = mergeItems(
+      { 'vercel/next.js': e(10), 'facebook/react': e(20) },
+      { 'facebook/react': e(25), 'huggingface/transformers': e(5) },
+    );
+    expect(merged['vercel/next.js']?.count7d).toBe(10);
+    expect(merged['facebook/react']?.count7d).toBe(25);
+    expect(merged['huggingface/transformers']?.count7d).toBe(5);
+    expect(Object.keys(merged)).toHaveLength(3);
+  });
+
+  it('returns existing untouched when fresh is empty', () => {
+    const existing = { 'vercel/next.js': e(10) };
+    expect(mergeItems(existing, {})).toEqual(existing);
+  });
+});
+
+describe('sevenDaysAgo', () => {
+  it('returns an ISO string 7d before the supplied now', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    expect(sevenDaysAgo(now)).toBe('2026-06-08T12:00:00.000Z');
+  });
+});
+
+describe('searchVideos', () => {
+  const baseOpts = {
+    query: 'vercel/next.js',
+    apiKey: 'YT_KEY',
+    publishedAfter: '2026-06-08T00:00:00Z',
+  };
+
+  it('parses totalResults and up to 5 snippet samples from a 200 OK', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({
+          pageInfo: { totalResults: 42, resultsPerPage: 50 },
+          items: Array.from({ length: 7 }, (_, i) => ({
+            id: { videoId: `vid${i}` },
+            snippet: {
+              title: `Video ${i}`,
+              channelTitle: `Channel ${i}`,
+              publishedAt: '2026-06-10T00:00:00Z',
+            },
+          })),
+        }),
+        { status: 200 },
+      );
+    const result = await searchVideos({ ...baseOpts, fetchImpl: fakeFetch });
+    expect(result.totalResults).toBe(42);
+    expect(result.topVideos).toHaveLength(5);
+    expect(result.topVideos[0]).toMatchObject({
+      title: 'Video 0',
+      url: 'https://www.youtube.com/watch?v=vid0',
+      channelTitle: 'Channel 0',
+      publishedAt: '2026-06-10T00:00:00Z',
+    });
+  });
+
+  it('skips snippet items missing videoId or title', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({
+          pageInfo: { totalResults: 3 },
+          items: [
+            { id: {}, snippet: { title: 'no id' } },
+            { id: { videoId: 'v1' }, snippet: {} },
+            { id: { videoId: 'v2' }, snippet: { title: 'ok' } },
+          ],
+        }),
+        { status: 200 },
+      );
+    const result = await searchVideos({ ...baseOpts, fetchImpl: fakeFetch });
+    expect(result.totalResults).toBe(3);
+    expect(result.topVideos).toHaveLength(1);
+    expect(result.topVideos[0]?.url).toBe('https://www.youtube.com/watch?v=v2');
+  });
+
+  it('throws YouTubeQuotaExceededError on 403 quotaExceeded', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 403,
+            message: 'The request cannot be completed because you have exceeded your quota.',
+            errors: [{ reason: 'quotaExceeded', message: 'quota gone' }],
+          },
+        }),
+        { status: 403 },
+      );
+    await expect(searchVideos({ ...baseOpts, fetchImpl: fakeFetch })).rejects.toBeInstanceOf(
+      YouTubeQuotaExceededError,
+    );
+  });
+
+  it('throws YouTubeQuotaExceededError on 403 dailyLimitExceeded', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 403,
+            errors: [{ reason: 'dailyLimitExceeded' }],
+          },
+        }),
+        { status: 403 },
+      );
+    await expect(searchVideos({ ...baseOpts, fetchImpl: fakeFetch })).rejects.toBeInstanceOf(
+      YouTubeQuotaExceededError,
+    );
+  });
+
+  it('throws YouTubeApiError on other non-OK statuses', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(JSON.stringify({ error: { message: 'bad request' } }), { status: 400 });
+    await expect(searchVideos({ ...baseOpts, fetchImpl: fakeFetch })).rejects.toBeInstanceOf(
+      YouTubeApiError,
+    );
+  });
+
+  it('returns totalResults=0 when pageInfo is missing', async () => {
+    const fakeFetch = async (): Promise<Response> =>
+      new Response(JSON.stringify({ items: [] }), { status: 200 });
+    const result = await searchVideos({ ...baseOpts, fetchImpl: fakeFetch });
+    expect(result.totalResults).toBe(0);
+    expect(result.topVideos).toEqual([]);
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/video-mentions/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/video-mentions/index.ts
@@ -1,0 +1,344 @@
+// video-mentions — YouTube-v1 mention counter for the top-200 repos.
+//
+// WHY THIS EXISTS (Tier B.3 — TrendShift multi-platform parity)
+// TrendShift's /live-mentions widget tracks mention velocity across X, Reddit,
+// HN, Bilibili, and XiaoHongShu. We already cover X (twitter-warm/cold/hot),
+// Reddit (paused), HN (hackernews) and add YouTube here for v1. Bilibili and
+// XiaoHongShu are v2 — no Chinese-platform crawler in v1, documented in the
+// PR body as known gap, not a TODO comment in the fetcher.
+//
+// METHOD
+// Calls the YouTube Data API v3 Search:list endpoint with
+//   part=snippet, q=<repo fullName>, type=video, publishedAfter=<now - 7d>,
+//   maxResults=50
+// for the top-N repos (default top-100 per hourly run), and stores
+// `pageInfo.totalResults` as the 7-day mention count plus the first 5 snippet
+// items as `topVideos[]`. Rotates through the full top-200 every 2 hours via
+// a Redis-backed cursor (`ss:video-mentions:cursor`).
+//
+// QUOTA HONESTY
+// Search:list costs 100 quota units per call against the API key. The free
+// tier ships a daily 10,000-unit quota → 100 search calls/day max. The default
+// fetcher cap of 100 repos/hour × 24 hourly runs = 2,400 calls/day, which is
+// 24× the free quota. Operator MUST either:
+//   1. Request a quota bump via Google Cloud Console for the API key, OR
+//   2. Set YOUTUBE_MAX_REPOS_PER_RUN to a number that fits (e.g. 4 → 96/day).
+// The fetcher does no quota accounting itself — it stops the run on the first
+// `YouTubeQuotaExceededError` to avoid burning whatever quota remains.
+//
+// NEW-FETCHER POLICY HARD RULE (per the ULTRA plan)
+// Payload includes `staleness_seconds`. Consumers MUST treat the payload as
+// missing once `now - computedAt > staleness_seconds`. UI integration is a
+// follow-up PR — this PR only ships the fetcher + redis publish.
+//
+// FALLBACK
+// Missing YOUTUBE_API_KEY → no-op tick, warn-level log. Same for missing
+// consensus-trending payload (no top-200 to iterate). No retries are added
+// beyond AbortSignal.timeout — YouTube's API is fast and stable; transient
+// failure on one repo just means the prior entry stays in the payload until
+// the next sweep refreshes it.
+
+import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
+import { readDataStore, writeDataStore } from '../../lib/redis.js';
+import { shouldPreserveCache } from '../../lib/util/cache-merge.js';
+import { loadEnv } from '../../lib/env.js';
+import {
+  searchVideos,
+  sevenDaysAgo,
+  YouTubeApiError,
+  YouTubeQuotaExceededError,
+} from './youtube-client.js';
+import {
+  VIDEO_MENTIONS_CURSOR_KEY,
+  VIDEO_MENTIONS_DEFAULT_STALENESS_SECONDS,
+  VIDEO_MENTIONS_SLUG,
+  type VideoMentionsEntry,
+  type VideoMentionsPayload,
+} from './types.js';
+
+// --- knobs -----------------------------------------------------------------
+
+const TOP_TIER_SIZE = 200;
+const DEFAULT_REPOS_PER_RUN = 100;
+
+function clampEnv(name: string, def: number, lo: number, hi: number): number {
+  const n = Number.parseInt(process.env[name] ?? '', 10);
+  const v = Number.isFinite(n) && n > 0 ? n : def;
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// Capped at TOP_TIER_SIZE on the high end — a single run covering >200 makes
+// the cursor math pointless. Floor of 1 lets operators tune all the way down
+// for the free-tier 100-quota path described in the QUOTA HONESTY block.
+const REPOS_PER_RUN = clampEnv(
+  'YOUTUBE_MAX_REPOS_PER_RUN',
+  DEFAULT_REPOS_PER_RUN,
+  1,
+  TOP_TIER_SIZE,
+);
+
+// Conservative — YouTube's quota is per-project-per-day, not per-second. The
+// rate-limit risk is total daily usage, not burst. Keep concurrency low so we
+// don't hammer the API and to surface quotaExceeded fast on a depleted key.
+const CONCURRENCY = 2;
+
+// --- consensus-trending source -------------------------------------------
+
+interface ConsensusItemLite {
+  fullName?: string;
+  rank?: number;
+}
+interface ConsensusTrendingPayloadLite {
+  items?: ConsensusItemLite[];
+}
+
+/**
+ * Read the top-N fullNames from the `consensus-trending` payload, ordered by
+ * rank ascending. Filters out malformed rows and slices to the tier size.
+ * Pure.
+ */
+export function topTierFullNames(
+  payload: ConsensusTrendingPayloadLite | null | undefined,
+  tierSize: number = TOP_TIER_SIZE,
+): string[] {
+  const items = Array.isArray(payload?.items) ? payload!.items : [];
+  const out: string[] = [];
+  for (const item of items) {
+    const fn = typeof item?.fullName === 'string' ? item.fullName.trim() : '';
+    if (fn && fn.includes('/')) out.push(fn);
+    if (out.length >= tierSize) break;
+  }
+  return out;
+}
+
+/**
+ * Slice the top-200 list at the current cursor position, taking up to
+ * `reposPerRun` repos and wrapping around the end. Returns the picked slice
+ * plus the next cursor (which wraps mod TOP_TIER_SIZE).
+ * Pure.
+ */
+export function pickRunSlice(
+  topTier: string[],
+  cursor: number,
+  reposPerRun: number,
+): { picked: string[]; nextCursor: number } {
+  if (topTier.length === 0) {
+    return { picked: [], nextCursor: 0 };
+  }
+  const effectiveTierSize = Math.min(TOP_TIER_SIZE, topTier.length);
+  const safeCursor = ((cursor % effectiveTierSize) + effectiveTierSize) % effectiveTierSize;
+  const safeReposPerRun = Math.max(1, Math.min(reposPerRun, effectiveTierSize));
+  const picked: string[] = [];
+  for (let i = 0; i < safeReposPerRun; i++) {
+    picked.push(topTier[(safeCursor + i) % effectiveTierSize]!);
+  }
+  const nextCursor = (safeCursor + safeReposPerRun) % effectiveTierSize;
+  return { picked, nextCursor };
+}
+
+/**
+ * Overlay fresh entries onto the prior payload (fresh wins) — preserves
+ * entries for repos not in this run's slice so the full top-200 is always
+ * represented after the first 2-hour sweep.
+ * Pure.
+ */
+export function mergeItems(
+  existing: Record<string, VideoMentionsEntry>,
+  fresh: Record<string, VideoMentionsEntry>,
+): Record<string, VideoMentionsEntry> {
+  return { ...existing, ...fresh };
+}
+
+// --- fetcher --------------------------------------------------------------
+
+const fetcher: Fetcher = {
+  name: 'video-mentions',
+  // Hourly at :00 — paired with the cursor (100/run, cycle = 2h).
+  schedule: '0 * * * *',
+  async run(ctx: FetcherContext): Promise<RunResult> {
+    const startedAt = new Date().toISOString();
+    const errors: RunResult['errors'] = [];
+
+    if (ctx.dryRun) {
+      ctx.log.info('video-mentions dry-run');
+      return done(startedAt, 0, false, errors);
+    }
+
+    const env = loadEnv();
+    const apiKey = env.YOUTUBE_API_KEY;
+    if (!apiKey) {
+      ctx.log.warn('video-mentions: YOUTUBE_API_KEY not set, skipping tick');
+      return done(startedAt, 0, false, errors);
+    }
+
+    const consensus = await readDataStore<ConsensusTrendingPayloadLite>(
+      'consensus-trending',
+    ).catch(() => null);
+    const topTier = topTierFullNames(consensus);
+    if (topTier.length === 0) {
+      ctx.log.warn(
+        'video-mentions: consensus-trending empty/missing, skipping tick',
+      );
+      return done(startedAt, 0, false, errors);
+    }
+
+    // Read cursor — bare-integer ASCII so we can rotate independently of the
+    // payload's own cursor field (the payload is reset on TTL).
+    let cursor = 0;
+    try {
+      const raw = (await ctx.redis.get(VIDEO_MENTIONS_CURSOR_KEY)) ?? '0';
+      const parsed = Number.parseInt(String(raw), 10);
+      if (Number.isFinite(parsed) && parsed >= 0) cursor = parsed;
+    } catch (err) {
+      ctx.log.warn(
+        { err: (err as Error).message },
+        'video-mentions: cursor read failed, defaulting to 0',
+      );
+    }
+
+    const { picked, nextCursor } = pickRunSlice(topTier, cursor, REPOS_PER_RUN);
+    if (picked.length === 0) {
+      ctx.log.warn('video-mentions: pickRunSlice returned 0 repos');
+      return done(startedAt, 0, false, errors);
+    }
+
+    const publishedAfter = sevenDaysAgo();
+    const fresh: Record<string, VideoMentionsEntry> = {};
+    let scanned = 0;
+    let failed = 0;
+    let quotaHit = false;
+
+    const queue = [...picked];
+    const workers = Array.from({ length: CONCURRENCY }, async () => {
+      while (queue.length > 0 && !quotaHit) {
+        const fullName = queue.shift();
+        if (!fullName) break;
+        try {
+          const result = await searchVideos({
+            query: fullName,
+            apiKey,
+            publishedAfter,
+          });
+          fresh[fullName.toLowerCase()] = {
+            count7d: result.totalResults,
+            topVideos: result.topVideos,
+            fetchedAt: new Date().toISOString(),
+          };
+          scanned += 1;
+        } catch (err) {
+          failed += 1;
+          if (err instanceof YouTubeQuotaExceededError) {
+            quotaHit = true;
+            errors.push({
+              stage: `quota:${fullName}`,
+              message: err.message,
+            });
+            // Drain the queue so other workers stop cleanly.
+            queue.length = 0;
+            break;
+          }
+          if (err instanceof YouTubeApiError) {
+            errors.push({
+              stage: `api:${fullName}`,
+              message: `status=${err.status} ${err.message}`,
+            });
+          } else {
+            errors.push({
+              stage: `repo:${fullName}`,
+              message: (err as Error).message ?? String(err),
+            });
+          }
+        }
+      }
+    });
+    await Promise.all(workers);
+
+    if (quotaHit) {
+      ctx.log.error(
+        { scanned, failed, queueRemaining: queue.length },
+        'video-mentions: YouTube quota exceeded — stopping run, preserving cursor',
+      );
+      // Do NOT advance the cursor on quota-hit — re-run from same offset next
+      // tick (likely after quota reset at midnight Pacific Time).
+    } else {
+      try {
+        await ctx.redis.set(VIDEO_MENTIONS_CURSOR_KEY, String(nextCursor));
+      } catch (err) {
+        ctx.log.warn(
+          { err: (err as Error).message },
+          'video-mentions: cursor write failed',
+        );
+      }
+    }
+
+    // Merge fresh entries onto whatever the prior sweep wrote, so the full
+    // top-200 stays represented after the first 2h cycle.
+    const prior = await readDataStore<VideoMentionsPayload>(
+      VIDEO_MENTIONS_SLUG,
+    ).catch(() => null);
+    const priorItems = prior?.items ?? {};
+    const freshEntries = Object.values(fresh);
+
+    // Zero-write guard — never replace a populated payload with an empty
+    // recompute (same hazard class as star-activity-deltas zero-write guard).
+    if (shouldPreserveCache({ fresh: freshEntries, existing: Object.values(priorItems) })) {
+      ctx.log.warn(
+        {
+          picked: picked.length,
+          priorItems: Object.keys(priorItems).length,
+          failed,
+        },
+        'video-mentions: empty recompute — preserving prior slug',
+      );
+      return done(startedAt, 0, false, errors);
+    }
+
+    const mergedItems = mergeItems(priorItems, fresh);
+    const payload: VideoMentionsPayload = {
+      computedAt: new Date().toISOString(),
+      staleness_seconds: VIDEO_MENTIONS_DEFAULT_STALENESS_SECONDS,
+      cursor: quotaHit ? cursor : nextCursor,
+      scanned,
+      failed,
+      items: mergedItems,
+    };
+    const result = await writeDataStore(VIDEO_MENTIONS_SLUG, payload, {
+      writer: 'video-mentions',
+    });
+    ctx.log.info(
+      {
+        picked: picked.length,
+        scanned,
+        failed,
+        totalItems: Object.keys(mergedItems).length,
+        cursor,
+        nextCursor: quotaHit ? cursor : nextCursor,
+        quotaHit,
+        redisSource: result.source,
+      },
+      'video-mentions published',
+    );
+
+    return done(startedAt, scanned, result.source === 'redis', errors);
+  },
+};
+
+export default fetcher;
+
+function done(
+  startedAt: string,
+  items: number,
+  redisPublished: boolean,
+  errors: RunResult['errors'],
+): RunResult {
+  return {
+    fetcher: 'video-mentions',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    itemsSeen: items,
+    itemsUpserted: 0,
+    metricsWritten: 0,
+    redisPublished,
+    errors,
+  };
+}

--- a/apps/trendingrepo-worker/src/fetchers/video-mentions/types.ts
+++ b/apps/trendingrepo-worker/src/fetchers/video-mentions/types.ts
@@ -1,0 +1,52 @@
+// video-mentions — payload shape for the YouTube-v1 mention counter.
+//
+// The fetcher writes `ss:data:v1:video-mentions` with one entry per repo
+// fullName lowercased; the read path treats anything older than
+// staleness_seconds as missing (TTL gate is consumer-side per the ULTRA plan
+// hard rule for new fetchers).
+//
+// `count7d` is the upstream-reported `pageInfo.totalResults` from a YouTube
+// Data API v3 Search:list call with `publishedAfter = now - 7d`. It's a count
+// of public videos matching the repo fullName as a free-text query — not
+// click-throughs, watch time, or any quality signal. Operators can promote it
+// to a cross-source signal in consensus-trending once the YouTube quota
+// settles and a few weeks of comparison data exists.
+
+export interface VideoMentionsTopVideo {
+  title: string;
+  url: string;
+  channelTitle?: string;
+  publishedAt?: string;
+}
+
+export interface VideoMentionsEntry {
+  /** Upstream pageInfo.totalResults for `q=<fullName>` over the last 7d. */
+  count7d: number;
+  /** Up to 5 sample videos, for hover/preview on the eventual UI. */
+  topVideos: VideoMentionsTopVideo[];
+  /** ISO timestamp this entry was scored. */
+  fetchedAt: string;
+}
+
+export interface VideoMentionsPayload {
+  /** When this snapshot was published. */
+  computedAt: string;
+  /**
+   * Hard TTL for the payload in seconds. Consumers MUST treat the payload as
+   * missing once `now - computedAt > staleness_seconds`. Default 24h covers
+   * the full top-200 sweep at 100 repos/hour with one cycle buffer.
+   */
+  staleness_seconds: number;
+  /** Cursor position in the top-200 sweep at the end of this run. */
+  cursor: number;
+  /** How many repos this run refreshed. */
+  scanned: number;
+  /** How many repos failed (rate-limit, 4xx, timeout, etc.). */
+  failed: number;
+  /** Repo fullName (lowercased) → mention entry. */
+  items: Record<string, VideoMentionsEntry>;
+}
+
+export const VIDEO_MENTIONS_SLUG = 'video-mentions';
+export const VIDEO_MENTIONS_CURSOR_KEY = 'ss:video-mentions:cursor';
+export const VIDEO_MENTIONS_DEFAULT_STALENESS_SECONDS = 24 * 60 * 60;

--- a/apps/trendingrepo-worker/src/fetchers/video-mentions/youtube-client.ts
+++ b/apps/trendingrepo-worker/src/fetchers/video-mentions/youtube-client.ts
@@ -1,0 +1,152 @@
+// youtube-client — thin wrapper around the YouTube Data API v3 search endpoint.
+//
+// We use the Search:list endpoint (https://developers.google.com/youtube/v3/docs/search/list)
+// with `part=snippet,id`, `type=video`, `publishedAfter=<ISO>`, `q=<query>` and
+// `maxResults=50`. The endpoint returns `pageInfo.totalResults` which is the
+// total number of matching videos across the whole result set — we use that
+// as the 7-day mention count, and pull the first 5 snippet items as a sample
+// for `topVideos`.
+//
+// QUOTA NOTE
+// Each Search:list call costs 100 quota units against the API key. The default
+// daily quota on the free tier is 10,000 units, so the practical ceiling is
+// ~100 search calls per day per project. The fetcher caps repos per run via
+// YOUTUBE_MAX_REPOS_PER_RUN (default 100, see index.ts) — operators tuning to
+// the free tier should drop this to ~4 so 24 hourly runs stay under quota.
+// To run the full top-200 sweep every 2h as designed, request a quota bump
+// in Google Cloud Console; the fetcher itself does no quota accounting.
+
+const YOUTUBE_SEARCH_ENDPOINT = 'https://www.googleapis.com/youtube/v3/search';
+
+export interface YouTubeSearchVideoSample {
+  title: string;
+  url: string;
+  channelTitle?: string;
+  publishedAt?: string;
+}
+
+export interface YouTubeSearchResult {
+  /** `pageInfo.totalResults` — the upstream-reported total match count. */
+  totalResults: number;
+  /** Up to 5 of the most relevant videos for context. */
+  topVideos: YouTubeSearchVideoSample[];
+}
+
+interface YouTubeSearchResponse {
+  pageInfo?: {
+    totalResults?: number;
+    resultsPerPage?: number;
+  };
+  items?: Array<{
+    id?: { videoId?: string };
+    snippet?: {
+      title?: string;
+      channelTitle?: string;
+      publishedAt?: string;
+    };
+  }>;
+  error?: {
+    code?: number;
+    message?: string;
+    errors?: Array<{ reason?: string; message?: string }>;
+  };
+}
+
+export class YouTubeQuotaExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'YouTubeQuotaExceededError';
+  }
+}
+
+export class YouTubeApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'YouTubeApiError';
+    this.status = status;
+  }
+}
+
+export interface SearchVideosOptions {
+  query: string;
+  apiKey: string;
+  publishedAfter: string;
+  maxResults?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Run a single Search:list call against the YouTube Data API v3. Returns the
+ * upstream `pageInfo.totalResults` and the first up-to-5 snippet items.
+ *
+ * Throws `YouTubeQuotaExceededError` when the upstream returns 403 + a
+ * `quotaExceeded`/`dailyLimitExceeded` reason — callers should stop the run
+ * rather than burning more quota.
+ *
+ * Throws `YouTubeApiError` for any other non-OK status with the upstream message.
+ */
+export async function searchVideos(opts: SearchVideosOptions): Promise<YouTubeSearchResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const maxResults = Math.max(1, Math.min(50, opts.maxResults ?? 50));
+  const params = new URLSearchParams({
+    part: 'snippet',
+    q: opts.query,
+    type: 'video',
+    publishedAfter: opts.publishedAfter,
+    maxResults: String(maxResults),
+    key: opts.apiKey,
+  });
+  const url = `${YOUTUBE_SEARCH_ENDPOINT}?${params.toString()}`;
+  const res = await fetchImpl(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(opts.timeoutMs ?? 15_000),
+  });
+  let body: YouTubeSearchResponse;
+  try {
+    body = (await res.json()) as YouTubeSearchResponse;
+  } catch {
+    throw new YouTubeApiError(`youtube: non-JSON response (${res.status})`, res.status);
+  }
+  if (!res.ok) {
+    const reasons = body.error?.errors?.map((e) => e.reason).filter(Boolean) ?? [];
+    const quotaHit = reasons.includes('quotaExceeded') || reasons.includes('dailyLimitExceeded');
+    const message = body.error?.message ?? `${res.status} ${res.statusText}`;
+    if (quotaHit) {
+      throw new YouTubeQuotaExceededError(`youtube: quota exceeded — ${message}`);
+    }
+    throw new YouTubeApiError(`youtube: ${message}`, res.status);
+  }
+  const totalResults =
+    typeof body.pageInfo?.totalResults === 'number' && Number.isFinite(body.pageInfo.totalResults)
+      ? body.pageInfo.totalResults
+      : 0;
+  const items = Array.isArray(body.items) ? body.items : [];
+  const topVideos: YouTubeSearchVideoSample[] = items
+    .slice(0, 5)
+    .map((it) => {
+      const videoId = it.id?.videoId;
+      if (!videoId || !it.snippet?.title) return null;
+      const sample: YouTubeSearchVideoSample = {
+        title: it.snippet.title,
+        url: `https://www.youtube.com/watch?v=${videoId}`,
+      };
+      if (it.snippet.channelTitle) sample.channelTitle = it.snippet.channelTitle;
+      if (it.snippet.publishedAt) sample.publishedAt = it.snippet.publishedAt;
+      return sample;
+    })
+    .filter((v): v is YouTubeSearchVideoSample => v !== null);
+  return { totalResults, topVideos };
+}
+
+/**
+ * Build the 7-day `publishedAfter` ISO timestamp the fetcher passes to the
+ * YouTube API for every query. Pure — exported so the fetcher and tests can
+ * agree on the window without dragging Date.now() into the units under test.
+ */
+export function sevenDaysAgo(now: Date = new Date()): string {
+  const past = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  return past.toISOString();
+}

--- a/apps/trendingrepo-worker/src/lib/env.ts
+++ b/apps/trendingrepo-worker/src/lib/env.ts
@@ -34,6 +34,12 @@ const envSchema = z
     // The artificialanalysis fetcher gracefully short-circuits when this is
     // unset — see apps/trendingrepo-worker/src/fetchers/artificialanalysis/.
     AA_API_KEY: z.string().optional(),
+    // YouTube Data API v3 key (https://developers.google.com/youtube/v3/getting-started).
+    // Free tier ships 10,000 quota units/day; Search:list costs 100 units per
+    // call → ~100 search calls/day on the default quota. The video-mentions
+    // fetcher gracefully short-circuits when this is unset, and stops the run
+    // on a `quotaExceeded` 403 to avoid burning the rest of the budget.
+    YOUTUBE_API_KEY: z.string().optional(),
     APIFY_API_TOKEN: z.string().optional(),
     APIFY_PROXY_GROUPS: z.string().optional(),
     APIFY_PROXY_COUNTRY: z.string().optional(),

--- a/apps/trendingrepo-worker/src/platform/source-contract.ts
+++ b/apps/trendingrepo-worker/src/platform/source-contract.ts
@@ -67,6 +67,7 @@ export type AuthScheme =
   | 'twitter_web_cookies'
   | 'firecrawl'
   | 'supabase_service'
+  | 'youtube_api_key'
   | 'none';
 
 export type CardinalitySource = 'watchlist' | 'static' | 'enum';

--- a/apps/trendingrepo-worker/src/platform/sources.json
+++ b/apps/trendingrepo-worker/src/platform/sources.json
@@ -2317,5 +2317,37 @@
     ],
     "supports_backfill": false,
     "fallback_strategy": "cache"
+  },
+  {
+    "id": "video-mentions",
+    "category": "social",
+    "kind": "collector",
+    "state": "active",
+    "freshness_budget_ms": 7200000,
+    "cost_signal_metric": {
+      "type": "rate_limit_pct",
+      "scope": "day"
+    },
+    "rate_limit": {
+      "per_hour": 100,
+      "scope": "token"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://www.googleapis.com/youtube/v3/search",
+    "auth_required": true,
+    "auth_scheme": "youtube_api_key",
+    "primary_output_keys": [
+      "video-mentions"
+    ],
+    "output_record_shape": "mention_feed",
+    "consumer_surfaces": [],
+    "depends_on": [
+      "consensus-trending"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "skip",
+    "writes_canonical_entity_kind": [
+      "mention"
+    ]
   }
 ]

--- a/apps/trendingrepo-worker/src/registry.ts
+++ b/apps/trendingrepo-worker/src/registry.ts
@@ -142,6 +142,13 @@ import editorialWriter from './fetchers/editorial-writer/index.js';
 import editorialCategories from './fetchers/editorial-categories/index.js';
 import editorialCompare from './fetchers/editorial-compare/index.js';
 import editorialAlternatives from './fetchers/editorial-alternatives/index.js';
+// Tier B.3 — YouTube-v1 video-mention counter for the top-200 consensus repos.
+// Hourly, rotates through the full top-200 every 2h via a Redis cursor. Closes
+// part of the TrendShift /live-mentions multi-platform gap (X is already
+// covered via twitter-*, HN via hackernews; Bilibili + XiaoHongShu are v2).
+// New-fetcher TTL gate: payload includes `staleness_seconds` (24h). UI
+// integration is a follow-up PR.
+import videoMentions from './fetchers/video-mentions/index.js';
 
 export const FETCHERS: Fetcher[] = [
   hnPulse,
@@ -193,6 +200,7 @@ export const FETCHERS: Fetcher[] = [
   editorialCategories,
   editorialCompare,
   editorialAlternatives,
+  videoMentions,
 ];
 
 export function getFetcher(name: string): Fetcher | undefined {

--- a/src/lib/worker-health-specs.ts
+++ b/src/lib/worker-health-specs.ts
@@ -114,6 +114,11 @@ export const WORKER_HEALTH_SPECS: ReadonlyArray<SlugHealthSpec> = [
   // weekly - slow-moving baselines
   { slug: "lmarena-text", fetcher: "lmarena", cadenceMin: 60 * 24 * 7, slowMoving: true, blocking: false },
 
+  // Tier B.3 — YouTube video-mention counter for the top-200 consensus repos.
+  // Hourly, 100 repos per run, full top-200 swept every 2h. Advisory until the
+  // UI integration ships and we have real operator-experience with quota; until
+  // then a missing or stale slug shouldn't gate the fleet ok state.
+  { slug: "video-mentions", fetcher: "video-mentions", cadenceMin: 120, blocking: false },
 ];
 
 export const WORKER_PAYLOAD_HEALTH_SLUGS: ReadonlySet<string> = new Set(


### PR DESCRIPTION
## Summary

- New hourly fetcher `apps/trendingrepo-worker/src/fetchers/video-mentions/` that counts YouTube videos mentioning each top-200 consensus-trending repo over the last 7 days via the YouTube Data API v3 Search:list endpoint.
- Rotates through the full top-200 every 2 hours via a Redis cursor (100 repos per run, schedule `0 * * * *`).
- Closes part of the TrendShift `/live-mentions` multi-platform gap. Coverage: X via `twitter-{hot,warm,cold}`, HN via `hackernews`, YouTube via this fetcher. Bilibili + XiaoHongShu are v2 — no Chinese-platform crawler in v1 (documented as known gap, not a TODO).
- New-fetcher TTL gate: payload includes `staleness_seconds` (24h) so consumers can drop past-TTL (ULTRA plan hard rule for net-new fetchers).
- UI integration is a follow-up PR. This PR ships the fetcher + Redis publish only.

Deltas evidence cited in audit:
- TrendShift `/live-mentions` — https://trendshift.io/live-mentions
- impact score 4.0 (multi-platform mention parity vs current X-only coverage)

## Quota honesty (please read before merging)

Search:list costs **100 quota units per call**. The default YouTube Data API free-tier quota is **10,000 units/day** → **~100 search calls/day max per project**.

The fetcher's default cap of 100 repos/hour × 24 hourly runs = **2,400 calls/day**, which is **24× the free quota**. Operator must choose:

1. **Request a quota bump** for the API key in Google Cloud Console (preferred — full top-200 sweep every 2h as designed), OR
2. **Set `YOUTUBE_MAX_REPOS_PER_RUN`** to a number that fits — e.g. `4` → 96 calls/day under the 100 limit (full top-200 swept once every ~50h).

Either path is supported in code:
- Fetcher gracefully short-circuits when `YOUTUBE_API_KEY` is unset (warn-level log, no-op tick).
- On the first `quotaExceeded` / `dailyLimitExceeded` 403, the fetcher stops the run, preserves the cursor (does NOT advance), and surfaces the error to the run summary. Next tick resumes from the same offset (likely after quota reset at midnight Pacific Time).

This is the "ship anyway with a clear note" path the task brief authorized — no quota accounting in the fetcher itself; operator decides the budget.

## Files

```
A  apps/trendingrepo-worker/src/fetchers/video-mentions/index.ts
A  apps/trendingrepo-worker/src/fetchers/video-mentions/youtube-client.ts
A  apps/trendingrepo-worker/src/fetchers/video-mentions/types.ts
A  apps/trendingrepo-worker/src/fetchers/video-mentions/__tests__/video-mentions.test.ts
M  apps/trendingrepo-worker/src/lib/env.ts                 (+ YOUTUBE_API_KEY)
M  apps/trendingrepo-worker/src/platform/source-contract.ts (+ youtube_api_key auth)
M  apps/trendingrepo-worker/src/platform/sources.json       (+ video-mentions contract)
M  apps/trendingrepo-worker/src/registry.ts                 (+ register fetcher)
M  src/lib/worker-health-specs.ts                           (+ advisory health spec)
```

## Payload shape (Redis slug `ss:data:v1:video-mentions`)

```ts
{
  computedAt: string;                       // ISO
  staleness_seconds: 86400;                 // 24h TTL gate
  cursor: number;                           // current top-200 offset
  scanned: number;                          // repos refreshed this run
  failed: number;                           // repos that errored
  items: Record<string /* fullName.toLowerCase() */, {
    count7d: number;                        // pageInfo.totalResults
    topVideos: Array<{
      title: string;
      url: string;                          // https://www.youtube.com/watch?v=<id>
      channelTitle?: string;
      publishedAt?: string;
    }>;
    fetchedAt: string;                      // per-entry ISO
  }>
}
```

## Test plan

- [x] `pnpm --filter @trendingrepo/worker typecheck` — passes
- [x] `pnpm --filter @trendingrepo/worker test` — **526 pass, 1 skipped, 2 todo** (full worker suite incl. registry.test.ts contract checks)
- [x] `tsx --test src/lib/pipeline/__tests__/health-availability.test.ts` — **18/18 pass** (verifies the new advisory health spec)
- [x] `tsc --noEmit -p tsconfig.json` (root) — passes
- [x] 19 new unit tests cover: `topTierFullNames`, `pickRunSlice` cursor wraparound, `mergeItems`, `searchVideos` (200 OK, `quotaExceeded`, `dailyLimitExceeded`, generic API error, missing pageInfo, malformed snippet items), `sevenDaysAgo`
- [ ] Manual smoke test: set `YOUTUBE_API_KEY` locally, run `npx tsx src/index.ts video-mentions` once, verify `ss:data:v1:video-mentions` keys exist with non-zero `count7d` for a popular repo

## Known gaps (v2)

- **Bilibili** and **XiaoHongShu** are TrendShift sources we do not cover. No Chinese-platform crawler in v1; tracker for v2 would land as a separate `bilibili-mentions` fetcher.
- No client-side rendering — `pageInfo.totalResults` is the upstream-reported count, which YouTube may approximate for high-cardinality queries. Acceptable for v1 ranking; v2 could paginate `nextPageToken` for an exact count (would 10× quota cost).
- No engagement signal (views, likes) — Search:list does not return statistics. A follow-up could enrich via Videos:list (1 unit/call vs Search's 100, so this is cheap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)