### PR TITLE
feat(engagement): gh-events-stream — 7d GH event aggregator + new ghEvents component

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/engagement-composite/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/engagement-composite/index.ts
@@ -89,6 +89,21 @@ interface PhLaunchesPayload {
   launches?: PhLaunch[];
 }
 
+interface GhEventsStreamRepoEntry {
+  events7d?: number;
+}
+interface GhEventsStreamPayload {
+  computedAt?: string;
+  repos?: Record<string, GhEventsStreamRepoEntry>;
+}
+
+/**
+ * Drop ghEvents data older than 90 minutes per the no-publicly-stale-batches
+ * rule. gh-events-stream runs at :15 + :45 so a healthy snapshot is at most
+ * 30 minutes old; 90min gives a 3x grace for transient cron misses.
+ */
+const GH_EVENTS_STALENESS_BUDGET_MS = 90 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // Aggregation helpers
 // ---------------------------------------------------------------------------
@@ -123,6 +138,7 @@ function ensureRow(accum: SignalAccum, fullName: string): NormalizedRepoSignals 
       npm: 0,
       ghStars: 0,
       ph: 0,
+      ghEvents: 0,
     };
     accum.rows.set(lower, row);
   }
@@ -226,6 +242,20 @@ const fetcher: Fetcher = {
       RepoMetadataPayload | null,
       PhLaunchesPayload | null,
     ];
+
+    // Soft read — gh-events-stream's absence MUST NOT block the composite
+    // (it's a new component as of 2026-06-15 and may not have written yet
+    // on cold start). We try once, log on failure, and treat null as
+    // "ghEvents contributes 0 for every repo this tick".
+    let ghEventsStream: GhEventsStreamPayload | null = null;
+    try {
+      ghEventsStream = await readDataStore<GhEventsStreamPayload>('gh-events-stream');
+    } catch (err) {
+      ctx.log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        'engagement-composite: gh-events-stream read failed; treating as missing',
+      );
+    }
 
     const accum = emptyAccum();
 
@@ -334,6 +364,40 @@ const fetcher: Fetcher = {
       row.ph = total;
     }
 
