### PR TITLE
feat(home): Tier C monetization-as-headline band above LiveTopTable

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,10 @@ import {
   type LiveRow,
   type CategoryFacet,
 } from "@/components/home/LiveTopTable";
+import { TierCMonetizationBand } from "@/components/home/TierCMonetizationBand";
 import { CATEGORIES } from "@/lib/constants";
+import { getRevenueOverlaysMeta } from "@/lib/revenue-overlays";
+import { getFundingFetchedAt } from "@/lib/funding-news";
 import { NewsletterCaptureForm } from "@/components/newsletter/NewsletterCaptureForm";
 import { repoLogoUrl } from "@/lib/logos";
 import type { Repo } from "@/lib/types";
@@ -864,6 +867,32 @@ export default async function HomePage() {
       .reduce((sum, repo) => sum + Math.max(0, repo.starsDelta24h), 0),
   })).sort((a, b) => b.delta - a.delta)[0];
 
+  // Tier C monetization band freshness — pulled once from the synchronous
+  // accessors and handed to the band component. Both reads are wrapped in
+  // try/catch so a cold cache renders the band with an honest "updating"
+  // pill rather than throwing the (ISR-cached) home render. The strategic
+  // wedge here is monetization (revenue calculator + funding/MRR radar +
+  // embed-ready SVGs) — defensible vs OSSInsight + TrendShift per the
+  // combined deep-crawl deltas.
+  let revenueOverlaysGeneratedAt: string | null = null;
+  try {
+    revenueOverlaysGeneratedAt = getRevenueOverlaysMeta().generatedAt;
+  } catch (err) {
+    console.error(
+      "[home] revenue-overlays meta read failed",
+      err instanceof Error ? err.message : err,
+    );
+  }
+  let fundingFetchedAt: string | null = null;
+  try {
+    fundingFetchedAt = getFundingFetchedAt();
+  } catch (err) {
+    console.error(
+      "[home] funding fetchedAt read failed",
+      err instanceof Error ? err.message : err,
+    );
+  }
+
   return (
     <>
       <FunnelMount step="home_view" flow="discover-repo" />
@@ -986,6 +1015,17 @@ export default async function HomePage() {
             <FeaturedCard key={`${entity.kind}-${entity.id}`} entity={entity} index={index} />
           ))}
         </div>
+
+        {/* Tier C monetization band — positions TrendingRepo's defensible
+            differentiation (revenue estimates, funding/MRR radar, embed-ready
+            star-history + treemap SVGs) directly above the live ranking table.
+            Rankings remain the entry point; this band names the angle no other
+            tracker ships (combined deep-crawl deltas — toolbox PR #241, L1
+            #3172, F4 #3173, C-CAT #3174). */}
+        <TierCMonetizationBand
+          revenueOverlaysGeneratedAt={revenueOverlaysGeneratedAt}
+          fundingFetchedAt={fundingFetchedAt}
+        />
 
         <SectionHead
           num="// 05"

