### PR TITLE
Keep retained consensus timeouts non-blocking

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/__tests__/empty-publish-guards.test.ts
+++ b/apps/trendingrepo-worker/src/fetchers/__tests__/empty-publish-guards.test.ts
@@ -320,6 +320,114 @@ describe('worker fetcher empty publish guards', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('consensus-analyst only keeps healthy status when every timed-out row is retained', async () => {
+    callLlmMock.mockImplementation(async (options: { systemPrompt: string; userMessage: string }) => {
+      if (options.systemPrompt.includes('Daily Verdict editor')) {
+        return {
+          text: '{"headline":"Today in repos","bullets":["One","Two"]}',
+          usage: { inputTokens: 4, outputTokens: 2, cachedInputTokens: 0 },
+          meta: { provider: 'nanogpt', model: 'moonshotai/kimi-k2.6' },
+        };
+      }
+      if (options.userMessage.includes('owner/repo-4')) {
+        throw new Error('LLM stream idle');
+      }
+      return {
+        text: '{"tagline":null,"verdict":"strong_consensus"}',
+        usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 0 },
+        meta: { provider: 'nanogpt', model: 'moonshotai/kimi-k2.6' },
+      };
+    });
+    const absent = { present: false, rank: null, score: null, normalized: 0 };
+    const items = Array.from({ length: 5 }, (_, index) => ({
+      fullName: `owner/repo-${index}`,
+      rank: index + 1,
+      consensusScore: 90 - index,
+      sourceCount: 1,
+      confidence: 90,
+      externalRank: index + 1,
+      oursRank: index + 1,
+      verdict: 'strong_consensus' as const,
+      maxRankGap: 0,
+      sources: {
+        ours: { present: true, rank: index + 1, score: 90, normalized: 0.9 },
+        gh: { present: true, rank: index + 1, score: 90, normalized: 0.9 },
+        hf: absent,
+        hn: absent,
+        x: absent,
+        r: absent,
+        pdh: absent,
+        dev: absent,
+        bs: absent,
+      },
+    }));
+    let retainFailedItem = true;
+    readDataStoreMock.mockImplementation(async (key: string) => {
+      if (key === 'consensus-trending') {
+        return {
+          itemCount: items.length,
+          bandCounts: {
+            strong_consensus: items.length,
+            early_call: 0,
+            divergence: 0,
+            external_only: 0,
+            single_source: 0,
+          },
+          sourceStats: {},
+          weights: {},
+          items,
+        };
+      }
+      if (key === 'consensus-verdicts') {
+        return {
+          items: retainFailedItem
+            ? {
+                'owner/repo-4': {
+                  fullName: 'owner/repo-4',
+                  summary: 'retained report',
+                },
+              }
+            : {},
+        };
+      }
+      return null;
+    });
+    const { default: fetcher } = await import('../consensus-analyst/index.js');
+
+    const result = await fetcher.run(makeContext());
+
+    expect(writeDataStoreMock).toHaveBeenCalledWith(
+      'consensus-verdicts',
+      expect.objectContaining({
+        status: 'ok',
+        warnings: [expect.objectContaining({ stage: 'item-call', itemSourceId: 'owner/repo-4' })],
+        items: expect.objectContaining({
+          'owner/repo-4': expect.objectContaining({ summary: 'retained report' }),
+        }),
+      }),
+    );
+    expect(result.errors).toEqual([]);
+
+    retainFailedItem = false;
+    writeDataStoreMock.mockClear();
+    const degradedResult = await fetcher.run(makeContext());
+    const degradedCalls = writeDataStoreMock.mock.calls as unknown as Array<[string, {
+      status: string;
+      errors?: Array<{ stage: string }>;
+      items: Record<string, unknown>;
+    }]>;
+    const degradedPayload = degradedCalls[0]![1];
+
+    expect(degradedPayload.status).toBe('degraded');
+    expect(degradedPayload.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ stage: 'unretained-item-failures' })]),
+    );
+    expect(degradedPayload.items).not.toHaveProperty('owner/repo-4');
+    expect(degradedResult.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ stage: 'unretained-item-failures' })]),
+    );
+  });
+
   it('consensus-analyst-tail normalizes a partial tail item instead of dropping it', async () => {
     callLlmMock.mockResolvedValue({
       text: 'null',
@@ -367,6 +475,9 @@ describe('worker fetcher empty publish guards', () => {
       }
       if (key === 'consensus-verdicts') {
         return {
+          status: 'degraded',
+          errors: [{ stage: 'insufficient-fresh-coverage', message: 'too few fresh rows' }],
+          warnings: [{ stage: 'item-call', message: 'retained timeout' }],
           generator: 'kimi',
           ribbon: { headline: 'Existing', bullets: ['One', 'Two'] },
           items: {},
@@ -387,6 +498,9 @@ describe('worker fetcher empty publish guards', () => {
     expect(writeDataStoreMock).toHaveBeenCalledWith(
       'consensus-verdicts',
       expect.objectContaining({
+        status: 'degraded',
+        errors: [{ stage: 'insufficient-fresh-coverage', message: 'too few fresh rows' }],
+        warnings: [{ stage: 'item-call', message: 'retained timeout' }],
         generator: 'template',
         items: {
           'owner/tail-repo': expect.objectContaining({

--- a/apps/trendingrepo-worker/src/fetchers/consensus-analyst-tail/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/consensus-analyst-tail/index.ts
@@ -70,6 +70,9 @@ interface VerdictsItemPayload extends ItemReport {
 
 interface VerdictsPayload {
   computedAt: string;
+  status?: 'ok' | 'degraded';
+  errors?: RunResult['errors'];
+  warnings?: RunResult['errors'];
   generator: LlmProvider | 'template';
   model?: string;
   ribbon: {
@@ -229,6 +232,9 @@ const fetcher: Fetcher = {
       : (usedProvider ?? getLlmProvider());
     const payload: VerdictsPayload = {
       computedAt: new Date().toISOString(),
+      ...(latestPayload?.status ? { status: latestPayload.status } : {}),
+      ...(latestPayload?.errors !== undefined ? { errors: latestPayload.errors } : {}),
+      ...(latestPayload?.warnings !== undefined ? { warnings: latestPayload.warnings } : {}),
       generator,
       ...(generator !== 'template' && usedModel ? { model: usedModel } : {}),
       // Preserve the latest ribbon/usage from the existing payload — the tail

--- a/apps/trendingrepo-worker/src/fetchers/consensus-analyst/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/consensus-analyst/index.ts
@@ -41,6 +41,10 @@ const TOP_N = 75;
 // to ~10min wall while staying conservative on the subscription's likely
 // concurrency cap.
 const ITEM_CONCURRENCY = 4;
+// A retained prior verdict absorbs occasional provider timeouts. Treat the
+// sweep as healthy when at least 80% of the requested cohort was refreshed;
+// lower coverage remains a blocking degradation.
+const MIN_HEALTHY_FRESH_COVERAGE_RATIO = 0.8;
 
 interface VerdictsItemPayload extends ItemReport {
   fullName: string;
@@ -50,6 +54,7 @@ interface VerdictsPayload {
   computedAt: string;
   status?: 'ok' | 'degraded';
   errors?: RunResult['errors'];
+  warnings?: RunResult['errors'];
   generator: LlmProvider | 'template';
   model?: string;
   ribbon: Ribbon;
@@ -114,7 +119,7 @@ const fetcher: Fetcher = {
     let usedProvider: LlmProvider | undefined;
     let usedModel: string | undefined;
     let repairedItems = 0;
-    const errors: RunResult['errors'] = [];
+    const warnings: RunResult['errors'] = [];
 
     // Bounded-concurrency sweep — N workers pulling from a shared queue.
     // Preserves per-call retry semantics (each item swallows its own errors)
@@ -162,7 +167,7 @@ const fetcher: Fetcher = {
             { fullName: item.fullName, err: message },
             'consensus-analyst: item call failed',
           );
-          errors.push({ stage: 'item-call', itemSourceId: item.fullName, message });
+          warnings.push({ stage: 'item-call', itemSourceId: item.fullName, message });
         }
       }
     };
@@ -200,7 +205,7 @@ const fetcher: Fetcher = {
         { err: message },
         'consensus-analyst: ribbon call failed — using template',
       );
-      errors.push({ stage: 'ribbon-call', message });
+      warnings.push({ stage: 'ribbon-call', message });
     }
 
     // Read-then-merge: preserve prior verdicts (backfill + older sweeps) and
@@ -210,15 +215,49 @@ const fetcher: Fetcher = {
     const freshCount = Object.keys(items).length;
     if (topItems.length > 0 && freshCount === 0) {
       ctx.log.warn(
-        { retainedItems: Object.keys(existingItems).length, errors: errors.length },
+        { retainedItems: Object.keys(existingItems).length, errors: warnings.length },
         'consensus-analyst: no fresh item verdicts produced - preserving existing payload',
       );
       return done(startedAt, Object.keys(existingItems).length, false, [
-        ...errors,
+        ...warnings,
         { stage: 'empty-verdicts', message: 'no fresh item verdicts produced; skipped consensus-verdicts write' },
       ]);
     }
     const mergedItems = { ...existingItems, ...items };
+    const minimumHealthyFreshCount = Math.max(
+      1,
+      Math.ceil(topItems.length * MIN_HEALTHY_FRESH_COVERAGE_RATIO),
+    );
+    const retainedKeys = new Set(Object.keys(existingItems).map((key) => key.toLowerCase()));
+    const unretainedItemFailures = warnings.filter(
+      (warning) =>
+        warning.stage === 'item-call'
+        && warning.itemSourceId
+        && !retainedKeys.has(warning.itemSourceId.toLowerCase()),
+    );
+    const degradationReasons: RunResult['errors'] = [];
+    if (freshCount < minimumHealthyFreshCount) {
+      degradationReasons.push(
+        {
+          stage: 'insufficient-fresh-coverage',
+          message: `refreshed ${freshCount}/${topItems.length} items; minimum healthy count is ${minimumHealthyFreshCount}`,
+        },
+      );
+    }
+    if (unretainedItemFailures.length > 0) {
+      degradationReasons.push(
+        {
+          stage: 'unretained-item-failures',
+          message: `${unretainedItemFailures.length} failed top-cohort item(s) had no retained verdict`,
+        },
+      );
+    }
+    const errors: RunResult['errors'] = degradationReasons.length > 0
+      ? [
+          ...warnings,
+          ...degradationReasons,
+        ]
+      : [];
     const generator = freshCount > 0 && repairedItems === freshCount
       ? 'template'
       : (usedProvider ?? getLlmProvider());
@@ -226,6 +265,7 @@ const fetcher: Fetcher = {
       computedAt: new Date().toISOString(),
       status: errors.length > 0 ? 'degraded' : 'ok',
       ...(errors.length > 0 ? { errors } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
       // Honestly report which provider actually produced this run (e.g.
       // 'nanogpt' while Kimi-for-coding billing is restored). Falls back to the
       // configured primary when no call succeeded this run.
@@ -245,6 +285,9 @@ const fetcher: Fetcher = {
       {
         freshThisRun: freshCount,
         repairedItems,
+        failedItems: warnings.length,
+        unretainedItemFailures: unretainedItemFailures.length,
+        freshCoverageRatio: Number((freshCount / topItems.length).toFixed(3)),
         totalRetained: Object.keys(mergedItems).length,
         ribbonBullets: ribbon.bullets.length,
         usage: payload.usage,


### PR DESCRIPTION
## What changed
- treat a high-coverage consensus sweep as healthy only when every failed top-cohort row has a retained verdict
- keep item and ribbon failures visible as payload warnings
- preserve the primary health envelope when the daily tail writer merges new rows
- keep low coverage or unretained failures blocking

## Production evidence
The deployed normalizer refreshed 74/75 current rows; one NanoGPT idle timeout was retained from the existing 786-row payload, but the old all-or-nothing status kept production degraded.

## Proof
- worker tests: 538 passed, 1 skipped, 2 todo
- focused guard tests: 11 passed
- worker build: passed
- root typecheck: passed
- exact-file ESLint: passed
- worker keep-last-50 guard: passed
- git diff check: passed