+    // ---- ghEvents (7d rolling event count from gh-events-stream) -----------
+    // no-publicly-stale-batches rule: drop the entire ghEvents block if the
+    // snapshot is older than 90 minutes (3x the :15/:45 cadence). Drop is
+    // all-or-nothing because the snapshot is a single computedAt anchor —
+    // there's no per-repo timestamp to selectively keep "fresh" ones.
+    let ghEventsRepoCount = 0;
+    let ghEventsStale = false;
+    if (ghEventsStream && typeof ghEventsStream.computedAt === 'string') {
+      const computedMs = Date.parse(ghEventsStream.computedAt);
+      if (Number.isFinite(computedMs)) {
+        const ageMs = Date.now() - computedMs;
+        if (ageMs <= GH_EVENTS_STALENESS_BUDGET_MS) {
+          for (const [fullName, entry] of Object.entries(ghEventsStream.repos ?? {})) {
+            if (!fullName.includes('/')) continue;
+            const events = nonNegative(safeNumber(entry?.events7d));
+            if (events <= 0) continue;
+            const row = ensureRow(accum, fullName);
+            row.ghEvents = events;
+            ghEventsRepoCount += 1;
+          }
+        } else {
+          ghEventsStale = true;
+          ctx.log.warn(
+            {
+              ageMs,
+              budgetMs: GH_EVENTS_STALENESS_BUDGET_MS,
+              computedAt: ghEventsStream.computedAt,
+            },
+            'engagement-composite: gh-events-stream stale > 90min; dropping ghEvents component this tick',
+          );
+        }
+      }
+    }
+
     // Resolve canonical fullName casing on every row (in case the row was
     // created from a lowercase mention key but a canonical exists).
     for (const [lower, row] of accum.rows.entries()) {
@@ -379,6 +443,8 @@ const fetcher: Fetcher = {
           npmRepos: npmByRepo.size,
           ghStars: ghStarsRepoCount,
           ph: phRepoCount,
+          ghEvents: ghEventsRepoCount,
+          ghEventsStale,
         },
         redisSource: result.source,
         writtenAt: result.writtenAt,

--- a/apps/trendingrepo-worker/src/fetchers/engagement-composite/scoring.ts
+++ b/apps/trendingrepo-worker/src/fetchers/engagement-composite/scoring.ts
@@ -32,22 +32,37 @@ import { COMPONENT_KEYS } from './types.js';
  * Component weights. Sum MUST equal 1.00 — asserted in unit tests so a
  * future tweak that breaks the invariant fails CI immediately.
  *
- *   ghStars (.30)  — strongest leading indicator of mainstream traction
- *   hn      (.20)  — best engagement signal pre-mainstream
- *   npm     (.25)  — actual usage, not just attention
- *   reddit  (.00)  — intentionally paused; component retained for payload compatibility
- *   ph      (.15)  — launch moment, mostly orthogonal to other signals
- *   bluesky (.05)  — early-mover signal, low volume so capped low
- *   devto   (.05)  — slow-burn long-tail content signal
+ *   ghStars  (.27)  — strongest leading indicator of mainstream traction
+ *   npm      (.25)  — actual usage, not just attention
+ *   hn       (.18)  — best engagement signal pre-mainstream
+ *   ph       (.15)  — launch moment, mostly orthogonal to other signals
+ *   ghEvents (.05)  — substantive contributor activity (PR+Issues+Push+Release)
+ *   bluesky  (.05)  — early-mover signal, low volume so capped low
+ *   devto    (.05)  — slow-burn long-tail content signal
+ *   reddit   (.00)  — intentionally paused; component retained for payload compatibility
+ *
+ * v3 deltas rebalance (2026-06-15):
+ *   - Added ghEvents (0.05) as a new dimension closing the OSSInsight "10B+
+ *     GitHub events" depth gap (impact 4.0 in the v3 deltas audit — see
+ *     https://ossinsight.io). Sourced from the gh-events-stream fetcher's
+ *     7d rolling PullRequest+Issues+Push+Release count, dropped per-tick
+ *     when staleness > 90min.
+ *   - Reduced ghStars (.30 → .27, -.03) and hn (.20 → .18, -.02). Pulled
+ *     the 0.05 from the two highest-weight components rather than zeroing
+ *     bluesky/devto — ghEvents is most-correlated with the GH-side velocity
+ *     signal (ghStars) so reducing there avoids double-counting growth
+ *     pressure; the small trim from hn keeps the social-attention mix
+ *     intact.
  */
 export const WEIGHTS: Record<ComponentKey, number> = {
-  hn: 0.20,
+  hn: 0.18,
   reddit: 0,
   bluesky: 0.05,
   devto: 0.05,
   npm: 0.25,
-  ghStars: 0.30,
+  ghStars: 0.27,
   ph: 0.15,
+  ghEvents: 0.05,
 };
 
 /** Components that use percentile-rank normalization. */
@@ -63,6 +78,10 @@ const PERCENTILE_COMPONENTS: ReadonlySet<ComponentKey> = new Set<ComponentKey>([
 const LOG_COMPONENTS: ReadonlySet<ComponentKey> = new Set<ComponentKey>([
   'npm',
   'ghStars',
+  // ghEvents is a count distribution: a handful of meta-repos (cloud-native
+  // monorepos, framework cores) push thousands of events/week while the long
+  // tail sits at 0-50. Log normalization keeps the tail readable.
+  'ghEvents',
 ]);
 
 /**

--- a/apps/trendingrepo-worker/src/fetchers/engagement-composite/types.ts
+++ b/apps/trendingrepo-worker/src/fetchers/engagement-composite/types.ts
@@ -16,7 +16,8 @@ export type ComponentKey =
   | 'devto'
   | 'npm'
   | 'ghStars'
-  | 'ph';
+  | 'ph'
+  | 'ghEvents';
 
 export const COMPONENT_KEYS: readonly ComponentKey[] = [
   'hn',
@@ -26,6 +27,7 @@ export const COMPONENT_KEYS: readonly ComponentKey[] = [
   'npm',
   'ghStars',
   'ph',
+  'ghEvents',
 ] as const;
 
 /** Per-repo raw aggregated signal values prior to normalization. */
@@ -38,6 +40,12 @@ export interface NormalizedRepoSignals {
   npm: number;       // npm weekly download count for any matched package
   ghStars: number;   // weekly star velocity (delta_7d, falling back to delta_24h * 7)
   ph: number;        // PH vote count for matching launch
+  /**
+   * 7-day rolling count of substantive GH events (PR + Issues + Push + Release)
+   * from the gh-events-stream fetcher. Zero when the snapshot is missing or
+   * has been dropped by the no-publicly-stale-batches rule (staleness > 90min).
+   */
+  ghEvents: number;
 }
 
 export interface ComponentScore {

--- a/apps/trendingrepo-worker/src/fetchers/gh-events-stream/filter.ts
+++ b/apps/trendingrepo-worker/src/fetchers/gh-events-stream/filter.ts
@@ -1,0 +1,97 @@
+// Pure event filtering + aggregation for gh-events-stream.
+//
+// Side-effect free so unit tests can exercise the windowing + byType
+// breakdown without touching Redis / HTTP / env. Mirrors the same split
+// github-events uses (parser.ts vs index.ts).
+
+import {
+  STREAM_EVENT_TYPES,
+  type ByTypeCounts,
+  type RepoEventCounts,
+  type StreamEventType,
+} from './types.js';
+
+const STREAM_TYPE_SET: ReadonlySet<string> = new Set(STREAM_EVENT_TYPES);
+
+/** Default window for the rolling aggregate. v3 deltas spec target. */
+export const WINDOW_DAYS = 7;
+const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+interface RawEvent {
+  type?: unknown;
+  created_at?: unknown;
+}
+
+function eventTimestamp(raw: unknown): number | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const e = raw as RawEvent;
+  if (typeof e.created_at !== 'string') return null;
+  const ts = Date.parse(e.created_at);
+  return Number.isFinite(ts) ? ts : null;
+}
+
+function eventTypeOf(raw: unknown): StreamEventType | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const e = raw as RawEvent;
+  if (typeof e.type !== 'string') return null;
+  return STREAM_TYPE_SET.has(e.type) ? (e.type as StreamEventType) : null;
+}
+
+/**
+ * Per-event predicate: keep only the 4 substantive contributor event types
+ * AND only those within the rolling window. Both predicates are needed —
+ * GH's per-repo /events endpoint returns up to 90 days of history so the
+ * window filter is the actual aggregation gate, not the API.
+ */
+export function isWithinWindow(
+  raw: unknown,
+  nowMs: number,
+  windowMs: number = WINDOW_MS,
+): boolean {
+  const ts = eventTimestamp(raw);
+  if (ts === null) return false;
+  // Strictly older than (now - window) → drop. Equal timestamps are kept
+  // (deterministic boundary).
+  return nowMs - ts <= windowMs;
+}
+
+/**
+ * Aggregate a raw GH events array into RepoEventCounts. Events outside
+ * the 7d window or not in STREAM_EVENT_TYPES are dropped; everything else
+ * is binned by event family into the byType map.
+ *
+ * `nowMs` is injected (not Date.now()) so tests can pin time. Production
+ * callers pass Date.now() once per tick so all repos share the same window.
+ */
+export function aggregateEvents(
+  rawEvents: unknown,
+  nowMs: number,
+  windowMs: number = WINDOW_MS,
+): RepoEventCounts {
+  const byType: ByTypeCounts = { pr: 0, issues: 0, push: 0, release: 0 };
+  if (!Array.isArray(rawEvents)) {
+    return { events7d: 0, byType };
+  }
+  let total = 0;
+  for (const raw of rawEvents) {
+    if (!isWithinWindow(raw, nowMs, windowMs)) continue;
+    const type = eventTypeOf(raw);
+    if (type === null) continue;
+    total += 1;
+    switch (type) {
+      case 'PullRequestEvent':
+        byType.pr += 1;
+        break;
+      case 'IssuesEvent':
+        byType.issues += 1;
+        break;
+      case 'PushEvent':
+        byType.push += 1;
+        break;
+      case 'ReleaseEvent':
+        byType.release += 1;
+        break;
+    }
+  }
+  return { events7d: total, byType };
+}

--- a/apps/trendingrepo-worker/src/fetchers/gh-events-stream/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/gh-events-stream/index.ts
@@ -1,0 +1,335 @@
+// Phase 3.4 — GitHub Events 7-day rolling aggregator for engagement-composite.
+//
+// Closes the OSSInsight "10B+ GitHub events tracked since 2011" depth gap
+// from the v3 deltas audit (impact 4.0 — see https://ossinsight.io). The
+// existing `github-events` firehose keeps a per-repo buffer of normalized
+// events for the live activity wall; this fetcher computes a *7-day rolling
+// aggregate* per repo across PullRequest/Issues/Push/Release events. The
+// aggregate is fed back into engagement-composite as a new `ghEvents`
+// component with a small weight (0.05).
+//
+// Cohort: top-200 repos from `engagement-composite` (already TOP_LIMIT=200
+// by spec). Falls back to `repo-metadata` if engagement-composite is cold
+// on a fresh deploy.
+//
+// Rate-limit math: 200 calls per tick × 2 ticks/hr = 400/hr against the
+// GH_TOKEN_POOL — 5K/hr per PAT × 10 PATs = 50K/hr capacity. 0.8% utilization.
+// Headroom is generous so we don't need ETag caching to be in budget; we use
+// it anyway because ctx.http.json handles it transparently.
+//
+// Cadence: '15,45 * * * *' — two ticks per hour, offset from velocity-refresh
+// (typical :00,:30) and star-activity-deltas crons so we don't pile onto the
+// same minute. Snapshot freshness is at most 30min; the engagement-composite
+// read path drops this component for repos whose snapshot is older than 90min
+// (no-publicly-stale-batches rule).
+//
+// Slug: `gh-events-stream`. Payload is ~6KB for 200 repos — well under the
+// 50KB gzip threshold so it stays plaintext in Redis.
+
+import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
+import { writeDataStore, readDataStore } from '../../lib/redis.js';
+import { pickGithubToken } from '../../lib/util/github-token-pool.js';
+import { aggregateEvents, WINDOW_DAYS } from './filter.js';
+import type { GhEventsStreamPayload, RepoEventCounts } from './types.js';
+
+const GITHUB_API = 'https://api.github.com';
+const GITHUB_API_VERSION = '2022-11-28';
+const PER_PAGE = 100;
+const SLUG = 'gh-events-stream';
+
+const COHORT_TARGET = Math.max(
+  10,
+  Math.min(
+    500,
+    Number.parseInt(process.env.GH_EVENTS_STREAM_COHORT ?? '200', 10) || 200,
+  ),
+);
+
+// Match github-events' concurrency floor — 5 is comfortable for a single-
+// core Railway box and a 200-repo batch finishes in ~2-3 min wall time.
+const FETCH_CONCURRENCY = Math.max(
+  1,
+  Math.min(
+    20,
+    Number.parseInt(process.env.GH_EVENTS_STREAM_CONCURRENCY ?? '5', 10) || 5,
+  ),
+);
+
+// ---- Upstream payload shapes (loose) --------------------------------------
+
+interface EngagementCompositeItem {
+  fullName?: string | null;
+  rank?: number | null;
+}
+interface EngagementCompositePayload {
+  items?: EngagementCompositeItem[];
+}
+
+interface RepoMetadataItem {
+  fullName?: string | null;
+  stars?: number | null;
+}
+interface RepoMetadataPayload {
+  items?: RepoMetadataItem[];
+}
+
+// ---- Cohort selection -----------------------------------------------------
+
+function isValidFullName(value: unknown): value is string {
+  return typeof value === 'string' && value.includes('/') && value.trim().length > 2;
+}
+
+/**
+ * Derive the top-N cohort. Priority chain:
+ *   1. engagement-composite (already 1-based ranked, TOP_LIMIT=200)
+ *   2. repo-metadata sorted by stars desc (cold-start fallback)
+ *
+ * Returns an empty array when both sources are empty — caller logs and skips.
+ */
+export function deriveCohort(
+  engagement: EngagementCompositePayload | null,
+  repoMetadata: RepoMetadataPayload | null,
+  target: number,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  const items = Array.isArray(engagement?.items) ? engagement.items : [];
+  for (const item of items) {
+    if (!isValidFullName(item?.fullName)) continue;
+    const fn = item.fullName;
+    const lower = fn.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(fn);
+    if (out.length >= target) return out;
+  }
+
+  // Fallback: repo-metadata sorted by stars desc.
+  const metaItems = Array.isArray(repoMetadata?.items) ? repoMetadata.items : [];
+  const ranked = metaItems
+    .filter((m): m is { fullName: string; stars: number } => {
+      return (
+        isValidFullName(m?.fullName) &&
+        typeof m?.stars === 'number' &&
+        Number.isFinite(m.stars)
+      );
+    })
+    .sort((a, b) => b.stars - a.stars);
+  for (const m of ranked) {
+    const lower = m.fullName.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(m.fullName);
+    if (out.length >= target) return out;
+  }
+  return out;
+}
+
+// ---- Per-repo polling -----------------------------------------------------
+
+interface FetchResult {
+  ok: boolean;
+  counts?: RepoEventCounts;
+  errorStage?: string;
+  errorMessage?: string;
+}
+
+async function fetchOneRepo(
+  ctx: FetcherContext,
+  fullName: string,
+  nowMs: number,
+): Promise<FetchResult> {
+  const token = pickGithubToken();
+  if (!token) {
+    return {
+      ok: false,
+      errorStage: `repo:${fullName}`,
+      errorMessage: 'no GH PAT available (token pool empty)',
+    };
+  }
+
+  const url = `${GITHUB_API}/repos/${fullName}/events?per_page=${PER_PAGE}`;
+
+  try {
+    // ctx.http.json transparently handles ETag caching: a 304 reply
+    // replays the cached body from Redis. With 200 repos × 2 ticks/hr and
+    // a 7d window, MOST ticks will see 304 on quiet repos — nice freebie.
+    const { data } = await ctx.http.json<unknown>(url, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'starscreener-worker/gh-events-stream',
+        'X-GitHub-Api-Version': GITHUB_API_VERSION,
+      },
+      timeoutMs: 20_000,
+      maxRetries: 2,
+    });
+    return { ok: true, counts: aggregateEvents(data, nowMs) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      errorStage: `repo:${fullName}`,
+      errorMessage: message,
+    };
+  }
+}
+
+async function pollCohort(
+  ctx: FetcherContext,
+  cohort: ReadonlyArray<string>,
+  nowMs: number,
+): Promise<FetchResult[]> {
+  const results = new Array<FetchResult>(cohort.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < cohort.length) {
+      const idx = cursor++;
+      const fullName = cohort[idx];
+      if (!fullName) continue;
+      results[idx] = await fetchOneRepo(ctx, fullName, nowMs);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(FETCH_CONCURRENCY, cohort.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+// ---- Fetcher entry point --------------------------------------------------
+
+const fetcher: Fetcher = {
+  name: 'gh-events-stream',
+  // Twice an hour at :15 and :45 — offset from velocity-refresh (typical
+  // :00,:30) and the engagement-composite hourly :45 (whose payload we
+  // read; :45 is fine because we read what's already in Redis from the
+  // previous hour's run — the new payload is published mid-tick).
+  schedule: '15,45 * * * *',
+  async run(ctx: FetcherContext): Promise<RunResult> {
+    const startedAt = new Date().toISOString();
+    const errors: RunResult['errors'] = [];
+
+    if (ctx.dryRun) {
+      ctx.log.info('gh-events-stream dry-run');
+      return done(startedAt, 0, false, errors);
+    }
+
+    if (!pickGithubToken()) {
+      const msg =
+        'GH_TOKEN_POOL / GITHUB_TOKEN not configured — skipping gh-events-stream';
+      ctx.log.warn(msg);
+      return done(startedAt, 0, false, [{ stage: 'auth', message: msg }]);
+    }
+
+    // AUDIT-2026-05-04 pattern: allSettled so a single Redis flake degrades
+    // to null instead of crashing the whole fetcher.
+    const reads = await Promise.allSettled([
+      readDataStore<EngagementCompositePayload>('engagement-composite'),
+      readDataStore<RepoMetadataPayload>('repo-metadata'),
+    ]);
+    const engagement = reads[0].status === 'fulfilled' ? reads[0].value : null;
+    const repoMetadata = reads[1].status === 'fulfilled' ? reads[1].value : null;
+    if (reads.some((r) => r.status === 'rejected')) {
+      ctx.log.warn(
+        {
+          engagement: reads[0].status === 'rejected' ? String(reads[0].reason) : null,
+          repoMetadata: reads[1].status === 'rejected' ? String(reads[1].reason) : null,
+        },
+        '[gh-events-stream] upstream read failed; degrading to null',
+      );
+    }
+
+    const cohort = deriveCohort(engagement, repoMetadata, COHORT_TARGET);
+    if (cohort.length === 0) {
+      const msg =
+        'cohort empty — engagement-composite + repo-metadata both yielded no candidates';
+      ctx.log.warn(msg);
+      return done(startedAt, 0, false, [{ stage: 'cohort', message: msg }]);
+    }
+
+    const nowMs = Date.now();
+    const results = await pollCohort(ctx, cohort, nowMs);
+
+    const repos: GhEventsStreamPayload['repos'] = {};
+    let errorCount = 0;
+    for (let i = 0; i < results.length; i += 1) {
+      const r = results[i]!;
+      const fullName = cohort[i]!;
+      if (!r.ok || !r.counts) {
+        errorCount += 1;
+        errors.push({
+          stage: r.errorStage ?? `repo:${fullName}`,
+          message: r.errorMessage ?? 'unknown failure',
+        });
+        continue;
+      }
+      // Only emit repos with at least one event in the window — keeps the
+      // payload compact and lets the consumer treat "missing" as "no recent
+      // contributor activity" without ambiguity.
+      if (r.counts.events7d > 0) {
+        repos[fullName] = r.counts;
+      }
+    }
+
+    const computedAt = new Date().toISOString();
+    // staleness_seconds is recorded at write time as a baseline; consumers
+    // compute live staleness as (now - computedAt) and apply the 90-min
+    // drop rule there. Writing 0 here keeps the field stable for tests.
+    const payload: GhEventsStreamPayload = {
+      computedAt,
+      staleness_seconds: 0,
+      cohortSize: cohort.length,
+      windowDays: WINDOW_DAYS,
+      repos,
+      errorCount,
+    };
+
+    let redisOk = false;
+    try {
+      const wr = await writeDataStore(SLUG, payload);
+      if (wr.source === 'redis') redisOk = true;
+    } catch (err) {
+      errors.push({
+        stage: 'write',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    ctx.log.info(
+      {
+        cohortSize: cohort.length,
+        reposWithEvents: Object.keys(repos).length,
+        errorCount,
+        windowDays: WINDOW_DAYS,
+      },
+      'gh-events-stream published',
+    );
+
+    return done(startedAt, Object.keys(repos).length, redisOk, errors);
+  },
+};
+
+export default fetcher;
+
+function done(
+  startedAt: string,
+  items: number,
+  redisPublished: boolean,
+  errors: RunResult['errors'],
+): RunResult {
+  return {
+    fetcher: 'gh-events-stream',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    itemsSeen: items,
+    itemsUpserted: 0,
+    metricsWritten: 0,
+    redisPublished,
+    errors,
+  };
+}

--- a/apps/trendingrepo-worker/src/fetchers/gh-events-stream/types.ts
+++ b/apps/trendingrepo-worker/src/fetchers/gh-events-stream/types.ts
@@ -1,0 +1,61 @@
+// Types for the gh-events-stream fetcher.
+//
+// Closes the OSSInsight "10B+ GitHub events tracked since 2011" depth gap
+// from the v3 deltas audit (impact 4.0). Unlike the per-repo github-events
+// firehose (which keeps a rolling buffer of normalized events for the live
+// activity wall), this fetcher computes a 7-day rolling aggregate per repo
+// across PullRequest/Issues/Push/Release events, suitable as a new
+// `ghEvents` component in engagement-composite scoring.
+//
+// Slug: `gh-events-stream`. Payload shape is intentionally small (one
+// integer + 4-key byType map per repo) so the entire top-200 fits in <8KB
+// uncompressed — well under the writeDataStore() gzip threshold (50KB).
+
+/**
+ * Event types this fetcher aggregates. Smaller than github-events'
+ * RELEVANT_EVENT_TYPES on purpose: we score *substantive contributor*
+ * activity, not passive Watch/Fork stars (which engagement-composite
+ * already captures via the `ghStars` velocity component).
+ */
+export const STREAM_EVENT_TYPES = [
+  'PullRequestEvent',
+  'IssuesEvent',
+  'PushEvent',
+  'ReleaseEvent',
+] as const;
+
+export type StreamEventType = (typeof STREAM_EVENT_TYPES)[number];
+
+export interface ByTypeCounts {
+  pr: number;
+  issues: number;
+  push: number;
+  release: number;
+}
+
+export interface RepoEventCounts {
+  /** Total events of relevant types within the 7-day window. */
+  events7d: number;
+  /** Breakdown by event family. Sum equals events7d. */
+  byType: ByTypeCounts;
+}
+
+export interface GhEventsStreamPayload {
+  computedAt: string;
+  /**
+   * Cohort-wide staleness in seconds. Engagement-composite's read path
+   * MUST drop the ghEvents component for any repo where the snapshot is
+   * older than 90 minutes (the no-publicly-stale-batches rule). Recorded
+   * at write time so consumers don't need to recompute against their own
+   * clock skew.
+   */
+  staleness_seconds: number;
+  /** Count of repos in the snapshot. */
+  cohortSize: number;
+  /** Window the byType counts apply to, in days. */
+  windowDays: number;
+  /** Keyed by `owner/name` (matches engagement-composite's fullName). */
+  repos: Record<string, RepoEventCounts>;
+  /** Diagnostic counter: how many repos hit a fetch error this tick. */
+  errorCount: number;
+}

--- a/apps/trendingrepo-worker/src/platform/sources.json
+++ b/apps/trendingrepo-worker/src/platform/sources.json
@@ -639,6 +639,41 @@
     ]
   },
   {
+    "id": "gh-events-stream",
+    "category": "repo-derived",
+    "kind": "collector",
+    "state": "active",
+    "freshness_budget_ms": 5400000,
+    "cost_signal_metric": {
+      "type": "pat_quota_pct",
+      "scope": "hour"
+    },
+    "rate_limit": {
+      "per_hour": 5000,
+      "scope": "token"
+    },
+    "owner": "UNASSIGNED",
+    "upstream_url": "https://api.github.com/repos/{owner}/{name}/events",
+    "auth_required": true,
+    "auth_scheme": "github_pat_pool",
+    "primary_output_keys": [
+      "gh-events-stream"
+    ],
+    "output_record_shape": "metric_snapshot",
+    "consumer_surfaces": [
+      "apps/trendingrepo-worker/src/fetchers/engagement-composite/index.ts"
+    ],
+    "depends_on": [
+      "engagement-composite",
+      "repo-metadata"
+    ],
+    "supports_backfill": false,
+    "fallback_strategy": "mark-degraded",
+    "writes_canonical_entity_kind": [
+      "repo"
+    ]
+  },
+  {
     "id": "consensus-trending",
     "category": "repo-derived",
     "kind": "enrichment",

--- a/apps/trendingrepo-worker/src/registry.ts
+++ b/apps/trendingrepo-worker/src/registry.ts
@@ -142,6 +142,17 @@ import editorialWriter from './fetchers/editorial-writer/index.js';
 import editorialCategories from './fetchers/editorial-categories/index.js';
 import editorialCompare from './fetchers/editorial-compare/index.js';
 import editorialAlternatives from './fetchers/editorial-alternatives/index.js';
+// 2026-06-15 — GH events 7d rolling aggregator feeds the new `ghEvents`
+// component in engagement-composite. Closes the OSSInsight "10B+ GitHub
+// events tracked since 2011" depth gap (impact 4.0 in the v3 deltas audit
+// — see https://ossinsight.io). Distinct from the existing per-repo
+// `github-events` firehose: that one keeps a normalized event buffer for
+// the live activity wall; this one only emits aggregate counts for scoring.
+// Cohort = top-200 from engagement-composite (fallback: repo-metadata by
+// stars desc). Cadence: '15,45 * * * *' — offset from velocity-refresh and
+// the engagement-composite :45 read so we publish before composite reads.
+// Rate-limit math: 200 calls × 2 ticks/hr = 400/hr against 50K/hr pool.
+import ghEventsStream from './fetchers/gh-events-stream/index.js';
 
 export const FETCHERS: Fetcher[] = [
   hnPulse,
@@ -160,6 +171,7 @@ export const FETCHERS: Fetcher[] = [
   trustmrr,
   revenueBenchmarks,
   trendshiftDaily,
+  ghEventsStream,
   engagementComposite,
   consensusTrending,
   consensusAnalyst,

--- a/apps/trendingrepo-worker/tests/fetchers/engagement-composite/scoring.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/engagement-composite/scoring.test.ts
@@ -31,6 +31,7 @@ function makeRow(fullName: string, overrides: Partial<NormalizedRepoSignals> = {
     npm: 0,
     ghStars: 0,
     ph: 0,
+    ghEvents: 0,
     ...overrides,
   };
 }
@@ -111,11 +112,13 @@ describe('normalizeOne', () => {
     expect(v).toBeLessThanOrEqual(1);
   });
 
-  it('uses log normalization for npm and ghStars', () => {
+  it('uses log normalization for npm, ghStars, and ghEvents', () => {
     const npm = normalizeOne('npm', 50, { sortedValues: [], max: 50 });
     expect(npm).toBeCloseTo(1, 6);
     const ghStars = normalizeOne('ghStars', 50, { sortedValues: [], max: 50 });
     expect(ghStars).toBeCloseTo(1, 6);
+    const ghEvents = normalizeOne('ghEvents', 50, { sortedValues: [], max: 50 });
+    expect(ghEvents).toBeCloseTo(1, 6);
   });
 
   it('uses percentile normalization for hn/reddit/bluesky/devto/ph', () => {
@@ -164,8 +167,8 @@ describe('composeScore', () => {
   it('clamps and rounds to 1 decimal', () => {
     const comps = emptyComponents();
     comps.hn = { raw: 100, normalized: 0.5 };
-    // Only hn contributes (weight 0.20 * 0.5 = 0.10) → 10.0
-    expect(composeScore(comps)).toBe(10);
+    // Only hn contributes (weight 0.18 * 0.5 = 0.09) → 9.0
+    expect(composeScore(comps)).toBe(9);
   });
 });
 
@@ -216,7 +219,10 @@ describe('scoreCohort', () => {
 
   it('emits the full component breakdown per item', () => {
     const rows: NormalizedRepoSignals[] = [
-      makeRow('a/a', { hn: 10, reddit: 20, bluesky: 5, devto: 3, npm: 1000, ghStars: 50, ph: 7 }),
+      makeRow('a/a', {
+        hn: 10, reddit: 20, bluesky: 5, devto: 3,
+        npm: 1000, ghStars: 50, ph: 7, ghEvents: 42,
+      }),
     ];
     const items = scoreCohort(rows);
     expect(items[0]!.components.hn.raw).toBe(10);
@@ -226,6 +232,7 @@ describe('scoreCohort', () => {
     expect(items[0]!.components.npm.raw).toBe(1000);
     expect(items[0]!.components.ghStars.raw).toBe(50);
     expect(items[0]!.components.ph.raw).toBe(7);
+    expect(items[0]!.components.ghEvents.raw).toBe(42);
     for (const key of COMPONENT_KEYS) {
       expect(items[0]!.components[key].normalized).toBeGreaterThanOrEqual(0);
       expect(items[0]!.components[key].normalized).toBeLessThanOrEqual(1);
@@ -236,11 +243,11 @@ describe('scoreCohort', () => {
     const rows: NormalizedRepoSignals[] = [
       makeRow('vercel/next.js', {
         hn: 250, reddit: 800, bluesky: 50, devto: 40,
-        npm: 5_000_000, ghStars: 1200, ph: 800,
+        npm: 5_000_000, ghStars: 1200, ph: 800, ghEvents: 4500,
       }),
       makeRow('foo/bar', {
         hn: 5, reddit: 20, bluesky: 0, devto: 0,
-        npm: 100, ghStars: 5, ph: 0,
+        npm: 100, ghStars: 5, ph: 0, ghEvents: 12,
       }),
       makeRow('cold/repo'),
     ];

--- a/apps/trendingrepo-worker/tests/fetchers/gh-events-stream/cohort.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/gh-events-stream/cohort.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCohort } from '../../../src/fetchers/gh-events-stream/index.js';
+
+describe('deriveCohort', () => {
+  it('returns engagement-composite items in order when present, capped at target', () => {
+    const engagement = {
+      items: [
+        { fullName: 'a/one', rank: 1 },
+        { fullName: 'b/two', rank: 2 },
+        { fullName: 'c/three', rank: 3 },
+      ],
+    };
+    const cohort = deriveCohort(engagement, null, 2);
+    expect(cohort).toEqual(['a/one', 'b/two']);
+  });
+
+  it('falls back to repo-metadata sorted by stars desc when engagement-composite is empty', () => {
+    const repoMetadata = {
+      items: [
+        { fullName: 'low/stars', stars: 100 },
+        { fullName: 'high/stars', stars: 50_000 },
+        { fullName: 'mid/stars', stars: 5_000 },
+      ],
+    };
+    const cohort = deriveCohort(null, repoMetadata, 3);
+    expect(cohort).toEqual(['high/stars', 'mid/stars', 'low/stars']);
+  });
+
+  it('merges engagement first, then top-stars repo-metadata for the tail (dedup by lowercase)', () => {
+    const engagement = { items: [{ fullName: 'A/one' }] };
+    const repoMetadata = {
+      items: [
+        { fullName: 'a/one', stars: 99 }, // dupe — must be skipped (case-insensitive)
+        { fullName: 'b/two', stars: 500 },
+      ],
+    };
+    const cohort = deriveCohort(engagement, repoMetadata, 5);
+    expect(cohort).toEqual(['A/one', 'b/two']);
+  });
+
+  it('rejects entries with missing or malformed fullName', () => {
+    const engagement = {
+      items: [
+        { fullName: 'good/one' },
+        { fullName: 'nope' }, // no slash
+        { fullName: '' }, // empty
+        { fullName: 42 as unknown as string }, // wrong type
+        {}, // missing
+        { fullName: 'b/two' },
+      ],
+    };
+    const cohort = deriveCohort(engagement, null, 10);
+    expect(cohort).toEqual(['good/one', 'b/two']);
+  });
+
+  it('returns an empty list when both sources are empty', () => {
+    expect(deriveCohort(null, null, 100)).toEqual([]);
+    expect(deriveCohort({ items: [] }, { items: [] }, 100)).toEqual([]);
+  });
+
+  it('respects target cap even when more candidates exist', () => {
+    const engagement = {
+      items: Array.from({ length: 500 }, (_, i) => ({
+        fullName: `owner/${i}`,
+      })),
+    };
+    const cohort = deriveCohort(engagement, null, 200);
+    expect(cohort).toHaveLength(200);
+    expect(cohort[0]).toBe('owner/0');
+    expect(cohort[199]).toBe('owner/199');
+  });
+});

--- a/apps/trendingrepo-worker/tests/fetchers/gh-events-stream/filter.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/gh-events-stream/filter.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateEvents,
+  isWithinWindow,
+  WINDOW_DAYS,
+} from '../../../src/fetchers/gh-events-stream/filter.js';
+
+const NOW = Date.parse('2026-06-15T12:00:00Z');
+const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+function event(
+  type: string,
+  createdAtIso: string,
+  extras: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { type, created_at: createdAtIso, ...extras };
+}
+
+describe('isWithinWindow', () => {
+  it('keeps events created exactly at the now boundary', () => {
+    const e = event('PullRequestEvent', new Date(NOW).toISOString());
+    expect(isWithinWindow(e, NOW)).toBe(true);
+  });
+
+  it('keeps events created at the trailing edge of the window', () => {
+    const edgeMs = NOW - WINDOW_MS;
+    const e = event('IssuesEvent', new Date(edgeMs).toISOString());
+    expect(isWithinWindow(e, NOW)).toBe(true);
+  });
+
+  it('drops events older than the window (8 days ago)', () => {
+    const oldMs = NOW - 8 * 24 * 60 * 60 * 1000;
+    const e = event('PushEvent', new Date(oldMs).toISOString());
+    expect(isWithinWindow(e, NOW)).toBe(false);
+  });
+
+  it('drops events with a missing or unparseable created_at', () => {
+    expect(isWithinWindow({ type: 'PushEvent' }, NOW)).toBe(false);
+    expect(
+      isWithinWindow({ type: 'PushEvent', created_at: 'not-a-date' }, NOW),
+    ).toBe(false);
+  });
+
+  it('drops non-object inputs', () => {
+    expect(isWithinWindow(null, NOW)).toBe(false);
+    expect(isWithinWindow(undefined, NOW)).toBe(false);
+    expect(isWithinWindow(42, NOW)).toBe(false);
+    expect(isWithinWindow('PullRequestEvent', NOW)).toBe(false);
+  });
+});
+
+describe('aggregateEvents', () => {
+  it('returns the zero record for non-array input', () => {
+    expect(aggregateEvents(null, NOW)).toEqual({
+      events7d: 0,
+      byType: { pr: 0, issues: 0, push: 0, release: 0 },
+    });
+    expect(aggregateEvents({}, NOW)).toEqual({
+      events7d: 0,
+      byType: { pr: 0, issues: 0, push: 0, release: 0 },
+    });
+    expect(aggregateEvents('whatever', NOW)).toEqual({
+      events7d: 0,
+      byType: { pr: 0, issues: 0, push: 0, release: 0 },
+    });
+  });
+
+  it('drops events older than 7d AND non-stream types', () => {
+    // Mix:
+    //   - 2 PR within window  → kept
+    //   - 1 PR 9 days old      → dropped (old)
+    //   - 1 WatchEvent today   → dropped (Watch is captured by ghStars)
+    //   - 1 ForkEvent today    → dropped (Fork not in STREAM_EVENT_TYPES)
+    //   - 1 ReleaseEvent today → kept
+    //   - 1 PushEvent today    → kept
+    //   - 1 IssuesEvent today  → kept
+    const isoNow = new Date(NOW).toISOString();
+    const isoOld = new Date(NOW - 9 * 24 * 60 * 60 * 1000).toISOString();
+    const events = [
+      event('PullRequestEvent', isoNow),
+      event('PullRequestEvent', isoNow),
+      event('PullRequestEvent', isoOld),
+      event('WatchEvent', isoNow),
+      event('ForkEvent', isoNow),
+      event('ReleaseEvent', isoNow),
+      event('PushEvent', isoNow),
+      event('IssuesEvent', isoNow),
+    ];
+    const out = aggregateEvents(events, NOW);
+    expect(out.events7d).toBe(5); // 2 PR + 1 release + 1 push + 1 issues
+    expect(out.byType).toEqual({ pr: 2, issues: 1, push: 1, release: 1 });
+  });
+
+  it('handles only-old-events as zero across the board', () => {
+    const isoOld = new Date(NOW - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const events = [
+      event('PullRequestEvent', isoOld),
+      event('IssuesEvent', isoOld),
+      event('PushEvent', isoOld),
+      event('ReleaseEvent', isoOld),
+    ];
+    expect(aggregateEvents(events, NOW)).toEqual({
+      events7d: 0,
+      byType: { pr: 0, issues: 0, push: 0, release: 0 },
+    });
+  });
+
+  it('byType counts sum to events7d (invariant)', () => {
+    const isoNow = new Date(NOW).toISOString();
+    const events = Array.from({ length: 20 }, (_, i) =>
+      event(
+        ['PullRequestEvent', 'IssuesEvent', 'PushEvent', 'ReleaseEvent'][i % 4]!,
+        isoNow,
+      ),
+    );
+    const out = aggregateEvents(events, NOW);
+    const sum =
+      out.byType.pr + out.byType.issues + out.byType.push + out.byType.release;
+    expect(sum).toBe(out.events7d);
+    expect(out.events7d).toBe(20);
+  });
+
+  it('ignores entries with malformed event objects', () => {
+    const isoNow = new Date(NOW).toISOString();
+    const events = [
+      event('PullRequestEvent', isoNow),
+      null,
+      undefined,
+      'PushEvent',
+      { type: 'PushEvent' /* missing created_at */ },
+      event('PushEvent', 'garbage'),
+      event('PushEvent', isoNow),
+    ];
+    const out = aggregateEvents(events, NOW);
+    // 1 PR + 1 Push valid; everything else dropped
+    expect(out.events7d).toBe(2);
+    expect(out.byType).toEqual({ pr: 1, issues: 0, push: 1, release: 0 });
+  });
+});

--- a/src/lib/engagement-composite.ts
+++ b/src/lib/engagement-composite.ts
@@ -25,7 +25,12 @@ export type EngagementComponentKey =
   | "devto"
   | "npm"
   | "ghStars"
-  | "ph";
+  | "ph"
+  // 7d rolling count of substantive GH events (PR+Issues+Push+Release).
+  // Sourced from gh-events-stream and only present in payloads written
+  // on/after 2026-06-15. Older cached payloads degrade to weight=0 via
+  // EMPTY_PAYLOAD below.
+  | "ghEvents";
 
 export interface EngagementComponentScore {
   raw: number;
@@ -52,7 +57,7 @@ const EMPTY_PAYLOAD: EngagementCompositePayload = {
   cohortSize: 0,
   itemCount: 0,
   weights: {
-    hn: 0, reddit: 0, bluesky: 0, devto: 0, npm: 0, ghStars: 0, ph: 0,
+    hn: 0, reddit: 0, bluesky: 0, devto: 0, npm: 0, ghStars: 0, ph: 0, ghEvents: 0,
   },
   items: [],
 };


### PR DESCRIPTION
## Summary
Closes the OSSInsight **"10B+ GitHub events tracked since 2011"** depth gap (impact 4.0 in the v3 deltas audit — see https://ossinsight.io). Adds a new `gh-events-stream` fetcher that ingests recent `PullRequest` / `Issues` / `Push` / `Release` events for each top-200 repo and aggregates a 7-day rolling count. The aggregate is fed back into `engagement-composite` as a new `ghEvents` component with a small weight (0.05).

- **New fetcher** `apps/trendingrepo-worker/src/fetchers/gh-events-stream/{index,filter,types}.ts` — cron `'15,45 * * * *'`, cohort = top-200 from `engagement-composite` (fallback: `repo-metadata` sorted by stars desc), `GH_TOKEN_POOL` round-robin via `pickGithubToken()`, 5 in-flight concurrency. Rate-limit budget: **200 calls × 2 ticks/hr = 400/hr** against the 50K/hr pool capacity = 0.8% utilization — well under the limit.
- **Wired into engagement-composite** — `ComponentKey` union + `COMPONENT_KEYS` array + `NormalizedRepoSignals` all gain `ghEvents`; `WEIGHTS` rebalanced (sum stays 1.00): pulled the new 0.05 from the two highest-weight components (ghStars .30→.27, hn .20→.18) rather than zeroing bluesky/devto — ghEvents is most-correlated with ghStars so reducing there avoids double-counting growth pressure. `LOG_COMPONENTS` adds `ghEvents` (count distribution, heavy-tailed).
- **no-publicly-stale-batches rule** — the composite read path drops the entire `ghEvents` component when the `gh-events-stream` snapshot is > 90min old (3x the :15/:45 cadence).

## Test plan
- [x] `pnpm --filter @trendingrepo/worker typecheck` clean
- [x] New tests pass — 16 (10 filter + 6 cohort) + 26 engagement-composite scoring tests adjusted for ghEvents + 11 registry tests
- [x] Full worker test suite passes — 523 tests pass, 1 skipped, 2 todo, 0 failures
- [ ] After merge: monitor `engagement-composite published` log lines for `coverage.ghEvents` count + `coverage.ghEventsStale: false`
- [ ] After merge: `GET /api/scoring/engagement?limit=10` returns items with `components.ghEvents` populated for any repo with 7d GH activity

Cite: OSSInsight homepage banner "10B+ GitHub events tracked since 2011" — v3 deltas audit Item-2-impact-4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)