### PR TITLE
feat(twitter-outbound): automated 10-repo X posting pipeline + arXiv AI cross-signal channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,17 @@ SENTRY_PROJECT=trendingrepo
 # Without any of these, the cron routes run as visible no-ops (audit rows
 # with status=skipped) — nothing is ever posted.
 #
-# PREFERRED — OAuth2 refresh-token rotation (all three required together).
+# Adapter priority: TWITTER_OUTBOUND_MODE override > toolbox engine >
+# OAuth2 rotation trio > static token > dev console > null no-op.
+#
+# END-STATE — VPS Twitter engine (toolbox box). When both are set, the
+# composed thread is POSTed to the engine and it owns credentials, rate
+# budgets, and the actual publish. Wins over direct X-API creds below.
+# Contract: src/lib/twitter/outbound/adapters/toolbox.ts header.
+# TOOLBOX_REACH_URL=
+# TOOLBOX_REACH_API_KEY=
+#
+# DIRECT X API — OAuth2 refresh-token rotation (all three required together).
 # X access tokens expire (~2h); this trio lets the app mint fresh ones
 # forever. One-time setup: create an OAuth2 app (confidential client) in the
 # X developer portal with tweet.read + tweet.write + users.read +
@@ -138,7 +148,9 @@ SENTRY_PROJECT=trendingrepo
 # TWITTER_USERNAME=trendingrepo
 #
 # Force a mode regardless of credentials: `console` logs composed threads
-# without publishing (good for previewing), `null` forces a no-op.
+# without publishing (good for previewing), `null` forces a no-op,
+# `toolbox` requires the TOOLBOX_REACH_* pair and fails loudly without it.
+# Dry runs are reviewable at GET /api/admin/twitter-outbound (ADMIN_TOKEN).
 # TWITTER_OUTBOUND_MODE=console
 
 # -- Optional: platform ops alerts -------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,35 @@ SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=trendingrepo
 
+# -- Outbound X/Twitter posting (daily breakouts + weekly recap threads) -----
+# Without any of these, the cron routes run as visible no-ops (audit rows
+# with status=skipped) — nothing is ever posted.
+#
+# PREFERRED — OAuth2 refresh-token rotation (all three required together).
+# X access tokens expire (~2h); this trio lets the app mint fresh ones
+# forever. One-time setup: create an OAuth2 app (confidential client) in the
+# X developer portal with tweet.read + tweet.write + users.read +
+# offline.access scopes, run the authorize flow once as the posting account,
+# and paste the refresh token below. Rotated refresh tokens are persisted to
+# the data dir (twitter-oauth-state.jsonl); the env value seeds the first run
+# only. If the data dir is wiped, re-run the authorize flow and re-seed.
+# TWITTER_OAUTH2_CLIENT_ID=
+# TWITTER_OAUTH2_CLIENT_SECRET=
+# TWITTER_OAUTH2_REFRESH_TOKEN=
+#
+# SIMPLE — static user-context access token. Works until X expires it
+# (~2h after issue), then posting silently degrades to errors. Only for
+# quick tests; use the rotation trio above for production.
+# TWITTER_OAUTH2_USER_TOKEN=
+#
+# Posting account handle (no @) — used to build public thread URLs for
+# audit rows and cron responses.
+# TWITTER_USERNAME=trendingrepo
+#
+# Force a mode regardless of credentials: `console` logs composed threads
+# without publishing (good for previewing), `null` forces a no-op.
+# TWITTER_OUTBOUND_MODE=console
+
 # -- Optional: platform ops alerts -------------------------------------------
 # Fatal platform paths (for example full Twitter source failure, GitHub pool
 # exhaustion) can post a best-effort JSON alert here.

--- a/.github/workflows/collect-twitter.yml
+++ b/.github/workflows/collect-twitter.yml
@@ -112,7 +112,14 @@ jobs:
           TWITTER_GRAPHQL_SEARCH_QUERY_ID: ${{ vars.TWITTER_GRAPHQL_SEARCH_QUERY_ID }}
           # TWITTER_WEB_DEBUG: "1"  # uncomment when diagnosing empty responses
           TWITTER_COLLECTOR_RUN_ID: "gh-actions-${{ github.run_id }}-${{ github.run_attempt }}"
-        run: npm run collect:twitter
+        # Hard 280s wall-clock cap inside the 20-min step budget. The
+        # forensic audit (docs/forensic/twitter-cancellation-2026-05-17.md)
+        # found the collector itself finishes in ~87s, but a stuck child
+        # process kept the step alive to the job timeout — which GH Actions
+        # then reports as a CANCELLED run, masking the real state and never
+        # letting the cookies-web fallback fire. `timeout` kills the hang
+        # fast so the exit code trips continue-on-error cleanly.
+        run: timeout 280 npm run collect:twitter
 
       # Third-tier fallback: when Apify is dead AND Nitter fails (instances
       # 503ing or returning empty), retry with the cookies-backed web provider

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ next-env.d.ts
 !/.data/trending-dual-write-trace.jsonl
 !/.data/aiso-rescan-queue.jsonl
 !/.data/mcp-usage.jsonl
+# SECURITY: never commit the outbound X OAuth2 state — it holds live rotated
+# refresh tokens. Already covered by `/.data/*`, but this explicit ignore
+# (placed AFTER the whitelist, so it wins) guarantees a future broad
+# `!/.data/*.jsonl` allow-rule can't ever expose it.
+/.data/twitter-oauth-state.jsonl
 
 # local Claude Code workspace (agent prompts, skills, settings)
 /.claude/

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -37,7 +37,7 @@ Workflows with multiple cron entries list each.
 | ci.yml | CI | `push`, `pull_request`, `workflow_dispatch` | `npm run typecheck`, `lint:guards`, `check-v3-token-budget`, `test:hooks` |
 | cleanup-stale-previews.yml | Cleanup Stale Vercel Previews | `23 2 * * 1` (Mon 02:23) | Deletes stale Vercel preview deployments via Vercel API |
 | collect-funding.yml | Collect Funding Signals | `0 */6 * * *` | `npm run scrape:funding` (techcrunch, venturebeat, sifted) + `scrape:funding:crunchbase` |
-| collect-twitter.yml | Collect Twitter Signals | `0 */3 * * *` | `npm run collect:twitter` (Apify `apidojo~tweet-scraper`) |
+| collect-twitter.yml | Collect Twitter Signals | `workflow_dispatch` only (manual backfill) | `timeout 280 npm run collect:twitter` (nitter primary + cookies-web fallback; Apify off per docs/POLICY-NO-APIFY.md). Production freshness is HOSTUP worker-owned. |
 | conventional-commits.yml | Conventional Commits | `pull_request`, `workflow_dispatch` | Lints PR titles |
 | cron-agent-commerce.yml | Refresh agent-commerce pipeline | `31 4 * * *` | `fetch-agentic-market.mjs` + `fetch-openrouter-models.mjs` + `fetch-coingecko-agents.mjs` + `fetch-artificial-analysis.mjs` + `fetch-base-x402-onchain.mjs` |
 | cron-aiso-drain.yml | Cron - AISO drain | `3,33 * * * *` | POST `/api/cron/aiso-drain` |

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -10,9 +10,32 @@ status: living
 
 **Purpose:** every Claude Code session can read this file and instantly know the current state of the engine, what is shipping, and what is broken. Refreshed by `/loop` autonomous runs and by hand. **Source of truth for the audit-2026-05-04 follow-up.**
 
-Last refreshed: 2026-05-05 (Phase 1.0 docs-drift verification pass)
+Last refreshed: 2026-07-09 (outbound-posting + arXiv-channel "go" wave)
 
 > **Current state:** PR #93 (audit-2026-05-04 stop-the-bleeding, 24 commits) merged as commit `0b3a477d`; follow-up PRs #96/#97/#99 also merged. For the latest pass, see the "2026-05-05 - Phase 1 docs restructure" section below.
+
+### 2026-07-09 — Automated X posting + arXiv AI channel (branch `claude/starscreener-repo-optimization-2gn8wz`)
+
+Shipped (4 waves, unmerged on the branch above — verified by unit tests +
+local dry-runs; live behavior needs provisioned creds + fresh prod data):
+
+- **Daily X thread, 10 truly-trending repos.** Tiered selector
+  (`src/lib/twitter/outbound/select.ts`): multi-signal breakouts → flagged
+  movers → raw 24h velocity, quality-floored, deterministic sort, 7-day
+  repeat cooldown. Every repo item carries its `/repo/<owner>/<name>` link.
+- **Weekly recap parity** + a 12h **freshness gate** on both cron routes
+  (skip, audited, rather than post stale data).
+- **OAuth2 refresh-token rotation** (`oauth.ts`) so posting doesn't die on
+  the ~2h access-token expiry; **toolbox-engine adapter** (`adapters/toolbox.ts`)
+  as the end-state VPS transport (config-only switch); **reviewable dry-runs**
+  via `GET /api/admin/twitter-outbound` (ADMIN_TOKEN).
+- **7th cross-signal channel `arxiv`** (`cross-signal.ts`): a repo cited by a
+  recent (<30d) arXiv paper ranks higher; decays off at 90d. Fixed the
+  arXiv→repo linker (bare-slug matching) that produced zero links.
+- **Go-live steps:** `docs/runbooks/twitter-outbound-bringup.md`. Nothing
+  publishes until creds are set; `TWITTER_OUTBOUND_MODE=null` is the kill-switch.
+- **Open follow-up:** the arXiv channel and the whole posting pipeline depend
+  on fresh prod data (scrape-arxiv.yml / worker fleet) — verify post-deploy.
 
 ---
 

