### PR TITLE
feat(classifier): NanoGPT-backed category-classify fetcher (32-axis taxonomy)

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/category-classify/__tests__/types.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/category-classify/__tests__/types.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CATEGORY_BRIEFS,
+  CHUNK_SIZE,
+  VALID_CATEGORY_IDS,
+} from '../types.js';
+
+describe('category-classify types', () => {
+  it('VALID_CATEGORY_IDS has exactly 32 entries (post-C-CAT)', () => {
+    expect(VALID_CATEGORY_IDS).toHaveLength(32);
+  });
+
+  it('CATEGORY_BRIEFS has a one-line description for every id', () => {
+    for (const id of VALID_CATEGORY_IDS) {
+      expect(CATEGORY_BRIEFS[id]).toBeDefined();
+      expect(CATEGORY_BRIEFS[id].length).toBeGreaterThan(20);
+    }
+  });
+
+  it('VALID_CATEGORY_IDS has no duplicates', () => {
+    const set = new Set(VALID_CATEGORY_IDS);
+    expect(set.size).toBe(VALID_CATEGORY_IDS.length);
+  });
+
+  it('CHUNK_SIZE keeps the LLM prompt small (≤25 repos per call)', () => {
+    expect(CHUNK_SIZE).toBeLessThanOrEqual(25);
+    expect(CHUNK_SIZE).toBeGreaterThan(0);
+  });
+});

