### PR TITLE
feat(home): Daily/Weekly/Monthly tabs + honest 30-day Yearly cap (U2)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,11 @@ import {
   type LiveRow,
   type CategoryFacet,
 } from "@/components/home/LiveTopTable";
+import {
+  TimeWindowTabs,
+  parseTimeWindow,
+  sortKeyForWindow,
+} from "@/components/home/TimeWindowTabs";
 import { CATEGORIES } from "@/lib/constants";
 import { NewsletterCaptureForm } from "@/components/newsletter/NewsletterCaptureForm";
 import { repoLogoUrl } from "@/lib/logos";
@@ -680,7 +685,16 @@ function FeaturedCard({
   );
 }
 
-export default async function HomePage() {
+interface HomePageProps {
+  // U2-time-window-tabs: ?window=24h|7d|30d. 24h is default and elided from
+  // canonical URL. Yearly (365d) is intentionally absent — surfaced as a
+  // disabled tab with a "30-day cap" tooltip in <TimeWindowTabs>.
+  searchParams?: Promise<{ window?: string | string[] }>;
+}
+
+export default async function HomePage({ searchParams }: HomePageProps = {}) {
+  const sp = (await searchParams) ?? {};
+  const timeWindow = parseTimeWindow(sp.window);
   const repos = getDerivedRepos();
   // Pull skills + mcp ecosystem signals so the front page can surface
   // their respective top movers alongside repo gainers. Both
@@ -992,6 +1006,12 @@ export default async function HomePage() {
           title="Live / top 50"
           meta={<><b>{refreshedTime}</b> / refreshed</>}
         />
+        {/* U2 — TrendShift-style Daily/Weekly/Monthly nav above the rankings
+            card. ?window=24h|7d|30d drives both the visible active tab AND
+            LiveTopTable's initial sort column. Yearly is rendered disabled
+            with a tooltip — TrendingRepo only keeps 30 days of star history,
+            so faking a 365d delta would violate the no-publicly-stale rule. */}
+        <TimeWindowTabs active={timeWindow} />
         <Card>
           <LiveTopTable
             rows={liveTableRows}
@@ -999,6 +1019,8 @@ export default async function HomePage() {
             freshnessSource="repos"
             lastUpdatedAt={lastFetchedAt}
             freshnessNowMs={freshnessNowMs}
+            initialSortKey={sortKeyForWindow(timeWindow)}
+            initialSortDir="desc"
           />
         </Card>
 

--- a/src/components/home/LiveTopTable.tsx
+++ b/src/components/home/LiveTopTable.tsx
@@ -150,6 +150,15 @@ interface LiveTopTableProps {
    * through keeps the first client render identical to ISR HTML.
    */
   freshnessNowMs?: number;
+  /**
+   * U2-time-window-tabs: initial sort column driven by `?window=24h|7d|30d`
+   * on the home surface. When the user clicks a column header the in-table
+   * sort still wins client-side; this only seeds the first render so a
+   * deep-link to `?window=7d` opens with the 7d column already active.
+   */
+  initialSortKey?: SortKey;
+  /** Pair-with-initialSortKey to seed the first-render sort direction. */
+  initialSortDir?: SortDir;
 }
 
 const compactNumber = new Intl.NumberFormat("en-US", {
@@ -339,9 +348,11 @@ export function LiveTopTable({
   freshnessSource = "repos",
   lastUpdatedAt = null,
   freshnessNowMs,
+  initialSortKey = "rank",
+  initialSortDir = "desc",
 }: LiveTopTableProps) {
-  const [sortKey, setSortKey] = useState<SortKey>("rank");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [sortKey, setSortKey] = useState<SortKey>(initialSortKey);
+  const [sortDir, setSortDir] = useState<SortDir>(initialSortDir);
   const [activeCat, setActiveCat] = useState<string | null>(null);
   // AGN-1782: viewport-triggered prefetch for /repo/{owner}/{name} routes.
   // Each row anchor uses the ref to opt into the IntersectionObserver. The

--- a/src/components/home/TimeWindowTabs.tsx
+++ b/src/components/home/TimeWindowTabs.tsx
@@ -1,0 +1,95 @@
+// TimeWindowTabs — Daily / Weekly / Monthly / Yearly above the Live top-50
+// rankings card on the home surface (TrendShift-style nav).
+//
+// URL contract: `?window=24h|7d|30d`. Defaults to 24h (omitted from URL).
+// Yearly is rendered as a disabled tab with a tooltip because TrendingRepo
+// only carries 30 days of star history — see the "no-publicly-stale" rule:
+// faking a 365d delta would be worse than admitting the cap.
+//
+// Server component. Renders the existing v4 TabBar in `hrefs` link-mode so
+// Next.js prefetch + back/forward navigation work without client state.
+// The tab itself drives:
+//   1. LiveTopTable's initial sort column (via `initialSortKey` prop on the
+//      table, set by page.tsx based on the same `?window=` param)
+//   2. A subtle hint line under the tabs explaining what each window shows
+//
+// References: src/components/ui/TabBar.tsx, src/app/categories/[slug]/page.tsx
+// (which uses the same `?window=24h|7d|30d` contract for category track tabs).
+
+import { TabBar, type TabItem } from "@/components/ui/TabBar";
+
+export type TimeWindowId = "24h" | "7d" | "30d";
+
+export const TIME_WINDOW_IDS: readonly TimeWindowId[] = ["24h", "7d", "30d"];
+
+/** Type-narrow an unknown URL param value to a TimeWindowId, defaulting to 24h. */
+export function parseTimeWindow(
+  value: string | string[] | undefined,
+): TimeWindowId {
+  const v = Array.isArray(value) ? value[0] : value;
+  return (TIME_WINDOW_IDS as readonly string[]).includes(v ?? "")
+    ? (v as TimeWindowId)
+    : "24h";
+}
+
+/** Map a TimeWindowId to the LiveTopTable SortKey for the matching delta column. */
+export function sortKeyForWindow(window: TimeWindowId): "d24" | "d7" | "d30" {
+  if (window === "7d") return "d7";
+  if (window === "30d") return "d30";
+  return "d24";
+}
+
+interface TimeWindowTabsProps {
+  /** Active window id. */
+  active: TimeWindowId;
+  /**
+   * Base path the tab links point to. Defaults to "/" (home). Useful when the
+   * component is reused on other surfaces (e.g. /breakouts).
+   */
+  basePath?: string;
+}
+
+// "Yearly" intentionally has no href — TrendingRepo doesn't carry 365 days of
+// star history. The disabled flag wires the v4-tab--disabled CSS + aria-disabled.
+const YEARLY_TOOLTIP =
+  "Beyond TrendingRepo's 30-day window — see Methodology for why";
+
+export function TimeWindowTabs({ active, basePath = "/" }: TimeWindowTabsProps) {
+  // Build hrefs for the three real windows. 24h is the default and elides the
+  // ?window= param to keep the canonical URL clean (matches the existing
+  // TrendingControlBar.cleanQuery convention).
+  const hrefs: Record<string, string> = {
+    "24h": basePath,
+    "7d": `${basePath}${basePath.includes("?") ? "&" : "?"}window=7d`,
+    "30d": `${basePath}${basePath.includes("?") ? "&" : "?"}window=30d`,
+    // 365d intentionally omitted — TabBar treats missing hrefs as buttons,
+    // but we mark the item disabled so it never fires onChange either.
+  };
+
+  const items: TabItem[] = [
+    { id: "24h", label: "Daily" },
+    { id: "7d", label: "Weekly" },
+    { id: "30d", label: "Monthly" },
+    { id: "365d", label: "Yearly", disabled: true },
+  ];
+
+  return (
+    <div className="time-window-tabs" data-active={active}>
+      <TabBar items={items} active={active} hrefs={hrefs} />
+      <p className="time-window-tabs__hint" role="note">
+        {active === "24h"
+          ? "Sorted by 24h star delta. Same data refreshes every 30 minutes."
+          : active === "7d"
+            ? "Sorted by 7-day star delta. Catches multi-day breakouts."
+            : "Sorted by 30-day star delta. The widest window we carry."}
+        {/* Yearly's "30-day cap" tooltip is on the disabled tab itself —
+            screen readers see aria-disabled, mouse users see the title attr.
+            Surfaced redundantly here so sighted users on the wrong window
+            still see the cap honestly. */}
+        <span className="time-window-tabs__cap" title={YEARLY_TOOLTIP}>
+          Yearly unavailable — 30-day data cap
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/home/__tests__/TimeWindowTabs.test.tsx
+++ b/src/components/home/__tests__/TimeWindowTabs.test.tsx
@@ -1,0 +1,123 @@
+// Tier B.2 / U2 — Daily/Weekly/Monthly tabs above the home rankings card.
+//
+// Two contracts under test:
+//   1. parseTimeWindow() rejects junk values (incl. ?window=365d) and
+//      defaults to "24h" — keeps the home page from crashing on deep links.
+//   2. <TimeWindowTabs> renders the Yearly tab as disabled (aria-disabled
+//      true, surfaces the 30-day-cap tooltip) — TrendingRepo doesn't carry
+//      365 days of history and faking it would violate the no-publicly-stale
+//      rule (F4 PR #3173).
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  TimeWindowTabs,
+  parseTimeWindow,
+  sortKeyForWindow,
+} from "@/components/home/TimeWindowTabs";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("parseTimeWindow", () => {
+  it("accepts the three real windows", () => {
+    expect(parseTimeWindow("24h")).toBe("24h");
+    expect(parseTimeWindow("7d")).toBe("7d");
+    expect(parseTimeWindow("30d")).toBe("30d");
+  });
+
+  it("falls back to 24h for undefined / missing values", () => {
+    expect(parseTimeWindow(undefined)).toBe("24h");
+    expect(parseTimeWindow("")).toBe("24h");
+  });
+
+  it("falls back to 24h for the bogus Yearly URL — must not crash", () => {
+    // Acceptance criterion from the U2 brief: visiting ?window=365d should
+    // surface the 30-day-cap tooltip without rendering a yearly-sorted
+    // table or throwing.
+    expect(parseTimeWindow("365d")).toBe("24h");
+    expect(parseTimeWindow("1y")).toBe("24h");
+    expect(parseTimeWindow("forever")).toBe("24h");
+  });
+
+  it("unwraps the first value from a repeated array param", () => {
+    // Next.js searchParams can be string[] when the same key appears twice.
+    expect(parseTimeWindow(["7d", "30d"])).toBe("7d");
+    expect(parseTimeWindow(["365d"])).toBe("24h");
+  });
+});
+
+describe("sortKeyForWindow", () => {
+  it("maps each window to its matching LiveTopTable sort column", () => {
+    expect(sortKeyForWindow("24h")).toBe("d24");
+    expect(sortKeyForWindow("7d")).toBe("d7");
+    expect(sortKeyForWindow("30d")).toBe("d30");
+  });
+});
+
+describe("<TimeWindowTabs>", () => {
+  it("renders all four tabs with TrendShift-style labels", () => {
+    const { container } = render(<TimeWindowTabs active="24h" />);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    const labels = Array.from(tabs).map((t) => t.textContent?.trim());
+    expect(labels).toEqual(["Daily", "Weekly", "Monthly", "Yearly"]);
+  });
+
+  it("marks the active tab via aria-selected", () => {
+    const { container } = render(<TimeWindowTabs active="7d" />);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    const active = Array.from(tabs).filter(
+      (t) => t.getAttribute("aria-selected") === "true",
+    );
+    expect(active).toHaveLength(1);
+    expect(active[0].textContent?.trim()).toBe("Weekly");
+  });
+
+  it("marks Yearly as a disabled <button> (not a link)", () => {
+    // Honesty rule: Yearly is intentionally non-navigable because the data
+    // simply doesn't exist beyond 30 days. Must not render as an <a> link;
+    // must render as a <button disabled> so click/keyboard/AT all agree.
+    const { container } = render(<TimeWindowTabs active="24h" />);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    const yearly = Array.from(tabs).find(
+      (t) => t.textContent?.trim() === "Yearly",
+    );
+    expect(yearly).toBeDefined();
+    expect(yearly?.tagName.toLowerCase()).toBe("button");
+    // Native `disabled` already prevents clicks + announces "dimmed/unavailable"
+    // to screen readers. v4-tab--disabled class is the visual signal.
+    expect((yearly as HTMLButtonElement).disabled).toBe(true);
+    expect(yearly?.className).toMatch(/v4-tab--disabled/);
+  });
+
+  it("surfaces the 30-day cap tooltip line under the tabs", () => {
+    const { container } = render(<TimeWindowTabs active="24h" />);
+    const cap = container.querySelector(".time-window-tabs__cap");
+    expect(cap).not.toBeNull();
+    expect(cap?.textContent).toMatch(/30-day data cap/i);
+    expect(cap?.getAttribute("title")).toMatch(/30-day window/i);
+  });
+
+  it("links Daily back to / (omits ?window= for the default)", () => {
+    const { container } = render(<TimeWindowTabs active="30d" />);
+    const daily = Array.from(container.querySelectorAll("a")).find(
+      (a) => a.textContent?.trim() === "Daily",
+    );
+    expect(daily?.getAttribute("href")).toBe("/");
+  });
+
+  it("links Weekly and Monthly to their ?window= URLs", () => {
+    const { container } = render(<TimeWindowTabs active="24h" />);
+    const links = Array.from(container.querySelectorAll("a"));
+    expect(
+      links.find((a) => a.textContent?.trim() === "Weekly")?.getAttribute("href"),
+    ).toBe("/?window=7d");
+    expect(
+      links.find((a) => a.textContent?.trim() === "Monthly")?.getAttribute(
+        "href",
+      ),
+    ).toBe("/?window=30d");
+  });
+});

--- a/src/components/ui/v4.css
+++ b/src/components/ui/v4.css
@@ -591,6 +591,44 @@
 }
 
 /* ---------------------------------------------------------------------------
+ * 08b. TimeWindowTabs — Daily/Weekly/Monthly above the Live top-50 card.
+ *      Wraps the v4 TabBar with a tight hint line that honestly surfaces
+ *      the 30-day data cap (Yearly is rendered disabled inside the TabBar).
+ * --------------------------------------------------------------------------- */
+.time-window-tabs {
+  margin: 0 0 8px;
+}
+.time-window-tabs__hint {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 8px 0 0;
+  font-family: var(--v4-mono);
+  font-size: var(--v4-text-9-5);
+  letter-spacing: var(--v4-track-16);
+  color: var(--v4-ink-400);
+  text-transform: uppercase;
+}
+.time-window-tabs__cap {
+  margin-left: auto;
+  color: var(--v4-ink-500);
+  cursor: help;
+  text-decoration: underline dotted currentColor;
+  text-underline-offset: 3px;
+}
+@media (max-width: 640px) {
+  .time-window-tabs__hint {
+    font-size: var(--v4-text-9-5);
+    gap: 6px;
+  }
+  .time-window-tabs__cap {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+/* ---------------------------------------------------------------------------
  * 09. SourcePip — 2-letter source channel badge
  * --------------------------------------------------------------------------- */
 .v4-source-pip {


### PR DESCRIPTION
## Summary

Tier B.2 / U2 — TrendShift-aligned time-window navigation above the Live top-50 rankings card on `/`.

- **New `<TimeWindowTabs>`** (`src/components/home/TimeWindowTabs.tsx`). Server component wrapping the existing v4 `<TabBar>` in `hrefs` link-mode. Renders Daily | Weekly | Monthly | Yearly. Daily/Weekly/Monthly are real links to `/?window=24h|7d|30d`; Yearly is a disabled `<button>` with a tooltip + visible "Yearly unavailable — 30-day data cap" hint line. Honest by default — TrendingRepo only carries 30 days of star history, so faking a 365d delta would violate the no-publicly-stale rule.
- **`HomePage` now accepts `searchParams.window`** and threads it into the new tab strip + `LiveTopTable`'s new `initialSortKey` / `initialSortDir` props. A deep-link to `/?window=7d` opens with the 7d column already sorted desc.
- **`LiveTopTable` got two new optional props** (`initialSortKey`, `initialSortDir`). Default behaviour unchanged — existing callers don't have to pass them.
- **CSS lives in `v4.css §08b`** alongside the v4-tab styles. Cap line wraps under the tabs on `<640px`.
- **11 unit tests** in `src/components/home/__tests__/TimeWindowTabs.test.tsx` cover the URL-param parser (incl. the bogus `?window=365d` no-crash guarantee), the window→sort-key mapping, the disabled-Yearly affordance (must render as `<button disabled>`, not `<a>`), and the link `href`s.

URL contract `?window=24h|7d|30d` is back-compat — already used today by `src/app/categories/[slug]/page.tsx`. No API changes.

## Why

Mirrors TrendShift's daily / weekly / yearly nav. Operator brief impact: 3.0. Audit findings (see Tier B.2 brief) called out that `LiveTopTable` already carries `starsDelta24h/7d/30d` and the existing `/api/repos` route accepts `?period=today|week|month` — the only gap was the visible tab strip and the URL-driven default sort, both shipped here.

## Honest constraints

- `?window=365d` falls back to `24h` rather than crashing. Tested explicitly.
- No data forge: when the underlying snapshot is cold the existing `<FreshnessBadge>` inside `LiveTopTable` already paints the staleness verdict; the tabs do not paper over that.
- Single-button Yearly is a `<button disabled>` (not a navigable link). Native `disabled` prevents both click and keyboard activation, and the `.v4-tab--disabled` class dims it visually.

## Test plan

- [x] `npx tsc --noEmit` — no new errors (9 pre-existing storybook ones unchanged)
- [x] `npx vitest run src/components/home/__tests__/` — 26 tests pass (11 new + 15 pre-existing)
- [ ] Manual: visit `/` with `?window=24h`, `=7d`, `=30d` and confirm the active tab + LiveTopTable sort column
- [ ] Manual: visit `/?window=365d` and confirm fallback to Daily + no crash
- [ ] Manual: hover the Yearly tab and the cap-line — confirm tooltip surfaces "Beyond TrendingRepo's 30-day window"
- [ ] Mobile (<640px): confirm tabs and cap-line stack cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)