--- a/docs/SITE-WIREMAP.md
+++ b/docs/SITE-WIREMAP.md
@@ -154,6 +154,7 @@ HF route note: the sidebar intentionally has one Hugging Face row (`/huggingface
 | `/admin/pool-aggregate` | private | Redis-aggregate fleet view (POOL-REDIS) | every `recordRateLimit` writes to Redis | live | n/a |
 | `/admin/staleness` | private | per-source freshness | reads `data/_meta/*.json` | live | n/a |
 | `/admin/scoring-shadow` | private | shadow-scoring run results | run-shadow-scoring | daily `0 2 * * *` | n/a |
+| `GET /api/admin/twitter-outbound` | private (ADMIN_TOKEN) | outbound X run audit incl. full composed threads (`twitter-outbound-runs.jsonl`) | written by `/api/cron/twitter-daily` + `/api/cron/twitter-weekly-recap` (cron-twitter-outbound.yml: daily `0 14 * * *`, Fri `0 16 * * 5`) | per cron run | n/a |
 
 ---
 

--- a/docs/SOURCE_DISCOVERY.md
+++ b/docs/SOURCE_DISCOVERY.md
@@ -69,6 +69,28 @@ Primary code paths:
 - repo detail mention feed: [`src/app/repo/[owner]/[name]/page.tsx`](../src/app/repo/[owner]/[name]/page.tsx)
 - mention markers on repo charts: [`src/components/repo-detail/MentionMarkers.tsx`](../src/components/repo-detail/MentionMarkers.tsx)
 
+### arXiv research-citation channel (2026-07)
+
+The seventh cross-signal channel (`arxiv`) lights when a repo is linked from
+a recent arXiv paper — the strongest "genuinely-novel AI/ML" signal we have.
+Papers are linked to repos in [`scripts/scrape-arxiv.mjs`](../scripts/scrape-arxiv.mjs)
+via `extractGithubRepoFullNames` (github.com URLs) **and**
+`extractTrackedBareRefs` (bare `owner/repo` slugs against the tracked set) —
+the bare-slug pass is what recovers the common "we release owner/repo"
+abstract mentions the URL-only pass dropped. The channel tiers on recent-link
+count + citation velocity / social mentions from `arxiv-enriched`.
+
+### Deferred: HuggingFace per-repo channel
+
+HF trending is collected (`src/lib/huggingface.ts`) but is **not** wired as a
+cross-signal channel: HF model IDs are model repos (`org/model`), not GitHub
+repos — only ~3/1000 trending models have an id that exactly matches a tracked
+GitHub `fullName`, and ~157 merely share an owner. A useful HF→GitHub bridge
+needs model-card link parsing (the card often links the GitHub repo) or an
+`arxiv:` tag cross-reference through the shared paper. Until that bridge
+exists, an HF channel would be too noisy; the owner-level overlap could later
+feed a category-momentum nudge rather than a per-repo channel.
+
 ## External references
 
 - Bluesky search operators: https://bsky.social/about/blog/05-31-2024-search

--- a/docs/runbooks/twitter-outbound-bringup.md
+++ b/docs/runbooks/twitter-outbound-bringup.md
@@ -1,0 +1,100 @@
+# Runbook — Twitter/X outbound posting bringup
+
+**When to use:** to activate the automated X posting pipeline (daily
+breakouts thread + Friday weekly recap). Until this runs, the cron routes
+are visible no-ops — they compose threads and write audit rows with
+`status:"skipped"` but never publish.
+
+**What ships it:** `.github/workflows/cron-twitter-outbound.yml` already fires
+`POST /api/cron/twitter-daily` (14:00 UTC daily) and
+`POST /api/cron/twitter-weekly-recap` (16:00 UTC Fri) with the `CRON_SECRET`
+bearer. The code is live; this runbook only provisions credentials and walks
+the review-first ramp.
+
+**Production is HOSTUP** (Docker tenant + Cloudflare Tunnel), NOT Vercel. Set
+env vars on the tenant (compose env / the tenant's `.env`), then restart the
+container. Never run Vercel commands for starscreener.
+
+## Adapter priority ladder
+
+`selectOutboundAdapter()` (`src/lib/twitter/outbound/adapters/index.ts`)
+picks, highest first:
+
+1. `TWITTER_OUTBOUND_MODE=null` → no-op. `=console` → log only. `=toolbox` →
+   force the VPS engine (fails loudly if its env pair is missing).
+2. `TOOLBOX_REACH_URL` + `TOOLBOX_REACH_API_KEY` → **VPS Twitter engine**
+   (end-state transport; wins over direct X creds).
+3. `TWITTER_OAUTH2_CLIENT_ID` + `_SECRET` + `_REFRESH_TOKEN` → **OAuth2
+   rotation** (self-renewing; preferred direct-to-X path).
+4. `TWITTER_OAUTH2_USER_TOKEN` → static token (decays in ~2h; test only).
+5. `NODE_ENV=development` → console. Otherwise → no-op + one-shot warn.
+
+## Stage 0 — Dry-run review (no credentials, do this first)
+
+1. Set `TWITTER_OUTBOUND_MODE=console` and an `ADMIN_TOKEN` on the tenant; restart.
+2. Fire a run: `curl -X POST -H "Authorization: Bearer $CRON_SECRET" https://trendingrepo.com/api/cron/twitter-daily` → expect `{"ok":true,"adapter":"console","status":"skipped"|"logged",...}`.
+3. Review what *would* post:
+   `curl -H "Authorization: Bearer $ADMIN_TOKEN" "https://trendingrepo.com/api/admin/twitter-outbound?limit=5"` —
+   inspect the stored `posts[]` (10 repos, each with its `/repo/<owner>/<name>`
+   URL, ordered by cross-signal score, no repeats). Let this run a few days
+   and confirm selection quality before going live.
+
+> If `status:"skipped"` with reason `stale-data (...)`, the trending payload
+> is >12h old — the freshness gate is refusing to post garbage. Fix data
+> freshness first (that's the point of the gate).
+
+## Stage 1 — Go live via the VPS engine (preferred, when ready)
+
+1. On the tenant, set `TOOLBOX_REACH_URL` (the engine's publish endpoint) and
+   `TOOLBOX_REACH_API_KEY`; unset `TWITTER_OUTBOUND_MODE`; restart.
+2. Fire the daily route; expect `"adapter":"toolbox_reach","status":"published"`
+   and a non-null `threadUrl`. Open it — verify the live 10-repo thread.
+
+## Stage 1-alt — Go live directly on X (OAuth2 rotation)
+
+1. In the X developer portal, create an OAuth2 **confidential** client with
+   scopes `tweet.read tweet.write users.read offline.access`.
+2. Run the authorize flow once as the posting account; capture the **refresh
+   token**.
+3. Set `TWITTER_OAUTH2_CLIENT_ID`, `TWITTER_OAUTH2_CLIENT_SECRET`,
+   `TWITTER_OAUTH2_REFRESH_TOKEN`, and `TWITTER_USERNAME` (no `@`); unset
+   `TWITTER_OUTBOUND_MODE`; restart.
+4. Fire the daily route; expect `"adapter":"twitter_api_v2","status":"published"`.
+
+> **CRITICAL — persistent volume.** X rotates the refresh token on every
+> exchange; the app persists the rotated token to
+> `<DATA_DIR>/.data/twitter-oauth-state.jsonl`. **That path must be a
+> persisted Docker volume.** If `.data/` is ephemeral, the rotated token is
+> lost on the next restart and the account strands (needs a fresh authorize
+> flow). The file is gitignored — it must never be committed.
+
+## Rate budget
+
+Free tier ≈17 posts/day. Daily thread = up to 12 (1 intro + 10 items + 1
+idea); Friday adds the recap (~5) → ~17 on Fridays. A mid-thread `429` is
+handled: `postThread` attaches the already-published posts to the error, and
+the cron route still cools-down those repos so tomorrow's thread doesn't
+repeat them.
+
+## arXiv AI channel activation
+
+The 7th cross-signal channel (`arxiv`) lights when a repo is linked from a
+recent (<30d) arXiv paper. It stays dark until `scrape-arxiv.yml` runs with
+the fixed linker (bare-slug matching) and writes `linkedRepos` to
+`arxiv-recent`. No action needed here — it activates on the next scheduled
+scrape; verify via a repo-detail page's channel row or
+`GET /api/admin/twitter-outbound` picks skewing toward research-backed repos.
+
+## Rollback
+
+Set `TWITTER_OUTBOUND_MODE=null` and restart — posting stops immediately, no
+code change. Audit rows keep recording `status:"skipped"` so cron-health
+dashboards stay green ("alive but disabled").
+
+## Verify checklist
+
+- [ ] Stage 0 dry-run reviewed; selection quality acceptable.
+- [ ] `.data/` is a persisted volume (OAuth path only).
+- [ ] Live run returns `status:"published"` + a working `threadUrl`.
+- [ ] Weekly recap intro count reflects the week (not the whole corpus).
+- [ ] Rollback tested (`TWITTER_OUTBOUND_MODE=null` → skipped).

--- a/scripts/__tests__/github-repo-links.test.mjs
+++ b/scripts/__tests__/github-repo-links.test.mjs
@@ -167,3 +167,53 @@ test("extractUnknownRepoCandidates: URL form only — does NOT match bare owner/
   const hits = extractUnknownRepoCandidates("excited about openai/whisper today", null);
   assert.equal(hits.size, 0);
 });
+
+// arXiv scraper linkedRepos wiring (scripts/scrape-arxiv.mjs parseEntry):
+// union the high-confidence URL hits with tracked bare-slug hits, deduped.
+// This is what recovers "we release owner/repo" mentions that the
+// URL-only pass silently dropped (the linkedRepoCount:0 defect).
+test("arxiv linkedRepos union: URL + bare-slug hits, deduped by fullName", () => {
+  const tracked = new Set([
+    "meta-llama/llama3",
+    "openai/whisper",
+    "google/gemma",
+  ]);
+  const abstract =
+    "We release meta-llama/llama3 and evaluate against " +
+    "https://github.com/openai/whisper. Weights: google/gemma.";
+
+  const urlHits = extractGithubRepoFullNames(abstract, tracked);
+  const bareHits = extractTrackedBareRefs(abstract, tracked);
+
+  // URL pass finds only the github.com link.
+  assert.deepEqual([...urlHits], ["openai/whisper"]);
+  // Bare pass recovers the two slug-only mentions. It intentionally does
+  // NOT re-match whisper — that slug is embedded in the github.com URL,
+  // which the bare matcher's lookbehind excludes.
+  assert.deepEqual(
+    [...bareHits].sort(),
+    ["google/gemma", "meta-llama/llama3"],
+  );
+
+  // parseEntry unions them, tagging URL hits first then bare-only hits,
+  // so no repo is double-counted.
+  const linked = [
+    ...[...urlHits].map((fullName) => ({ fullName, matchType: "abstract" })),
+    ...[...bareHits]
+      .filter((fullName) => !urlHits.has(fullName))
+      .map((fullName) => ({ fullName, matchType: "slug" })),
+  ];
+  assert.equal(linked.length, 3);
+  assert.equal(
+    linked.filter((l) => l.fullName === "openai/whisper").length,
+    1,
+  );
+  assert.equal(
+    linked.find((l) => l.fullName === "openai/whisper").matchType,
+    "abstract",
+  );
+  assert.equal(
+    linked.find((l) => l.fullName === "meta-llama/llama3").matchType,
+    "slug",
+  );
+});

--- a/scripts/scrape-arxiv.mjs
+++ b/scripts/scrape-arxiv.mjs
@@ -36,7 +36,11 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fetchWithTimeout, sleep, parseRetryAfterMs } from "./_fetch-json.mjs";
-import { extractGithubRepoFullNames, extractUnknownRepoCandidates } from "./_github-repo-links.mjs";
+import {
+  extractGithubRepoFullNames,
+  extractTrackedBareRefs,
+  extractUnknownRepoCandidates,
+} from "./_github-repo-links.mjs";
 import { appendUnknownMentions } from "./_unknown-mentions-lake.mjs";
 import { loadTrackedReposFromFiles } from "./_tracked-repos.mjs";
 import { writeDataStore, verifyMetaLanded, closeDataStore } from "./_data-store-write.mjs";
@@ -150,12 +154,28 @@ function parseEntry(entryXml, tracked) {
   const { abs, pdf } = pickLinks(entryXml);
 
   const blob = `${title}\n${summary}`;
-  const repoHits = extractGithubRepoFullNames(blob, tracked);
-  const linkedRepos = Array.from(repoHits, (lower) => ({
-    fullName: tracked.get(lower) ?? lower,
-    matchType: "abstract",
-    confidence: 1.0,
-  }));
+  // Full github.com/<owner>/<repo> URLs are the high-confidence signal.
+  const urlHits = extractGithubRepoFullNames(blob, tracked);
+  // Bare `owner/repo` mentions ("we release meta-llama/llama3 at …") are the
+  // common shape in abstracts that never spell out the github.com host. The
+  // tracked-set membership check inside extractTrackedBareRefs makes this
+  // safe — a slug we don't already track can never be emitted. Drop any that
+  // the URL pass already found so a repo isn't double-tagged.
+  const bareHits = extractTrackedBareRefs(blob, tracked);
+  const linkedRepos = [
+    ...Array.from(urlHits, (lower) => ({
+      fullName: tracked.get(lower) ?? lower,
+      matchType: "abstract",
+      confidence: 1.0,
+    })),
+    ...Array.from(bareHits, (lower) => lower)
+      .filter((lower) => !urlHits.has(lower))
+      .map((lower) => ({
+        fullName: tracked.get(lower) ?? lower,
+        matchType: "slug",
+        confidence: 0.9,
+      })),
+  ];
 
   const publishedMs = published ? Date.parse(published) : NaN;
   const updatedMs = updated ? Date.parse(updated) : NaN;

--- a/src/app/api/admin/twitter-outbound/route.ts
+++ b/src/app/api/admin/twitter-outbound/route.ts
@@ -1,0 +1,63 @@
+// GET /api/admin/twitter-outbound
+//
+// Operator review surface for the outbound X posting pipeline. Returns
+// the most recent outbound runs (daily threads, weekly recaps, idea
+// posts) newest-first, INCLUDING the full composed post texts + URLs —
+// so selection quality can be judged from console/null-mode dry runs
+// before real publishing is switched on.
+//
+// Auth: ADMIN_TOKEN via verifyAdminAuth. Read-only; Cache-Control:
+// no-store.
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { adminAuthFailureResponse, verifyAdminAuth } from "@/lib/api/auth";
+import { listOutboundRuns } from "@/lib/twitter/outbound/audit";
+import type { OutboundRunRecord } from "@/lib/twitter/outbound/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+interface AdminOutboundResponse {
+  ok: true;
+  count: number;
+  runs: OutboundRunRecord[];
+}
+
+interface AdminOutboundErrorResponse {
+  ok: false;
+  error: string;
+}
+
+async function handle(
+  request: NextRequest,
+): Promise<NextResponse<AdminOutboundResponse | AdminOutboundErrorResponse>> {
+  const deny = adminAuthFailureResponse(verifyAdminAuth(request));
+  if (deny) return deny as NextResponse<AdminOutboundErrorResponse>;
+
+  const rawLimit = request.nextUrl.searchParams.get("limit");
+  const parsed = rawLimit ? Number.parseInt(rawLimit, 10) : DEFAULT_LIMIT;
+  const limit = Number.isFinite(parsed)
+    ? Math.min(Math.max(parsed, 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  try {
+    // listOutboundRuns already sorts newest-first.
+    const runs = (await listOutboundRuns()).slice(0, limit);
+    return NextResponse.json(
+      { ok: true, count: runs.length, runs },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = handle;

--- a/src/app/api/cron/twitter-daily/route.ts
+++ b/src/app/api/cron/twitter-daily/route.ts
@@ -25,6 +25,7 @@ import { getLastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
 
 import {
   listOutboundRuns,
+  partialPublishedRepos,
   recordOutboundRun,
   zipRunPosts,
 } from "@/lib/twitter/outbound/audit";
@@ -103,6 +104,9 @@ async function handle(
 
   const startedAt = new Date().toISOString();
   const adapter = selectOutboundAdapter();
+  // Hoisted so the catch can still cool-down repos that posted before a
+  // mid-thread failure.
+  let breakouts: ReturnType<typeof pickDailyBreakouts> = [];
 
   try {
     // Pull the freshest worker-owned payload from Redis before reading
@@ -146,7 +150,7 @@ async function handle(
     // repeat itself. Best-effort — an empty/fresh audit file means no
     // exclusions.
     const previousRuns = await listOutboundRuns().catch(() => []);
-    const breakouts = pickDailyBreakouts(getDerivedRepos(), {
+    breakouts = pickDailyBreakouts(getDerivedRepos(), {
       count: DAILY_BREAKOUT_COUNT,
       // Cooldown only counts prior DAILY threads — a Friday-recap
       // appearance shouldn't knock a repo out of a week of dailies.
@@ -198,6 +202,9 @@ async function handle(
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // A thread that published some posts then threw must still cool-down
+    // the repos that DID post, or they re-feature tomorrow.
+    const partiallyFeatured = partialPublishedRepos(err, breakouts);
     await recordOutboundRun({
       kind: "daily_breakouts",
       adapterName: adapter.name,
@@ -206,6 +213,8 @@ async function handle(
       postCount: 0,
       startedAt,
       errorMessage: message,
+      featuredRepos:
+        partiallyFeatured.length > 0 ? partiallyFeatured : undefined,
     }).catch(() => undefined);
     return NextResponse.json(
       { ok: false, error: message },

--- a/src/app/api/cron/twitter-daily/route.ts
+++ b/src/app/api/cron/twitter-daily/route.ts
@@ -21,12 +21,28 @@ import {
   countReactions,
   listReactionsForObject,
 } from "@/lib/reactions";
+import { getLastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
 
-import { recordOutboundRun } from "@/lib/twitter/outbound/audit";
+import {
+  listOutboundRuns,
+  recordOutboundRun,
+} from "@/lib/twitter/outbound/audit";
 import { selectOutboundAdapter } from "@/lib/twitter/outbound/adapters";
 import { composeDailyBreakouts } from "@/lib/twitter/outbound/composer";
+import {
+  DAILY_BREAKOUT_COUNT,
+  pickDailyBreakouts,
+  recentlyFeaturedRepos,
+} from "@/lib/twitter/outbound/select";
 
 export const runtime = "nodejs";
+
+/**
+ * Don't post from data older than this. Stale trending data is what
+ * produces "random-looking" picks — better to skip the day (visibly,
+ * via the audit row) than to post garbage.
+ */
+const MAX_DATA_AGE_MS = 12 * 60 * 60 * 1000;
 
 interface DailyResponse {
   ok: true;
@@ -35,30 +51,13 @@ interface DailyResponse {
   postCount: number;
   threadUrl: string | null;
   runId: string;
+  /** Set when status=skipped for a reason other than a null adapter. */
+  skippedReason?: string;
 }
 
 interface ErrorResponse {
   ok: false;
   error: string;
-}
-
-/**
- * Pick the top 3 repos to highlight today. "Top" = highest
- * cross-signal score among repos with channelsFiring >= 2, sorted by
- * 24h star delta as the tiebreaker.
- */
-function pickDailyBreakouts(now: Date = new Date()) {
-  void now;
-  const repos = getDerivedRepos();
-  return repos
-    .filter((r) => (r.channelsFiring ?? 0) >= 2)
-    .sort((a, b) => {
-      const aCSS = a.crossSignalScore ?? 0;
-      const bCSS = b.crossSignalScore ?? 0;
-      if (bCSS !== aCSS) return bCSS - aCSS;
-      return (b.starsDelta24h ?? 0) - (a.starsDelta24h ?? 0);
-    })
-    .slice(0, 3);
 }
 
 /**
@@ -105,7 +104,51 @@ async function handle(
   const adapter = selectOutboundAdapter();
 
   try {
-    const breakouts = pickDailyBreakouts();
+    // Pull the freshest worker-owned payload from Redis before reading
+    // anything — a cold container otherwise composes from the bundled
+    // (build-time) JSON. Failure degrades to whatever is cached.
+    await refreshTrendingFromStore().catch((err) => {
+      console.warn("[api:cron:twitter-daily] refreshTrendingFromStore failed", err);
+    });
+
+    // Freshness gate: skip the day rather than post from stale data.
+    const fetchedAtMs = Date.parse(getLastFetchedAt());
+    const dataAgeMs = Number.isFinite(fetchedAtMs)
+      ? Date.now() - fetchedAtMs
+      : Number.POSITIVE_INFINITY;
+    if (dataAgeMs > MAX_DATA_AGE_MS) {
+      const ageHours = Number.isFinite(dataAgeMs)
+        ? `${(dataAgeMs / 3_600_000).toFixed(1)}h`
+        : "unknown";
+      const reason = `stale-data (trending payload age ${ageHours} > 12h)`;
+      const run = await recordOutboundRun({
+        kind: "daily_breakouts",
+        adapterName: adapter.name,
+        status: "skipped",
+        threadUrl: null,
+        postCount: 0,
+        startedAt,
+        errorMessage: reason,
+      });
+      return NextResponse.json({
+        ok: true,
+        adapter: adapter.name,
+        status: "skipped",
+        postCount: 0,
+        threadUrl: null,
+        runId: run.id,
+        skippedReason: reason,
+      });
+    }
+
+    // Repos featured in the last 7 days sit out so the thread doesn't
+    // repeat itself. Best-effort — an empty/fresh audit file means no
+    // exclusions.
+    const previousRuns = await listOutboundRuns().catch(() => []);
+    const breakouts = pickDailyBreakouts(getDerivedRepos(), {
+      count: DAILY_BREAKOUT_COUNT,
+      exclude: recentlyFeaturedRepos(previousRuns),
+    });
     const topIdeaRaw = await pickTopIdeaOfWeek();
     const thread = composeDailyBreakouts({
       breakouts,
@@ -131,6 +174,12 @@ async function handle(
       threadUrl: result.threadUrl,
       postCount: thread.length,
       startedAt,
+      // Only published repos enter the 7-day cooldown — a skipped or
+      // logged run shouldn't burn the picks.
+      featuredRepos:
+        status === "published"
+          ? breakouts.map((r) => r.fullName)
+          : undefined,
     });
 
     return NextResponse.json({

--- a/src/app/api/cron/twitter-daily/route.ts
+++ b/src/app/api/cron/twitter-daily/route.ts
@@ -26,6 +26,7 @@ import { getLastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
 import {
   listOutboundRuns,
   recordOutboundRun,
+  zipRunPosts,
 } from "@/lib/twitter/outbound/audit";
 import { selectOutboundAdapter } from "@/lib/twitter/outbound/adapters";
 import { composeDailyBreakouts } from "@/lib/twitter/outbound/composer";
@@ -147,7 +148,11 @@ async function handle(
     const previousRuns = await listOutboundRuns().catch(() => []);
     const breakouts = pickDailyBreakouts(getDerivedRepos(), {
       count: DAILY_BREAKOUT_COUNT,
-      exclude: recentlyFeaturedRepos(previousRuns),
+      // Cooldown only counts prior DAILY threads — a Friday-recap
+      // appearance shouldn't knock a repo out of a week of dailies.
+      exclude: recentlyFeaturedRepos(previousRuns, {
+        kinds: ["daily_breakouts"],
+      }),
     });
     const topIdeaRaw = await pickTopIdeaOfWeek();
     const thread = composeDailyBreakouts({
@@ -180,6 +185,7 @@ async function handle(
         status === "published"
           ? breakouts.map((r) => r.fullName)
           : undefined,
+      posts: zipRunPosts(thread, result),
     });
 
     return NextResponse.json({

--- a/src/app/api/cron/twitter-weekly-recap/route.ts
+++ b/src/app/api/cron/twitter-weekly-recap/route.ts
@@ -18,12 +18,21 @@ import {
   countReactions,
   listReactionsForObject,
 } from "@/lib/reactions";
+import { getLastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
 
-import { recordOutboundRun } from "@/lib/twitter/outbound/audit";
+import { recordOutboundRun, zipRunPosts } from "@/lib/twitter/outbound/audit";
 import { selectOutboundAdapter } from "@/lib/twitter/outbound/adapters";
-import { composeWeeklyRecap } from "@/lib/twitter/outbound/composer";
+import {
+  composeWeeklyRecap,
+  MAX_WEEKLY_ITEMS,
+} from "@/lib/twitter/outbound/composer";
+import { pickDailyBreakouts } from "@/lib/twitter/outbound/select";
 
 export const runtime = "nodejs";
+
+/** Same stale-data threshold as the daily route: skip visibly rather
+ * than compose a recap from a frozen payload. */
+const MAX_DATA_AGE_MS = 12 * 60 * 60 * 1000;
 
 interface WeeklyResponse {
   ok: true;
@@ -32,6 +41,8 @@ interface WeeklyResponse {
   postCount: number;
   threadUrl: string | null;
   runId: string;
+  /** Set when status=skipped for a reason other than a null adapter. */
+  skippedReason?: string;
 }
 
 interface ErrorResponse {
@@ -55,19 +66,57 @@ async function handle(
     const now = new Date();
     const weekAgoMs = now.getTime() - 7 * 24 * 60 * 60 * 1000;
 
-    // Top breakout of the week = highest crossSignalScore among repos
-    // with any meaningful 7d star delta. Ties broken by absolute delta.
-    const repos = getDerivedRepos();
-    const weeklyBreakouts = repos
-      .filter((r) => (r.starsDelta7d ?? 0) > 0)
-      .sort((a, b) => {
-        const aCSS = a.crossSignalScore ?? 0;
-        const bCSS = b.crossSignalScore ?? 0;
-        if (bCSS !== aCSS) return bCSS - aCSS;
-        return (b.starsDelta7d ?? 0) - (a.starsDelta7d ?? 0);
+    // Pull the freshest worker-owned payload from Redis before reading
+    // anything — a cold container otherwise composes from the bundled
+    // (build-time) JSON. Failure degrades to whatever is cached.
+    await refreshTrendingFromStore().catch((err) => {
+      console.warn(
+        "[api:cron:twitter-weekly-recap] refreshTrendingFromStore failed",
+        err,
+      );
+    });
+
+    // Freshness gate: skip the recap rather than post from stale data.
+    const fetchedAtMs = Date.parse(getLastFetchedAt());
+    const dataAgeMs = Number.isFinite(fetchedAtMs)
+      ? Date.now() - fetchedAtMs
+      : Number.POSITIVE_INFINITY;
+    if (dataAgeMs > MAX_DATA_AGE_MS) {
+      const ageHours = Number.isFinite(dataAgeMs)
+        ? `${(dataAgeMs / 3_600_000).toFixed(1)}h`
+        : "unknown";
+      const reason = `stale-data (trending payload age ${ageHours} > 12h)`;
+      const run = await recordOutboundRun({
+        kind: "weekly_recap",
+        adapterName: adapter.name,
+        status: "skipped",
+        threadUrl: null,
+        postCount: 0,
+        startedAt,
+        errorMessage: reason,
       });
-    const topBreakout = weeklyBreakouts[0] ?? null;
-    const breakoutsThisWeek = weeklyBreakouts.filter(
+      return NextResponse.json({
+        ok: true,
+        adapter: adapter.name,
+        status: "skipped",
+        postCount: 0,
+        threadUrl: null,
+        runId: run.id,
+        skippedReason: reason,
+      });
+    }
+
+    // Top breakouts of the week via the shared tiered selector in its
+    // 7d window (multi-signal first, then flagged movers, then raw 7d
+    // star velocity). No cooldown exclusion: the recap runs once a
+    // week and the week's #1 belongs in it even if a daily already
+    // featured it.
+    const repos = getDerivedRepos();
+    const topBreakouts = pickDailyBreakouts(repos, {
+      count: MAX_WEEKLY_ITEMS,
+      window: "7d",
+    });
+    const breakoutsThisWeek = repos.filter(
       (r) => (r.channelsFiring ?? 0) >= 2,
     ).length;
 
@@ -98,7 +147,7 @@ async function handle(
     }
 
     const thread = composeWeeklyRecap({
-      topBreakout,
+      topBreakouts,
       topIdea,
       ideasPublishedThisWeek: publishedThisWeek.length,
       breakoutsThisWeek,
@@ -120,6 +169,11 @@ async function handle(
       threadUrl: result.threadUrl,
       postCount: thread.length,
       startedAt,
+      featuredRepos:
+        status === "published"
+          ? topBreakouts.map((r) => r.fullName)
+          : undefined,
+      posts: zipRunPosts(thread, result),
     });
 
     return NextResponse.json({

--- a/src/app/api/cron/twitter-weekly-recap/route.ts
+++ b/src/app/api/cron/twitter-weekly-recap/route.ts
@@ -20,13 +20,20 @@ import {
 } from "@/lib/reactions";
 import { getLastFetchedAt, refreshTrendingFromStore } from "@/lib/trending";
 
-import { recordOutboundRun, zipRunPosts } from "@/lib/twitter/outbound/audit";
+import {
+  partialPublishedRepos,
+  recordOutboundRun,
+  zipRunPosts,
+} from "@/lib/twitter/outbound/audit";
 import { selectOutboundAdapter } from "@/lib/twitter/outbound/adapters";
 import {
   composeWeeklyRecap,
   MAX_WEEKLY_ITEMS,
 } from "@/lib/twitter/outbound/composer";
-import { pickDailyBreakouts } from "@/lib/twitter/outbound/select";
+import {
+  countWeeklyBreakouts,
+  pickDailyBreakouts,
+} from "@/lib/twitter/outbound/select";
 
 export const runtime = "nodejs";
 
@@ -61,6 +68,9 @@ async function handle(
 
   const startedAt = new Date().toISOString();
   const adapter = selectOutboundAdapter();
+  // Hoisted so the catch can still cool-down repos that posted before a
+  // mid-thread failure.
+  let topBreakouts: ReturnType<typeof pickDailyBreakouts> = [];
 
   try {
     const now = new Date();
@@ -112,13 +122,11 @@ async function handle(
     // week and the week's #1 belongs in it even if a daily already
     // featured it.
     const repos = getDerivedRepos();
-    const topBreakouts = pickDailyBreakouts(repos, {
+    topBreakouts = pickDailyBreakouts(repos, {
       count: MAX_WEEKLY_ITEMS,
       window: "7d",
     });
-    const breakoutsThisWeek = repos.filter(
-      (r) => (r.channelsFiring ?? 0) >= 2,
-    ).length;
+    const breakoutsThisWeek = countWeeklyBreakouts(repos);
 
     const allIdeas = await listIdeas();
     const publishedThisWeek = allIdeas.filter((r) => {
@@ -186,6 +194,9 @@ async function handle(
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // A thread that published some posts then threw must still cool-down
+    // the repos that DID post, or they re-feature next week.
+    const partiallyFeatured = partialPublishedRepos(err, topBreakouts);
     await recordOutboundRun({
       kind: "weekly_recap",
       adapterName: adapter.name,
@@ -194,6 +205,8 @@ async function handle(
       postCount: 0,
       startedAt,
       errorMessage: message,
+      featuredRepos:
+        partiallyFeatured.length > 0 ? partiallyFeatured : undefined,
     }).catch(() => undefined);
     return NextResponse.json(
       { ok: false, error: message },

--- a/src/components/brand/BrandIcons.tsx
+++ b/src/components/brand/BrandIcons.tsx
@@ -433,3 +433,31 @@ export function NewsIcon({ size = 16, className }: IconProps) {
     </svg>
   );
 }
+
+/**
+ * arXiv — the preprint server. No simple-icons mark ships with the pack;
+ * we render a document glyph with a downward "cite" chevron so it reads as
+ * "research paper" at chip scale without redistributing their wordmark.
+ * Canonical fill: #B31B1B (arXiv red).
+ */
+export function ArxivIcon({ size = 16, className, monochrome }: IconProps) {
+  const stroke = monochrome ? "currentColor" : "#B31B1B";
+  return (
+    <svg {...svgRoot(size, className)}>
+      <path
+        d="M7 3 H14 L19 8 V21 H7 Z M14 3 V8 H19"
+        fill="none"
+        stroke={stroke}
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10 12 H16 M10 15 H16 M10 18 H13"
+        fill="none"
+        stroke={stroke}
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/compare/CrossSignalStrip.tsx
+++ b/src/components/compare/CrossSignalStrip.tsx
@@ -2,8 +2,10 @@
 
 // Compact cross-signal strip. Translates `countsBySource` (per-platform
 // mention totals from the canonical profile) into ChannelDots props so a
-// platform with >=1 mention counts as "firing". Keeps the same 6-dot
-// vocabulary the rest of the product uses.
+// platform with >=1 mention counts as "firing". Uses the same 7-channel
+// vocabulary as the rest of the product; arXiv (research citations) has no
+// per-platform mention count on this social-profile surface, so it's
+// always off here — the /7 denominator stays consistent with ChannelDots.
 
 import { ChannelDots } from "@/components/cross-signal/ChannelDots";
 import type { SocialPlatform } from "@/lib/types";
@@ -47,7 +49,7 @@ export function CrossSignalStrip({ mentions }: CrossSignalStripProps) {
           Cross-Signal
         </span>
         <span className="text-xs font-mono text-text-tertiary tabular-nums">
-          {firing}/6
+          {firing}/7
         </span>
       </div>
       <ChannelDots

--- a/src/components/compare/CrossSignalStrip.tsx
+++ b/src/components/compare/CrossSignalStrip.tsx
@@ -28,6 +28,9 @@ export function CrossSignalStrip({ mentions }: CrossSignalStripProps) {
     bluesky: blueskyCount > 0,
     devto: devtoCount > 0,
     twitter: twitterCount > 0,
+    // arXiv is a research-citation channel with no per-platform mention
+    // count on the social-profile surface, so it's always off here.
+    arxiv: false,
   };
   const firing =
     (status.github ? 1 : 0) +

--- a/src/components/cross-signal/ChannelDots.tsx
+++ b/src/components/cross-signal/ChannelDots.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-// ChannelDots — six small inline dots representing GitHub / Reddit / HN /
-// Bluesky / dev.to / Twitter channel state. Filled = component > 0;
+// ChannelDots — seven small inline dots representing GitHub / Reddit / HN /
+// Bluesky / dev.to / Twitter / arXiv channel state. Filled = component > 0;
 // outlined = inactive.
 //
 // PREVIOUSLY this component imported getChannelStatus from
@@ -23,6 +23,7 @@ interface ChannelStatus {
   bluesky: boolean;
   devto: boolean;
   twitter: boolean;
+  arxiv: boolean;
 }
 
 type ChannelKey = keyof ChannelStatus;
@@ -57,6 +58,7 @@ const CHANNEL_COLORS = {
   bluesky: "#0085FF",
   devto: "#0a0a0a",
   twitter: "#1d9bf0",
+  arxiv: "#b31b1b",
 };
 
 function buildTooltip(status: ChannelStatus, firing: number): string {
@@ -67,8 +69,9 @@ function buildTooltip(status: ChannelStatus, firing: number): string {
     `Bluesky: ${status.bluesky ? "active" : "—"}`,
     `dev.to: ${status.devto ? "active" : "—"}`,
     `X: ${status.twitter ? "active" : "—"}`,
+    `arXiv: ${status.arxiv ? "active" : "—"}`,
   ];
-  return `${firing}/6 channels firing\n${parts.join(" · ")}`;
+  return `${firing}/7 channels firing\n${parts.join(" · ")}`;
 }
 
 const ZERO_STATUS: ChannelStatus = {
@@ -78,6 +81,7 @@ const ZERO_STATUS: ChannelStatus = {
   bluesky: false,
   devto: false,
   twitter: false,
+  arxiv: false,
 };
 
 function resolveStatus(props: ChannelDotsProps): ChannelStatus {
@@ -93,6 +97,7 @@ const CHANNEL_DEFAULT_LABEL: Record<ChannelKey, string> = {
   bluesky: "Bluesky",
   devto: "dev.to",
   twitter: "X",
+  arxiv: "arXiv",
 };
 
 export function ChannelDots(props: ChannelDotsProps) {
@@ -104,7 +109,8 @@ export function ChannelDots(props: ChannelDotsProps) {
     (status.hn ? 1 : 0) +
     (status.bluesky ? 1 : 0) +
     (status.devto ? 1 : 0) +
-    (status.twitter ? 1 : 0);
+    (status.twitter ? 1 : 0) +
+    (status.arxiv ? 1 : 0);
   if (firing === 0 && hideWhenEmpty) return null;
 
   const dotSize = size === "md" ? "w-2 h-2" : "w-1.5 h-1.5";
@@ -134,7 +140,7 @@ export function ChannelDots(props: ChannelDotsProps) {
     <span
       className={`inline-flex items-center ${gap} shrink-0`}
       title={buildTooltip(status, firing)}
-      aria-label={`${firing} of 6 cross-signal channels firing`}
+      aria-label={`${firing} of 7 cross-signal channels firing`}
     >
       {dot("github", status.github, CHANNEL_COLORS.github)}
       {dot("reddit", status.reddit, CHANNEL_COLORS.reddit)}
@@ -142,6 +148,7 @@ export function ChannelDots(props: ChannelDotsProps) {
       {dot("bluesky", status.bluesky, CHANNEL_COLORS.bluesky)}
       {dot("devto", status.devto, CHANNEL_COLORS.devto)}
       {dot("twitter", status.twitter, CHANNEL_COLORS.twitter)}
+      {dot("arxiv", status.arxiv, CHANNEL_COLORS.arxiv)}
     </span>
   );
 }

--- a/src/components/layout/SidebarWatchlistPreview.tsx
+++ b/src/components/layout/SidebarWatchlistPreview.tsx
@@ -37,6 +37,7 @@ export interface SidebarWatchlistPreviewRepo {
     bluesky: boolean;
     devto: boolean;
     twitter: boolean;
+    arxiv: boolean;
   };
 }
 

--- a/src/components/repo-detail/ChannelChipRow.tsx
+++ b/src/components/repo-detail/ChannelChipRow.tsx
@@ -1,7 +1,7 @@
-// 6-up channel chip row for the repo-detail hero.
+// 7-up channel chip row for the repo-detail hero.
 //
 // Renders one chip per channel (GitHub / HackerNews / Reddit / Bluesky /
-// dev.to / X) with the canonical brand color, primary 24h metric, FIRING / QUIET
+// dev.to / X / arXiv) with the canonical brand color, primary 24h metric, FIRING / QUIET
 // status pill, and a mini sparkline. Reads exclusively from the in-memory
 // Repo (channelStatus, mentions.perSource, starsDelta24h, sparklineData) so
 // no extra fetches happen here.
@@ -24,6 +24,7 @@ import {
   BlueskyIcon,
   DevtoIcon,
   XIcon,
+  ArxivIcon,
 } from "@/components/brand/BrandIcons";
 import { Sparkline } from "@/components/shared/Sparkline";
 import { formatNumber } from "@/lib/utils";
@@ -35,7 +36,8 @@ type ChannelKey =
   | "reddit"
   | "bluesky"
   | "devto"
-  | "twitter";
+  | "twitter"
+  | "arxiv";
 
 interface ChannelDef {
   key: ChannelKey;
@@ -51,6 +53,7 @@ const CHANNELS: ReadonlyArray<ChannelDef> = [
   { key: "bluesky", label: "Bluesky", icon: BlueskyIcon, color: "#0085FF" },
   { key: "devto", label: "Dev.to", icon: DevtoIcon, color: "#0a0a0a" },
   { key: "twitter", label: "X", icon: XIcon, color: "#1d9bf0" },
+  { key: "arxiv", label: "arXiv", icon: ArxivIcon, color: "#b31b1b" },
 ];
 
 interface ChannelChipRowProps {
@@ -84,11 +87,24 @@ function deriveChip(repo: Repo, key: ChannelKey): ChipData {
     };
   }
 
+  // arXiv is the research-backed channel — it has no mentions.perSource
+  // entry (it's cited-by-paper, not posted-about), so it renders from the
+  // firing boolean only. No 24h/7d post counts to show.
+  if (key === "arxiv") {
+    const fired = status?.arxiv === true;
+    return {
+      metric: fired ? "cited" : "—",
+      windowLabel: "30d",
+      fired,
+      spark: [],
+    };
+  }
+
   // mentions.perSource carries count24h + count7d for the registry-style
   // sources. We render the 24h count as the headline and use count7d as a
   // single-point amplitude proxy for the inline spark when there's no
   // per-day breakdown.
-  const sourceMap: Record<Exclude<ChannelKey, "github">, keyof NonNullable<Repo["mentions"]>["perSource"]> = {
+  const sourceMap: Record<Exclude<ChannelKey, "github" | "arxiv">, keyof NonNullable<Repo["mentions"]>["perSource"]> = {
     hackernews: "hackernews",
     reddit: "reddit",
     bluesky: "bluesky",
@@ -164,7 +180,7 @@ export function ChannelChipRow({ repo }: ChannelChipRowProps): JSX.Element {
       <style>{`
         .channel-chip-row {
           display: grid;
-          grid-template-columns: repeat(6, minmax(0, 1fr));
+          grid-template-columns: repeat(7, minmax(0, 1fr));
           gap: 8px;
         }
         @media (max-width: 720px) {

--- a/src/components/repo-detail/CrossSignalBreakdown.tsx
+++ b/src/components/repo-detail/CrossSignalBreakdown.tsx
@@ -26,7 +26,7 @@ interface CrossSignalBreakdownProps {
 }
 
 interface ChannelRow {
-  key: "github" | "reddit" | "hn" | "bluesky" | "devto" | "twitter";
+  key: "github" | "reddit" | "hn" | "bluesky" | "devto" | "twitter" | "arxiv";
   label: string;
   color: string;
   value: number; // 0..1
@@ -43,6 +43,7 @@ const CHANNEL_COLORS = {
   bluesky: "#0085FF",
   devto: "#0a0a0a",
   twitter: "#1d9bf0",
+  arxiv: "#b31b1b",
 };
 
 /**
@@ -73,6 +74,7 @@ export function CrossSignalBreakdown({
   const bskyVal = crossSignalInternals.blueskyComponent(repo.fullName);
   const devtoVal = crossSignalInternals.devtoComponent(repo.fullName);
   const twitterVal = crossSignalInternals.twitterComponent(repo.fullName);
+  const arxivVal = crossSignalInternals.arxivComponent(repo.fullName, nowMs);
 
   const rows: ChannelRow[] = [
     {
@@ -160,6 +162,21 @@ export function CrossSignalBreakdown({
             : twitterVal === 0.4
               ? "1-2 mentions / 24h (0.4)"
               : "no X chatter",
+    },
+    {
+      key: "arxiv",
+      label: "arXiv",
+      color: CHANNEL_COLORS.arxiv,
+      value: arxivVal,
+      active: status.arxiv,
+      hint:
+        arxivVal === 1.0
+          ? "cited by ≥2 recent papers, or 1 high-impact (1.0)"
+          : arxivVal === 0.7
+            ? "cited by 1 recent paper (0.7)"
+            : arxivVal === 0.4
+              ? "cited by an older paper (0.4)"
+              : "no research citations",
     },
   ];
 

--- a/src/components/repo-detail/RepoIdHero.tsx
+++ b/src/components/repo-detail/RepoIdHero.tsx
@@ -41,7 +41,7 @@ interface NarrativePart {
   tone?: "positive" | "neutral" | "negative" | "muted";
 }
 
-const CHANNEL_TOTAL = 6;
+const CHANNEL_TOTAL = 7;
 
 function buildNarrative(repo: Repo): NarrativePart[] {
   const ps = repo.mentions?.perSource;
@@ -95,6 +95,9 @@ function buildNarrative(repo: Repo): NarrativePart[] {
   if (status?.twitter && (ps?.twitter.count24h ?? 0) > 0) {
     fired.push(`X posts (${ps?.twitter.count24h} / 24h)`);
   }
+  if (status?.arxiv) {
+    fired.push("arXiv research citations");
+  }
   if (fired.length > 0) {
     const joined =
       fired.length === 1
@@ -112,6 +115,7 @@ function buildNarrative(repo: Repo): NarrativePart[] {
     if (status && !status.bluesky) quiet.push("Bluesky");
     if (status && !status.devto) quiet.push("Dev.to");
     if (status && !status.twitter) quiet.push("X");
+    if (status && !status.arxiv) quiet.push("arXiv");
     if (quiet.length > 0) {
       const list =
         quiet.length === 1

--- a/src/lib/__tests__/twitter-outbound-select.test.ts
+++ b/src/lib/__tests__/twitter-outbound-select.test.ts
@@ -8,13 +8,14 @@
 
 import { test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { appendFile, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import type { Repo } from "../types";
 
 import {
+  countWeeklyBreakouts,
   DAILY_BREAKOUT_COUNT,
   pickDailyBreakouts,
   recentlyFeaturedRepos,
@@ -29,6 +30,7 @@ import {
   recordOutboundRun,
   zipRunPosts,
 } from "../twitter/outbound/audit";
+import { FatalConfigError, TransientHttpError } from "../errors";
 import type { OutboundRunRecord } from "../twitter/outbound/types";
 
 function makeRepo(partial: Partial<Repo> & { fullName: string }): Repo {
@@ -262,6 +264,29 @@ test('window "7d" ignores the 24h backfill marker', () => {
 });
 
 // ---------------------------------------------------------------------------
+// countWeeklyBreakouts
+// ---------------------------------------------------------------------------
+
+test("countWeeklyBreakouts counts only 7d-movers that are multi-signal", () => {
+  const repos = [
+    // Qualifies: moved this week AND multi-signal.
+    makeRepo({ fullName: "a/real", starsDelta7d: 200, channelsFiring: 3 }),
+    // No 7d movement — excluded even though multi-signal (this is the bug
+    // the helper fixes: it used to count the whole corpus).
+    makeRepo({ fullName: "b/flat", starsDelta7d: 0, channelsFiring: 4 }),
+    // Moved but single-signal — excluded.
+    makeRepo({ fullName: "c/single", starsDelta7d: 500, channelsFiring: 1 }),
+    // Negative 7d — excluded.
+    makeRepo({ fullName: "d/decline", starsDelta7d: -10, channelsFiring: 2 }),
+  ];
+  assert.equal(countWeeklyBreakouts(repos), 1);
+});
+
+test("countWeeklyBreakouts is 0 for an empty corpus", () => {
+  assert.equal(countWeeklyBreakouts([]), 0);
+});
+
+// ---------------------------------------------------------------------------
 // recentlyFeaturedRepos
 // ---------------------------------------------------------------------------
 
@@ -337,6 +362,19 @@ function tokenResponse(body: Record<string, unknown>): Response {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+async function recordPersistedOAuthState(row: {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  rotatedAt: string;
+}): Promise<void> {
+  await appendFile(
+    path.join(dataDir!, OAUTH_STATE_FILE),
+    JSON.stringify(row) + "\n",
+    "utf8",
+  );
 }
 
 test("readTwitterOAuthConfigFromEnv requires the full trio", () => {
@@ -525,7 +563,7 @@ test("zipRunPosts marks unattempted posts as skipped when a thread aborts mid-wa
   assert.equal(posts[1]!.status, "skipped");
 });
 
-test("TwitterOAuthTokenManager surfaces token-endpoint failures", async () => {
+test("TwitterOAuthTokenManager classifies a 400 refresh failure as FATAL (not retryable)", async () => {
   const fetchImpl: typeof fetch = async () =>
     new Response("invalid_request", { status: 400 });
   const manager = new TwitterOAuthTokenManager({
@@ -534,8 +572,64 @@ test("TwitterOAuthTokenManager surfaces token-endpoint failures", async () => {
     seedRefreshToken: "rt-dead",
     fetchImpl,
   });
-  await assert.rejects(
-    () => manager.getAccessToken(),
-    /token refresh failed with 400/,
-  );
+  await assert.rejects(() => manager.getAccessToken(), (err: unknown) => {
+    assert.ok(err instanceof FatalConfigError, "expected FatalConfigError");
+    assert.match((err as Error).message, /token refresh failed with 400/);
+    return true;
+  });
+});
+
+test("TwitterOAuthTokenManager keeps a 503 refresh failure TRANSIENT (retryable)", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response("upstream down", { status: 503 });
+  const manager = new TwitterOAuthTokenManager({
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt",
+    fetchImpl,
+  });
+  await assert.rejects(() => manager.getAccessToken(), (err: unknown) => {
+    assert.ok(err instanceof TransientHttpError, "expected TransientHttpError");
+    return true;
+  });
+});
+
+test("concurrent getAccessToken uses the persisted rotated token, never the stale seed (load race)", async () => {
+  // Seed a persisted rotated token on disk. A cold manager must load it
+  // before exchanging — two concurrent callers must both wait for that
+  // load, not short-circuit with state=null and fall back to the seed.
+  await recordPersistedOAuthState({
+    accessToken: "at-expired",
+    refreshToken: "rt-persisted",
+    // Already expired so getAccessToken triggers a refresh.
+    expiresAt: new Date(0).toISOString(),
+    rotatedAt: "2026-07-01T00:00:00Z",
+  });
+
+  const seenRefreshTokens: string[] = [];
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    const params = new URLSearchParams((init?.body as string) ?? "");
+    seenRefreshTokens.push(params.get("refresh_token") ?? "");
+    return tokenResponse({
+      access_token: "at-new",
+      refresh_token: "rt-next",
+      expires_in: 7200,
+    });
+  };
+  const manager = new TwitterOAuthTokenManager({
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt-SEED-must-not-be-used",
+    fetchImpl,
+  });
+
+  const [a, b] = await Promise.all([
+    manager.getAccessToken(),
+    manager.getAccessToken(),
+  ]);
+  assert.equal(a, "at-new");
+  assert.equal(b, "at-new");
+  // The single-flight refresh means exactly one exchange, and it used the
+  // PERSISTED token — never the seed.
+  assert.deepEqual(seenRefreshTokens, ["rt-persisted"]);
 });

--- a/src/lib/__tests__/twitter-outbound-select.test.ts
+++ b/src/lib/__tests__/twitter-outbound-select.test.ts
@@ -24,6 +24,11 @@ import {
   TwitterOAuthTokenManager,
   readTwitterOAuthConfigFromEnv,
 } from "../twitter/outbound/oauth";
+import {
+  listOutboundRuns,
+  recordOutboundRun,
+  zipRunPosts,
+} from "../twitter/outbound/audit";
 import type { OutboundRunRecord } from "../twitter/outbound/types";
 
 function makeRepo(partial: Partial<Repo> & { fullName: string }): Repo {
@@ -211,6 +216,51 @@ test("pickDailyBreakouts skips Tier C repos whose 24h delta is missing", () => {
   );
 });
 
+test('window "7d" ranks Tier C by weekly delta and floors on it', () => {
+  const repos = [
+    makeRepo({
+      fullName: "a/daily-spike",
+      starsDelta24h: 300,
+      starsDelta7d: 320,
+    }),
+    makeRepo({
+      fullName: "b/weekly-grinder",
+      starsDelta24h: 5,
+      starsDelta7d: 900,
+    }),
+    makeRepo({
+      fullName: "c/no-weekly-movement",
+      starsDelta24h: 50,
+      starsDelta7d: 0,
+    }),
+  ];
+  const weekly = pickDailyBreakouts(repos, { count: 3, window: "7d" });
+  assert.deepEqual(
+    weekly.map((r) => r.fullName),
+    // Tier C sorted by 7d delta; c/no-weekly-movement has starsDelta7d=0
+    // so it fails the 7d Tier C filter (still passes the global floor via
+    // its 24h delta but lands in no tier).
+    ["b/weekly-grinder", "a/daily-spike"],
+  );
+
+  const daily = pickDailyBreakouts(repos, { count: 3 });
+  assert.equal(daily[0]!.fullName, "a/daily-spike");
+  assert.equal(daily.length, 3);
+});
+
+test('window "7d" ignores the 24h backfill marker', () => {
+  const repos = [
+    makeRepo({
+      fullName: "a/weekly-only",
+      starsDelta24h: 0,
+      starsDelta7d: 400,
+      starsDelta24hMissing: true,
+    }),
+  ];
+  assert.equal(pickDailyBreakouts(repos, { window: "7d" }).length, 1);
+  assert.equal(pickDailyBreakouts(repos, { window: "24h" }).length, 0);
+});
+
 // ---------------------------------------------------------------------------
 // recentlyFeaturedRepos
 // ---------------------------------------------------------------------------
@@ -227,8 +277,31 @@ test("recentlyFeaturedRepos returns lowercased names inside the window only", ()
       featuredRepos: ["acme/ancient"],
     }),
   ];
-  const featured = recentlyFeaturedRepos(runs, 7, now);
+  const featured = recentlyFeaturedRepos(runs, { days: 7, now });
   assert.deepEqual([...featured], ["acme/yesterday"]);
+});
+
+test("recentlyFeaturedRepos kinds filter scopes the cooldown per thread type", () => {
+  const now = new Date("2026-07-09T14:00:00Z");
+  const runs = [
+    makeRun({
+      startedAt: "2026-07-08T14:00:00Z",
+      kind: "daily_breakouts",
+      featuredRepos: ["acme/from-daily"],
+    }),
+    makeRun({
+      startedAt: "2026-07-04T16:00:00Z",
+      kind: "weekly_recap",
+      featuredRepos: ["acme/from-weekly"],
+    }),
+  ];
+  const dailyOnly = recentlyFeaturedRepos(runs, {
+    now,
+    kinds: ["daily_breakouts"],
+  });
+  assert.deepEqual([...dailyOnly], ["acme/from-daily"]);
+  const all = recentlyFeaturedRepos(runs, { now });
+  assert.equal(all.size, 2);
 });
 
 test("recentlyFeaturedRepos tolerates pre-upgrade rows without featuredRepos", () => {
@@ -398,6 +471,58 @@ test("invalidateAndRefresh forces a new exchange even before expiry", async () =
   const refreshed = await manager.invalidateAndRefresh();
   assert.equal(refreshed, "at-2");
   assert.equal(exchanges, 2);
+});
+
+test("audit rows round-trip the composed posts for dry-run review", async () => {
+  const thread = [
+    {
+      kind: "daily_breakouts_intro" as const,
+      text: "🔥 Top 2 trending repos",
+      url: "https://trendingrepo.com/breakouts",
+    },
+    { kind: "daily_breakouts_item" as const, text: "1/ acme/repo" },
+  ];
+  const posts = zipRunPosts(thread, {
+    posts: [
+      { remoteId: null, url: null, status: "logged" },
+      { remoteId: null, url: null, status: "logged" },
+    ],
+    threadUrl: null,
+  });
+  await recordOutboundRun({
+    kind: "daily_breakouts",
+    adapterName: "console",
+    status: "logged",
+    threadUrl: null,
+    postCount: thread.length,
+    startedAt: new Date().toISOString(),
+    featuredRepos: ["acme/repo"],
+    posts,
+  });
+
+  const runs = await listOutboundRuns();
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0]!.posts?.length, 2);
+  assert.equal(runs[0]!.posts?.[0]?.text, "🔥 Top 2 trending repos");
+  assert.equal(runs[0]!.posts?.[0]?.url, "https://trendingrepo.com/breakouts");
+  assert.equal(runs[0]!.posts?.[1]?.url, null);
+  assert.equal(runs[0]!.posts?.[1]?.status, "logged");
+  assert.deepEqual(runs[0]!.featuredRepos, ["acme/repo"]);
+});
+
+test("zipRunPosts marks unattempted posts as skipped when a thread aborts mid-way", () => {
+  const posts = zipRunPosts(
+    [
+      { kind: "daily_breakouts_intro", text: "intro" },
+      { kind: "daily_breakouts_item", text: "item" },
+    ],
+    {
+      posts: [{ remoteId: "1", url: null, status: "published" }],
+      threadUrl: null,
+    },
+  );
+  assert.equal(posts[0]!.status, "published");
+  assert.equal(posts[1]!.status, "skipped");
 });
 
 test("TwitterOAuthTokenManager surfaces token-endpoint failures", async () => {

--- a/src/lib/__tests__/twitter-outbound-select.test.ts
+++ b/src/lib/__tests__/twitter-outbound-select.test.ts
@@ -1,0 +1,416 @@
+// Tests for the daily-breakouts selection tiers and the OAuth2
+// refresh-token rotation manager:
+//   - pickDailyBreakouts (tier ordering, tie-breaks, quality floor,
+//     cooldown exclusion, dedupe, graceful <count)
+//   - recentlyFeaturedRepos (window math, pre-upgrade rows)
+//   - TwitterOAuthTokenManager (refresh call shape, rotated-token
+//     persistence, expiry reuse, single-flight)
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { Repo } from "../types";
+
+import {
+  DAILY_BREAKOUT_COUNT,
+  pickDailyBreakouts,
+  recentlyFeaturedRepos,
+} from "../twitter/outbound/select";
+import {
+  OAUTH_STATE_FILE,
+  TwitterOAuthTokenManager,
+  readTwitterOAuthConfigFromEnv,
+} from "../twitter/outbound/oauth";
+import type { OutboundRunRecord } from "../twitter/outbound/types";
+
+function makeRepo(partial: Partial<Repo> & { fullName: string }): Repo {
+  return {
+    id: partial.fullName.replace("/", "--"),
+    fullName: partial.fullName,
+    name: partial.fullName.split("/")[1] ?? "",
+    owner: partial.fullName.split("/")[0] ?? "",
+    ownerAvatarUrl: "",
+    description: partial.description ?? "",
+    url: `https://github.com/${partial.fullName}`,
+    language: null,
+    topics: [],
+    categoryId: "devtools",
+    stars: partial.stars ?? 1000,
+    forks: 0,
+    contributors: 0,
+    openIssues: 0,
+    lastCommitAt: new Date().toISOString(),
+    lastReleaseAt: null,
+    lastReleaseTag: null,
+    createdAt: "2022-01-01T00:00:00.000Z",
+    starsDelta24h: partial.starsDelta24h ?? 0,
+    starsDelta7d: partial.starsDelta7d ?? 0,
+    starsDelta30d: partial.starsDelta30d ?? 0,
+    forksDelta7d: 0,
+    contributorsDelta30d: 0,
+    momentumScore: partial.momentumScore ?? 50,
+    movementStatus: partial.movementStatus ?? "stable",
+    rank: 100,
+    categoryRank: 10,
+    sparklineData: [],
+    socialBuzzScore: 0,
+    mentionCount24h: 0,
+    channelsFiring: partial.channelsFiring,
+    crossSignalScore: partial.crossSignalScore,
+    starsDelta24hMissing: partial.starsDelta24hMissing,
+  };
+}
+
+function makeRun(
+  partial: Partial<OutboundRunRecord> & { startedAt: string },
+): OutboundRunRecord {
+  return {
+    id: "run-1",
+    kind: "daily_breakouts",
+    adapterName: "twitter_api_v2",
+    status: "published",
+    threadUrl: null,
+    postCount: 12,
+    finishedAt: partial.startedAt,
+    errorMessage: null,
+    ...partial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pickDailyBreakouts
+// ---------------------------------------------------------------------------
+
+test("pickDailyBreakouts returns up to 10 by default", () => {
+  const repos = Array.from({ length: 25 }, (_, i) =>
+    makeRepo({ fullName: `acme/repo${i}`, starsDelta24h: 100 + i }),
+  );
+  const picked = pickDailyBreakouts(repos);
+  assert.equal(picked.length, DAILY_BREAKOUT_COUNT);
+  assert.equal(DAILY_BREAKOUT_COUNT, 10);
+});
+
+test("pickDailyBreakouts puts multi-signal repos first, regardless of star delta", () => {
+  const repos = [
+    makeRepo({ fullName: "c/star-monster", starsDelta24h: 9999 }),
+    makeRepo({
+      fullName: "a/multi-signal",
+      starsDelta24h: 10,
+      channelsFiring: 3,
+      crossSignalScore: 2.4,
+    }),
+    makeRepo({
+      fullName: "b/hot-repo",
+      starsDelta24h: 500,
+      movementStatus: "hot",
+      momentumScore: 80,
+    }),
+  ];
+  const picked = pickDailyBreakouts(repos);
+  assert.deepEqual(
+    picked.map((r) => r.fullName),
+    ["a/multi-signal", "b/hot-repo", "c/star-monster"],
+  );
+});
+
+test("pickDailyBreakouts breaks cross-signal ties with momentum, not array order", () => {
+  const repos = [
+    makeRepo({
+      fullName: "a/first-in-array",
+      channelsFiring: 2,
+      crossSignalScore: 2.0,
+      momentumScore: 40,
+    }),
+    makeRepo({
+      fullName: "b/stronger-momentum",
+      channelsFiring: 2,
+      crossSignalScore: 2.0,
+      momentumScore: 90,
+    }),
+  ];
+  const picked = pickDailyBreakouts(repos);
+  assert.equal(picked[0]!.fullName, "b/stronger-momentum");
+});
+
+test("pickDailyBreakouts is deterministic when every score ties", () => {
+  const repos = [
+    makeRepo({ fullName: "b/beta", starsDelta24h: 50 }),
+    makeRepo({ fullName: "a/alpha", starsDelta24h: 50 }),
+  ];
+  const first = pickDailyBreakouts(repos).map((r) => r.fullName);
+  const second = pickDailyBreakouts([...repos].reverse()).map(
+    (r) => r.fullName,
+  );
+  assert.deepEqual(first, second);
+});
+
+test("pickDailyBreakouts never pads with repos that have no movement", () => {
+  const repos = [
+    makeRepo({ fullName: "a/mover", starsDelta24h: 10 }),
+    makeRepo({ fullName: "b/dead", starsDelta24h: 0, starsDelta7d: 0 }),
+    makeRepo({ fullName: "c/negative", starsDelta24h: -5, starsDelta7d: 0 }),
+  ];
+  const picked = pickDailyBreakouts(repos, { count: 10 });
+  assert.deepEqual(
+    picked.map((r) => r.fullName),
+    ["a/mover"],
+  );
+});
+
+test("pickDailyBreakouts lets a flat-delta multi-signal repo through the floor", () => {
+  const repos = [
+    makeRepo({
+      fullName: "a/social-only",
+      starsDelta24h: 0,
+      starsDelta7d: 0,
+      channelsFiring: 3,
+    }),
+  ];
+  assert.equal(pickDailyBreakouts(repos).length, 1);
+});
+
+test("pickDailyBreakouts excludes recently featured repos case-insensitively", () => {
+  const repos = [
+    makeRepo({ fullName: "Acme/Featured", starsDelta24h: 500 }),
+    makeRepo({ fullName: "acme/new", starsDelta24h: 100 }),
+  ];
+  const picked = pickDailyBreakouts(repos, {
+    exclude: new Set(["acme/featured"]),
+  });
+  assert.deepEqual(
+    picked.map((r) => r.fullName),
+    ["acme/new"],
+  );
+});
+
+test("pickDailyBreakouts dedupes repeated fullNames across the input", () => {
+  const repos = [
+    makeRepo({ fullName: "acme/dup", starsDelta24h: 100 }),
+    makeRepo({ fullName: "acme/dup", starsDelta24h: 90 }),
+  ];
+  assert.equal(pickDailyBreakouts(repos).length, 1);
+});
+
+test("pickDailyBreakouts skips Tier C repos whose 24h delta is missing", () => {
+  const repos = [
+    makeRepo({
+      fullName: "a/backfilled-delta",
+      starsDelta24h: 100,
+      starsDelta7d: 300,
+      starsDelta24hMissing: true,
+    }),
+    makeRepo({ fullName: "b/real-delta", starsDelta24h: 10 }),
+  ];
+  const picked = pickDailyBreakouts(repos);
+  assert.deepEqual(
+    picked.map((r) => r.fullName),
+    ["b/real-delta"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// recentlyFeaturedRepos
+// ---------------------------------------------------------------------------
+
+test("recentlyFeaturedRepos returns lowercased names inside the window only", () => {
+  const now = new Date("2026-07-09T14:00:00Z");
+  const runs = [
+    makeRun({
+      startedAt: "2026-07-08T14:00:00Z",
+      featuredRepos: ["Acme/Yesterday"],
+    }),
+    makeRun({
+      startedAt: "2026-06-20T14:00:00Z",
+      featuredRepos: ["acme/ancient"],
+    }),
+  ];
+  const featured = recentlyFeaturedRepos(runs, 7, now);
+  assert.deepEqual([...featured], ["acme/yesterday"]);
+});
+
+test("recentlyFeaturedRepos tolerates pre-upgrade rows without featuredRepos", () => {
+  const runs = [makeRun({ startedAt: new Date().toISOString() })];
+  assert.equal(recentlyFeaturedRepos(runs).size, 0);
+});
+
+// ---------------------------------------------------------------------------
+// TwitterOAuthTokenManager
+// ---------------------------------------------------------------------------
+
+let dataDir: string | null = null;
+let savedDataDir: string | undefined;
+
+beforeEach(async () => {
+  savedDataDir = process.env.STARSCREENER_DATA_DIR;
+  dataDir = await mkdtemp(path.join(tmpdir(), "twitter-oauth-test-"));
+  process.env.STARSCREENER_DATA_DIR = dataDir;
+});
+
+afterEach(async () => {
+  if (savedDataDir === undefined) {
+    delete process.env.STARSCREENER_DATA_DIR;
+  } else {
+    process.env.STARSCREENER_DATA_DIR = savedDataDir;
+  }
+  if (dataDir) await rm(dataDir, { recursive: true, force: true });
+  dataDir = null;
+});
+
+function tokenResponse(body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("readTwitterOAuthConfigFromEnv requires the full trio", () => {
+  delete process.env.TWITTER_OAUTH2_CLIENT_ID;
+  delete process.env.TWITTER_OAUTH2_CLIENT_SECRET;
+  delete process.env.TWITTER_OAUTH2_REFRESH_TOKEN;
+  assert.equal(readTwitterOAuthConfigFromEnv(), null);
+  process.env.TWITTER_OAUTH2_CLIENT_ID = "cid";
+  assert.equal(readTwitterOAuthConfigFromEnv(), null);
+  process.env.TWITTER_OAUTH2_CLIENT_SECRET = "csecret";
+  process.env.TWITTER_OAUTH2_REFRESH_TOKEN = "rt";
+  assert.deepEqual(readTwitterOAuthConfigFromEnv(), {
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt",
+  });
+  delete process.env.TWITTER_OAUTH2_CLIENT_ID;
+  delete process.env.TWITTER_OAUTH2_CLIENT_SECRET;
+  delete process.env.TWITTER_OAUTH2_REFRESH_TOKEN;
+});
+
+test("TwitterOAuthTokenManager exchanges the seed refresh token with Basic auth", async () => {
+  const calls: Array<{ url: string; auth: string; body: string }> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    calls.push({
+      url: input.toString(),
+      auth:
+        (init?.headers as Record<string, string> | undefined)?.Authorization ??
+        "",
+      body: (init?.body as string) ?? "",
+    });
+    return tokenResponse({
+      access_token: "at-1",
+      refresh_token: "rt-2",
+      expires_in: 7200,
+    });
+  };
+  const manager = new TwitterOAuthTokenManager({
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt-1",
+    fetchImpl,
+  });
+
+  const token = await manager.getAccessToken();
+  assert.equal(token, "at-1");
+  assert.equal(calls.length, 1);
+  assert.match(calls[0]!.url, /api\.twitter\.com\/2\/oauth2\/token/);
+  assert.equal(
+    calls[0]!.auth,
+    `Basic ${Buffer.from("cid:csecret").toString("base64")}`,
+  );
+  const params = new URLSearchParams(calls[0]!.body);
+  assert.equal(params.get("grant_type"), "refresh_token");
+  assert.equal(params.get("refresh_token"), "rt-1");
+});
+
+test("TwitterOAuthTokenManager persists the rotated refresh token and reuses a live one", async () => {
+  let exchanges = 0;
+  const fetchImpl: typeof fetch = async () => {
+    exchanges += 1;
+    return tokenResponse({
+      access_token: `at-${exchanges}`,
+      refresh_token: `rt-${exchanges + 1}`,
+      expires_in: 7200,
+    });
+  };
+  const manager = new TwitterOAuthTokenManager({
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt-1",
+    fetchImpl,
+  });
+
+  const first = await manager.getAccessToken();
+  const second = await manager.getAccessToken();
+  assert.equal(first, "at-1");
+  assert.equal(second, "at-1"); // still fresh — no second exchange
+  assert.equal(exchanges, 1);
+
+  const persisted = await readFile(
+    path.join(dataDir!, OAUTH_STATE_FILE),
+    "utf8",
+  );
+  const row = JSON.parse(persisted.trim()) as { refreshToken: string };
+  assert.equal(row.refreshToken, "rt-2");
+});
+
+test("a new manager instance resumes from the persisted rotated token, not the seed", async () => {
+  const seenRefreshTokens: string[] = [];
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    const params = new URLSearchParams((init?.body as string) ?? "");
+    seenRefreshTokens.push(params.get("refresh_token") ?? "");
+    return tokenResponse({
+      access_token: `at-${seenRefreshTokens.length}`,
+      refresh_token: `rt-${seenRefreshTokens.length + 1}`,
+      // Expire immediately so the second manager must exchange again.
+      expires_in: 1,
+    });
+  };
+  const config = {
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt-1",
+    fetchImpl,
+  };
+
+  await new TwitterOAuthTokenManager(config).getAccessToken();
+  await new TwitterOAuthTokenManager(config).getAccessToken();
+
+  assert.deepEqual(seenRefreshTokens, ["rt-1", "rt-2"]);
+});
+
+test("invalidateAndRefresh forces a new exchange even before expiry", async () => {
+  let exchanges = 0;
+  const fetchImpl: typeof fetch = async () => {
+    exchanges += 1;
+    return tokenResponse({
+      access_token: `at-${exchanges}`,
+      refresh_token: `rt-${exchanges + 1}`,
+      expires_in: 7200,
+    });
+  };
+  const manager = new TwitterOAuthTokenManager({
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt-1",
+    fetchImpl,
+  });
+
+  await manager.getAccessToken();
+  const refreshed = await manager.invalidateAndRefresh();
+  assert.equal(refreshed, "at-2");
+  assert.equal(exchanges, 2);
+});
+
+test("TwitterOAuthTokenManager surfaces token-endpoint failures", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response("invalid_request", { status: 400 });
+  const manager = new TwitterOAuthTokenManager({
+    clientId: "cid",
+    clientSecret: "csecret",
+    seedRefreshToken: "rt-dead",
+    fetchImpl,
+  });
+  await assert.rejects(
+    () => manager.getAccessToken(),
+    /token refresh failed with 400/,
+  );
+});

--- a/src/lib/__tests__/twitter-outbound.test.ts
+++ b/src/lib/__tests__/twitter-outbound.test.ts
@@ -29,6 +29,8 @@ import {
   ConsoleOutboundAdapter,
   NullOutboundAdapter,
 } from "../twitter/outbound/adapters";
+import { _resetSharedTwitterOAuthManagerForTests } from "../twitter/outbound/oauth";
+import type { OutboundTokenProvider } from "../twitter/outbound/types";
 
 function makeRepo(partial: Partial<Repo> & { fullName: string }): Repo {
   return {
@@ -130,8 +132,8 @@ test("composeDailyBreakouts always returns at least one intro post", () => {
   assert.equal(thread[0]!.kind, "daily_breakouts_intro");
 });
 
-test("composeDailyBreakouts emits one item per breakout, capped at 3", () => {
-  const breakouts = Array.from({ length: 5 }, (_, i) =>
+test("composeDailyBreakouts emits one item per breakout, capped at 10", () => {
+  const breakouts = Array.from({ length: 13 }, (_, i) =>
     makeRepo({
       fullName: `acme/repo${i}`,
       starsDelta24h: 100 + i,
@@ -139,11 +141,44 @@ test("composeDailyBreakouts emits one item per breakout, capped at 3", () => {
     }),
   );
   const thread = composeDailyBreakouts({ breakouts, topIdea: null });
-  // Intro + 3 items = 4 posts, no idea spotlight.
-  assert.equal(thread.length, 4);
-  assert.equal(thread[1]!.kind, "daily_breakouts_item");
-  assert.equal(thread[2]!.kind, "daily_breakouts_item");
-  assert.equal(thread[3]!.kind, "daily_breakouts_item");
+  // Intro + 10 items = 11 posts, no idea spotlight.
+  assert.equal(thread.length, 11);
+  for (let i = 1; i <= 10; i++) {
+    assert.equal(thread[i]!.kind, "daily_breakouts_item");
+  }
+});
+
+test("composeDailyBreakouts gives every repo item its trendingrepo link", () => {
+  const breakouts = Array.from({ length: 10 }, (_, i) =>
+    makeRepo({
+      fullName: `acme/repo${i}`,
+      starsDelta24h: 100 + i,
+      channelsFiring: 2,
+    }),
+  );
+  const thread = composeDailyBreakouts({ breakouts, topIdea: null });
+  const items = thread.filter((p) => p.kind === "daily_breakouts_item");
+  assert.equal(items.length, 10);
+  for (let i = 0; i < items.length; i++) {
+    assert.ok(
+      items[i]!.url?.endsWith(`/repo/acme/repo${i}`),
+      `item ${i} url is ${items[i]!.url}`,
+    );
+  }
+});
+
+test("composeDailyBreakouts includes the description and skips a zero delta", () => {
+  const repo = makeRepo({
+    fullName: "acme/quiet-mover",
+    starsDelta24h: 0,
+    channelsFiring: 3,
+  });
+  repo.description = "Local-first vector DB for agents";
+  const thread = composeDailyBreakouts({ breakouts: [repo], topIdea: null });
+  const line = thread[1]!.text;
+  assert.ok(!line.includes("stars in 24h"), `line advertises a zero delta: ${line}`);
+  assert.match(line, /3 signals firing/);
+  assert.match(line, /Local-first vector DB/);
 });
 
 test("composeDailyBreakouts adds idea spotlight as the last post", () => {
@@ -296,6 +331,9 @@ test("buildShareToXUrl omits via when the handle is empty", () => {
 const ENV_KEYS = [
   "TWITTER_OUTBOUND_MODE",
   "TWITTER_OAUTH2_USER_TOKEN",
+  "TWITTER_OAUTH2_CLIENT_ID",
+  "TWITTER_OAUTH2_CLIENT_SECRET",
+  "TWITTER_OAUTH2_REFRESH_TOKEN",
   "TWITTER_USERNAME",
   "NODE_ENV",
 ] as const;
@@ -309,6 +347,7 @@ beforeEach(() => {
     savedEnv[k] = env[k];
     delete env[k];
   }
+  _resetSharedTwitterOAuthManagerForTests();
 });
 
 afterEach(() => {
@@ -342,6 +381,24 @@ test("selectOutboundAdapter returns ApiV2OutboundAdapter when token is set", () 
   const adapter = selectOutboundAdapter();
   assert.ok(adapter instanceof ApiV2OutboundAdapter);
   assert.equal(adapter.publishes, true);
+});
+
+test("selectOutboundAdapter prefers the OAuth2 rotation trio over a static token", () => {
+  (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_ID = "cid";
+  (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_SECRET = "csecret";
+  (process.env as MutableEnv).TWITTER_OAUTH2_REFRESH_TOKEN = "rt";
+  (process.env as MutableEnv).TWITTER_OAUTH2_USER_TOKEN = "static-token";
+  const adapter = selectOutboundAdapter();
+  assert.ok(adapter instanceof ApiV2OutboundAdapter);
+  assert.equal(adapter.publishes, true);
+});
+
+test("selectOutboundAdapter ignores a partial OAuth2 trio and falls back to the static token", () => {
+  (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_ID = "cid";
+  // secret + refresh token missing
+  (process.env as MutableEnv).TWITTER_OAUTH2_USER_TOKEN = "static-token";
+  const adapter = selectOutboundAdapter();
+  assert.ok(adapter instanceof ApiV2OutboundAdapter);
 });
 
 test("selectOutboundAdapter TWITTER_OUTBOUND_MODE=null overrides token", () => {
@@ -416,6 +473,62 @@ test("ApiV2OutboundAdapter surfaces API errors", async () => {
         { kind: "daily_breakouts_intro", text: "intro" },
       ]),
     /Twitter API 429/,
+  );
+});
+
+test("ApiV2OutboundAdapter retries once with a refreshed token on 401", async () => {
+  const tokensSeen: string[] = [];
+  let refreshes = 0;
+  const provider: OutboundTokenProvider = {
+    getAccessToken: async () => "expired-token",
+    invalidateAndRefresh: async () => {
+      refreshes += 1;
+      return "fresh-token";
+    },
+  };
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    const auth =
+      (init?.headers as Record<string, string> | undefined)?.Authorization ??
+      "";
+    tokensSeen.push(auth.replace("Bearer ", ""));
+    if (auth.includes("expired-token")) {
+      return new Response("unauthorized", { status: 401 });
+    }
+    return new Response(
+      JSON.stringify({ data: { id: "id-1", text: "ok" } }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+
+  const adapter = new ApiV2OutboundAdapter({
+    tokenProvider: provider,
+    username: "trendingrepo",
+    fetchImpl,
+  });
+  const result = await adapter.postThread([
+    { kind: "daily_breakouts_intro", text: "intro" },
+  ]);
+
+  assert.equal(refreshes, 1);
+  assert.deepEqual(tokensSeen, ["expired-token", "fresh-token"]);
+  assert.equal(result.posts[0]!.status, "published");
+});
+
+test("ApiV2OutboundAdapter surfaces the error when the post-refresh retry also 401s", async () => {
+  const provider: OutboundTokenProvider = {
+    getAccessToken: async () => "t1",
+    invalidateAndRefresh: async () => "t2",
+  };
+  const fetchImpl: typeof fetch = async () =>
+    new Response("unauthorized", { status: 401 });
+  const adapter = new ApiV2OutboundAdapter({
+    tokenProvider: provider,
+    fetchImpl,
+  });
+  await assert.rejects(
+    () =>
+      adapter.postThread([{ kind: "daily_breakouts_intro", text: "intro" }]),
+    /Twitter API 401/,
   );
 });
 

--- a/src/lib/__tests__/twitter-outbound.test.ts
+++ b/src/lib/__tests__/twitter-outbound.test.ts
@@ -28,6 +28,7 @@ import {
   ApiV2OutboundAdapter,
   ConsoleOutboundAdapter,
   NullOutboundAdapter,
+  ToolboxOutboundAdapter,
 } from "../twitter/outbound/adapters";
 import { _resetSharedTwitterOAuthManagerForTests } from "../twitter/outbound/oauth";
 import type { OutboundTokenProvider } from "../twitter/outbound/types";
@@ -239,7 +240,7 @@ test("composeDailyBreakouts formats a breakout line with k-style delta and signa
 
 test("composeWeeklyRecap always returns an intro; optional top items follow", () => {
   const empty = composeWeeklyRecap({
-    topBreakout: null,
+    topBreakouts: [],
     topIdea: null,
     ideasPublishedThisWeek: 0,
     breakoutsThisWeek: 0,
@@ -248,12 +249,35 @@ test("composeWeeklyRecap always returns an intro; optional top items follow", ()
   assert.equal(empty[0]!.kind, "weekly_recap_intro");
 
   const populated = composeWeeklyRecap({
-    topBreakout: makeRepo({ fullName: "vercel/next.js", starsDelta7d: 800 }),
+    topBreakouts: [makeRepo({ fullName: "vercel/next.js", starsDelta7d: 800 })],
     topIdea: makeIdea({ id: "y" }),
     ideasPublishedThisWeek: 12,
     breakoutsThisWeek: 3,
   });
   assert.equal(populated.length, 3);
+});
+
+test("composeWeeklyRecap emits up to 3 breakout items, each linked and in budget", () => {
+  const breakouts = Array.from({ length: 5 }, (_, i) =>
+    makeRepo({ fullName: `acme/weekly${i}`, starsDelta7d: 1000 - i }),
+  );
+  const thread = composeWeeklyRecap({
+    topBreakouts: breakouts,
+    topIdea: null,
+    ideasPublishedThisWeek: 4,
+    breakoutsThisWeek: 9,
+  });
+  const items = thread.filter((p) => p.kind === "weekly_recap_item");
+  assert.equal(items.length, 3);
+  for (let i = 0; i < items.length; i++) {
+    assert.ok(
+      items[i]!.url?.endsWith(`/repo/acme/weekly${i}`),
+      `item ${i} url is ${items[i]!.url}`,
+    );
+    assert.ok(effectiveLength(items[i]!) <= 280);
+  }
+  assert.match(items[0]!.text, /🥇/);
+  assert.match(items[0]!.text, /\+1\.0K stars this week/);
 });
 
 test("isoWeekLabel returns YYYY-Wnn format", () => {
@@ -335,6 +359,8 @@ const ENV_KEYS = [
   "TWITTER_OAUTH2_CLIENT_SECRET",
   "TWITTER_OAUTH2_REFRESH_TOKEN",
   "TWITTER_USERNAME",
+  "TOOLBOX_REACH_URL",
+  "TOOLBOX_REACH_API_KEY",
   "NODE_ENV",
 ] as const;
 const savedEnv: Record<string, string | undefined> = {};
@@ -383,6 +409,32 @@ test("selectOutboundAdapter returns ApiV2OutboundAdapter when token is set", () 
   assert.equal(adapter.publishes, true);
 });
 
+test("selectOutboundAdapter prefers the toolbox engine over every direct X credential", () => {
+  (process.env as MutableEnv).TOOLBOX_REACH_URL = "https://api.aiso.tools/v1/reach/publish";
+  (process.env as MutableEnv).TOOLBOX_REACH_API_KEY = "tbk";
+  (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_ID = "cid";
+  (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_SECRET = "csecret";
+  (process.env as MutableEnv).TWITTER_OAUTH2_REFRESH_TOKEN = "rt";
+  (process.env as MutableEnv).TWITTER_OAUTH2_USER_TOKEN = "static-token";
+  const adapter = selectOutboundAdapter();
+  assert.ok(adapter instanceof ToolboxOutboundAdapter);
+  assert.equal(adapter.name, "toolbox_reach");
+  assert.equal(adapter.publishes, true);
+});
+
+test("selectOutboundAdapter TWITTER_OUTBOUND_MODE=toolbox throws loudly without the env pair", () => {
+  (process.env as MutableEnv).TWITTER_OUTBOUND_MODE = "toolbox";
+  assert.throws(() => selectOutboundAdapter(), /TOOLBOX_REACH_URL/);
+});
+
+test("selectOutboundAdapter TWITTER_OUTBOUND_MODE=null still wins over toolbox env", () => {
+  (process.env as MutableEnv).TOOLBOX_REACH_URL = "https://api.aiso.tools/v1/reach/publish";
+  (process.env as MutableEnv).TOOLBOX_REACH_API_KEY = "tbk";
+  (process.env as MutableEnv).TWITTER_OUTBOUND_MODE = "null";
+  const adapter = selectOutboundAdapter();
+  assert.ok(adapter instanceof NullOutboundAdapter);
+});
+
 test("selectOutboundAdapter prefers the OAuth2 rotation trio over a static token", () => {
   (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_ID = "cid";
   (process.env as MutableEnv).TWITTER_OAUTH2_CLIENT_SECRET = "csecret";
@@ -413,6 +465,105 @@ test("selectOutboundAdapter TWITTER_OUTBOUND_MODE=console overrides token", () =
   (process.env as MutableEnv).TWITTER_OUTBOUND_MODE = "console";
   const adapter = selectOutboundAdapter();
   assert.ok(adapter instanceof ConsoleOutboundAdapter);
+});
+
+// ---------------------------------------------------------------------------
+// ToolboxOutboundAdapter — fetch mocking
+// ---------------------------------------------------------------------------
+
+test("ToolboxOutboundAdapter POSTs the whole thread once with bearer auth", async () => {
+  const calls: Array<{ url: string; auth: string; body: string }> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    calls.push({
+      url: input.toString(),
+      auth:
+        (init?.headers as Record<string, string> | undefined)?.Authorization ??
+        "",
+      body: (init?.body as string) ?? "",
+    });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        threadUrl: "https://twitter.com/trendingrepo/status/1",
+        posts: [
+          { remoteId: "1", url: "https://twitter.com/trendingrepo/status/1", status: "published" },
+          { remoteId: "2", url: "https://twitter.com/trendingrepo/status/2", status: "published" },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+
+  const adapter = new ToolboxOutboundAdapter({
+    endpointUrl: "https://api.aiso.tools/v1/reach/publish",
+    apiKey: "tbk_test",
+    fetchImpl,
+  });
+  const result = await adapter.postThread([
+    { kind: "daily_breakouts_intro", text: "intro", url: "https://trendingrepo.com/breakouts" },
+    { kind: "daily_breakouts_item", text: "item" },
+  ]);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.auth, "Bearer tbk_test");
+  const body = JSON.parse(calls[0]!.body) as {
+    kind: string;
+    posts: Array<{ kind: string; text: string; url: string | null }>;
+  };
+  assert.equal(body.kind, "thread");
+  assert.equal(body.posts.length, 2);
+  assert.equal(body.posts[0]!.url, "https://trendingrepo.com/breakouts");
+  assert.equal(body.posts[1]!.url, null);
+  assert.equal(result.threadUrl, "https://twitter.com/trendingrepo/status/1");
+  assert.equal(result.posts[1]!.remoteId, "2");
+});
+
+test("ToolboxOutboundAdapter tolerates a bare {ok:true} response", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  const adapter = new ToolboxOutboundAdapter({
+    endpointUrl: "https://api.aiso.tools/v1/reach/publish",
+    apiKey: "tbk_test",
+    fetchImpl,
+  });
+  const result = await adapter.postThread([
+    { kind: "daily_breakouts_intro", text: "intro" },
+    { kind: "daily_breakouts_item", text: "item" },
+  ]);
+  assert.equal(result.posts.length, 2);
+  assert.ok(result.posts.every((p) => p.status === "published"));
+  assert.equal(result.threadUrl, null);
+});
+
+test("ToolboxOutboundAdapter surfaces non-2xx and ok:false responses", async () => {
+  const adapter503 = new ToolboxOutboundAdapter({
+    endpointUrl: "https://api.aiso.tools/v1/reach/publish",
+    apiKey: "tbk_test",
+    fetchImpl: async () => new Response("upstream down", { status: 503 }),
+  });
+  await assert.rejects(
+    () =>
+      adapter503.postThread([{ kind: "daily_breakouts_intro", text: "x" }]),
+    /Toolbox reach endpoint 503/,
+  );
+
+  const adapterNotOk = new ToolboxOutboundAdapter({
+    endpointUrl: "https://api.aiso.tools/v1/reach/publish",
+    apiKey: "tbk_test",
+    fetchImpl: async () =>
+      new Response(JSON.stringify({ ok: false, error: "rate budget spent" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  });
+  await assert.rejects(
+    () =>
+      adapterNotOk.postThread([{ kind: "daily_breakouts_intro", text: "x" }]),
+    /rate budget spent/,
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/__tests__/twitter-outbound.test.ts
+++ b/src/lib/__tests__/twitter-outbound.test.ts
@@ -31,6 +31,7 @@ import {
   ToolboxOutboundAdapter,
 } from "../twitter/outbound/adapters";
 import { _resetSharedTwitterOAuthManagerForTests } from "../twitter/outbound/oauth";
+import { partialPublishedRepos } from "../twitter/outbound/audit";
 import type { OutboundTokenProvider } from "../twitter/outbound/types";
 
 function makeRepo(partial: Partial<Repo> & { fullName: string }): Repo {
@@ -625,6 +626,53 @@ test("ApiV2OutboundAdapter surfaces API errors", async () => {
       ]),
     /Twitter API 429/,
   );
+});
+
+test("ApiV2OutboundAdapter attaches partialPosts, and partialPublishedRepos maps them to picks", async () => {
+  // Publish intro + item0 + item1, then 429 on item2. The error must carry
+  // the 3 published posts so the cron route can still cool-down the 2 repos
+  // that actually posted (thread: [intro, item0, item1, item2] → items map
+  // to breakouts[0..]).
+  let n = 0;
+  const fetchImpl: typeof fetch = async () => {
+    n += 1;
+    if (n <= 3) {
+      return new Response(
+        JSON.stringify({ data: { id: `id-${n}`, text: "ok" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("rate limited", { status: 429 });
+  };
+  const adapter = new ApiV2OutboundAdapter({ bearerToken: "t", fetchImpl });
+  const thread = [
+    { kind: "daily_breakouts_intro" as const, text: "intro" },
+    { kind: "daily_breakouts_item" as const, text: "1/ acme/one" },
+    { kind: "daily_breakouts_item" as const, text: "2/ acme/two" },
+    { kind: "daily_breakouts_item" as const, text: "3/ acme/three" },
+  ];
+  const breakouts = [
+    { fullName: "acme/one" },
+    { fullName: "acme/two" },
+    { fullName: "acme/three" },
+  ];
+
+  let caught: unknown;
+  try {
+    await adapter.postThread(thread);
+  } catch (err) {
+    caught = err;
+  }
+  assert.ok(caught, "expected postThread to throw");
+  // intro published (index 0) + item0 (index 1) + item1 (index 2) → the two
+  // items map to breakouts[0] and breakouts[1]; item2/breakouts[2] never
+  // posted.
+  const featured = partialPublishedRepos(caught, breakouts);
+  assert.deepEqual(featured, ["acme/one", "acme/two"]);
+});
+
+test("partialPublishedRepos returns empty for a non-partial error", () => {
+  assert.deepEqual(partialPublishedRepos(new Error("boom"), [{ fullName: "a/b" }]), []);
 });
 
 test("ApiV2OutboundAdapter retries once with a refreshed token on 401", async () => {

--- a/src/lib/arxiv.ts
+++ b/src/lib/arxiv.ts
@@ -335,3 +335,11 @@ export function _resetArxivEnrichmentForTests(): void {
   enrichedFile = arxivEnrichedData as unknown as ArxivEnrichedFile;
   enrichmentIndex = buildEnrichmentIndex(enrichedFile);
 }
+
+export function _setArxivRecentForTests(file: ArxivRecentFile): void {
+  recentFile = file;
+}
+
+export function _resetArxivRecentForTests(): void {
+  recentFile = arxivRecentData as unknown as ArxivRecentFile;
+}

--- a/src/lib/pipeline/__tests__/cross-signal.test.ts
+++ b/src/lib/pipeline/__tests__/cross-signal.test.ts
@@ -291,16 +291,33 @@ test("arxivComponent: one recent linking paper → 0.7, two → 1.0", () => {
   _resetArxivRecentForTests();
 });
 
-test("arxivComponent: only an old (>30d) linking paper → 0.4 floor", () => {
+test("arxivComponent: a semi-recent (30-90d) linking paper → 0.4 floor", () => {
   const now = Date.parse("2026-07-09T00:00:00Z");
   setArxivRecent([
     arxivPaper({
-      arxivId: "old",
+      arxivId: "semi",
+      linked: ["acme/semi"],
+      // ~60 days before now — inside the 90d stale window, past the 30d
+      // recent window.
+      publishedAt: "2026-05-10T00:00:00Z",
+    }),
+  ]);
+  assert.equal(arxivComponent("acme/semi", now), 0.4);
+  _resetArxivRecentForTests();
+});
+
+test("arxivComponent: an ancient (>90d) linking paper decays off entirely → 0", () => {
+  const now = Date.parse("2026-07-09T00:00:00Z");
+  setArxivRecent([
+    arxivPaper({
+      arxivId: "ancient",
       linked: ["acme/legacy"],
+      // ~189 days before now — an old citation must NOT keep the channel
+      // lit forever (the P2 fix).
       publishedAt: "2026-01-01T00:00:00Z",
     }),
   ]);
-  assert.equal(arxivComponent("acme/legacy", now), 0.4);
+  assert.equal(arxivComponent("acme/legacy", now), 0);
   _resetArxivRecentForTests();
 });
 

--- a/src/lib/pipeline/__tests__/cross-signal.test.ts
+++ b/src/lib/pipeline/__tests__/cross-signal.test.ts
@@ -3,6 +3,10 @@ import assert from "node:assert/strict";
 
 import type { Repo } from "../../types";
 import { getDevtoLeaderboard } from "../../devto";
+import {
+  _setArxivRecentForTests,
+  _resetArxivRecentForTests,
+} from "../../arxiv";
 import { attachCrossSignal, getChannelStatus, __test } from "../cross-signal";
 
 const { githubComponent, hnComponent, blueskyComponent, devtoComponent, twitterComponent } = __test;
@@ -186,6 +190,7 @@ test("getChannelStatus: stable + unknown repo lights nothing", () => {
     bluesky: false,
     devto: false,
     twitter: false,
+    arxiv: false,
   });
 });
 
@@ -201,9 +206,10 @@ test("getChannelStatus: hot status lights github", () => {
   assert.equal(status.bluesky, false);
   assert.equal(status.devto, false);
   assert.equal(status.twitter, false);
+  assert.equal(status.arxiv, false);
 });
 
-test("attachCrossSignal: score + firing range is 0-6 (six channels)", () => {
+test("attachCrossSignal: score + firing range is 0-7 (seven channels)", () => {
   const repos = [
     makeRepo({
       fullName: "ghost/repo-breakout",
@@ -212,12 +218,12 @@ test("attachCrossSignal: score + firing range is 0-6 (six channels)", () => {
   ];
   const out = attachCrossSignal(repos);
   assert.ok(
-    (out[0].crossSignalScore ?? 0) <= 6.0,
-    `score must be in 0..6, got ${out[0].crossSignalScore}`,
+    (out[0].crossSignalScore ?? 0) <= 7.0,
+    `score must be in 0..7, got ${out[0].crossSignalScore}`,
   );
   assert.ok(
-    (out[0].channelsFiring ?? 0) <= 6,
-    `firing count must be in 0..6, got ${out[0].channelsFiring}`,
+    (out[0].channelsFiring ?? 0) <= 7,
+    `firing count must be in 0..7, got ${out[0].channelsFiring}`,
   );
 });
 
@@ -225,4 +231,94 @@ test("getChannelStatus: HN-mentioned real repo lights hn", () => {
   const repo = makeRepo({ fullName: "anthropics/claude-code" });
   const status = getChannelStatus(repo);
   assert.equal(status.hn, true);
+});
+
+// ---------------------------------------------------------------------------
+// arxivComponent + arXiv channel fusion (synthetic fixture, no Redis)
+// ---------------------------------------------------------------------------
+
+const { arxivComponent } = __test;
+
+function arxivPaper(overrides: {
+  arxivId: string;
+  linked: string[];
+  publishedAt: string;
+}) {
+  return {
+    arxivId: overrides.arxivId,
+    title: "t",
+    summary: "s",
+    authors: [],
+    categories: [],
+    primaryCategory: null,
+    absUrl: "",
+    pdfUrl: "",
+    publishedAt: overrides.publishedAt,
+    updatedAt: overrides.publishedAt,
+    linkedRepos: overrides.linked.map((fullName) => ({
+      fullName,
+      matchType: "slug",
+      confidence: 0.9,
+    })),
+  };
+}
+
+function setArxivRecent(papers: ReturnType<typeof arxivPaper>[]): void {
+  _setArxivRecentForTests({
+    fetchedAt: new Date().toISOString(),
+    source: "test",
+    count: papers.length,
+    linkedRepoCount: papers.reduce((n, p) => n + p.linkedRepos.length, 0),
+    papers,
+  });
+}
+
+test("arxivComponent: unknown repo returns 0", () => {
+  _resetArxivRecentForTests();
+  assert.equal(arxivComponent("nobody/here", Date.now()), 0);
+});
+
+test("arxivComponent: one recent linking paper → 0.7, two → 1.0", () => {
+  const now = Date.parse("2026-07-09T00:00:00Z");
+  const recent = "2026-07-01T00:00:00Z";
+  setArxivRecent([
+    arxivPaper({ arxivId: "1", linked: ["acme/solo"], publishedAt: recent }),
+    arxivPaper({ arxivId: "2", linked: ["acme/duo"], publishedAt: recent }),
+    arxivPaper({ arxivId: "3", linked: ["acme/duo"], publishedAt: recent }),
+  ]);
+  assert.equal(arxivComponent("acme/solo", now), 0.7);
+  assert.equal(arxivComponent("acme/duo", now), 1.0);
+  _resetArxivRecentForTests();
+});
+
+test("arxivComponent: only an old (>30d) linking paper → 0.4 floor", () => {
+  const now = Date.parse("2026-07-09T00:00:00Z");
+  setArxivRecent([
+    arxivPaper({
+      arxivId: "old",
+      linked: ["acme/legacy"],
+      publishedAt: "2026-01-01T00:00:00Z",
+    }),
+  ]);
+  assert.equal(arxivComponent("acme/legacy", now), 0.4);
+  _resetArxivRecentForTests();
+});
+
+test("attachCrossSignal: an arXiv-linked repo lights the arxiv channel and adds to the score", () => {
+  const now = Date.parse("2026-07-09T00:00:00Z");
+  setArxivRecent([
+    arxivPaper({
+      arxivId: "x",
+      linked: ["acme/researchy"],
+      publishedAt: "2026-07-05T00:00:00Z",
+    }),
+  ]);
+  const out = attachCrossSignal(
+    [makeRepo({ fullName: "acme/researchy" })],
+    now,
+  );
+  assert.equal(out[0].channelStatus?.arxiv, true);
+  assert.ok((out[0].channelsFiring ?? 0) >= 1);
+  assert.ok((out[0].crossSignalScore ?? 0) >= 0.7);
+  _resetArxivRecentForTests();
 });

--- a/src/lib/pipeline/cross-signal.ts
+++ b/src/lib/pipeline/cross-signal.ts
@@ -35,9 +35,9 @@
 //             : 0
 //   arxiv   = ≥2 recent papers, or 1 recent paper w/ citationVelocity>0
 //             or socialMentions≥1                          ? 1.0
-//             : exactly 1 recent linking paper             ? 0.7
-//             : linked only by an older (>30d) paper        ? 0.4
-//             : 0
+//             : exactly 1 recent (≤30d) linking paper       ? 0.7
+//             : linked only by a semi-recent (30–90d) paper ? 0.4
+//             : 0   (papers >90d decay off entirely)
 //   crossSignalScore = github + reddit + hn + bluesky + devto + twitter + arxiv (range 0..7)
 //   channelsFiring   = count of components > 0                                  (range 0..7)
 //
@@ -70,9 +70,14 @@ import { getCrossSourceDetail } from "../cross-source-mentions";
 
 const REDDIT_WINDOW_MS = 48 * 60 * 60 * 1000;
 // A linking paper counts as "recent" (full-weight signal) within this
-// window of its published/updated date; older links still light the
-// channel at the floor tier.
+// window of its published/updated date; between here and the stale
+// window it lights the channel at the floor tier only.
 const ARXIV_RECENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+// Beyond this, a linking paper no longer lights the channel at all — the
+// arxiv signal reflects CURRENT research interest, so an ancient citation
+// must decay off rather than keep a channel (and channelsFiring) lit
+// forever and leak stale repos into the daily selector's Tier A.
+const ARXIV_STALE_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
 
 // Read the per-channel 7d count from the cross-source sweep rollup, when
 // it's present. The sweep runs per-repo (Apify Tier-1 query bundle, HN
@@ -181,8 +186,11 @@ function getArxivIndex(nowMs: number): Map<string, ArxivRepoSignal> {
       Number.isFinite(publishedMs) ? publishedMs : 0,
       Number.isFinite(updatedMs) ? updatedMs : 0,
     );
-    const isRecent =
-      freshest > 0 && nowMs - freshest <= ARXIV_RECENT_WINDOW_MS;
+    const age = freshest > 0 ? nowMs - freshest : Number.POSITIVE_INFINITY;
+    // Papers older than the stale window contribute nothing — skip them
+    // entirely so an ancient citation can't keep the channel lit.
+    if (age > ARXIV_STALE_WINDOW_MS) continue;
+    const isRecent = age <= ARXIV_RECENT_WINDOW_MS;
     const enrichment = getArxivEnrichment(paper.arxivId);
     const boosted =
       (enrichment?.citationVelocity ?? 0) > 0 ||

--- a/src/lib/pipeline/cross-signal.ts
+++ b/src/lib/pipeline/cross-signal.ts
@@ -1,13 +1,16 @@
-// Six-channel cross-signal fusion.
+// Seven-channel cross-signal fusion.
 //
 // Combines GitHub momentum classification + Reddit 48h trending velocity +
 // HN front-page presence + Bluesky mentions + dev.to tutorials/writeups
-// + Twitter/X 24h mention burst into a single score per repo. The premise:
-// any one channel can be noise (a github star spike, a viral reddit post,
-// a Show HN flash, a trending bsky post, a tutorial pumped by one author,
-// a single influencer's tweet). Two channels lit at once = signal. Three
-// or more = a real breakout. A 6/6 firing repo is rare and indicates the
-// repo broke out across every social surface we track.
+// + Twitter/X 24h mention burst + arXiv research citations into a single
+// score per repo. The premise: any one channel can be noise (a github star
+// spike, a viral reddit post, a Show HN flash, a trending bsky post, a
+// tutorial pumped by one author, a single influencer's tweet, one preprint).
+// Two channels lit at once = signal. Three or more = a real breakout. A 7/7
+// firing repo is rare and indicates the repo broke out across every surface
+// we track. arXiv is the "research-backed" channel — a repo cited by a
+// recent paper is the strongest signal that a genuinely-novel AI/ML project
+// is breaking out, which is exactly what we want to rank up.
 //
 // Formula:
 //   github  = movementStatus ∈ {breakout: 1.0, hot: 0.7, rising: 0.4, *: 0}
@@ -30,8 +33,13 @@
 //             : TW.mentionCount24h >= 3 ? 0.7
 //             : TW.mentionCount24h >= 1 ? 0.4
 //             : 0
-//   crossSignalScore = github + reddit + hn + bluesky + devto + twitter (range 0..6)
-//   channelsFiring   = count of components > 0                          (range 0..6)
+//   arxiv   = ≥2 recent papers, or 1 recent paper w/ citationVelocity>0
+//             or socialMentions≥1                          ? 1.0
+//             : exactly 1 recent linking paper             ? 0.7
+//             : linked only by an older (>30d) paper        ? 0.4
+//             : 0
+//   crossSignalScore = github + reddit + hn + bluesky + devto + twitter + arxiv (range 0..7)
+//   channelsFiring   = count of components > 0                                  (range 0..7)
 //
 // Why Twitter thresholds are higher than Bluesky's: Twitter publishes
 // orders of magnitude more posts on the same keywords, so one tweet
@@ -57,9 +65,14 @@ import { getHnMentions } from "../hackernews";
 import { getBlueskyMentions } from "../bluesky";
 import { getDevtoMentions } from "../devto";
 import { getTwitterSignalSync } from "../twitter";
+import { getArxivRecentFile, getArxivEnrichment } from "../arxiv";
 import { getCrossSourceDetail } from "../cross-source-mentions";
 
 const REDDIT_WINDOW_MS = 48 * 60 * 60 * 1000;
+// A linking paper counts as "recent" (full-weight signal) within this
+// window of its published/updated date; older links still light the
+// channel at the floor tier.
+const ARXIV_RECENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 // Read the per-channel 7d count from the cross-source sweep rollup, when
 // it's present. The sweep runs per-repo (Apify Tier-1 query bundle, HN
@@ -134,6 +147,71 @@ function twitterComponent(fullName: string): number {
   return 0;
 }
 
+// arXiv "research-backed" signal, indexed once per file version so both
+// attachCrossSignal (corpus pass) and getChannelStatus (per-target) read it
+// in O(1). A repo's signal aggregates every paper that links it: how many
+// link it recently, and whether any linking paper carries citation velocity
+// or social mentions from the enrichment overlay.
+interface ArxivRepoSignal {
+  recentPapers: number;
+  olderPapers: number;
+  boosted: boolean;
+}
+
+// Memoize per file-object identity (robust to fetchedAt collisions) plus
+// the day-bucket of nowMs (so recency re-evaluates once a day, not every
+// millisecond-apart call in the same request).
+const arxivIndexCache = new WeakMap<
+  object,
+  { dayBucket: number; index: Map<string, ArxivRepoSignal> }
+>();
+
+function getArxivIndex(nowMs: number): Map<string, ArxivRepoSignal> {
+  const file = getArxivRecentFile();
+  const dayBucket = Math.floor(nowMs / 86_400_000);
+  const cached = arxivIndexCache.get(file);
+  if (cached && cached.dayBucket === dayBucket) return cached.index;
+
+  const index = new Map<string, ArxivRepoSignal>();
+  for (const paper of file.papers ?? []) {
+    if (!paper.linkedRepos?.length) continue;
+    const publishedMs = Date.parse(paper.publishedAt ?? "");
+    const updatedMs = Date.parse(paper.updatedAt ?? "");
+    const freshest = Math.max(
+      Number.isFinite(publishedMs) ? publishedMs : 0,
+      Number.isFinite(updatedMs) ? updatedMs : 0,
+    );
+    const isRecent =
+      freshest > 0 && nowMs - freshest <= ARXIV_RECENT_WINDOW_MS;
+    const enrichment = getArxivEnrichment(paper.arxivId);
+    const boosted =
+      (enrichment?.citationVelocity ?? 0) > 0 ||
+      (enrichment?.socialMentions ?? 0) >= 1;
+    for (const link of paper.linkedRepos) {
+      if (!link.fullName) continue;
+      const keyLower = link.fullName.toLowerCase();
+      const prev =
+        index.get(keyLower) ??
+        ({ recentPapers: 0, olderPapers: 0, boosted: false } as ArxivRepoSignal);
+      if (isRecent) prev.recentPapers += 1;
+      else prev.olderPapers += 1;
+      if (boosted) prev.boosted = true;
+      index.set(keyLower, prev);
+    }
+  }
+  arxivIndexCache.set(file, { dayBucket, index });
+  return index;
+}
+
+function arxivComponent(fullName: string, nowMs: number): number {
+  const sig = getArxivIndex(nowMs).get(fullName.toLowerCase());
+  if (!sig) return 0;
+  if (sig.recentPapers >= 2 || (sig.recentPapers >= 1 && sig.boosted)) return 1.0;
+  if (sig.recentPapers >= 1) return 0.7;
+  if (sig.olderPapers >= 1) return 0.4;
+  return 0;
+}
+
 /**
  * Attach `crossSignalScore`, `channelsFiring`, and the `bluesky` rollup
  * to every repo.
@@ -169,14 +247,16 @@ export function attachCrossSignal(
     const bs = blueskyComponent(repo.fullName);
     const dv = devtoComponent(repo.fullName);
     const tw = twitterComponent(repo.fullName);
-    const score = gh + rd + hn + bs + dv + tw;
+    const ax = arxivComponent(repo.fullName, nowMs);
+    const score = gh + rd + hn + bs + dv + tw + ax;
     const firing =
       (gh > 0 ? 1 : 0) +
       (rd > 0 ? 1 : 0) +
       (hn > 0 ? 1 : 0) +
       (bs > 0 ? 1 : 0) +
       (dv > 0 ? 1 : 0) +
-      (tw > 0 ? 1 : 0);
+      (tw > 0 ? 1 : 0) +
+      (ax > 0 ? 1 : 0);
 
     const bskyMention = getBlueskyMentions(repo.fullName);
     const bskyRollup = bskyMention
@@ -260,6 +340,7 @@ export function attachCrossSignal(
         bluesky: bs > 0,
         devto: dv > 0,
         twitter: tw > 0,
+        arxiv: ax > 0,
       },
       reddit: redditRollup,
       bluesky: bskyRollup,
@@ -281,6 +362,7 @@ export interface ChannelStatus {
   bluesky: boolean;
   devto: boolean;
   twitter: boolean;
+  arxiv: boolean;
 }
 
 /** Minimal shape getChannelStatus needs — accepts a full Repo or any object
@@ -307,6 +389,7 @@ export function getChannelStatus(
     bluesky: blueskyComponent(target.fullName) > 0,
     devto: devtoComponent(target.fullName) > 0,
     twitter: twitterComponent(target.fullName) > 0,
+    arxiv: arxivComponent(target.fullName, nowMs) > 0,
   };
 }
 
@@ -318,4 +401,5 @@ export const __test = {
   blueskyComponent,
   devtoComponent,
   twitterComponent,
+  arxivComponent,
 };

--- a/src/lib/twitter/outbound/adapters/api-v2.ts
+++ b/src/lib/twitter/outbound/adapters/api-v2.ts
@@ -9,9 +9,12 @@
 //     operator regenerates the token manually.
 //
 // Rate limits (as of 2026): Twitter's free tier caps at ~17 posts/day.
-// Our cron schedule (1 daily thread of ~5 posts + 1 weekly recap of
-// ~5 posts + per-published-idea posts at 1/account/day) sits well
-// under that ceiling.
+// Our cron schedule (1 daily thread of up to 12 posts = 1 intro + 10
+// items + 1 idea, + 1 weekly recap of up to ~5 posts on Fridays, +
+// per-published-idea posts at 1/account/day) can reach ~17 on a Friday —
+// right at the ceiling. A mid-thread 429 is therefore realistic, which is
+// why postThread attaches partialPosts to the thrown error (see below) so
+// already-posted repos still enter the cooldown.
 
 import { FatalConfigError, TransientHttpError } from "@/lib/errors";
 import type {
@@ -109,14 +112,15 @@ export class ApiV2OutboundAdapter implements OutboundAdapter {
       }
 
       if (!res.ok) {
-        // Throw so the cron route records the run as `error` with the
-        // failing message. Partial-thread state is recorded too — the
-        // results list gets appended for every post we attempted.
+        // Throw so the cron route records the run as `error`. Attach the
+        // posts published SO FAR (`results`) as partialPosts — the route's
+        // catch reads them to still cool-down the repos that DID post, so
+        // a mid-thread failure can't re-feature them tomorrow.
         const text = await res.text();
         throw new TransientHttpError(
           `Twitter API ${res.status} on post "${post.kind}": ${text.slice(0, 200)}`,
           res.status,
-          { kind: post.kind },
+          { kind: post.kind, partialPosts: [...results] },
         );
       }
 
@@ -126,7 +130,7 @@ export class ApiV2OutboundAdapter implements OutboundAdapter {
         throw new TransientHttpError(
           `Twitter API returned no id for post "${post.kind}": ${JSON.stringify(payload).slice(0, 200)}`,
           0,
-          { kind: post.kind },
+          { kind: post.kind, partialPosts: [...results] },
         );
       }
       if (!previousId) firstId = id;

--- a/src/lib/twitter/outbound/adapters/api-v2.ts
+++ b/src/lib/twitter/outbound/adapters/api-v2.ts
@@ -1,13 +1,12 @@
 // Twitter API v2 adapter — posts via direct fetch() calls so the
 // project doesn't take a hard dep on a third-party SDK.
 //
-// Auth model: OAuth 2.0 user-context bearer token. The operator
-// generates a long-lived token via the Twitter developer console for
-// (sprint 5.6: imports placed below file header)
-//
-// the TrendingRepo posting account and puts it in TWITTER_OAUTH2_USER_TOKEN.
-// Refresh-token rotation is a P1 follow-up — for v1, when the token
-// expires the operator regenerates it manually.
+// Auth model: OAuth 2.0 user-context. Two modes:
+//   - tokenProvider (preferred): refresh-token rotation via
+//     ../oauth.ts — tokens self-renew, 401s trigger one refresh+retry.
+//   - bearerToken: static TWITTER_OAUTH2_USER_TOKEN. Kept for simple
+//     setups, but X expires these (~2h) so posting decays until the
+//     operator regenerates the token manually.
 //
 // Rate limits (as of 2026): Twitter's free tier caps at ~17 posts/day.
 // Our cron schedule (1 daily thread of ~5 posts + 1 weekly recap of
@@ -20,6 +19,7 @@ import type {
   AdapterThreadResult,
   ComposedPost,
   OutboundAdapter,
+  OutboundTokenProvider,
 } from "../types";
 
 const API_BASE = "https://api.twitter.com/2";
@@ -30,7 +30,18 @@ interface TwitterTweetResponse {
 }
 
 export interface ApiV2AdapterOptions {
-  bearerToken: string;
+  /**
+   * Static access token. Simple but decays — X user-context tokens
+   * expire (~2h), after which every post 401s until the operator
+   * regenerates it. Prefer `tokenProvider`.
+   */
+  bearerToken?: string;
+  /**
+   * Refresh-capable token source (OAuth2 rotation). When set it wins
+   * over `bearerToken`, and a 401 mid-thread triggers one
+   * invalidate-and-refresh retry before the error surfaces.
+   */
+  tokenProvider?: OutboundTokenProvider;
   /**
    * Username for building shareable URLs. Optional — when missing we
    * still publish, we just can't construct a public URL for the audit
@@ -45,17 +56,26 @@ export class ApiV2OutboundAdapter implements OutboundAdapter {
   readonly name = "twitter_api_v2";
   readonly publishes = true;
 
-  private readonly bearerToken: string;
+  private readonly bearerToken: string | null;
+  private readonly tokenProvider: OutboundTokenProvider | null;
   private readonly username: string | null;
   private readonly fetchImpl: typeof fetch;
 
   constructor(opts: ApiV2AdapterOptions) {
-    if (!opts.bearerToken) {
-      throw new FatalConfigError("ApiV2OutboundAdapter: bearerToken is required");
+    if (!opts.bearerToken && !opts.tokenProvider) {
+      throw new FatalConfigError(
+        "ApiV2OutboundAdapter: either bearerToken or tokenProvider is required",
+      );
     }
-    this.bearerToken = opts.bearerToken;
+    this.bearerToken = opts.bearerToken ?? null;
+    this.tokenProvider = opts.tokenProvider ?? null;
     this.username = opts.username ?? null;
     this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private async currentToken(): Promise<string> {
+    if (this.tokenProvider) return this.tokenProvider.getAccessToken();
+    return this.bearerToken as string;
   }
 
   async postThread(thread: ComposedPost[]): Promise<AdapterThreadResult> {
@@ -70,14 +90,23 @@ export class ApiV2OutboundAdapter implements OutboundAdapter {
       if (previousId) {
         body.reply = { in_reply_to_tweet_id: previousId };
       }
-      const res = await this.fetchImpl(`${API_BASE}/tweets`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${this.bearerToken}`,
-        },
-        body: JSON.stringify(body),
-      });
+
+      const send = (token: string) =>
+        this.fetchImpl(`${API_BASE}/tweets`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(body),
+        });
+
+      let res = await send(await this.currentToken());
+      if (res.status === 401 && this.tokenProvider) {
+        // Token died between the provider's expiry estimate and now —
+        // force a rotation and retry this post once before giving up.
+        res = await send(await this.tokenProvider.invalidateAndRefresh());
+      }
 
       if (!res.ok) {
         // Throw so the cron route records the run as `error` with the

--- a/src/lib/twitter/outbound/adapters/index.ts
+++ b/src/lib/twitter/outbound/adapters/index.ts
@@ -6,21 +6,32 @@
 // Selection rules (highest priority first):
 //   1. TWITTER_OUTBOUND_MODE=null     → NullOutboundAdapter (force no-op)
 //   2. TWITTER_OUTBOUND_MODE=console  → ConsoleOutboundAdapter (log only)
-//   3. OAuth2 rotation trio set       → ApiV2OutboundAdapter with a
+//   3. TWITTER_OUTBOUND_MODE=toolbox  → ToolboxOutboundAdapter (throws
+//      FatalConfigError when TOOLBOX_REACH_URL / TOOLBOX_REACH_API_KEY
+//      are missing — an explicit mode misconfig should be loud)
+//   4. TOOLBOX_REACH_URL + _API_KEY   → ToolboxOutboundAdapter. The VPS
+//      Twitter engine is the declared end-state transport, so when its
+//      env is present it wins over direct X-API credentials.
+//   5. OAuth2 rotation trio set       → ApiV2OutboundAdapter with a
 //      refresh-capable token provider (TWITTER_OAUTH2_CLIENT_ID +
 //      TWITTER_OAUTH2_CLIENT_SECRET + TWITTER_OAUTH2_REFRESH_TOKEN).
-//      Preferred: tokens self-renew, so posting doesn't silently die
-//      when the ~2h access-token expiry hits.
-//   4. TWITTER_OAUTH2_USER_TOKEN set  → ApiV2OutboundAdapter (static token)
-//   5. NODE_ENV=development           → ConsoleOutboundAdapter (safe default)
-//   6. otherwise                      → NullOutboundAdapter (no-op + warn)
+//      Tokens self-renew, so posting doesn't silently die when the ~2h
+//      access-token expiry hits.
+//   6. TWITTER_OAUTH2_USER_TOKEN set  → ApiV2OutboundAdapter (static token)
+//   7. NODE_ENV=development           → ConsoleOutboundAdapter (safe default)
+//   8. otherwise                      → NullOutboundAdapter (no-op + warn)
 //
-// In rule 6 we emit a one-shot console.warn so a misconfigured prod
+// In rule 8 we emit a one-shot console.warn so a misconfigured prod
 // deploy is visible in the logs without blowing up cron runs.
 
+import { FatalConfigError } from "@/lib/errors";
 import { ApiV2OutboundAdapter } from "./api-v2";
 import { ConsoleOutboundAdapter } from "./console";
 import { NullOutboundAdapter } from "./null";
+import {
+  readToolboxReachConfigFromEnv,
+  ToolboxOutboundAdapter,
+} from "./toolbox";
 import { getSharedTwitterOAuthManager } from "../oauth";
 import type { OutboundAdapter } from "../types";
 
@@ -30,6 +41,19 @@ export function selectOutboundAdapter(): OutboundAdapter {
   const mode = process.env.TWITTER_OUTBOUND_MODE?.toLowerCase();
   if (mode === "null") return new NullOutboundAdapter();
   if (mode === "console") return new ConsoleOutboundAdapter();
+
+  const toolboxConfig = readToolboxReachConfigFromEnv();
+  if (mode === "toolbox") {
+    if (!toolboxConfig) {
+      throw new FatalConfigError(
+        "TWITTER_OUTBOUND_MODE=toolbox requires TOOLBOX_REACH_URL and TOOLBOX_REACH_API_KEY",
+      );
+    }
+    return new ToolboxOutboundAdapter(toolboxConfig);
+  }
+  if (toolboxConfig) {
+    return new ToolboxOutboundAdapter(toolboxConfig);
+  }
 
   const username = process.env.TWITTER_USERNAME?.trim() || undefined;
 
@@ -57,14 +81,20 @@ export function selectOutboundAdapter(): OutboundAdapter {
     prodMissingTokenWarned = true;
     console.warn(
       "[twitter:outbound] no Twitter credentials configured. Cron " +
-        "endpoints will run as no-ops. Set the OAuth2 rotation trio " +
-        "(TWITTER_OAUTH2_CLIENT_ID/SECRET/REFRESH_TOKEN, preferred) or a " +
-        "static TWITTER_OAUTH2_USER_TOKEN (plus TWITTER_USERNAME for nice " +
-        "URLs) to enable publishing, or TWITTER_OUTBOUND_MODE=console " +
-        "to log composed threads without publishing.",
+        "endpoints will run as no-ops. Set TOOLBOX_REACH_URL + " +
+        "TOOLBOX_REACH_API_KEY (VPS engine, preferred), the OAuth2 rotation " +
+        "trio (TWITTER_OAUTH2_CLIENT_ID/SECRET/REFRESH_TOKEN), or a static " +
+        "TWITTER_OAUTH2_USER_TOKEN (plus TWITTER_USERNAME for nice URLs) " +
+        "to enable publishing, or TWITTER_OUTBOUND_MODE=console to log " +
+        "composed threads without publishing.",
     );
   }
   return new NullOutboundAdapter();
 }
 
-export { ApiV2OutboundAdapter, ConsoleOutboundAdapter, NullOutboundAdapter };
+export {
+  ApiV2OutboundAdapter,
+  ConsoleOutboundAdapter,
+  NullOutboundAdapter,
+  ToolboxOutboundAdapter,
+};

--- a/src/lib/twitter/outbound/adapters/index.ts
+++ b/src/lib/twitter/outbound/adapters/index.ts
@@ -6,16 +6,22 @@
 // Selection rules (highest priority first):
 //   1. TWITTER_OUTBOUND_MODE=null     → NullOutboundAdapter (force no-op)
 //   2. TWITTER_OUTBOUND_MODE=console  → ConsoleOutboundAdapter (log only)
-//   3. TWITTER_OAUTH2_USER_TOKEN set  → ApiV2OutboundAdapter (publish)
-//   4. NODE_ENV=development           → ConsoleOutboundAdapter (safe default)
-//   5. otherwise                      → NullOutboundAdapter (no-op + warn)
+//   3. OAuth2 rotation trio set       → ApiV2OutboundAdapter with a
+//      refresh-capable token provider (TWITTER_OAUTH2_CLIENT_ID +
+//      TWITTER_OAUTH2_CLIENT_SECRET + TWITTER_OAUTH2_REFRESH_TOKEN).
+//      Preferred: tokens self-renew, so posting doesn't silently die
+//      when the ~2h access-token expiry hits.
+//   4. TWITTER_OAUTH2_USER_TOKEN set  → ApiV2OutboundAdapter (static token)
+//   5. NODE_ENV=development           → ConsoleOutboundAdapter (safe default)
+//   6. otherwise                      → NullOutboundAdapter (no-op + warn)
 //
-// In rule 5 we emit a one-shot console.warn so a misconfigured prod
+// In rule 6 we emit a one-shot console.warn so a misconfigured prod
 // deploy is visible in the logs without blowing up cron runs.
 
 import { ApiV2OutboundAdapter } from "./api-v2";
 import { ConsoleOutboundAdapter } from "./console";
 import { NullOutboundAdapter } from "./null";
+import { getSharedTwitterOAuthManager } from "../oauth";
 import type { OutboundAdapter } from "../types";
 
 let prodMissingTokenWarned = false;
@@ -25,11 +31,21 @@ export function selectOutboundAdapter(): OutboundAdapter {
   if (mode === "null") return new NullOutboundAdapter();
   if (mode === "console") return new ConsoleOutboundAdapter();
 
+  const username = process.env.TWITTER_USERNAME?.trim() || undefined;
+
+  const oauthManager = getSharedTwitterOAuthManager();
+  if (oauthManager) {
+    return new ApiV2OutboundAdapter({
+      tokenProvider: oauthManager,
+      username,
+    });
+  }
+
   const token = process.env.TWITTER_OAUTH2_USER_TOKEN;
   if (token && token.trim()) {
     return new ApiV2OutboundAdapter({
       bearerToken: token.trim(),
-      username: process.env.TWITTER_USERNAME?.trim() || undefined,
+      username,
     });
   }
 
@@ -40,9 +56,11 @@ export function selectOutboundAdapter(): OutboundAdapter {
   if (!prodMissingTokenWarned) {
     prodMissingTokenWarned = true;
     console.warn(
-      "[twitter:outbound] TWITTER_OAUTH2_USER_TOKEN is not set. Cron " +
-        "endpoints will run as no-ops. Set the token (and TWITTER_USERNAME " +
-        "for nice URLs) to enable publishing, or TWITTER_OUTBOUND_MODE=console " +
+      "[twitter:outbound] no Twitter credentials configured. Cron " +
+        "endpoints will run as no-ops. Set the OAuth2 rotation trio " +
+        "(TWITTER_OAUTH2_CLIENT_ID/SECRET/REFRESH_TOKEN, preferred) or a " +
+        "static TWITTER_OAUTH2_USER_TOKEN (plus TWITTER_USERNAME for nice " +
+        "URLs) to enable publishing, or TWITTER_OUTBOUND_MODE=console " +
         "to log composed threads without publishing.",
     );
   }

--- a/src/lib/twitter/outbound/adapters/toolbox.ts
+++ b/src/lib/twitter/outbound/adapters/toolbox.ts
@@ -1,0 +1,131 @@
+// Toolbox-engine adapter — forwards the composed thread to the Twitter
+// engine running on the VPS (toolbox box) instead of calling the X API
+// directly. The engine owns credentials, rate budgets, and the actual
+// publish; this app stays responsible for WHAT gets posted (selection,
+// composition, dedupe, freshness) and the audit trail.
+//
+// Wire contract (deliberately minimal so the engine side can evolve):
+//   POST ${TOOLBOX_REACH_URL}
+//   Authorization: Bearer ${TOOLBOX_REACH_API_KEY}
+//   { "kind": "thread", "posts": [{ "kind", "text", "url" }] }
+// Expected response:
+//   { "ok": true, "threadUrl"?: string|null,
+//     "posts"?: [{ "remoteId"?, "url"?, "status"? }] }
+// A bare `{ "ok": true }` is accepted — every post is then recorded as
+// published with null URLs. Non-2xx or `ok:false` throws so the cron
+// route records the run as `error`, mirroring the api-v2 adapter.
+
+import { FatalConfigError, TransientHttpError } from "@/lib/errors";
+import type {
+  AdapterPostResult,
+  AdapterThreadResult,
+  ComposedPost,
+  OutboundAdapter,
+} from "../types";
+
+export interface ToolboxAdapterOptions {
+  /** Full URL of the engine's publish endpoint (TOOLBOX_REACH_URL). */
+  endpointUrl: string;
+  /** Bearer credential for the endpoint (TOOLBOX_REACH_API_KEY). */
+  apiKey: string;
+  /** Override for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+interface ToolboxPublishResponse {
+  ok?: boolean;
+  threadUrl?: string | null;
+  posts?: Array<{
+    remoteId?: string | null;
+    url?: string | null;
+    status?: AdapterPostResult["status"];
+  }>;
+  error?: string;
+}
+
+export class ToolboxOutboundAdapter implements OutboundAdapter {
+  readonly name = "toolbox_reach";
+  readonly publishes = true;
+
+  private readonly endpointUrl: string;
+  private readonly apiKey: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: ToolboxAdapterOptions) {
+    if (!opts.endpointUrl || !opts.apiKey) {
+      throw new FatalConfigError(
+        "ToolboxOutboundAdapter: endpointUrl and apiKey are both required",
+      );
+    }
+    this.endpointUrl = opts.endpointUrl;
+    this.apiKey = opts.apiKey;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async postThread(thread: ComposedPost[]): Promise<AdapterThreadResult> {
+    const res = await this.fetchImpl(this.endpointUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        kind: "thread",
+        posts: thread.map((post) => ({
+          kind: post.kind,
+          text: post.text,
+          url: post.url ?? null,
+        })),
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new TransientHttpError(
+        `Toolbox reach endpoint ${res.status}: ${text.slice(0, 200)}`,
+        res.status,
+        { postCount: thread.length },
+      );
+    }
+
+    let payload: ToolboxPublishResponse;
+    try {
+      payload = (await res.json()) as ToolboxPublishResponse;
+    } catch {
+      throw new TransientHttpError(
+        "Toolbox reach endpoint returned non-JSON body on a 2xx response",
+        res.status,
+      );
+    }
+    if (payload.ok === false) {
+      throw new TransientHttpError(
+        `Toolbox reach endpoint reported failure: ${payload.error ?? "no error message"}`,
+        res.status,
+      );
+    }
+
+    const posts: AdapterPostResult[] = thread.map((_, i) => {
+      const remote = payload.posts?.[i];
+      return {
+        remoteId: remote?.remoteId ?? null,
+        url: remote?.url ?? null,
+        status: remote?.status ?? "published",
+      };
+    });
+
+    return {
+      posts,
+      threadUrl: payload.threadUrl ?? posts[0]?.url ?? null,
+    };
+  }
+}
+
+export function readToolboxReachConfigFromEnv(): {
+  endpointUrl: string;
+  apiKey: string;
+} | null {
+  const endpointUrl = process.env.TOOLBOX_REACH_URL?.trim();
+  const apiKey = process.env.TOOLBOX_REACH_API_KEY?.trim();
+  if (!endpointUrl || !apiKey) return null;
+  return { endpointUrl, apiKey };
+}

--- a/src/lib/twitter/outbound/audit.ts
+++ b/src/lib/twitter/outbound/audit.ts
@@ -30,6 +30,7 @@ export interface RecordRunInput {
   postCount: number;
   startedAt: string;
   errorMessage?: string | null;
+  featuredRepos?: string[];
 }
 
 /**
@@ -50,6 +51,7 @@ export async function recordOutboundRun(
     startedAt: input.startedAt,
     finishedAt: new Date().toISOString(),
     errorMessage: input.errorMessage ?? null,
+    ...(input.featuredRepos ? { featuredRepos: input.featuredRepos } : {}),
   };
   await appendJsonlFile(OUTBOUND_RUNS_FILE, record);
   return record;

--- a/src/lib/twitter/outbound/audit.ts
+++ b/src/lib/twitter/outbound/audit.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/pipeline/storage/file-persistence";
 
 import type {
+  AdapterPostResult,
   AdapterThreadResult,
   ComposedPost,
   OutboundRunPost,
@@ -40,6 +41,37 @@ export function zipRunPosts(
     url: post.url ?? null,
     status: result.posts[i]?.status ?? "skipped",
   }));
+}
+
+/**
+ * Which featured repos actually got posted before a thread threw
+ * mid-way. Adapters attach the posts published so far as
+ * `metadata.partialPosts` on the thrown error; the thread layout is
+ * [intro, item0..itemN-1, (idea)], so a published result at index j
+ * (1..N) maps to `breakouts[j-1]`. Returning these lets the cron route
+ * still cool-down the repos that DID post — otherwise a mid-thread
+ * failure re-features them the next day (near-duplicate thread).
+ *
+ * Best-effort and defensive: unknown error shape → empty list.
+ */
+export function partialPublishedRepos(
+  err: unknown,
+  breakouts: ReadonlyArray<{ fullName: string }>,
+): string[] {
+  const meta =
+    err && typeof err === "object" && "metadata" in err
+      ? (err as { metadata?: Record<string, unknown> }).metadata
+      : undefined;
+  const partial = meta?.partialPosts;
+  if (!Array.isArray(partial)) return [];
+  const posts = partial as AdapterPostResult[];
+  const featured: string[] = [];
+  for (let j = 1; j <= breakouts.length; j++) {
+    if (posts[j]?.status === "published") {
+      featured.push(breakouts[j - 1]!.fullName);
+    }
+  }
+  return featured;
 }
 
 export const OUTBOUND_RUNS_FILE = "twitter-outbound-runs.jsonl";

--- a/src/lib/twitter/outbound/audit.ts
+++ b/src/lib/twitter/outbound/audit.ts
@@ -18,7 +18,29 @@ import {
   readJsonlFile,
 } from "@/lib/pipeline/storage/file-persistence";
 
-import type { OutboundRunRecord } from "./types";
+import type {
+  AdapterThreadResult,
+  ComposedPost,
+  OutboundRunPost,
+  OutboundRunRecord,
+} from "./types";
+
+/**
+ * Zip the composed thread with the adapter's per-post outcome into the
+ * audit shape. Adapters return one result per post in order; a missing
+ * result (thread aborted mid-way) records as "skipped".
+ */
+export function zipRunPosts(
+  thread: ComposedPost[],
+  result: AdapterThreadResult,
+): OutboundRunPost[] {
+  return thread.map((post, i) => ({
+    kind: post.kind,
+    text: post.text,
+    url: post.url ?? null,
+    status: result.posts[i]?.status ?? "skipped",
+  }));
+}
 
 export const OUTBOUND_RUNS_FILE = "twitter-outbound-runs.jsonl";
 
@@ -31,6 +53,7 @@ export interface RecordRunInput {
   startedAt: string;
   errorMessage?: string | null;
   featuredRepos?: string[];
+  posts?: OutboundRunPost[];
 }
 
 /**
@@ -52,6 +75,7 @@ export async function recordOutboundRun(
     finishedAt: new Date().toISOString(),
     errorMessage: input.errorMessage ?? null,
     ...(input.featuredRepos ? { featuredRepos: input.featuredRepos } : {}),
+    ...(input.posts ? { posts: input.posts } : {}),
   };
   await appendJsonlFile(OUTBOUND_RUNS_FILE, record);
   return record;

--- a/src/lib/twitter/outbound/composer.ts
+++ b/src/lib/twitter/outbound/composer.ts
@@ -21,8 +21,15 @@ import type { ComposedPost } from "./types";
 const TWEET_MAX = 280;
 const URL_BUDGET = 24; // 23 chars Twitter t.co + 1 leading space
 
+/**
+ * Item cap for the daily thread. 1 intro + 10 items + 1 idea = 12
+ * posts/day, which stays under the ~17/day free-tier write ceiling
+ * even with the Friday recap and one idea auto-post on top.
+ */
+export const MAX_DAILY_ITEMS = 10;
+
 export interface DailyBreakoutsInput {
-  /** Top breakouts of the last 24h. Composer takes up to 3. */
+  /** Top breakouts of the last 24h. Composer takes up to MAX_DAILY_ITEMS. */
   breakouts: Repo[];
   /** Top idea of the last 7d. Optional — composer skips if missing. */
   topIdea: PublicIdea | null;
@@ -68,28 +75,29 @@ export function effectiveLength(post: ComposedPost): number {
 
 /**
  * Daily breakouts thread:
- *   [intro]   "🔥 Trending today across multiple signals: ..."
- *   [item 1]  "1/ owner/name +Δ stars in 24h — momentum"
- *   [item 2]  "2/ ..."
- *   [item 3]  "3/ ..."
+ *   [intro]   "🔥 Top 10 trending repos 2026-07-09 ..."
+ *   [item 1]  "1/ owner/name +Δ stars in 24h (k signals firing) — description"
+ *   ...
+ *   [item 10] "10/ ..."
  *   [idea]    "💡 Top idea: '...' — @handle"
  *
  * Returns at least the intro post; items + idea slot in only if
- * the input had data.
+ * the input had data. Every repo item carries its canonical
+ * trendingrepo.com URL — no repo appears without its link.
  */
 export function composeDailyBreakouts(
   input: DailyBreakoutsInput,
   now: Date = new Date(),
 ): ComposedPost[] {
-  const top = input.breakouts.slice(0, 3);
+  const top = input.breakouts.slice(0, MAX_DAILY_ITEMS);
   const dateStr = now.toISOString().slice(0, 10);
 
   const posts: ComposedPost[] = [];
 
-  // Intro — count of signals, link to /breakouts.
+  // Intro — count of repos, link to /breakouts.
   const introBody =
     top.length > 0
-      ? `🔥 Trending ${dateStr}: ${top.length} repo${top.length === 1 ? "" : "s"} firing across multiple signals. Thread ↓`
+      ? `🔥 Top ${top.length} trending repo${top.length === 1 ? "" : "s"} ${dateStr} — ranked by stars + social signals. Thread ↓`
       : `🔥 Trending ${dateStr}: quiet day on the breakouts board. Watch this space.`;
   posts.push({
     kind: "daily_breakouts_intro",
@@ -122,12 +130,18 @@ function formatBreakoutLine(repo: Repo, position: number): string {
   const delta = repo.starsDelta24h;
   const deltaStr =
     delta >= 1000 ? `+${(delta / 1000).toFixed(1)}K` : `+${delta}`;
+  // A multi-signal repo can headline with a flat star delta — skip the
+  // "+0 stars" segment rather than advertise no movement.
+  const deltaHint = delta > 0 ? ` ${deltaStr} stars in 24h` : "";
   // Channel firing count surfaces "this isn't just one source noise".
   const channels = repo.channelsFiring ?? 0;
   const channelHint = channels >= 2 ? ` (${channels} signals firing)` : "";
-  // Compose ON the prefix that wraps to TWEET_MAX-URL_BUDGET.
-  const prefix = `${position}/ ${repo.fullName} ${deltaStr} stars in 24h${channelHint}`;
-  return truncate(prefix, TWEET_MAX - URL_BUDGET);
+  const prefix = `${position}/ ${repo.fullName}${deltaHint}${channelHint}`;
+  // One-line description gives the reader a reason to click; it soaks
+  // up whatever budget the stats left over.
+  const description = repo.description?.trim() ?? "";
+  const body = description ? `${prefix} — ${description}` : prefix;
+  return truncate(body, TWEET_MAX - URL_BUDGET);
 }
 
 function formatIdeaSpotlight(idea: PublicIdea): string {

--- a/src/lib/twitter/outbound/composer.ts
+++ b/src/lib/twitter/outbound/composer.ts
@@ -35,9 +35,12 @@ export interface DailyBreakoutsInput {
   topIdea: PublicIdea | null;
 }
 
+/** Item cap for the weekly recap thread — short and skimmable. */
+export const MAX_WEEKLY_ITEMS = 3;
+
 export interface WeeklyRecapInput {
-  /** Top breakout of the week (highest cross-signal score). */
-  topBreakout: Repo | null;
+  /** Top breakouts of the week. Composer takes up to MAX_WEEKLY_ITEMS. */
+  topBreakouts: Repo[];
   /** Top idea of the week (highest hot-score). */
   topIdea: PublicIdea | null;
   /** Number of new ideas published this week, for the "ideas posted" line. */
@@ -178,16 +181,21 @@ export function composeWeeklyRecap(
     url: absoluteUrl("/breakouts"),
   });
 
-  if (input.topBreakout) {
+  const medals = ["🥇", "🥈", "🥉"];
+  input.topBreakouts.slice(0, MAX_WEEKLY_ITEMS).forEach((repo, idx) => {
+    const delta = repo.starsDelta7d ?? 0;
+    const deltaStr =
+      delta >= 1000 ? `+${(delta / 1000).toFixed(1)}K` : `+${delta}`;
+    const deltaHint = delta > 0 ? ` (${deltaStr} stars this week)` : "";
+    const prefix = `${medals[idx] ?? `${idx + 1}.`} ${repo.fullName}${deltaHint}`;
+    const description = repo.description?.trim() ?? "";
+    const body = description ? `${prefix} — ${description}` : prefix;
     posts.push({
       kind: "weekly_recap_item",
-      text: truncate(
-        `🥇 Top breakout: ${input.topBreakout.fullName} (+${input.topBreakout.starsDelta7d} stars this week)`,
-        TWEET_MAX - URL_BUDGET,
-      ),
-      url: absoluteUrl(`/repo/${input.topBreakout.fullName}`),
+      text: truncate(body, TWEET_MAX - URL_BUDGET),
+      url: absoluteUrl(`/repo/${repo.fullName}`),
     });
-  }
+  });
 
   if (input.topIdea) {
     posts.push({

--- a/src/lib/twitter/outbound/oauth.ts
+++ b/src/lib/twitter/outbound/oauth.ts
@@ -69,7 +69,8 @@ interface TokenEndpointResponse {
 
 export class TwitterOAuthTokenManager implements OutboundTokenProvider {
   private state: TwitterOAuthState | null = null;
-  private stateLoaded = false;
+  private loadInflight: Promise<void> | null = null;
+  private loaded = false;
   private inflight: Promise<string> | null = null;
   private readonly fetchImpl: typeof fetch;
 
@@ -104,18 +105,33 @@ export class TwitterOAuthTokenManager implements OutboundTokenProvider {
     return this.refresh();
   }
 
-  private async loadPersistedState(): Promise<void> {
-    if (this.stateLoaded) return;
-    this.stateLoaded = true;
-    try {
-      const rows = await readJsonlFile<TwitterOAuthState>(OAUTH_STATE_FILE);
-      const latest = rows
-        .filter((r) => r.accessToken && r.refreshToken && r.rotatedAt)
-        .sort((a, b) => Date.parse(b.rotatedAt) - Date.parse(a.rotatedAt))[0];
-      if (latest) this.state = latest;
-    } catch {
-      // Fresh container / missing file — the env seed covers first run.
+  private loadPersistedState(): Promise<void> {
+    if (this.loaded) return Promise.resolve();
+    // Single-flight the read: concurrent callers must await the SAME load,
+    // not short-circuit on a flag while the read is still in flight — else
+    // a second caller sees state=null and exchanges the stale env seed
+    // instead of the persisted rotated token (dead-token 400, posting dies
+    // with a valid token on disk).
+    if (!this.loadInflight) {
+      this.loadInflight = (async () => {
+        try {
+          const rows =
+            await readJsonlFile<TwitterOAuthState>(OAUTH_STATE_FILE);
+          const latest = rows
+            .filter((r) => r.accessToken && r.refreshToken && r.rotatedAt)
+            .sort(
+              (a, b) => Date.parse(b.rotatedAt) - Date.parse(a.rotatedAt),
+            )[0];
+          if (latest) this.state = latest;
+        } catch {
+          // Fresh container / missing file — the env seed covers first run.
+        } finally {
+          this.loaded = true;
+          this.loadInflight = null;
+        }
+      })();
     }
+    return this.loadInflight;
   }
 
   /** Single-flight: concurrent callers share one token exchange, since a
@@ -150,14 +166,18 @@ export class TwitterOAuthTokenManager implements OutboundTokenProvider {
 
     if (!res.ok) {
       const text = await res.text();
-      // 400 invalid_request here almost always means the refresh token
-      // was consumed elsewhere (or the seed is stale after a container
-      // rebuild that lost the state file) — the operator must re-run
-      // the authorize flow and update TWITTER_OAUTH2_REFRESH_TOKEN.
-      throw new TransientHttpError(
-        `Twitter OAuth2 token refresh failed with ${res.status}: ${text.slice(0, 200)}`,
-        res.status,
-      );
+      // A 4xx (other than 429) means the refresh token itself is bad —
+      // consumed elsewhere, or a stale seed after a container rebuild that
+      // lost the state file. That is NOT transient: retrying re-hammers the
+      // endpoint with the same dead credential. Surface it as a fatal
+      // config error so retry wrappers back off and the operator knows to
+      // re-run the authorize flow + update TWITTER_OAUTH2_REFRESH_TOKEN.
+      // 429/5xx/network stay transient (worth a retry).
+      const isPermanent = res.status >= 400 && res.status < 500 && res.status !== 429;
+      const message = `Twitter OAuth2 token refresh failed with ${res.status}: ${text.slice(0, 200)}`;
+      throw isPermanent
+        ? new FatalConfigError(message, { status: res.status })
+        : new TransientHttpError(message, res.status);
     }
 
     const payload = (await res.json()) as TokenEndpointResponse;

--- a/src/lib/twitter/outbound/oauth.ts
+++ b/src/lib/twitter/outbound/oauth.ts
@@ -1,0 +1,220 @@
+// OAuth2 refresh-token rotation for the X (Twitter) API v2.
+//
+// X user-context access tokens expire (~2h), which is why a statically
+// provisioned TWITTER_OAUTH2_USER_TOKEN goes dead shortly after setup
+// and every cron run afterwards 401s. This manager keeps posting alive
+// indefinitely: it exchanges a refresh token for a fresh access token
+// before each expiry window.
+//
+// Rotation caveat that shapes the design: X invalidates the used
+// refresh token on every exchange and returns a NEW one. The rotated
+// token must therefore be persisted immediately — losing it means the
+// operator has to re-authorize the app and re-seed the env var. State
+// rides the existing JSONL file-persistence layer (same as the
+// outbound audit trail): append-only rows, latest row wins on boot,
+// `TWITTER_OAUTH2_REFRESH_TOKEN` env seed used only when no persisted
+// row exists yet.
+
+import { FatalConfigError, TransientHttpError } from "@/lib/errors";
+import {
+  appendJsonlFile,
+  readJsonlFile,
+} from "@/lib/pipeline/storage/file-persistence";
+
+import type { OutboundTokenProvider } from "./types";
+
+export const OAUTH_STATE_FILE = "twitter-oauth-state.jsonl";
+
+const TOKEN_URL = "https://api.twitter.com/2/oauth2/token";
+
+/** Refresh this long before recorded expiry so a slow thread never
+ * straddles the cliff mid-post. */
+const EXPIRY_SAFETY_MS = 5 * 60 * 1000;
+
+/** X returns expires_in=7200 today; assume that when the field is absent. */
+const DEFAULT_EXPIRES_IN_SEC = 7200;
+
+export interface TwitterOAuthState {
+  accessToken: string;
+  refreshToken: string;
+  /** ISO timestamp the access token stops working. */
+  expiresAt: string;
+  /** ISO timestamp this row was written — latest row wins on boot. */
+  rotatedAt: string;
+}
+
+export interface TwitterOAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  /** Initial refresh token from the one-time authorize flow. Only used
+   * until the first rotation lands in the state file. */
+  seedRefreshToken: string;
+  /** Override for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export function readTwitterOAuthConfigFromEnv(): TwitterOAuthConfig | null {
+  const clientId = process.env.TWITTER_OAUTH2_CLIENT_ID?.trim();
+  const clientSecret = process.env.TWITTER_OAUTH2_CLIENT_SECRET?.trim();
+  const seedRefreshToken = process.env.TWITTER_OAUTH2_REFRESH_TOKEN?.trim();
+  if (!clientId || !clientSecret || !seedRefreshToken) return null;
+  return { clientId, clientSecret, seedRefreshToken };
+}
+
+interface TokenEndpointResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+export class TwitterOAuthTokenManager implements OutboundTokenProvider {
+  private state: TwitterOAuthState | null = null;
+  private stateLoaded = false;
+  private inflight: Promise<string> | null = null;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly config: TwitterOAuthConfig) {
+    if (!config.clientId || !config.clientSecret || !config.seedRefreshToken) {
+      throw new FatalConfigError(
+        "TwitterOAuthTokenManager: clientId, clientSecret and seedRefreshToken are all required",
+      );
+    }
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  async getAccessToken(): Promise<string> {
+    await this.loadPersistedState();
+    const state = this.state;
+    if (
+      state &&
+      Date.parse(state.expiresAt) - EXPIRY_SAFETY_MS > Date.now()
+    ) {
+      return state.accessToken;
+    }
+    return this.refresh();
+  }
+
+  async invalidateAndRefresh(): Promise<string> {
+    await this.loadPersistedState();
+    // Drop the cached access token but keep the refresh token — that's
+    // the credential the retry needs.
+    if (this.state) {
+      this.state = { ...this.state, expiresAt: new Date(0).toISOString() };
+    }
+    return this.refresh();
+  }
+
+  private async loadPersistedState(): Promise<void> {
+    if (this.stateLoaded) return;
+    this.stateLoaded = true;
+    try {
+      const rows = await readJsonlFile<TwitterOAuthState>(OAUTH_STATE_FILE);
+      const latest = rows
+        .filter((r) => r.accessToken && r.refreshToken && r.rotatedAt)
+        .sort((a, b) => Date.parse(b.rotatedAt) - Date.parse(a.rotatedAt))[0];
+      if (latest) this.state = latest;
+    } catch {
+      // Fresh container / missing file — the env seed covers first run.
+    }
+  }
+
+  /** Single-flight: concurrent callers share one token exchange, since a
+   * second exchange with the same refresh token would be rejected. */
+  private refresh(): Promise<string> {
+    if (!this.inflight) {
+      this.inflight = this.exchangeRefreshToken().finally(() => {
+        this.inflight = null;
+      });
+    }
+    return this.inflight;
+  }
+
+  private async exchangeRefreshToken(): Promise<string> {
+    const refreshToken =
+      this.state?.refreshToken ?? this.config.seedRefreshToken;
+    const basic = Buffer.from(
+      `${this.config.clientId}:${this.config.clientSecret}`,
+    ).toString("base64");
+
+    const res = await this.fetchImpl(TOKEN_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basic}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }).toString(),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      // 400 invalid_request here almost always means the refresh token
+      // was consumed elsewhere (or the seed is stale after a container
+      // rebuild that lost the state file) — the operator must re-run
+      // the authorize flow and update TWITTER_OAUTH2_REFRESH_TOKEN.
+      throw new TransientHttpError(
+        `Twitter OAuth2 token refresh failed with ${res.status}: ${text.slice(0, 200)}`,
+        res.status,
+      );
+    }
+
+    const payload = (await res.json()) as TokenEndpointResponse;
+    if (!payload.access_token) {
+      throw new TransientHttpError(
+        `Twitter OAuth2 token endpoint returned no access_token: ${JSON.stringify(payload).slice(0, 200)}`,
+        0,
+      );
+    }
+
+    const now = Date.now();
+    const expiresInSec =
+      typeof payload.expires_in === "number" && payload.expires_in > 0
+        ? payload.expires_in
+        : DEFAULT_EXPIRES_IN_SEC;
+    const next: TwitterOAuthState = {
+      accessToken: payload.access_token,
+      // X rotates the refresh token on every exchange; if it ever
+      // doesn't, the old one is still valid so keep using it.
+      refreshToken: payload.refresh_token ?? refreshToken,
+      expiresAt: new Date(now + expiresInSec * 1000).toISOString(),
+      rotatedAt: new Date(now).toISOString(),
+    };
+    this.state = next;
+
+    try {
+      await appendJsonlFile(OAUTH_STATE_FILE, next);
+    } catch (err) {
+      // Don't fail the post over a persistence hiccup — but shout,
+      // because losing a rotated refresh token strands the account on
+      // the next container boot until the operator re-seeds.
+      console.error(
+        "[twitter:oauth] failed to persist rotated refresh token — " +
+          "re-authorization will be needed after the next restart",
+        err,
+      );
+    }
+    return next.accessToken;
+  }
+}
+
+// One shared manager per process so every cron invocation in a
+// container sees the same rotation state (two managers would race each
+// other's refresh tokens).
+let shared: { key: string; manager: TwitterOAuthTokenManager } | null = null;
+
+export function getSharedTwitterOAuthManager(): TwitterOAuthTokenManager | null {
+  const config = readTwitterOAuthConfigFromEnv();
+  if (!config) return null;
+  const key = `${config.clientId}:${config.seedRefreshToken}`;
+  if (!shared || shared.key !== key) {
+    shared = { key, manager: new TwitterOAuthTokenManager(config) };
+  }
+  return shared.manager;
+}
+
+/** Test hook — clears the process-wide manager singleton. */
+export function _resetSharedTwitterOAuthManagerForTests(): void {
+  shared = null;
+}

--- a/src/lib/twitter/outbound/select.ts
+++ b/src/lib/twitter/outbound/select.ts
@@ -29,6 +29,20 @@ export const DAILY_BREAKOUT_COUNT = 10;
 /** Days a featured repo sits out before it can headline again. */
 export const FEATURED_COOLDOWN_DAYS = 7;
 
+/**
+ * Count repos that actually broke out THIS WEEK — a positive 7-day star
+ * delta AND multi-signal (>=2 channels firing). Used for the weekly
+ * recap intro line. This is deliberately NOT "every repo that has ever
+ * lit 2 channels": without the 7d-movement gate the count is a stable,
+ * corpus-sized number that never reflects the week (the bug this
+ * replaces rendered ~191 "breakouts" into every Friday tweet).
+ */
+export function countWeeklyBreakouts(repos: Repo[]): number {
+  return repos.filter(
+    (r) => (r.starsDelta7d ?? 0) > 0 && (r.channelsFiring ?? 0) >= 2,
+  ).length;
+}
+
 export interface PickDailyBreakoutsOptions {
   /** How many repos to return. Defaults to DAILY_BREAKOUT_COUNT. */
   count?: number;

--- a/src/lib/twitter/outbound/select.ts
+++ b/src/lib/twitter/outbound/select.ts
@@ -1,0 +1,140 @@
+// Daily-breakouts selection — which repos make the outbound thread.
+//
+// Lives outside the cron route because Next 15 forbids non-handler
+// exports from route.ts, and the selection math deserves direct unit
+// tests (the "3 random-looking repos" failure mode came from an
+// untested picker buried in the route).
+//
+// Selection is tiered so the thread degrades gracefully when signal
+// data is partially stale instead of collapsing to array order:
+//   Tier A — multi-signal breakouts (channelsFiring >= 2), the real
+//            "firing across multiple signals" cohort.
+//   Tier B — single-signal movers the scoring pipeline already flags
+//            (movementStatus breakout/hot/rising).
+//   Tier C — raw 24h star velocity, the always-available fallback.
+// Every tier has a deterministic multi-key sort so equal primary
+// scores never fall through to insertion order.
+//
+// A quality floor applies to all tiers: a repo with no positive
+// movement never makes the thread. Fewer-than-count real repos beats
+// count padded with dead ones.
+
+import type { Repo } from "@/lib/types";
+
+import type { OutboundRunRecord } from "./types";
+
+/** Repos per daily thread. 1 intro + 10 items + 1 idea = 12 posts/day. */
+export const DAILY_BREAKOUT_COUNT = 10;
+
+/** Days a featured repo sits out before it can headline again. */
+export const FEATURED_COOLDOWN_DAYS = 7;
+
+export interface PickDailyBreakoutsOptions {
+  /** How many repos to return. Defaults to DAILY_BREAKOUT_COUNT. */
+  count?: number;
+  /** Lowercased fullNames to skip (e.g. featured in the last 7 days). */
+  exclude?: ReadonlySet<string>;
+}
+
+/**
+ * Repos featured in recent runs, as a lowercased fullName set. Runs
+ * older than `days` (or without a featuredRepos list — pre-upgrade
+ * audit rows) are ignored.
+ */
+export function recentlyFeaturedRepos(
+  runs: OutboundRunRecord[],
+  days: number = FEATURED_COOLDOWN_DAYS,
+  now: Date = new Date(),
+): Set<string> {
+  const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
+  const featured = new Set<string>();
+  for (const run of runs) {
+    const startedAt = Date.parse(run.startedAt);
+    if (!Number.isFinite(startedAt) || startedAt < cutoff) continue;
+    for (const fullName of run.featuredRepos ?? []) {
+      featured.add(fullName.toLowerCase());
+    }
+  }
+  return featured;
+}
+
+/**
+ * Quality floor: only repos with some positive movement qualify.
+ * Multi-signal repos pass even with a flat star delta — the other
+ * channels are the movement.
+ */
+function hasPositiveMovement(repo: Repo): boolean {
+  if ((repo.channelsFiring ?? 0) >= 2) return true;
+  if ((repo.starsDelta24h ?? 0) > 0) return true;
+  if ((repo.starsDelta7d ?? 0) > 0) return true;
+  return false;
+}
+
+function byCrossSignal(a: Repo, b: Repo): number {
+  const css = (b.crossSignalScore ?? 0) - (a.crossSignalScore ?? 0);
+  if (css !== 0) return css;
+  return byMomentum(a, b);
+}
+
+function byMomentum(a: Repo, b: Repo): number {
+  const momentum = (b.momentumScore ?? 0) - (a.momentumScore ?? 0);
+  if (momentum !== 0) return momentum;
+  return byStarDelta(a, b);
+}
+
+function byStarDelta(a: Repo, b: Repo): number {
+  const delta = (b.starsDelta24h ?? 0) - (a.starsDelta24h ?? 0);
+  if (delta !== 0) return delta;
+  // Final stable tiebreak so runs are reproducible for identical data.
+  return a.fullName.localeCompare(b.fullName);
+}
+
+const TIER_B_STATUSES: ReadonlySet<Repo["movementStatus"]> = new Set([
+  "breakout",
+  "hot",
+  "rising",
+]);
+
+/**
+ * Pick the repos for today's thread. Returns up to `count` repos —
+ * fewer when the data doesn't support more, never padded.
+ */
+export function pickDailyBreakouts(
+  repos: Repo[],
+  options: PickDailyBreakoutsOptions = {},
+): Repo[] {
+  const count = options.count ?? DAILY_BREAKOUT_COUNT;
+  const exclude = options.exclude ?? new Set<string>();
+
+  const seen = new Set<string>();
+  const candidates: Repo[] = [];
+  for (const repo of repos) {
+    if (!repo.fullName) continue;
+    const key = repo.fullName.toLowerCase();
+    if (seen.has(key) || exclude.has(key)) continue;
+    if (!hasPositiveMovement(repo)) continue;
+    seen.add(key);
+    candidates.push(repo);
+  }
+
+  const tierA = candidates
+    .filter((r) => (r.channelsFiring ?? 0) >= 2)
+    .sort(byCrossSignal);
+  const tierB = candidates
+    .filter(
+      (r) =>
+        (r.channelsFiring ?? 0) < 2 && TIER_B_STATUSES.has(r.movementStatus),
+    )
+    .sort(byMomentum);
+  const tierC = candidates
+    .filter(
+      (r) =>
+        (r.channelsFiring ?? 0) < 2 &&
+        !TIER_B_STATUSES.has(r.movementStatus) &&
+        !r.starsDelta24hMissing &&
+        (r.starsDelta24h ?? 0) > 0,
+    )
+    .sort(byStarDelta);
+
+  return [...tierA, ...tierB, ...tierC].slice(0, count);
+}

--- a/src/lib/twitter/outbound/select.ts
+++ b/src/lib/twitter/outbound/select.ts
@@ -34,21 +34,41 @@ export interface PickDailyBreakoutsOptions {
   count?: number;
   /** Lowercased fullNames to skip (e.g. featured in the last 7 days). */
   exclude?: ReadonlySet<string>;
+  /**
+   * Which star-delta window drives the floor, Tier C, and tie-breaks.
+   * "24h" (default) for the daily thread; "7d" for the weekly recap.
+   */
+  window?: "24h" | "7d";
+}
+
+export interface RecentlyFeaturedOptions {
+  /** Cooldown window in days. Defaults to FEATURED_COOLDOWN_DAYS. */
+  days?: number;
+  /** Clock override for tests. */
+  now?: Date;
+  /** Restrict to these run kinds; omit to count every run. */
+  kinds?: ReadonlyArray<OutboundRunRecord["kind"]>;
 }
 
 /**
  * Repos featured in recent runs, as a lowercased fullName set. Runs
  * older than `days` (or without a featuredRepos list — pre-upgrade
- * audit rows) are ignored.
+ * audit rows) are ignored. Pass `kinds` to scope the cooldown to
+ * specific run kinds — the daily thread only excludes repos its OWN
+ * past runs featured, so a Friday-recap appearance doesn't knock a
+ * repo out of the next week of dailies.
  */
 export function recentlyFeaturedRepos(
   runs: OutboundRunRecord[],
-  days: number = FEATURED_COOLDOWN_DAYS,
-  now: Date = new Date(),
+  options: RecentlyFeaturedOptions = {},
 ): Set<string> {
+  const days = options.days ?? FEATURED_COOLDOWN_DAYS;
+  const now = options.now ?? new Date();
+  const kinds = options.kinds;
   const cutoff = now.getTime() - days * 24 * 60 * 60 * 1000;
   const featured = new Set<string>();
   for (const run of runs) {
+    if (kinds && !kinds.includes(run.kind)) continue;
     const startedAt = Date.parse(run.startedAt);
     if (!Number.isFinite(startedAt) || startedAt < cutoff) continue;
     for (const fullName of run.featuredRepos ?? []) {
@@ -56,6 +76,18 @@ export function recentlyFeaturedRepos(
     }
   }
   return featured;
+}
+
+type DeltaWindow = NonNullable<PickDailyBreakoutsOptions["window"]>;
+
+function windowDelta(repo: Repo, window: DeltaWindow): number {
+  return (window === "7d" ? repo.starsDelta7d : repo.starsDelta24h) ?? 0;
+}
+
+function windowDeltaMissing(repo: Repo, window: DeltaWindow): boolean {
+  // Only the 24h delta carries a backfill marker today; the 7d delta
+  // comes straight from the deltas snapshot ring.
+  return window === "24h" && repo.starsDelta24hMissing === true;
 }
 
 /**
@@ -70,23 +102,29 @@ function hasPositiveMovement(repo: Repo): boolean {
   return false;
 }
 
-function byCrossSignal(a: Repo, b: Repo): number {
-  const css = (b.crossSignalScore ?? 0) - (a.crossSignalScore ?? 0);
-  if (css !== 0) return css;
-  return byMomentum(a, b);
+function byCrossSignal(window: DeltaWindow) {
+  return (a: Repo, b: Repo): number => {
+    const css = (b.crossSignalScore ?? 0) - (a.crossSignalScore ?? 0);
+    if (css !== 0) return css;
+    return byMomentum(window)(a, b);
+  };
 }
 
-function byMomentum(a: Repo, b: Repo): number {
-  const momentum = (b.momentumScore ?? 0) - (a.momentumScore ?? 0);
-  if (momentum !== 0) return momentum;
-  return byStarDelta(a, b);
+function byMomentum(window: DeltaWindow) {
+  return (a: Repo, b: Repo): number => {
+    const momentum = (b.momentumScore ?? 0) - (a.momentumScore ?? 0);
+    if (momentum !== 0) return momentum;
+    return byStarDelta(window)(a, b);
+  };
 }
 
-function byStarDelta(a: Repo, b: Repo): number {
-  const delta = (b.starsDelta24h ?? 0) - (a.starsDelta24h ?? 0);
-  if (delta !== 0) return delta;
-  // Final stable tiebreak so runs are reproducible for identical data.
-  return a.fullName.localeCompare(b.fullName);
+function byStarDelta(window: DeltaWindow) {
+  return (a: Repo, b: Repo): number => {
+    const delta = windowDelta(b, window) - windowDelta(a, window);
+    if (delta !== 0) return delta;
+    // Final stable tiebreak so runs are reproducible for identical data.
+    return a.fullName.localeCompare(b.fullName);
+  };
 }
 
 const TIER_B_STATUSES: ReadonlySet<Repo["movementStatus"]> = new Set([
@@ -105,6 +143,7 @@ export function pickDailyBreakouts(
 ): Repo[] {
   const count = options.count ?? DAILY_BREAKOUT_COUNT;
   const exclude = options.exclude ?? new Set<string>();
+  const window = options.window ?? "24h";
 
   const seen = new Set<string>();
   const candidates: Repo[] = [];
@@ -119,22 +158,22 @@ export function pickDailyBreakouts(
 
   const tierA = candidates
     .filter((r) => (r.channelsFiring ?? 0) >= 2)
-    .sort(byCrossSignal);
+    .sort(byCrossSignal(window));
   const tierB = candidates
     .filter(
       (r) =>
         (r.channelsFiring ?? 0) < 2 && TIER_B_STATUSES.has(r.movementStatus),
     )
-    .sort(byMomentum);
+    .sort(byMomentum(window));
   const tierC = candidates
     .filter(
       (r) =>
         (r.channelsFiring ?? 0) < 2 &&
         !TIER_B_STATUSES.has(r.movementStatus) &&
-        !r.starsDelta24hMissing &&
-        (r.starsDelta24h ?? 0) > 0,
+        !windowDeltaMissing(r, window) &&
+        windowDelta(r, window) > 0,
     )
-    .sort(byStarDelta);
+    .sort(byStarDelta(window));
 
   return [...tierA, ...tierB, ...tierC].slice(0, count);
 }

--- a/src/lib/twitter/outbound/types.ts
+++ b/src/lib/twitter/outbound/types.ts
@@ -78,4 +78,26 @@ export interface OutboundRunRecord {
   startedAt: string;
   finishedAt: string;
   errorMessage: string | null;
+  /**
+   * fullNames of repos featured in this run. Optional — rows written
+   * before the field existed lack it. The daily selector reads this to
+   * keep a repo from headlining two days in a row.
+   */
+  featuredRepos?: string[];
+}
+
+/**
+ * Bearer-token source for publishing adapters. A static env token
+ * satisfies this trivially; the OAuth2 refresh-rotation manager
+ * implements the full contract. Pure interface (no node:* imports)
+ * per this module's header rule.
+ */
+export interface OutboundTokenProvider {
+  /** Current access token, refreshing first if it's expired/near expiry. */
+  getAccessToken(): Promise<string>;
+  /**
+   * Drop the cached token and force a refresh — called when the API
+   * rejects a token the provider thought was valid (401 mid-thread).
+   */
+  invalidateAndRefresh(): Promise<string>;
 }

--- a/src/lib/twitter/outbound/types.ts
+++ b/src/lib/twitter/outbound/types.ts
@@ -84,6 +84,22 @@ export interface OutboundRunRecord {
    * keep a repo from headlining two days in a row.
    */
   featuredRepos?: string[];
+  /**
+   * The composed thread as it went to the adapter, zipped with the
+   * adapter's per-post outcome. Optional — rows written before the
+   * field existed lack it. This is what makes console/null-mode runs
+   * reviewable: an operator can read exactly what WOULD have been
+   * posted from the audit trail (surfaced via
+   * GET /api/admin/twitter-outbound).
+   */
+  posts?: OutboundRunPost[];
+}
+
+export interface OutboundRunPost {
+  kind: OutboundPostKind;
+  text: string;
+  url: string | null;
+  status: AdapterPostResult["status"];
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -224,6 +224,7 @@ export interface Repo {
     bluesky: boolean;
     devto: boolean;
     twitter: boolean;
+    arxiv: boolean;
   };
 
   /**

--- a/tests/e2e/repo-detail.spec.ts
+++ b/tests/e2e/repo-detail.spec.ts
@@ -31,9 +31,9 @@ test.describe("repo detail", () => {
     await expect(eyebrow).toBeVisible();
     await expect(eyebrow).toContainText(/Repo/i);
     await expect(eyebrow).toContainText(/Rank/i);
-    await expect(eyebrow).toContainText(/\/6 firing/i);
+    await expect(eyebrow).toContainText(/\/7 firing/i);
 
-    await expect(hero.locator(".channel-chip")).toHaveCount(6);
+    await expect(hero.locator(".channel-chip")).toHaveCount(7);
 
     const snapshot = page.locator('section[aria-label="Signal snapshot"]').first();
     await expect(snapshot).toBeVisible();


### PR DESCRIPTION
## Summary

Turns the dormant Twitter outbound path into a real distribution engine and sharpens ranking toward AI repos — the "become the #1 source for trending AI/OSS repos" goal. Four waves, one branch:

1. **Daily X thread, 10 truly-trending repos.** A tiered selector (multi-signal breakouts → flagged movers → raw 24h velocity, quality-floored, deterministic sort, 7-day repeat cooldown) replaces the old hard-capped-at-3, tie-collapsing picker. Every repo item carries its `trendingrepo.com/repo/<owner>/<name>` link.
2. **Reliable publishing.** OAuth2 refresh-token rotation so posting survives the ~2h access-token expiry; a **toolbox-engine adapter** (`TOOLBOX_REACH_URL`) as the end-state VPS transport, switchable by config alone; a 12h **freshness gate** that skips (audited) rather than posting stale data; **reviewable dry-runs** via `GET /api/admin/twitter-outbound`.
3. **Weekly recap parity** on the same selector/gate.
4. **arXiv AI channel** — a 7th cross-signal channel that ranks up repos cited by a recent (<30d) arXiv paper, plus a fix to the arXiv→repo linker that was producing zero links.

A pre-merge adversarial review found 5 defects (1 P1 public-facing count bug + 4 P2); all are fixed with tests in the final commit. Nothing publishes until credentials are provisioned — go-live steps in [`docs/runbooks/twitter-outbound-bringup.md`](docs/runbooks/twitter-outbound-bringup.md); `TWITTER_OUTBOUND_MODE=null` is the kill-switch.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors; no new warnings in changed files)
- [x] `npm test` passes (1417 tests; ~50 new across selection, OAuth rotation, adapters, arXiv channel, linker)
- [x] `npm run lint:guards` clean
- [x] `npm run build` (production `next build`) succeeds — all three new routes compile
- [x] Console-mode e2e on the dev server: POST both cron routes → reviewed the stored 12-post / recap threads via the admin endpoint (10 linked repos, correct order, no repeats); confirmed the freshness gate skips stale data with a reason; confirmed a simulated mid-thread 429 records `featuredRepos` for the repos that posted
- [x] Real-data checks: weekly "breakouts" count now week-scoped (191 corpus → 132 movers); a 120-day arXiv paper leaves the channel dark; daily picks unchanged where arXiv data is stale (no regression)

**Verified vs. infra-blind:** everything above ran locally. Live behavior (actual publishing, the arXiv channel lighting) needs provisioned creds + fresh prod data from `scrape-arxiv.yml` / the HOSTUP worker fleet — verify post-deploy per the runbook.

**Review findings fixed (all with tests):**
- P1 — weekly recap posted a corpus-sized "N breakouts" count into the public tweet; restored the 7d-mover filter.
- P2 — arXiv channel lit forever on an ancient citation; papers now decay off past 90d.
- P2 — OAuth load race exchanged the stale env seed instead of the persisted rotated token; now single-flighted.
- P2 — OAuth 400 (dead refresh token) misclassified as transient; now fatal so retries back off.
- P2 — partial thread (published-then-threw) leaked its repos out of the cooldown; adapters now surface partial results and both routes cool-down the posted repos.

## Checklist

- [x] Branch is up to date with `main` (verified: 0 commits behind `origin/main`, 4 ahead — no rebase needed)
- [x] Conventional-commits style commit messages
- [x] No `console.log` left in production paths (only `console.warn`/`console.error` for operational visibility)
- [x] No `.env*` files committed (added an explicit `.gitignore` for the OAuth token state file — it holds live refresh tokens)
- [x] Workflow touched (`collect-twitter.yml`): `permissions:`, `concurrency:`, and schedule comments present; change is a `timeout 280` wrapper on the collector step
- [x] No new collector added (existing `scrape-arxiv.mjs` linker fix dual-writes as before)
- [x] Documentation updated: new go-live runbook, refreshed `OPERATOR.md`, corrected `ENGINE.md`/`SITE-WIREMAP.md`, HF-deferral note in `SOURCE_DISCOVERY.md`

## Screenshots / output

Composed daily thread (console mode, real data):
```
[intro] 🔥 Top 10 trending repos 2026-07-09 — ranked by stars + social signals. Thread ↓
        https://trendingrepo.com/breakouts
[1/] garrytan/gbrain +92 stars in 24h (4 signals firing) — …   https://trendingrepo.com/repo/garrytan/gbrain
… 10 items, each linked, ordered by cross-signal score …
```
Cron response after the freshness gate (stale bundled data):
```
{"ok":true,"adapter":"console","status":"skipped","skippedReason":"stale-data (trending payload age 1005.5h > 12h)"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dyj1ywJQF3Eiwg8DnZE1BQ