--- a/apps/trendingrepo-worker/src/fetchers/category-classify/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/category-classify/index.ts
@@ -1,0 +1,250 @@
+/**
+ * category-classify — maps each consensus-trending repo to one of 32 CATEGORIES
+ * (the post-C-CAT taxonomy in src/lib/constants.ts) via NanoGPT (Kimi-K2).
+ *
+ * Without this fetcher the 17 new categories shipped in C-CAT PR #3174 read
+ * "0 repos" since nothing tags repos against them. Runs once a day; skips
+ * any repo classified within RECLASSIFY_AFTER_DAYS so cost stays bounded.
+ *
+ * Cost discipline:
+ *   ~$0.00003/call * (1000 repos / 20-per-batch) = $0.0015/day at full pool.
+ *
+ * No-publicly-stale-batches rule:
+ *   Payload includes `staleness_seconds`; UI consumers drop the category
+ *   facet when staleness > 25h (configurable).
+ */
+
+import type { Fetcher, FetcherContext, RunResult } from '../../lib/types.js';
+import { readDataStore, writeDataStore } from '../../lib/redis.js';
+import { callClassify, parseJson, isLlmConfigured, activeProvider } from './llm.js';
+import {
+  CATEGORY_BRIEFS,
+  CHUNK_SIZE,
+  EMPTY_PAYLOAD,
+  RECLASSIFY_AFTER_DAYS,
+  VALID_CATEGORY_IDS,
+  type CategoryClassifyPayload,
+  type RepoCategoryAssignment,
+} from './types.js';
+import type {
+  ConsensusItem,
+  ConsensusTrendingPayload,
+} from '../consensus-trending/types.js';
+
+const TOP_N = 1000;
+const CHUNK_CONCURRENCY = 3;
+
+const SYSTEM_PROMPT = `You are a precise open-source repo categorizer. Given a list of repos with their names, you assign each to EXACTLY ONE category from the provided taxonomy.
+
+Rules:
+- Pick the single best-fitting category id. If a repo could fit two, pick the more specific one.
+- Use category id strings VERBATIM from the taxonomy; never invent new ids.
+- If a repo's purpose is genuinely unclear from its name, assign category id "devtools" (default) and set confidence to 0.3.
+- Output ONLY valid JSON matching the response_format schema. No prose, no markdown fences.
+
+Taxonomy (id → 1-line description):
+${VALID_CATEGORY_IDS.map((id) => `- ${id}: ${CATEGORY_BRIEFS[id]}`).join('\n')}`;
+
+function buildChunkUserMessage(repos: ConsensusItem[]): string {
+  return `Classify each repo below into EXACTLY ONE category id from the taxonomy.
+
+Repos to classify (${repos.length}):
+${repos.map((r) => `- ${r.fullName}`).join('\n')}
+
+Return a JSON object with this shape:
+{
+  "classifications": [
+    {"fullName": "owner/name", "categoryId": "<one of the 32 ids>", "confidence": 0.0-1.0},
+    ...
+  ]
+}`;
+}
+
+interface ChunkResultEntry {
+  fullName: string;
+  categoryId: string;
+  confidence?: number;
+}
+
+interface ChunkResult {
+  classifications?: ChunkResultEntry[];
+}
+
+const fetcher: Fetcher = {
+  name: 'category-classify',
+  // Daily at 03:17 UTC — well off the hour peaks where other fetchers run.
+  schedule: '17 3 * * *',
+  async run(ctx: FetcherContext): Promise<RunResult> {
+    const startedAt = new Date().toISOString();
+
+    if (ctx.dryRun) {
+      ctx.log.info('category-classify dry-run');
+      return done(startedAt, 0, false);
+    }
+
+    const provider = activeProvider();
+    if (!isLlmConfigured()) {
+      ctx.log.warn(
+        'category-classify: no LLM provider configured (NANOGPT_API_KEY/KIMI_API_KEY missing), skipping',
+      );
+      return done(startedAt, 0, false);
+    }
+
+    const consensus = await readDataStore<ConsensusTrendingPayload>('consensus-trending');
+    if (!consensus || !Array.isArray(consensus.items) || consensus.items.length === 0) {
+      ctx.log.warn('category-classify: no consensus-trending payload yet, skipping');
+      return done(startedAt, 0, false);
+    }
+
+    const existing = (await readDataStore<CategoryClassifyPayload>('repo-categories')) ?? EMPTY_PAYLOAD;
+    const now = Date.now();
+    const reclassifyThresholdMs = RECLASSIFY_AFTER_DAYS * 24 * 3600 * 1000;
+
+    const topRepos = consensus.items.slice(0, TOP_N);
+    const toClassify: ConsensusItem[] = [];
+    for (const r of topRepos) {
+      const prev = existing.assignments[r.fullName];
+      if (!prev) {
+        toClassify.push(r);
+        continue;
+      }
+      const prevAt = Date.parse(prev.classifiedAt);
+      if (!Number.isFinite(prevAt) || now - prevAt > reclassifyThresholdMs) {
+        toClassify.push(r);
+      }
+    }
+
+    if (toClassify.length === 0) {
+      const merged = freshenPayload(existing, now);
+      const result = await writeDataStore('repo-categories', merged);
+      ctx.log.info(
+        { totalAssignments: Object.keys(merged.assignments).length, redis: result.source },
+        'category-classify: no repos due for re-classification',
+      );
+      return done(startedAt, 0, result.source === 'redis');
+    }
+
+    const chunks: ConsensusItem[][] = [];
+    for (let i = 0; i < toClassify.length; i += CHUNK_SIZE) {
+      chunks.push(toClassify.slice(i, i + CHUNK_SIZE));
+    }
+
+    ctx.log.info(
+      { provider, chunks: chunks.length, toClassify: toClassify.length, total: topRepos.length },
+      'category-classify: starting batched classification',
+    );
+
+    const validIdSet = new Set<string>(VALID_CATEGORY_IDS);
+    const assignments: Record<string, RepoCategoryAssignment> = { ...existing.assignments };
+    const unclassified: string[] = [];
+    let resolvedModel: string | undefined;
+
+    const queue: ConsensusItem[][] = [...chunks];
+    const sweep = async (): Promise<void> => {
+      while (queue.length > 0) {
+        const chunk = queue.shift();
+        if (!chunk) return;
+        try {
+          const r = await callClassify({
+            systemPrompt: SYSTEM_PROMPT,
+            userMessage: buildChunkUserMessage(chunk),
+            maxTokens: 1500,
+            temperature: 0.2,
+          });
+          resolvedModel = r.model;
+          const parsed = parseJson(r.text) as ChunkResult | null;
+          const classifications = parsed?.classifications;
+          if (!classifications || !Array.isArray(classifications)) {
+            ctx.log.warn(
+              { chunkSize: chunk.length, preview: r.text.slice(0, 200) },
+              'category-classify: chunk returned no classifications array',
+            );
+            for (const item of chunk) unclassified.push(item.fullName);
+            continue;
+          }
+          const seen = new Set<string>();
+          for (const c of classifications) {
+            if (!c || typeof c.fullName !== 'string') continue;
+            if (!validIdSet.has(c.categoryId)) {
+              unclassified.push(c.fullName);
+              continue;
+            }
+            assignments[c.fullName] = {
+              fullName: c.fullName,
+              categoryId: c.categoryId,
+              confidence:
+                typeof c.confidence === 'number' && c.confidence >= 0 && c.confidence <= 1
+                  ? c.confidence
+                  : 0.5,
+              classifiedAt: new Date().toISOString(),
+              generator: r.provider,
+            };
+            seen.add(c.fullName);
+          }
+          for (const item of chunk) {
+            if (!seen.has(item.fullName) && !assignments[item.fullName]) {
+              unclassified.push(item.fullName);
+            }
+          }
+        } catch (err) {
+          ctx.log.warn(
+            { err: err instanceof Error ? err.message : String(err), chunkSize: chunk.length },
+            'category-classify: chunk call failed',
+          );
+          for (const item of chunk) unclassified.push(item.fullName);
+        }
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: Math.min(CHUNK_CONCURRENCY, chunks.length) }, () => sweep()),
+    );
+
+    const computedAt = new Date().toISOString();
+    const payload: CategoryClassifyPayload = {
+      computedAt,
+      staleness_seconds: 0,
+      itemCount: Object.keys(assignments).length,
+      assignments,
+      unclassified,
+      generator: provider === 'fallback' ? 'fallback' : provider,
+      model: resolvedModel,
+    };
+
+    const result = await writeDataStore('repo-categories', payload);
+    ctx.log.info(
+      {
+        newClassifications: toClassify.length - unclassified.length,
+        unclassified: unclassified.length,
+        totalAssignments: payload.itemCount,
+        provider,
+        model: resolvedModel,
+        redis: result.source,
+      },
+      'category-classify published',
+    );
+    return done(startedAt, toClassify.length - unclassified.length, result.source === 'redis');
+  },
+};
+
+function freshenPayload(payload: CategoryClassifyPayload, nowMs: number): CategoryClassifyPayload {
+  const computedAt = payload.computedAt || new Date(nowMs).toISOString();
+  const computedMs = Date.parse(computedAt);
+  const staleness = Number.isFinite(computedMs) ? Math.max(0, Math.floor((nowMs - computedMs) / 1000)) : 0;
+  return { ...payload, staleness_seconds: staleness };
+}
+
+function done(startedAt: string, items: number, persisted: boolean): RunResult {
+  return {
+    fetcher: 'category-classify',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    itemsSeen: items,
+    itemsUpserted: items,
+    metricsWritten: 0,
+    redisPublished: persisted,
+    errors: [],
+  };
+}
+
+export default fetcher;

