### PR TITLE
fix(funding): reject market-research/earnings headlines as funding deals

### DIFF
--- a/scripts/__tests__/scrape-funding.test.mjs
+++ b/scripts/__tests__/scrape-funding.test.mjs
@@ -7,6 +7,8 @@ import {
   extractCompanyName,
   extractTags,
   extractFunding,
+  isNonFundingHeadline,
+  hasFundingCue,
   parseRssItems,
 } from "../scrape-funding-news.mjs";
 
@@ -155,6 +157,69 @@ describe("extractFunding", () => {
     assert.equal(result?.amount, 7_500_000);
     assert.equal(result?.roundType, "undisclosed");
     assert.equal(result?.confidence, "medium");
+  });
+
+  it("rejects market-research headlines (the /funding false positive)", () => {
+    const result = extractFunding(
+      "Light Field Technology Market to Reach US$ 440.3 Million by 2032, Driven by AI",
+      "New report projects strong CAGR growth.",
+    );
+    assert.equal(result, null);
+  });
+
+  it("rejects earnings / stock-move headlines even with a dollar figure", () => {
+    assert.equal(
+      extractFunding("Nvidia shares surge after $30B quarterly revenue beat", ""),
+      null,
+    );
+    assert.equal(
+      extractFunding("AI chipmaker reports record profit of $2.1 billion", ""),
+      null,
+    );
+  });
+
+  it("rejects an amount + company with no funding cue", () => {
+    // Capitalized phrase + amount but no raise/round/funding verb.
+    assert.equal(
+      extractFunding("OpenAI unveils GPT-6 priced at $200 per month", ""),
+      null,
+    );
+  });
+
+  it("still extracts genuine raises", () => {
+    const seed = extractFunding("Acme lands $4M to build agentic tooling", "");
+    assert.equal(seed?.companyName, "Acme");
+    assert.equal(seed?.amount, 4_000_000);
+    const backed = extractFunding(
+      "Cursor secures $900M Series C backed by Thrive",
+      "",
+    );
+    assert.equal(backed?.roundType, "series-c");
+    assert.equal(backed?.confidence, "high");
+  });
+});
+
+describe("isNonFundingHeadline / hasFundingCue", () => {
+  it("flags market-size, forecast, earnings, and stock headlines", () => {
+    assert.equal(
+      isNonFundingHeadline("Global AI Market Size to Reach $1.3T by 2030"),
+      true,
+    );
+    assert.equal(
+      isNonFundingHeadline("Startup projected to reach $50M ARR next year"),
+      true,
+    );
+    assert.equal(
+      isNonFundingHeadline("Palantir stock jumps 12% on earnings beat"),
+      true,
+    );
+    assert.equal(isNonFundingHeadline("Acme raises $10M Series A"), false);
+  });
+
+  it("requires a real funding cue, not just an amount", () => {
+    assert.equal(hasFundingCue("Acme raises $5M seed round"), true);
+    assert.equal(hasFundingCue("backed by Sequoia"), true);
+    assert.equal(hasFundingCue("worth $440 million by 2032"), false);
   });
 });
 

--- a/scripts/scrape-funding-news.mjs
+++ b/scripts/scrape-funding-news.mjs
@@ -536,13 +536,52 @@ function extractInvestorsFromText(text) {
   return found;
 }
 