--- a/src/components/home/TierCMonetizationBand.tsx
+++ b/src/components/home/TierCMonetizationBand.tsx
@@ -1,0 +1,274 @@
+// TierCMonetizationBand — homepage value-prop band positioning TrendingRepo's
+// monetization-angle differentiation (revenue estimates, funding/MRR radar,
+// star-history SVG + treemap) directly above the LiveTopTable rankings card.
+//
+// SERVER component. No client deps. Reuses the V4 design-system primitives
+// (Card variant="tool", SectionHead, FreshnessBadge, --v4-money accent token)
+// so the band inherits the terminal-corpus aesthetic without introducing any
+// new shell CSS.
+//
+// Sequence on /:
+//   page-head        (hero + newsletter)
+//   MetricGrid       (six KPI cells)
+//   SectionHead 01   "Trending now / top 5 by category"  + 3 HeroPanels
+//   SectionHead 02   "What multiple feeds agree on"      + 2 consensus cards
+//   SectionHead 03   "Signal map / momentum vs scale"    + BubbleMap
+//   SectionHead 04   "Featured / curated this week"      + 5 feat cards
+//   ─► TierCMonetizationBand  (this — positions the angle)
+//   SectionHead 05   "Live / top 50"                     + LiveTopTable
+//   SectionHead 06   "TrendingRepo Index / last 30 days" + chart
+//
+// Strategic framing: combined deep-crawl deltas (toolbox PR #241, L1 #3172,
+// F4 #3173, C-CAT #3174) flagged monetization (revenue calculator 4.0, MRR
+// radar 4.0, star-history SVG 3.0, embed virality wedge) as our defensible
+// differentiation vs OSSInsight + TrendShift. This band names that angle on
+// the home page without displacing rankings as the entry point.
+//
+// Honest staleness: each card derives an "is-live" boolean from
+// classifyFreshness. A cold source flips the right-aligned chip from a green
+// "live" indicator to an amber "updating" one — never publishes a stale
+// figure as if it were current.
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Card, CardHeader } from "@/components/ui/Card";
+import { SectionHead } from "@/components/ui/SectionHead";
+import { FreshnessBadge } from "@/components/shared/FreshnessBadge";
+import { classifyFreshness, type NewsSource } from "@/lib/news/freshness";
+
+export interface TierCMonetizationBandProps {
+  /**
+   * ISO of the most recent verified-revenue-overlay snapshot. When stale or
+   * absent, the Revenue Estimate card flips its corner badge from "DAILY"
+   * to "UPDATING" so we never imply a fresh ARR figure when the underlying
+   * snapshot is cold.
+   */
+  revenueOverlaysGeneratedAt: string | null | undefined;
+  /**
+   * ISO of the most recent funding-news fetch. Same treatment for the
+   * Funding & MRR Radar card.
+   */
+  fundingFetchedAt: string | null | undefined;
+}
+
+interface TierCCard {
+  num: string;
+  href: string;
+  routeLabel: string;
+  /** Title rendered in the .ds-card-head .key slot. */
+  title: string;
+  /** One-line value prop. */
+  blurb: ReactNode;
+  /** Mono CTA in the foot — terminal-corpus style. */
+  cta: string;
+  /** NewsSource ladder slot for the FreshnessBadge in the head-right. */
+  source: NewsSource;
+  /** ISO of the last underlying write — drives FreshnessBadge + isLive. */
+  lastUpdatedAt: string | null | undefined;
+  /**
+   * When false, the card swaps its "live" foot chip for an "updating" one.
+   * Strict no-publicly-stale-batches: visible state never lies about
+   * source health.
+   */
+  isLive: boolean;
+  /** Foot-chip copy for live vs. updating states. */
+  liveLabel: string;
+  staleLabel: string;
+}
+
+export function TierCMonetizationBand({
+  revenueOverlaysGeneratedAt,
+  fundingFetchedAt,
+}: TierCMonetizationBandProps) {
+  // Revenue overlays ride the same daily-rebuild cadence as the trending
+  // pipeline. classifyFreshness("repos", …) is the closest source-health
+  // contract that already gates the home page — anything past its STALE
+  // threshold flips to "updating" honestly.
+  const revenueFresh = classifyFreshness("repos", revenueOverlaysGeneratedAt ?? null);
+  const revenueIsLive = revenueFresh.status === "live";
+
+  // Funding signals are event-driven — they can sit quiet for days between
+  // rounds without being meaningfully stale, so we treat anything that's
+  // not flat-out cold as live. The "cold" tier (past the configured stale
+  // threshold) still trips the updating pill. We piggyback on the "npm"
+  // source slot — it shares the 50h slow-cron Redis-published threshold
+  // that funding-news rides on, and reusing an existing NewsSource slot
+  // keeps a future per-source freshness contract auto-applied here too.
+  const fundingFresh = classifyFreshness("npm", fundingFetchedAt ?? null);
+  const fundingIsLive = fundingFresh.status !== "cold";
+
+  const cards: TierCCard[] = [
+    {
+      num: "01",
+      href: "/tools/revenue-estimate",
+      routeLabel: "/tools/revenue-estimate",
+      title: "Revenue Estimate",
+      blurb: (
+        <>
+          <b>ARR calculator</b> with verified overlays and a comp set — point
+          at a repo, get a defensible ARR band, ship the share card.
+        </>
+      ),
+      cta: "OPEN ESTIMATOR →",
+      source: "repos",
+      lastUpdatedAt: revenueOverlaysGeneratedAt ?? null,
+      isLive: revenueIsLive,
+      liveLabel: "DAILY BUILD",
+      staleLabel: "UPDATING",
+    },
+    {
+      num: "02",
+      href: "/funding",
+      routeLabel: "/funding",
+      title: "Funding & MRR Radar",
+      blurb: (
+        <>
+          <b>Live tape</b> of OSS-adjacent rounds, founder-led MRR signals,
+          and pre-IPO movers — none of which OSSInsight or TrendShift ship.
+        </>
+      ),
+      cta: "OPEN RADAR →",
+      source: "npm",
+      lastUpdatedAt: fundingFetchedAt ?? null,
+      isLive: fundingIsLive,
+      liveLabel: "EVENT-DRIVEN",
+      staleLabel: "REFRESHING",
+    },
+    {
+      num: "03",
+      href: "/tools/star-history",
+      routeLabel: "/tools/star-history · /tools/treemap",
+      title: "Star-history & Treemap",
+      blurb: (
+        <>
+          <b>Embed-ready SVGs</b> — 30-day cumulative curves and a category
+          treemap you can drop into a README or a screenshot thread.
+        </>
+      ),
+      cta: "PLOT REPOS →",
+      // Star-history is computed from snapshots that ship with every build,
+      // so it inherits the build cadence — same source slot as revenue.
+      source: "repos",
+      lastUpdatedAt: revenueOverlaysGeneratedAt ?? null,
+      // Visual exports degrade gracefully even when the input snapshot is
+      // mid-rotation (they fall back to whatever sparkline data is on hand),
+      // so we keep this lane on regardless of revenue's freshness.
+      isLive: true,
+      liveLabel: "SVG · EMBED",
+      staleLabel: "WARMING",
+    },
+  ];
+
+  return (
+    <>
+      <SectionHead
+        num="// 04.5"
+        title="Monetization signals / what OSSInsight + TrendShift don't ship"
+        meta={
+          <>
+            <b>3 surfaces</b> · revenue · funding · embeds
+          </>
+        }
+      />
+      <div className="grid">
+        {cards.map((card) => (
+          <Link
+            key={card.num}
+            href={card.href}
+            prefetch={false}
+            className="col-4"
+            style={{ textDecoration: "none", color: "inherit" }}
+            aria-label={`${card.title} — ${card.routeLabel}`}
+          >
+            <Card variant="tool" className="tier-c-card">
+              <CardHeader
+                right={
+                  <FreshnessBadge
+                    source={card.source}
+                    lastUpdatedAt={card.lastUpdatedAt}
+                  />
+                }
+                showCorner
+              >
+                <span
+                  className="cat-pip"
+                  style={{ background: "var(--v4-money)" }}
+                  aria-hidden="true"
+                />
+                {`// ${card.num} `}
+                <b style={{ color: "var(--v4-money)" }}>{card.title}</b>
+              </CardHeader>
+              <div
+                className="panel-body"
+                style={{ padding: "12px 14px", display: "flex", flexDirection: "column", gap: 10 }}
+              >
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: 13,
+                    lineHeight: 1.55,
+                    color: "var(--v4-ink-200, var(--ink-200, #d6d6d6))",
+                  }}
+                >
+                  {card.blurb}
+                </p>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    marginTop: 4,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono, ui-monospace)",
+                      fontSize: 11,
+                      letterSpacing: "0.08em",
+                      color: "var(--v4-money)",
+                      fontWeight: 600,
+                    }}
+                  >
+                    {card.cta}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono, ui-monospace)",
+                      fontSize: 9.5,
+                      letterSpacing: "0.12em",
+                      padding: "2px 6px",
+                      borderRadius: 2,
+                      border: "1px solid",
+                      borderColor: card.isLive
+                        ? "color-mix(in srgb, var(--v4-money) 32%, transparent)"
+                        : "color-mix(in srgb, var(--v4-amber, #f5a623) 36%, transparent)",
+                      color: card.isLive ? "var(--v4-money)" : "var(--v4-amber, #f5a623)",
+                      background: card.isLive
+                        ? "color-mix(in srgb, var(--v4-money) 10%, transparent)"
+                        : "color-mix(in srgb, var(--v4-amber, #f5a623) 12%, transparent)",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {card.isLive ? card.liveLabel : card.staleLabel}
+                  </span>
+                </div>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono, ui-monospace)",
+                    fontSize: 9.5,
+                    letterSpacing: "0.10em",
+                    color: "var(--v4-ink-500, var(--ink-500, #8a8a8a))",
+                  }}
+                >
+                  {card.routeLabel}
+                </span>
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/home/__tests__/TierCMonetizationBand.test.tsx
+++ b/src/components/home/__tests__/TierCMonetizationBand.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+
+import { TierCMonetizationBand } from "../TierCMonetizationBand";
+
+// Honest staleness rendering — the band swaps a card's right-aligned
+// foot chip from "live" to "updating" when the underlying source is cold.
+// We test both poles so a regression that drops the cold-tier guard is
+// caught at commit time.
+
+describe("TierCMonetizationBand", () => {
+  test("renders three monetization cards linking to /tools/revenue-estimate, /funding, and /tools/star-history", () => {
+    const now = new Date().toISOString();
+    const { container } = render(
+      <TierCMonetizationBand
+        revenueOverlaysGeneratedAt={now}
+        fundingFetchedAt={now}
+      />,
+    );
+
+    const anchors = Array.from(container.querySelectorAll("a[href]"));
+    const hrefs = anchors.map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("/tools/revenue-estimate");
+    expect(hrefs).toContain("/funding");
+    expect(hrefs).toContain("/tools/star-history");
+  });
+
+  test("revenue card flips to UPDATING when the overlay snapshot is cold", () => {
+    const { getAllByText } = render(
+      <TierCMonetizationBand
+        revenueOverlaysGeneratedAt={null}
+        fundingFetchedAt={new Date().toISOString()}
+      />,
+    );
+    expect(getAllByText("UPDATING").length).toBeGreaterThan(0);
+  });
+
+  test("funding card flips to REFRESHING when the news feed is cold", () => {
+    const { getAllByText } = render(
+      <TierCMonetizationBand
+        revenueOverlaysGeneratedAt={new Date().toISOString()}
+        fundingFetchedAt={null}
+      />,
+    );
+    expect(getAllByText("REFRESHING").length).toBeGreaterThan(0);
+  });
+
+  test("section head carries the strategic positioning copy", () => {
+    const { container } = render(
+      <TierCMonetizationBand
+        revenueOverlaysGeneratedAt={new Date().toISOString()}
+        fundingFetchedAt={new Date().toISOString()}
+      />,
+    );
+    // SectionHead V4 renders to .v4-section-head with __title / __num / __meta.
+    const title = container.querySelector(".v4-section-head__title");
+    expect(title?.textContent).toContain("Monetization signals");
+    expect(title?.textContent).toContain("OSSInsight");
+  });
+
+  test("daily build pill is shown when revenue snapshot is fresh", () => {
+    const { getAllByText } = render(
+      <TierCMonetizationBand
+        revenueOverlaysGeneratedAt={new Date().toISOString()}
+        fundingFetchedAt={new Date().toISOString()}
+      />,
+    );
+    // React testing-library matches every ancestor whose textContent
+    // contains the string, so the pill literal shows up on .panel-body,
+    // .ds-card-body, and the chip itself. Asserting non-empty is enough.
+    expect(getAllByText("DAILY BUILD").length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces TrendingRepo's defensible differentiation as a **3-card band positioned directly above the LiveTopTable rankings card** on the homepage. The band names the angle no other OSS tracker ships:

- **Revenue Estimate** — ARR calculator with verified overlays + comp set (`/tools/revenue-estimate`)
- **Funding & MRR Radar** — live tape of OSS-adjacent rounds, founder-led MRR signals, pre-IPO movers (`/funding`)
- **Star-history & Treemap** — embed-ready SVGs you drop into a README or screenshot thread (`/tools/star-history` + `/tools/treemap`)

Rankings remain the entry point — the band sits between `// 04 Featured` and `// 05 Live / top 50`, framed by a new `// 04.5` SectionHead: *"Monetization signals / what OSSInsight + TrendShift don't ship"*.

### Strategic framing

The combined deep-crawl deltas flagged **monetization** as our defensible wedge vs OSSInsight and TrendShift:

| Signal | Defensibility | Source |
|---|---|---|
| Revenue calculator | 4.0 | toolbox PR #241 |
| MRR / funding radar | 4.0 | L1 #3172 |
| Star-history SVG API | 3.0 (+ virality wedge) | F4 #3173 |
| Webhook / Slack alerts | 3.0 | F4 #3173 |
| Daily email digest | 2.0 | C-CAT #3174 |

Until now those tools lived on `/tools` as an afterthought. This PR moves them to the home page without displacing the rankings.

### Honest staleness

Each card derives an `isLive` boolean from `classifyFreshness` over the underlying snapshot (revenue-overlay `generatedAt`, funding-news `fetchedAt`). When a source is cold the foot chip flips from a green pill (`DAILY BUILD` / `EVENT-DRIVEN` / `SVG · EMBED`) to an amber `UPDATING` / `REFRESHING` / `WARMING` — explicit, never publishes a stale figure as if it were live. Cold reads are caught in `page.tsx` so the band never throws the ISR-cached home render.

### Implementation

- **Server component**, no client deps. Reuses the V4 design-system primitives (`Card variant="tool"`, `SectionHead`, `FreshnessBadge`, `--v4-money` accent token) — no `globals.css` / shell-CSS changes.
- 3-column layout via the existing 12-col `.grid` + `.col-4` pattern that `HeroPanel` already uses on `/`.
- Vitest coverage (5 tests) proves the three card routes, both freshness poles, the strategic positioning copy, and the live-pill happy path.

## Test plan

- [x] `npx vitest run src/components/home/__tests__/TierCMonetizationBand.test.tsx` (5/5)
- [x] `npx vitest run src/components/home src/components/ui` (100/100)
- [x] `npx tsc --noEmit` (no new errors outside pre-existing `.next/types` and `*.stories.tsx` storybook noise)
- [ ] Visual smoke on `/` — band renders above the Live/top 50 card, both light and dark mode read correctly via `--v4-money` token
- [ ] Cold-source smoke — drop the revenue-overlays JSON locally, confirm the Revenue Estimate card flips to amber `UPDATING`
- [ ] Mobile smoke — `.col-4` collapses to single-column on narrow viewports via existing `.grid` rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)