--- a/apps/trendingrepo-worker/src/fetchers/category-classify/llm.ts
+++ b/apps/trendingrepo-worker/src/fetchers/category-classify/llm.ts
@@ -1,0 +1,133 @@
+/**
+ * NanoGPT (Kimi-K2-Instruct) client for category classification.
+ *
+ * Mirrors the L1 PR #3172 pattern in consensus-analyst/llm.ts: prefer
+ * NanoGPT when NANOGPT_API_KEY is set, fall back to Kimi if only Kimi
+ * is configured. Non-streamed OpenAI-compatible chat for speed (each
+ * batch is small + JSON-only).
+ */
+
+import OpenAI from 'openai';
+import { loadEnv } from '../../lib/env.js';
+
+const NANOGPT_DEFAULT_BASE = 'https://nano-gpt.com/api/v1';
+const NANOGPT_DEFAULT_MODEL = 'moonshotai/Kimi-K2-Instruct';
+
+const KIMI_DEFAULT_BASE = 'https://api.kimi.com/coding/v1';
+const KIMI_DEFAULT_MODEL = 'kimi-for-coding';
+
+export type ClassifyProvider = 'nanogpt' | 'kimi';
+
+let cachedClient: { provider: ClassifyProvider; model: string; client: OpenAI } | null = null;
+
+function resolveClient(): { provider: ClassifyProvider; model: string; client: OpenAI } {
+  if (cachedClient) return cachedClient;
+  const env = loadEnv();
+  if (env.NANOGPT_API_KEY) {
+    cachedClient = {
+      provider: 'nanogpt',
+      model: env.NANOGPT_MODEL ?? NANOGPT_DEFAULT_MODEL,
+      client: new OpenAI({
+        apiKey: env.NANOGPT_API_KEY,
+        baseURL: env.NANOGPT_BASE_URL ?? NANOGPT_DEFAULT_BASE,
+      }),
+    };
+    return cachedClient;
+  }
+  if (env.KIMI_API_KEY) {
+    cachedClient = {
+      provider: 'kimi',
+      model: env.KIMI_MODEL ?? KIMI_DEFAULT_MODEL,
+      client: new OpenAI({
+        apiKey: env.KIMI_API_KEY,
+        baseURL: env.KIMI_BASE_URL ?? KIMI_DEFAULT_BASE,
+        defaultHeaders: { 'User-Agent': 'claude-cli/1.0' },
+      }),
+    };
+    return cachedClient;
+  }
+  throw new Error('No LLM provider configured (NANOGPT_API_KEY or KIMI_API_KEY required)');
+}
+
+export function isLlmConfigured(): boolean {
+  const env = loadEnv();
+  return Boolean(env.NANOGPT_API_KEY || env.KIMI_API_KEY);
+}
+
+export function activeProvider(): ClassifyProvider | 'fallback' {
+  const env = loadEnv();
+  if (env.NANOGPT_API_KEY) return 'nanogpt';
+  if (env.KIMI_API_KEY) return 'kimi';
+  return 'fallback';
+}
+
+export interface CallClassifyOpts {
+  systemPrompt: string;
+  userMessage: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface CallClassifyResult {
+  text: string;
+  provider: ClassifyProvider;
+  model: string;
+}
+
+export async function callClassify(opts: CallClassifyOpts): Promise<CallClassifyResult> {
+  const { provider, model, client } = resolveClient();
+
+  if (provider === 'kimi') {
+    const stream = await client.chat.completions.create({
+      model,
+      max_tokens: opts.maxTokens ?? 2048,
+      temperature: opts.temperature ?? 0.2,
+      stream: true,
+      messages: [
+        { role: 'system', content: opts.systemPrompt },
+        { role: 'user', content: opts.userMessage },
+      ],
+      response_format: { type: 'json_object' as const },
+    });
+    let text = '';
+    for await (const chunk of stream) {
+      const delta = chunk.choices?.[0]?.delta as { content?: string } | undefined;
+      if (delta?.content) text += delta.content;
+    }
+    return { text, provider, model };
+  }
+
+  // NanoGPT — non-streamed
+  const completion = await client.chat.completions.create({
+    model,
+    max_tokens: opts.maxTokens ?? 2048,
+    temperature: opts.temperature ?? 0.2,
+    response_format: { type: 'json_object' as const },
+    messages: [
+      { role: 'system', content: opts.systemPrompt },
+      { role: 'user', content: opts.userMessage },
+    ],
+  });
+  const text = completion.choices?.[0]?.message?.content ?? '';
+  return { text, provider, model };
+}
+
+export function parseJson(text: string): unknown {
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const firstBrace = trimmed.indexOf('{');
+    const lastBrace = trimmed.lastIndexOf('}');
+    if (firstBrace === -1 || lastBrace <= firstBrace) return null;
+    try {
+      return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1));
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function _resetClassifyCacheForTests(): void {
+  cachedClient = null;
+}

--- a/apps/trendingrepo-worker/src/fetchers/category-classify/types.ts
+++ b/apps/trendingrepo-worker/src/fetchers/category-classify/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Category classification — maps each consensus-trending repo to one of the
+ * 32 categories from C-CAT (src/lib/constants.ts). Without this, the 17 new
+ * chips shipped in C-CAT PR #3174 read "0 repos."
+ */
+
+export interface RepoCategoryAssignment {
+  fullName: string;
+  categoryId: string;
+  confidence: number;
+  classifiedAt: string;
+  generator: 'nanogpt' | 'kimi' | 'fallback';
+}
+
+export interface CategoryClassifyPayload {
+  computedAt: string;
+  staleness_seconds: number;
+  itemCount: number;
+  assignments: Record<string, RepoCategoryAssignment>;
+  unclassified: string[];
+  generator: 'nanogpt' | 'kimi' | 'fallback';
+  model?: string;
+}
+
+export const EMPTY_PAYLOAD: CategoryClassifyPayload = {
+  computedAt: '',
+  staleness_seconds: 0,
+  itemCount: 0,
+  assignments: {},
+  unclassified: [],
+  generator: 'fallback',
+};
+
+/** The 32 valid category IDs from src/lib/constants.ts (C-CAT taxonomy). */
+export const VALID_CATEGORY_IDS = [
+  'ai-agents',
+  'mcp',
+  'devtools',
+  'browser-automation',
+  'local-llm',
+  'security',
+  'infrastructure',
+  'design-engineering',
+  'ai-ml',
+  'web-frameworks',
+  'databases',
+  'mobile',
+  'data-analytics',
+  'crypto-web3',
+  'rust-ecosystem',
+  'game-dev',
+  'iot-edge',
+  'education',
+  'robotics',
+  'ar-vr-3d',
+  'bio-health',
+  'productivity-nocode',
+  'open-models-datasets',
+  'networking',
+  'observability',
+  'compilers-runtimes',
+  'testing-qa',
+  'documentation',
+  'embedded-systems',
+  'media-streaming',
+  'cryptography',
+  'privacy',
+] as const;
+
+export type CategoryId = (typeof VALID_CATEGORY_IDS)[number];
+
+/** One-line descriptions handed to the LLM as the classification schema. */
+export const CATEGORY_BRIEFS: Record<CategoryId, string> = {
+  'ai-agents': 'Agent frameworks, copilots, autonomous workflows, multi-agent systems',
+  mcp: 'Model Context Protocol servers, connectors, registries, MCP ecosystems',
+  devtools: 'Build tools, linters, formatters, editors, DX utilities',
+  'browser-automation': 'Browser-use stacks, automation agents, web operators, testing runtimes',
+  'local-llm': 'On-device inference engines, local model runtimes, self-hosted LLM stacks',
+  security: 'Vulnerability scanning, secrets detection, security automation',
+  infrastructure: 'Cloud platforms, orchestration, containers, deployment tools',
+  'design-engineering': 'Design-to-code systems, UI generation, design tooling, frontend engineering kits',
+  'ai-ml': 'LLMs, inference engines, training frameworks, AI tooling',
+  'web-frameworks': 'Frontend and full-stack frameworks for the modern web',
+  databases: 'SQL, NoSQL, vector, time-series, analytical databases',
+  mobile: 'Cross-platform frameworks, native tooling, desktop apps',
+  'data-analytics': 'BI tools, data pipelines, visualization, analytics engines',
+  'crypto-web3': 'Blockchain clients, smart-contract tooling, DeFi infrastructure',
+  'rust-ecosystem': 'Rust-native libraries, frameworks, performance tools',
+  'game-dev': 'Engines, frameworks, mod tooling, game-runtime libraries',
+  'iot-edge': 'Embedded firmware, edge runtimes, sensor stacks, home-automation hubs',
+  education: 'Curricula, interactive lessons, learn-by-doing repos, CS-101 references',
+  robotics: 'ROS stacks, motion planning, simulators, physical-agent toolkits',
+  'ar-vr-3d': 'Spatial computing runtimes, 3D engines, WebXR, immersive UI tooling',
+  'bio-health': 'Bioinformatics pipelines, clinical-data tooling, life-sciences libraries',
+  'productivity-nocode': 'Workflow automators, no-code builders, RPA stacks, self-hosted productivity',
+  'open-models-datasets': 'Open-weight model repos, curated datasets, evaluation suites',
+  networking: 'Proxies, mesh networking, protocol implementations, packet-level tooling',
+  observability: 'Tracing, metrics, logging, OpenTelemetry collectors, SLO platforms',
+  'compilers-runtimes': 'Language toolchains, compilers, JIT runtimes, parser frameworks',
+  'testing-qa': 'Test runners, fuzzers, property-based testing, CI gates',
+  documentation: 'Static-site generators, docs-as-code, knowledge bases, changelog tooling',
+  'embedded-systems': 'Bare-metal kernels, RTOSes, MCU libraries, embedded build pipelines',
+  'media-streaming': 'Audio/video pipelines, codecs, broadcasting servers, live-streaming tooling',
+  cryptography: 'Symmetric/asymmetric primitives, zero-knowledge proofs, crypto libraries',
+  privacy: 'Self-hosted alternatives, end-to-end-encrypted apps, tracker-blocking tooling',
+};
+
+export const CHUNK_SIZE = 20;
+export const RECLASSIFY_AFTER_DAYS = 7;

--- a/apps/trendingrepo-worker/src/lib/env.ts
+++ b/apps/trendingrepo-worker/src/lib/env.ts
@@ -63,13 +63,13 @@ const envSchema = z
     KIMI_BASE_URL: z.string().url().optional(),
     KIMI_MODEL: z.string().optional(),
 
-    // OpenRouter / LLM-router config consumed by `lib/llm/*`. All optional;
-    // the LLM modules short-circuit when OPENROUTER_API_KEY is missing.
-    // Pre-2026-05-07 these were referenced via `env.X` but never declared
-    // in the schema, which left tsc red on every `npm run typecheck` run.
+    NANOGPT_API_KEY: z.string().optional(),
+    NANOGPT_BASE_URL: z.string().url().optional(),
+    NANOGPT_MODEL: z.string().optional(),
+
     OPENROUTER_API_KEY: z.string().optional(),
     OPENROUTER_REFERER: z.string().optional(),
-    LLM_PROVIDER: z.enum(['kimi', 'openrouter']).optional(),
+    LLM_PROVIDER: z.enum(['kimi', 'openrouter', 'nanogpt']).optional(),
     LLM_USER_HASH_SALT: z.string().optional(),
 
     NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),