+// Non-funding gate + funding-cue detection. Mirror of the same two helpers
+// in src/lib/funding/extract.ts — keep both in sync. Rationale: the amount
+// regex matches dollar figures in market-research ("... Market to Reach US$
+// 440.3 Million by 2032"), earnings, and stock-move headlines, which then
+// pass the naive company+amount => "medium" rule and surface as funding
+// deals. Two guards fix it: reject non-funding headlines outright, and
+// require an explicit funding cue (an amount alone is not a cue).
+const NON_FUNDING_HEADLINE_PATTERNS = [
+  /\bmarket\b[^.]*\b(?:size|share|worth|value|valuation|revenue|outlook|report|analysis|forecast|to\s+reach|to\s+hit|to\s+surpass|to\s+cross|projected|expected|anticipated|estimated|growth)\b/i,
+  /\bCAGR\b/i,
+  /\bto\s+(?:reach|hit|surpass|cross|exceed)\s+(?:US)?\$?\s?[\d.,]+\s*(?:billion|million|trillion|[bmt])\b[^.]*\bby\s+\d{4}\b/i,
+  /\b(?:projected|expected|anticipated|estimated|forecast(?:ed)?|poised|set|slated)\s+to\s+(?:reach|hit|grow|surpass|cross|exceed|witness)\b/i,
+  /\bgrowth\s+(?:rate|forecast|outlook)\b/i,
+  /\b(?:quarterly|annual|Q[1-4])\s+(?:earnings|results|revenue|report)\b/i,
+  /\bearnings\s+(?:report|call|beat|miss|per\s+share)\b/i,
+  /\breports?\s+(?:record\s+)?(?:revenue|earnings|profit|loss)\b/i,
+  /\b(?:shares?|stock)\s+(?:rose|fell|jumps?|jumped|surges?|surged|drops?|dropped|gains?|gained|slumps?|slumped|tumbles?|tumbled|soars?|soared|plunges?|plunged|rally|rallied|climbs?|climbed|slid|sinks?|sank)\b/i,
+  /\bmarket\s+cap(?:italization)?\b/i,
+];
+
+const FUNDING_CUE_PATTERN =
+  /\braises?\b|\braised\b|\braising\b|\bsecures?\b|\bsecured\b|\bcloses?\b|\bclosed\b|\bclosing\b|\blands?\b|\blanded\b|\bnabs?\b|\bnabbed\b|\bbags?\b|\bbagged\b|\bhauls?\b|\bfunding\b|\bfunded\b|\bpre[-\s]?seed\b|\bseed\b|\bseries\s+[a-k]\b|\bround\b|\binvestment\b|\binvests?\b|\binvested\b|\binvesting\b|\bbacked\b|\bbacking\b|\bled\s+by\b|\bventure\b|\bcapital\s+raise\b|\bfinancing\b|\bacquires?\b|\bacquired\b|\bacquisition\b/i;
+
+function isNonFundingHeadline(headline) {
+  return NON_FUNDING_HEADLINE_PATTERNS.some((re) => re.test(headline));
+}
+
+function hasFundingCue(text) {
+  return FUNDING_CUE_PATTERN.test(text);
+}
+
 function extractFunding(headline, description) {
   const combined = `${headline} ${description}`;
+
+  // Reject market-research / earnings / stock-move headlines outright.
+  if (isNonFundingHeadline(headline)) return null;
+
   const companyName = extractCompanyName(headline);
   const amount = extractAmount(combined);
   const roundType = extractRoundType(combined);
 
   if (!companyName && !amount && !roundType) return null;
+
+  // Require an explicit funding cue when there's no round type — an amount
+  // alone (million/billion) is not a funding signal.
+  if (roundType === null && !hasFundingCue(combined)) return null;
 
   let confidence = "none";
   if (companyName && amount && roundType) confidence = "high";
@@ -933,5 +972,7 @@ export {
   extractCompanyName,
   extractTags,
   extractFunding,
+  isNonFundingHeadline,
+  hasFundingCue,
   parseRssItems,
 };

--- a/src/lib/funding-news.ts
+++ b/src/lib/funding-news.ts
@@ -18,7 +18,7 @@ import { readFileSync, statSync } from "fs";
 import { resolve } from "path";
 
 import type { FundingNewsFile, FundingSignal, FundingStats } from "./funding/types";
-import { buildFundingStats } from "./funding/extract";
+import { buildFundingStats, isNonFundingHeadline } from "./funding/extract";
 const FUNDING_NEWS_PATH = resolve(process.cwd(), "data", "funding-news.json");
 const EPOCH_ZERO = "1970-01-01T00:00:00.000Z";
 
@@ -47,6 +47,25 @@ function getFileSignature(path: string): string {
   }
 }
 
