### PR TITLE
Repair schema-invalid consensus reports

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/__tests__/empty-publish-guards.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/__tests__/empty-publish-guards.test.ts
@@ -233,6 +233,172 @@ describe('worker fetcher empty publish guards', () => {
     expect(result.errors.some((error) => error.stage === 'empty-verdicts')).toBe(true);
   });
 
+  it('consensus-analyst normalizes partial model output and publishes a healthy merge', async () => {
+    callLlmMock
+      .mockResolvedValueOnce({
+        text: '{"tagline":null,"verdict":"strong_consensus"}',
+        usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 0 },
+        meta: { provider: 'nanogpt', model: 'moonshotai/kimi-k2.6' },
+      })
+      .mockResolvedValueOnce({
+        text: '{"headline":"Today in repos","bullets":["One","Two"]}',
+        usage: { inputTokens: 4, outputTokens: 2, cachedInputTokens: 0 },
+        meta: { provider: 'nanogpt', model: 'moonshotai/kimi-k2.6' },
+      });
+    readDataStoreMock.mockImplementation(async (key: string) => {
+      if (key === 'consensus-trending') {
+        const absent = { present: false, rank: null, score: null, normalized: 0 };
+        return {
+          itemCount: 1,
+          bandCounts: {
+            strong_consensus: 1,
+            early_call: 0,
+            divergence: 0,
+            external_only: 0,
+            single_source: 0,
+          },
+          sourceStats: {},
+          weights: {},
+          items: [
+            {
+              fullName: 'owner/repo',
+              rank: 1,
+              consensusScore: 90,
+              sourceCount: 1,
+              confidence: 90,
+              externalRank: 1,
+              oursRank: 1,
+              verdict: 'strong_consensus',
+              maxRankGap: 0,
+              sources: {
+                ours: { present: true, rank: 1, score: 90, normalized: 0.9 },
+                gh: { present: true, rank: 1, score: 90, normalized: 0.9 },
+                hf: absent,
+                hn: absent,
+                x: absent,
+                r: absent,
+                pdh: absent,
+                dev: absent,
+                bs: absent,
+              },
+            },
+          ],
+        };
+      }
+      if (key === 'consensus-verdicts') {
+        return {
+          items: {
+            'old/repo': {
+              fullName: 'old/repo',
+              summary: 'old',
+            },
+          },
+        };
+      }
+      return null;
+    });
+    const { default: fetcher } = await import('../consensus-analyst/index.js');
+
+    const result = await fetcher.run(makeContext());
+
+    expect(callLlmMock.mock.calls[0]).toHaveLength(2);
+    expect(callLlmMock.mock.calls[1]).toHaveLength(2);
+    expect(writeDataStoreMock).toHaveBeenCalledWith(
+      'consensus-verdicts',
+      expect.objectContaining({
+        status: 'ok',
+        items: expect.objectContaining({
+          'old/repo': expect.any(Object),
+          'owner/repo': expect.objectContaining({
+            summary: expect.stringContaining('owner/repo'),
+            verdict: 'strong',
+          }),
+        }),
+      }),
+    );
+    expect(result.redisPublished).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('consensus-analyst-tail normalizes a partial tail item instead of dropping it', async () => {
+    callLlmMock.mockResolvedValue({
+      text: 'null',
+      usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 0 },
+      meta: { provider: 'nanogpt', model: 'moonshotai/kimi-k2.6' },
+    });
+    const absent = { present: false, rank: null, score: null, normalized: 0 };
+    const items = Array.from({ length: 31 }, (_, index) => ({
+      fullName: index === 30 ? 'owner/tail-repo' : `owner/repo-${index}`,
+      rank: index + 1,
+      consensusScore: 70,
+      sourceCount: 1,
+      confidence: 65,
+      externalRank: index + 1,
+      oursRank: index + 1,
+      verdict: 'early_call' as const,
+      maxRankGap: 0,
+      sources: {
+        ours: { present: true, rank: index + 1, score: 70, normalized: 0.7 },
+        gh: { present: true, rank: index + 1, score: 70, normalized: 0.7 },
+        hf: absent,
+        hn: absent,
+        x: absent,
+        r: absent,
+        pdh: absent,
+        dev: absent,
+        bs: absent,
+      },
+    }));
+    readDataStoreMock.mockImplementation(async (key: string) => {
+      if (key === 'consensus-trending') {
+        return {
+          itemCount: items.length,
+          bandCounts: {
+            strong_consensus: 0,
+            early_call: items.length,
+            divergence: 0,
+            external_only: 0,
+            single_source: 0,
+          },
+          sourceStats: {},
+          weights: {},
+          items,
+        };
+      }
+      if (key === 'consensus-verdicts') {
+        return {
+          generator: 'kimi',
+          ribbon: { headline: 'Existing', bullets: ['One', 'Two'] },
+          items: {},
+          usage: {
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCachedInputTokens: 0,
+          },
+        };
+      }
+      return null;
+    });
+    const { default: fetcher } = await import('../consensus-analyst-tail/index.js');
+
+    const result = await fetcher.run(makeContext());
+
+    expect(callLlmMock.mock.calls[0]).toHaveLength(2);
+    expect(writeDataStoreMock).toHaveBeenCalledWith(
+      'consensus-verdicts',
+      expect.objectContaining({
+        generator: 'template',
+        items: {
+          'owner/tail-repo': expect.objectContaining({
+            verdict: 'early',
+            summary: expect.stringContaining('owner/tail-repo'),
+          }),
+        },
+      }),
+    );
+    expect(result.redisPublished).toBe(true);
+  });
+
   it('funding-news preserves the prior slug when every RSS feed fails', async () => {
     fetchWithTimeoutMock.mockRejectedValue(new Error('rss unavailable'));
     const { default: fetcher } = await import('../funding-news/index.js');

--- a/apps/trendingrepo-worker/src/fetchers/consensus-analyst-tail/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/consensus-analyst-tail/index.ts
@@ -45,6 +45,7 @@ import {
   ItemReportSchema,
   SYSTEM_PROMPT,
   buildItemUserMessage,
+  normalizeItemReport,
   type AnalystUserMessageContext,
   type ItemReport,
 } from '../consensus-analyst/prompt.js';
@@ -144,6 +145,7 @@ const fetcher: Fetcher = {
     let totalCached = 0;
     let usedProvider: LlmProvider | undefined;
     let usedModel: string | undefined;
+    let repairedItems = 0;
 
     const queue: ConsensusItem[] = [...candidates];
     const sweepItem = async (): Promise<void> => {
@@ -167,7 +169,6 @@ const fetcher: Fetcher = {
               task_type: 'item',
               request_id: randomUUID(),
             },
-            (text) => ItemReportSchema.safeParse(parseJson(text)).success,
           );
           usedProvider = r.meta.provider;
           usedModel = r.meta.model;
@@ -178,16 +179,19 @@ const fetcher: Fetcher = {
           const parsed = parseJson(r.text);
           const validated = ItemReportSchema.safeParse(parsed);
           if (!validated.success) {
+            repairedItems += 1;
             ctx.log.warn(
               {
                 fullName: item.fullName,
                 issues: validated.error.issues.slice(0, 3),
               },
-              'consensus-analyst-tail: item report failed schema validation',
+              'consensus-analyst-tail: repaired item report with deterministic consensus facts',
             );
-            continue;
           }
-          items[item.fullName] = { fullName: item.fullName, ...validated.data };
+          items[item.fullName] = {
+            fullName: item.fullName,
+            ...normalizeItemReport(parsed, item),
+          };
         } catch (err) {
           ctx.log.warn(
             {
@@ -220,10 +224,13 @@ const fetcher: Fetcher = {
     const latestExisting = await loadExistingItems();
     const latestPayload = await readDataStore<VerdictsPayload>('consensus-verdicts');
     const mergedItems = { ...latestExisting, ...items };
+    const generator = repairedItems === freshCount
+      ? 'template'
+      : (usedProvider ?? getLlmProvider());
     const payload: VerdictsPayload = {
       computedAt: new Date().toISOString(),
-      generator: usedProvider ?? getLlmProvider(),
-      model: usedModel,
+      generator,
+      ...(generator !== 'template' && usedModel ? { model: usedModel } : {}),
       // Preserve the latest ribbon/usage from the existing payload — the tail
       // fetcher's job is item-coverage only, not ribbon regeneration.
       ribbon: latestPayload?.ribbon ?? {
@@ -244,6 +251,7 @@ const fetcher: Fetcher = {
     ctx.log.info(
       {
         freshThisRun: freshCount,
+        repairedItems,
         candidates: candidates.length,
         totalRetained: Object.keys(mergedItems).length,
         usage: { totalInput, totalOutput, totalCached },

--- a/apps/trendingrepo-worker/src/fetchers/consensus-analyst/__tests__/prompt.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/consensus-analyst/__tests__/prompt.test.ts
@@ -5,6 +5,7 @@ import {
   ItemReportSchema,
   buildCitationCandidates,
   buildItemUserMessage,
+  normalizeItemReport,
 } from '../prompt.js';
 import type {
   ConsensusItem,
@@ -147,21 +148,21 @@ describe('ItemReportSchema (rolling-deploy compat)', () => {
   // dropped entirely. Verdict + scores stay strict — those must be present
   // for the ranking to be honest.
   it('defaults evidence to [] when omitted (Wave B lenience)', () => {
-    const { evidence: _omit, ...minusEvidence } = baseValid;
+    const minusEvidence = { ...baseValid, evidence: undefined };
     const r = ItemReportSchema.safeParse(minusEvidence);
     expect(r.success).toBe(true);
     if (r.success) expect(r.data.evidence).toEqual([]);
   });
 
   it('defaults contrarian to "" when omitted (Wave B lenience)', () => {
-    const { contrarian: _omit, ...minusContrarian } = baseValid;
+    const minusContrarian = { ...baseValid, contrarian: undefined };
     const r = ItemReportSchema.safeParse(minusContrarian);
     expect(r.success).toBe(true);
     if (r.success) expect(r.data.contrarian).toBe('');
   });
 
   it('still rejects when verdict is missing — verdict integrity is load-bearing for ranking', () => {
-    const { verdict: _omit, ...minusVerdict } = baseValid;
+    const minusVerdict = { ...baseValid, verdict: undefined };
     expect(ItemReportSchema.safeParse(minusVerdict).success).toBe(false);
   });
 
@@ -169,6 +170,85 @@ describe('ItemReportSchema (rolling-deploy compat)', () => {
     expect(
       ItemReportSchema.safeParse({ ...baseValid, verdict: 'maybe' }).success,
     ).toBe(false);
+  });
+});
+
+describe('normalizeItemReport', () => {
+  it('repairs the partial and null response shape observed in production', () => {
+    const item = makeItem('owner/repo', { gh: 2, hn: 4, dev: 8 });
+
+    const report = normalizeItemReport(
+      {
+        tagline: null,
+        summary: undefined,
+        scores: undefined,
+        evidence: null,
+        contrarian: null,
+        verdict: 'strong_consensus',
+      },
+      item,
+    );
+
+    expect(ItemReportSchema.safeParse(report).success).toBe(true);
+    expect(report.summary).toContain('owner/repo');
+    expect(report.scores).toEqual({
+      momentum: 75,
+      credibility: 80,
+      crossSource: 38,
+      developerAdoption: 98,
+      marketRelevance: 78,
+      hypeRisk: 20,
+    });
+    expect(report.verdict).toBe('strong');
+    expect(report.evidence).toEqual([]);
+    expect(report.contrarian).toBe('');
+  });
+
+  it('clamps optional text and rejects citations outside the item allowlist', () => {
+    const item = makeItem('owner/repo', { gh: 1, hn: 5 });
+    const allowed = buildCitationCandidates(item)[0]!;
+
+    const report = normalizeItemReport(
+      {
+        tagline: `  ${'x'.repeat(170)}  `,
+        summary: 'Valid model summary',
+        scores: {
+          momentum: 10,
+          credibility: 20,
+          crossSource: 30,
+          developerAdoption: 40,
+          marketRelevance: 50,
+          hypeRisk: 60,
+        },
+        evidence: ['signal', null, 3],
+        contrarian: 'risk',
+        verdict: 'early',
+        confidence: 70,
+        whyNow: 'today',
+        whatToDo: 'watch',
+        whatToDoDetail: 'monitor it',
+        citations: [
+          allowed,
+          { title: 'Untrusted', url: 'https://attacker.example/report' },
+        ],
+      },
+      item,
+    );
+
+    expect(report.tagline).toHaveLength(160);
+    expect(report.evidence).toEqual(['signal']);
+    expect(report.citations).toEqual([allowed]);
+    expect(report.summary).toBe('Valid model summary');
+    expect(report.scores.momentum).toBe(10);
+  });
+
+  it('maps an invalid model verdict from the authoritative consensus band', () => {
+    const item = { ...makeItem('owner/repo', { gh: 1 }), verdict: 'early_call' as const };
+    const report = normalizeItemReport({ verdict: 'maybe' }, item);
+
+    expect(report.verdict).toBe('early');
+    expect(report.whatToDo).toBe('watch');
+    expect(ItemReportSchema.safeParse(report).success).toBe(true);
   });
 });
 
@@ -211,6 +291,16 @@ describe('buildCitationCandidates', () => {
     const item = makeItem('owner/repo with spaces', { hn: 1 });
     const candidates = buildCitationCandidates(item);
     expect(candidates[0]?.url).toContain('owner%2Frepo%20with%20spaces');
+  });
+
+  it('clamps canonical citation titles before strict normalization', () => {
+    const fullName = `${'owner'.repeat(15)}/${'repo'.repeat(30)}`;
+    const item = makeItem(fullName, { gh: 1 });
+    const candidate = buildCitationCandidates(item)[0]!;
+
+    expect(candidate.title.length).toBeLessThanOrEqual(80);
+    expect(CitationSchema.safeParse(candidate).success).toBe(true);
+    expect(normalizeItemReport({ citations: [candidate] }, item).citations).toEqual([candidate]);
   });
 
   it('returns empty array when no external sources are present', () => {

--- a/apps/trendingrepo-worker/src/fetchers/consensus-analyst/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/consensus-analyst/index.ts
@@ -11,6 +11,7 @@ import {
   RIBBON_SYSTEM_PROMPT,
   buildItemUserMessage,
   buildRibbonUserMessage,
+  normalizeItemReport,
   type AnalystUserMessageContext,
   type ItemReport,
   type Ribbon,
@@ -112,6 +113,7 @@ const fetcher: Fetcher = {
     // result meta so a NanoGPT-fallback run reports honestly (not 'kimi').
     let usedProvider: LlmProvider | undefined;
     let usedModel: string | undefined;
+    let repairedItems = 0;
     const errors: RunResult['errors'] = [];
 
     // Bounded-concurrency sweep — N workers pulling from a shared queue.
@@ -134,7 +136,6 @@ const fetcher: Fetcher = {
               jsonMode: true,
             },
             { feature: 'ai_analyst', task_type: 'item', request_id: randomUUID() },
-            (text) => ItemReportSchema.safeParse(parseJson(text)).success,
           );
           usedProvider = r.meta.provider;
           usedModel = r.meta.model;
@@ -145,22 +146,16 @@ const fetcher: Fetcher = {
           const parsed = parseJson(r.text);
           const validated = ItemReportSchema.safeParse(parsed);
           if (!validated.success) {
+            repairedItems += 1;
             ctx.log.warn(
               { fullName: item.fullName, issues: validated.error.issues.slice(0, 3) },
-              'consensus-analyst: item report failed schema validation',
+              'consensus-analyst: repaired item report with deterministic consensus facts',
             );
-            errors.push({
-              stage: 'item-schema',
-              itemSourceId: item.fullName,
-              message:
-                validated.error.issues
-                  .slice(0, 3)
-                  .map((issue) => issue.message)
-                  .join('; ') || 'item report failed schema validation',
-            });
-            continue;
           }
-          items[item.fullName] = { fullName: item.fullName, ...validated.data };
+          items[item.fullName] = {
+            fullName: item.fullName,
+            ...normalizeItemReport(parsed, item),
+          };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           ctx.log.warn(
@@ -186,7 +181,6 @@ const fetcher: Fetcher = {
           jsonMode: true,
         },
         { feature: 'ai_analyst', task_type: 'ribbon', request_id: randomUUID() },
-        (text) => RibbonSchema.safeParse(parseJson(text)).success,
       );
       usedProvider = r.meta.provider;
       usedModel = r.meta.model;
@@ -199,14 +193,6 @@ const fetcher: Fetcher = {
         ribbon = validated.data;
       } else {
         ctx.log.warn({ issues: validated.error.issues.slice(0, 3) }, 'consensus-analyst: ribbon schema invalid');
-        errors.push({
-          stage: 'ribbon-schema',
-          message:
-            validated.error.issues
-              .slice(0, 3)
-              .map((issue) => issue.message)
-              .join('; ') || 'ribbon schema invalid',
-        });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -233,6 +219,9 @@ const fetcher: Fetcher = {
       ]);
     }
     const mergedItems = { ...existingItems, ...items };
+    const generator = freshCount > 0 && repairedItems === freshCount
+      ? 'template'
+      : (usedProvider ?? getLlmProvider());
     const payload: VerdictsPayload = {
       computedAt: new Date().toISOString(),
       status: errors.length > 0 ? 'degraded' : 'ok',
@@ -240,8 +229,8 @@ const fetcher: Fetcher = {
       // Honestly report which provider actually produced this run (e.g.
       // 'nanogpt' while Kimi-for-coding billing is restored). Falls back to the
       // configured primary when no call succeeded this run.
-      generator: usedProvider ?? getLlmProvider(),
-      model: usedModel,
+      generator,
+      ...(generator !== 'template' && usedModel ? { model: usedModel } : {}),
       ribbon,
       items: mergedItems,
       usage: {
@@ -255,6 +244,7 @@ const fetcher: Fetcher = {
     ctx.log.info(
       {
         freshThisRun: freshCount,
+        repairedItems,
         totalRetained: Object.keys(mergedItems).length,
         ribbonBullets: ribbon.bullets.length,
         usage: payload.usage,

--- a/apps/trendingrepo-worker/src/fetchers/consensus-analyst/prompt.ts
+++ b/apps/trendingrepo-worker/src/fetchers/consensus-analyst/prompt.ts
@@ -238,7 +238,98 @@ export function buildCitationCandidates(item: ConsensusItem): Citation[] {
     });
   }
   candidates.sort((a, b) => a.sortKey - b.sortKey);
-  return candidates.map(({ title, url }) => ({ title, url }));
+  return candidates.map(({ title, url }) => ({ title: title.slice(0, 80), url }));
+}
+
+/**
+ * Convert unreliable model JSON into the strict report contract using only
+ * facts already present in the consensus item. Model prose wins when valid;
+ * missing load-bearing fields get deterministic, non-hallucinated defaults.
+ */
+export function normalizeItemReport(raw: unknown, item: ConsensusItem): ItemReport {
+  const input = isRecord(raw) ? raw : {};
+  const rawScores = isRecord(input.scores) ? input.scores : {};
+  const derivedScores = {
+    momentum: score(item.consensusScore),
+    credibility: score(item.confidence),
+    crossSource: score((item.sourceCount / 8) * 100),
+    developerAdoption: score(item.sources.gh.normalized * 100),
+    marketRelevance: score((item.consensusScore + item.confidence) / 2),
+    hypeRisk: score(100 - item.confidence),
+  };
+  const verdict = isVerdict(input.verdict)
+    ? input.verdict
+    : item.verdict === 'strong_consensus'
+      ? 'strong'
+      : item.verdict === 'early_call'
+        ? 'early'
+        : 'weak';
+  const fallbackAction = verdict === 'strong' || verdict === 'early' ? 'watch' : 'research';
+  const tagline = cleanString(input.tagline)?.slice(0, 160);
+  const allowedCitations = new Map(buildCitationCandidates(item).map((citation) => [citation.url, citation]));
+  const citations = Array.isArray(input.citations)
+    ? input.citations
+        .map((citation) => (isRecord(citation) && typeof citation.url === 'string'
+          ? allowedCitations.get(citation.url)
+          : undefined))
+        .filter((citation): citation is Citation => Boolean(citation))
+        .slice(0, 8)
+    : [];
+
+  return ItemReportSchema.parse({
+    ...(tagline ? { tagline } : {}),
+    summary:
+      cleanString(input.summary) ??
+      `${item.fullName} ranks #${item.rank} with ${item.sourceCount}-source confirmation and a consensus score of ${score(item.consensusScore)}.`,
+    scores: {
+      momentum: score(rawScores.momentum, derivedScores.momentum),
+      credibility: score(rawScores.credibility, derivedScores.credibility),
+      crossSource: score(rawScores.crossSource, derivedScores.crossSource),
+      developerAdoption: score(rawScores.developerAdoption, derivedScores.developerAdoption),
+      marketRelevance: score(rawScores.marketRelevance, derivedScores.marketRelevance),
+      hypeRisk: score(rawScores.hypeRisk, derivedScores.hypeRisk),
+    },
+    evidence: Array.isArray(input.evidence)
+      ? input.evidence
+          .map(cleanString)
+          .filter((value): value is string => Boolean(value))
+          .slice(0, 8)
+      : [],
+    contrarian: cleanString(input.contrarian) ?? '',
+    verdict,
+    confidence: score(input.confidence, item.confidence),
+    whyNow:
+      cleanString(input.whyNow) ??
+      `${item.fullName} is currently ranked #${item.rank} across ${item.sourceCount} external sources.`,
+    whatToDo: isAction(input.whatToDo) ? input.whatToDo : fallbackAction,
+    whatToDoDetail:
+      cleanString(input.whatToDoDetail) ??
+      'Review the current source mix and rank movement before acting.',
+    ...(citations.length > 0 ? { citations } : {}),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const cleaned = value.trim();
+  return cleaned || undefined;
+}
+
+function score(value: unknown, fallback = 0): number {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  return Math.round(Math.max(0, Math.min(100, numeric)));
+}
+
+function isVerdict(value: unknown): value is ItemReport['verdict'] {
+  return value === 'strong' || value === 'early' || value === 'weak' || value === 'noise';
+}
+
+function isAction(value: unknown): value is ItemReport['whatToDo'] {
+  return value === 'watch' || value === 'build' || value === 'ignore' || value === 'research';
 }
 
 export function buildItemUserMessage(


### PR DESCRIPTION
## What changed
- normalize schema-invalid consensus analyst responses from existing repository facts
- preserve transport/model failover while avoiding repeated schema-invalid calls
- guard both primary and tail publishers from empty-output degradation
- clamp canonical citation titles before strict parsing

## Proof
- worker tests: 537 passed, 1 skipped, 2 todo
- worker build: passed
- root typecheck: passed
- exact-file ESLint: passed
- worker keep-last-50 guard: passed
- git diff check: passed

## Production context
The expanded capture/social release is already live on HOSTUP. This hotfix addresses the remaining consensus-analyst degraded health lane; it does not touch Vercel.