--- a/apps/trendingrepo-worker/src/lib/llm/router.ts
+++ b/apps/trendingrepo-worker/src/lib/llm/router.ts
@@ -22,7 +22,12 @@ import { hashUserId, recordLlmEvent } from './usage-recorder.js';
 import type { LlmErrorCode, LlmEvent, LlmTelemetry } from './types.js';
 
 export function getLlmProvider(): 'kimi' | 'openrouter' {
-  return loadEnv().LLM_PROVIDER ?? 'kimi';
+  const raw = loadEnv().LLM_PROVIDER;
+  // The shared LLM_PROVIDER enum also covers 'nanogpt', which has its own
+  // client (in category-classify and consensus-analyst) and never enters
+  // this router. Treat it as the default ('kimi') from here.
+  if (raw === 'openrouter') return 'openrouter';
+  return 'kimi';
 }
 
 export async function callLlm(

--- a/apps/trendingrepo-worker/src/registry.ts
+++ b/apps/trendingrepo-worker/src/registry.ts
@@ -73,6 +73,9 @@ import mcpUsageSnapshot from './fetchers/mcp-usage-snapshot/index.js';
 // covers 6 lab RSS sources via AI_LAB_REGISTRY).
 import arxiv from './fetchers/arxiv/index.js';
 import aiBlogs from './fetchers/ai-blogs/index.js';
+// 2026-06-15 — C-CAT classifier. Maps each consensus-trending repo to one of
+// the 32 categories (post-C-CAT taxonomy) via NanoGPT (Kimi-K2-Instruct).
+import categoryClassify from './fetchers/category-classify/index.js';
 
 export const FETCHERS: Fetcher[] = [
   hnPulse,
@@ -95,6 +98,7 @@ export const FETCHERS: Fetcher[] = [
   engagementComposite,
   consensusTrending,
   consensusAnalyst,
+  categoryClassify,
   lobsters,
   bluesky,
   mcpRegistryOfficial,

--- a/scripts/classify-categories.ts
+++ b/scripts/classify-categories.ts
@@ -1,0 +1,53 @@
+/**
+ * One-shot seed script for the C-CAT classifier.
+ *
+ * Operators run this manually after deploy to seed the
+ * `repo-categories` redis key without waiting for the daily cron tick
+ * (worker schedule: '17 3 * * *' UTC). Calls the same fetcher.run()
+ * with a no-op FetcherContext.
+ *
+ * Usage:
+ *   NANOGPT_API_KEY=... pnpm tsx scripts/classify-categories.ts
+ */
+
+import categoryClassify from '../apps/trendingrepo-worker/src/fetchers/category-classify/index.js';
+import type { FetcherContext } from '../apps/trendingrepo-worker/src/lib/types.js';
+
+type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+function makeLog(): FetcherContext['log'] {
+  const print = (level: LogLevel) => (...args: unknown[]) => {
+    const ts = new Date().toISOString();
+    const [first, ...rest] = args;
+    const obj = typeof first === 'object' && first !== null ? first : undefined;
+    const msg = obj ? rest[0] : first;
+    const tail = obj ? JSON.stringify(obj) : '';
+    console.log(`${ts} [${level}] ${String(msg ?? '')} ${tail}`);
+  };
+  return {
+    trace: print('trace'),
+    debug: print('debug'),
+    info: print('info'),
+    warn: print('warn'),
+    error: print('error'),
+    fatal: print('fatal'),
+    child: () => makeLog(),
+  } as unknown as FetcherContext['log'];
+}
+
+async function main() {
+  const ctx: FetcherContext = {
+    log: makeLog(),
+    dryRun: false,
+    runId: `seed-${Date.now()}`,
+  } as unknown as FetcherContext;
+
+  const result = await categoryClassify.run(ctx);
+  console.log('\nResult:', JSON.stringify(result, null, 2));
+  process.exit(result.errors.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('classify-categories seed failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Without a classifier, the 17 new chips shipped in [C-CAT PR #3174](https://github.com/0motionguy/starscreener/pull/3174) read "0 repos." This PR wires the missing piece: a daily NanoGPT-backed classifier that maps every consensus-trending repo into one of the 32 category ids.

## Approach

- **New fetcher** ``apps/trendingrepo-worker/src/fetchers/category-classify/`` — reads consensus-trending payload, batches the top-1000 fullNames into chunks of 20, sends each chunk to NanoGPT (Kimi-K2-Instruct via OpenAI-compatible chat) with strict ``response_format: { type: 'json_object' }`` and the full 32-id taxonomy embedded in the system prompt.
- **Re-classification skip rule** — any repo whose previous classification is fresher than 7 days is skipped. Bounds cost as the pool grows.
- **Schedule** — ``'17 3 * * *'`` UTC, well off the on-the-hour peaks where the other fetchers run.
- **Cost discipline** — ~$0.00003/call × (1000 / 20-per-batch) = $0.0015/day at full pool. Documented in code.
- **No publicly stale batches rule** — payload emits ``computedAt`` + ``staleness_seconds`` so UI consumers can drop the category facet when stale.

## Companion PRs

- [#3174](https://github.com/0motionguy/starscreener/pull/3174) C-CAT — ships the 32 taxonomy entries
- [#3181](https://github.com/0motionguy/starscreener/pull/3181) per-category-landing-pages — renders ``/categories/<slug>`` with JSON-LD
- This PR — the classifier that ties them together so each chip lights up with real repos

## Files

```
apps/trendingrepo-worker/src/fetchers/category-classify/
├── index.ts        — fetcher (batched LLM sweep, skip-fresh, write payload)
├── llm.ts          — NanoGPT primary + Kimi fallback (lifted from L1 PR #3172 pattern)
├── types.ts        — CategoryClassifyPayload, VALID_CATEGORY_IDS, CATEGORY_BRIEFS
└── __tests__/types.test.ts — 4 vitest tests asserting taxonomy schema
apps/trendingrepo-worker/src/lib/env.ts — NANOGPT_API_KEY/_BASE_URL/_MODEL + widen LLM_PROVIDER enum
apps/trendingrepo-worker/src/lib/llm/router.ts — narrows the wider enum back to 'kimi'|'openrouter' for the unrelated router
apps/trendingrepo-worker/src/registry.ts — register categoryClassify in FETCHERS
scripts/classify-categories.ts — one-shot seed script for post-deploy
```

## Test plan

- [x] ``pnpm --filter trendingrepo-worker tsc --noEmit`` — clean
- [x] ``pnpm --filter trendingrepo-worker test src/fetchers/category-classify`` — 4/4 pass
- [ ] Operator sets ``NANOGPT_API_KEY`` and runs ``pnpm tsx scripts/classify-categories.ts`` once — verify ``ss:data:v1:repo-categories`` populates with assignments
- [ ] Verify per-category landing page (#3181) reads the assignments and lights up the new C-CAT chips

## Evidence

Deep-crawl deltas v3: OSSInsight ships 102 curated collections to TrendingRepo's 15; C-CAT brought us to 32; this classifier makes those 32 actually useful. Toolbox PR [#241](https://github.com/0motionguy/toolbox/pull/241) has the underlying delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)