+// Read-time defensive guard: declassify signals whose headline is a
+// market-research / earnings / stock-move story. The scraper's extractFunding
+// now rejects these at the source, but already-scraped payloads in Redis /
+// the bundled seed can still carry a non-funding headline with a populated
+// `extracted` block (that's how a market-size report became a top mover on
+// /funding). Null out `extracted` so those signals drop from every
+// funding-deal surface immediately, without waiting for a re-scrape.
+function declassifyNonFunding(signals: FundingSignal[]): FundingSignal[] {
+  let changed = false;
+  const cleaned = signals.map((s) => {
+    if (s.extracted && isNonFundingHeadline(s.headline)) {
+      changed = true;
+      return { ...s, extracted: null };
+    }
+    return s;
+  });
+  return changed ? cleaned : signals;
+}
+
 function normalizeFile(input: unknown): FundingNewsFile {
   if (!input || typeof input !== "object") {
     return createFallbackFile();
@@ -62,7 +81,9 @@ function normalizeFile(input: unknown): FundingNewsFile {
       typeof file.windowDays === "number" && Number.isFinite(file.windowDays)
         ? file.windowDays
         : 7,
-    signals: Array.isArray(file.signals) ? (file.signals as FundingSignal[]) : [],
+    signals: Array.isArray(file.signals)
+      ? declassifyNonFunding(file.signals as FundingSignal[])
+      : [],
   };
 }
 

--- a/src/lib/funding/__tests__/extract.test.ts
+++ b/src/lib/funding/__tests__/extract.test.ts
@@ -1,0 +1,77 @@
+// Vitest coverage for the funding-headline gate in src/lib/funding/extract.ts.
+//
+// Focus: the non-funding guard + funding-cue requirement that stops market-
+// research / earnings / stock headlines (with incidental dollar figures) from
+// being mislabeled as funding deals. Mirrors the scraper-side coverage in
+// scripts/__tests__/scrape-funding.test.mjs.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  extractFundingFromHeadline,
+  hasFundingCue,
+  isNonFundingHeadline,
+} from "../extract";
+
+describe("isNonFundingHeadline", () => {
+  it("flags market-size / forecast / CAGR reports", () => {
+    expect(
+      isNonFundingHeadline(
+        "Light Field Technology Market to Reach US$ 440.3 Million by 2032",
+      ),
+    ).toBe(true);
+    expect(isNonFundingHeadline("Global AI Market Size to Reach $1.3T by 2030")).toBe(true);
+    expect(isNonFundingHeadline("Report projects 24% CAGR for agent tooling")).toBe(true);
+  });
+
+  it("flags earnings and stock-move headlines", () => {
+    expect(isNonFundingHeadline("Nvidia shares surge on quarterly earnings beat")).toBe(true);
+    expect(isNonFundingHeadline("AI chipmaker reports record revenue")).toBe(true);
+  });
+
+  it("does not flag genuine funding headlines", () => {
+    expect(isNonFundingHeadline("Anthropic raises $450M in Series C funding")).toBe(false);
+    expect(isNonFundingHeadline("Cursor secures $900M backed by Thrive")).toBe(false);
+  });
+});
+
+describe("hasFundingCue", () => {
+  it("true for funding verbs/nouns", () => {
+    expect(hasFundingCue("Acme raises $5M seed round")).toBe(true);
+    expect(hasFundingCue("startup backed by a16z")).toBe(true);
+    expect(hasFundingCue("closes Series B led by Index")).toBe(true);
+  });
+
+  it("false when only an amount is present", () => {
+    expect(hasFundingCue("valued at $440 million by 2032")).toBe(false);
+    expect(hasFundingCue("priced at $200 per month")).toBe(false);
+  });
+});
+
+describe("extractFundingFromHeadline gate", () => {
+  it("returns null for the market-research false positive", () => {
+    expect(
+      extractFundingFromHeadline(
+        "Light Field Technology Market to Reach US$ 440.3 Million by 2032, Driven by AI",
+        "New report forecasts strong CAGR.",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for an amount + company with no funding cue", () => {
+    expect(
+      extractFundingFromHeadline("OpenAI unveils GPT-6 priced at $200 per month", ""),
+    ).toBeNull();
+  });
+
+  it("still extracts genuine raises", () => {
+    const r = extractFundingFromHeadline(
+      "Anthropic raises $450M in Series C funding",
+      "",
+    );
+    expect(r?.companyName).toBe("Anthropic");
+    expect(r?.amount).toBe(450_000_000);
+    expect(r?.roundType).toBe("series-c");
+    expect(r?.confidence).toBe("high");
+  });
+});

--- a/src/lib/funding/extract.ts
+++ b/src/lib/funding/extract.ts
@@ -190,6 +190,55 @@ export function extractRoundType(text: string): FundingRoundType | null {
 }
 
 // ---------------------------------------------------------------------------
+// Non-funding gate + funding-cue detection
+// ---------------------------------------------------------------------------
+//
+// The AMOUNT_PATTERN happily matches dollar figures in market-research
+// ("Light Field Technology Market to Reach US$ 440.3 Million by 2032"),
+// earnings, and stock-move headlines. Those carry a capitalized phrase +
+// an amount, so the naive company+amount => "medium" rule mislabels them as
+// funding deals — one such headline was the top mover on /funding. Two
+// guards fix this at the root:
+//   1. isNonFundingHeadline() rejects market-size / forecast / CAGR /
+//      earnings / stock-move headlines outright.
+//   2. hasFundingCue() requires an actual funding verb/noun (raise, secure,
+//      round, seed, series, backed-by, led-by, invest, acquire, ...). An
+//      amount alone (million/billion) is NOT a cue.
+//
+// Mirror of the same two helpers in scripts/scrape-funding-news.mjs — keep
+// both in sync (the scraper is the producer, this is the read-time guard).
+
+const NON_FUNDING_HEADLINE_PATTERNS: RegExp[] = [
+  // Market-research / forecast reports: "... Market to Reach US$ X by 2032",
+  // "Market Size", "Market Share", CAGR, growth-rate outlooks.
+  /\bmarket\b[^.]*\b(?:size|share|worth|value|valuation|revenue|outlook|report|analysis|forecast|to\s+reach|to\s+hit|to\s+surpass|to\s+cross|projected|expected|anticipated|estimated|growth)\b/i,
+  /\bCAGR\b/i,
+  /\bto\s+(?:reach|hit|surpass|cross|exceed)\s+(?:US)?\$?\s?[\d.,]+\s*(?:billion|million|trillion|[bmt])\b[^.]*\bby\s+\d{4}\b/i,
+  /\b(?:projected|expected|anticipated|estimated|forecast(?:ed)?|poised|set|slated)\s+to\s+(?:reach|hit|grow|surpass|cross|exceed|witness)\b/i,
+  /\bgrowth\s+(?:rate|forecast|outlook)\b/i,
+  // Earnings / financial results.
+  /\b(?:quarterly|annual|Q[1-4])\s+(?:earnings|results|revenue|report)\b/i,
+  /\bearnings\s+(?:report|call|beat|miss|per\s+share)\b/i,
+  /\breports?\s+(?:record\s+)?(?:revenue|earnings|profit|loss)\b/i,
+  // Public-market / stock moves.
+  /\b(?:shares?|stock)\s+(?:rose|fell|jumps?|jumped|surges?|surged|drops?|dropped|gains?|gained|slumps?|slumped|tumbles?|tumbled|soars?|soared|plunges?|plunged|rally|rallied|climbs?|climbed|slid|sinks?|sank)\b/i,
+  /\bmarket\s+cap(?:italization)?\b/i,
+];
+
+const FUNDING_CUE_PATTERN =
+  /\braises?\b|\braised\b|\braising\b|\bsecures?\b|\bsecured\b|\bcloses?\b|\bclosed\b|\bclosing\b|\blands?\b|\blanded\b|\bnabs?\b|\bnabbed\b|\bbags?\b|\bbagged\b|\bhauls?\b|\bfunding\b|\bfunded\b|\bpre[-\s]?seed\b|\bseed\b|\bseries\s+[a-k]\b|\bround\b|\binvestment\b|\binvests?\b|\binvested\b|\binvesting\b|\bbacked\b|\bbacking\b|\bled\s+by\b|\bventure\b|\bcapital\s+raise\b|\bfinancing\b|\bacquires?\b|\bacquired\b|\bacquisition\b/i;
+
+/** True when the headline is a market-research / earnings / stock story, not a raise. */
+export function isNonFundingHeadline(headline: string): boolean {
+  return NON_FUNDING_HEADLINE_PATTERNS.some((re) => re.test(headline));
+}
+
+/** True when the text carries an explicit funding cue (verb/noun, not just an amount). */
+export function hasFundingCue(text: string): boolean {
+  return FUNDING_CUE_PATTERN.test(text);
+}
+
+// ---------------------------------------------------------------------------
 // Company name extraction
 // ---------------------------------------------------------------------------
 
@@ -375,11 +424,25 @@ export function extractFundingFromHeadline(
 ): FundingExtraction | null {
   const combined = `${headline} ${description}`;
 
+  // Reject market-research / earnings / stock-move headlines outright — their
+  // dollar figures are market sizes or share prices, never a raise.
+  if (isNonFundingHeadline(headline)) {
+    return null;
+  }
+
   const companyName = extractCompanyName(headline);
   const amount = extractAmount(combined);
   const roundType = extractRoundType(combined);
 
   if (!companyName && !amount && !roundType) {
+    return null;
+  }
+
+  // A real funding story carries a funding cue. A round type already implies
+  // one; otherwise require an explicit verb/noun (raise/secure/round/seed/
+  // backed-by/...). An amount alone (million/billion) is not a cue — that's
+  // what let market-size headlines through as "medium" confidence.
+  if (roundType === null && !hasFundingCue(combined)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

The `/funding` amount regex matched dollar figures in market-size reports, earnings, and stock-move headlines. Combined with a capitalized phrase, the naive `company + amount => "medium"` rule mislabeled them as funding deals — a market-research headline ("Light Field Technology Market to Reach US$ 440.3 Million by 2032") had surfaced as the **top mover** on `/funding`. This adds two precision guards (mirrored in the scraper producer and the TS extractor) plus a read-time defensive guard so already-scraped bad data is cleaned immediately.

## What changed

- **`isNonFundingHeadline()`** — rejects market-size / forecast / CAGR / earnings / stock-move headlines outright.
- **`hasFundingCue()`** — requires an explicit funding verb/noun (raise, secure, close, round, seed, series, backed-by, led-by, invest, acquire). An amount alone (`million`/`billion`) is no longer a cue — the exact hole that let market-size headlines through.
- Both wired into `extractFunding` (scraper) and `extractFundingFromHeadline` (TS): non-funding headline → `null`; no round-type **and** no cue → `null`.
- **Read-time guard** in `src/lib/funding-news.ts`: `normalizeFile` now declassifies (`extracted -> null`) signals whose headline is non-funding, so payloads already in Redis / the bundled seed drop off funding-deal surfaces on read, without waiting for a re-scrape.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run lint:guards` clean
- [x] `npm test` — 1433 node:test pass (incl. new scraper cases)
- [x] `npm run test:hooks` — 347 vitest pass (incl. new `src/lib/funding/__tests__/extract.test.ts`)
- [x] `npm run build` — production `next build` exits 0
- [x] Verified against live `data/funding-news.json` (50 signals): **2** false-positive "deals" declassified (the Light Field market report + a national fund launch that had surfaced with `companyName: "UK"`), **48** genuine raises unaffected.

New tests cover: the Light Field false positive → `null`, earnings/stock headlines with dollar figures → `null`, an amount + company with no funding cue → `null`, and that genuine raises (e.g. "Anthropic raises $450M in Series C") still extract at `high` confidence.

## Checklist

- [x] Branch is up to date with `main` (branched from latest `origin/main`)
- [x] Conventional-commits style commit message
- [x] No `console.log` left in production paths (`src/`)
- [x] No `.env*` files committed
- [ ] No workflow touched
- [ ] No new collector added (existing scraper hardened)
- [x] Behavior change is code-internal; inline docs/comments updated in both mirrored implementations

## Notes

The two mirrored predicate blocks (scraper `.mjs` + TS `extract.ts`) follow the existing "keep both regexes in sync" convention already used for the low-quality `badNames` filter in this codebase. The "UK Launches $675M Fund" declassification is a deliberate, conservative trade-off: it was rendering as company "UK" (a garbage card), so dropping it is a net precision win rather than a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dyj1ywJQF3Eiwg8DnZE1BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyj1ywJQF3Eiwg8DnZE1BQ)_