### PR TITLE
Add trending GitHub skills category

### DIFF
--- a/apps/trendingrepo-worker/src/fetchers/recent-repos/index.ts
+++ b/apps/trendingrepo-worker/src/fetchers/recent-repos/index.ts
@@ -42,6 +42,7 @@ const GENERAL_QUERIES: DiscoveryQuery[] = [
 
 export const CATEGORY_QUERIES: DiscoveryQuery[] = [
   ['ai-agents', 'topic:ai-agent'],
+  ['skills', 'topic:agent-skills'],
   ['mcp', 'topic:model-context-protocol'],
   ['devtools', 'topic:developer-tools'],
   ['browser-automation', 'topic:browser-automation'],

--- a/apps/trendingrepo-worker/tests/fetchers/recent-repos/discovery.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/recent-repos/discovery.test.ts
@@ -66,8 +66,15 @@ describe('recent-repos discovery plan', () => {
   it('uses five general pages plus one page for each focused category', async () => {
     const { DISCOVERY_QUERIES } = await import('../../../src/fetchers/recent-repos/index.js');
 
-    expect(DISCOVERY_QUERIES.reduce((sum, query) => sum + query.pages, 0)).toBe(20);
-    expect(DISCOVERY_QUERIES.filter((query) => query.categoryId)).toHaveLength(15);
+    expect(DISCOVERY_QUERIES.reduce((sum, query) => sum + query.pages, 0)).toBe(21);
+    expect(DISCOVERY_QUERIES.filter((query) => query.categoryId)).toHaveLength(16);
+    expect(DISCOVERY_QUERIES).toContainEqual(
+      expect.objectContaining({
+        id: 'category:skills',
+        categoryId: 'skills',
+        qualifier: 'topic:agent-skills',
+      }),
+    );
     expect(
       DISCOVERY_QUERIES.filter((query) => query.categoryId).every(
         (query) => query.days === 30 && query.minStars === 5 && query.pages === 1,
@@ -222,7 +229,7 @@ describe('recent-repos discovery plan', () => {
     const payload = store.write.mock.calls[0]?.[1];
     expect(payload).toMatchObject({
       diagnostics: {
-        attemptedQueries: 18,
+        attemptedQueries: 19,
         succeededQueries: 1,
         incompleteQueries: 1,
       },

--- a/apps/trendingrepo-worker/tests/fetchers/recent-repos/token-pool.test.ts
+++ b/apps/trendingrepo-worker/tests/fetchers/recent-repos/token-pool.test.ts
@@ -305,11 +305,11 @@ describe('recent-repos GitHub authentication', () => {
 
     await fetcher.run(makeContext(seenHeaders));
 
-    expect(seenHeaders).toHaveLength(20);
+    expect(seenHeaders).toHaveLength(21);
     expect(seenHeaders.map((headers) => headers.Authorization)).toEqual([
       'Bearer pool-token-alpha',
       'Bearer pool-token-bravo',
-      ...Array.from({ length: 18 }, (_, index) =>
+      ...Array.from({ length: 19 }, (_, index) =>
         index % 2 === 0 ? 'Bearer pool-token-alpha' : 'Bearer pool-token-bravo',
       ),
     ]);

--- a/next.config.ts
+++ b/next.config.ts
@@ -227,8 +227,8 @@ const nextConfig: NextConfig = {
       { source: "/trends", destination: "/", permanent: true },
 
       // ---- T2 — Subsumed by v6 hub pages ----------------------------------
-      { source: "/skills", destination: "/tools", permanent: true },
-      { source: "/agent-repos", destination: "/agent-commerce", permanent: true },
+      { source: "/skills", destination: "/?cat=skills", permanent: true },
+      { source: "/agent-repos", destination: "/?cat=agents", permanent: true },
       { source: "/papers", destination: "/", permanent: true },
       { source: "/research", destination: "/", permanent: true },
       // Consensus-style breakout signal lives inside /breakout in v6.

--- a/public/shell.css
+++ b/public/shell.css
@@ -6818,6 +6818,10 @@ a.repo-avatar:hover {
     gap: 6px;
     padding: 8px;
   }
+  .trending-controlbar .tcb-group {
+    flex-wrap: wrap;
+    width: 100%;
+  }
   .trending-controlbar .tcb-divider {
     flex-basis: 100%;
     height: 1px;

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -7,9 +7,11 @@ import { getDerivedRepos, getDerivedRepoCount } from "@/lib/derived-repos";
 import { getSidebarSourceCounts } from "@/lib/sidebar-source-counts";
 import {
   getAgentsAsRepos,
+  getSkillsAsRepos,
   getLlmsAsRepos,
   refreshCategoryFromStore,
 } from "@/lib/category-adapters";
+import { getGithubSkillsTrendingCount } from "@/lib/skills-github-trending";
 import { refreshAaLlmsFromStore, getAaLlmsRanked, getAaLlmsFile } from "@/lib/aa-llms";
 import {
   refreshOpenrouterFromStore,
@@ -117,6 +119,7 @@ export default async function TrendingHubPage({ searchParams }: Props) {
   const rawRepos = (() => {
     if (category === "repos") return safe(() => getDerivedRepos(), []);
     if (category === "agents") return safe(() => getAgentsAsRepos(), []);
+    if (category === "skills") return safe(() => getSkillsAsRepos(), []);
     if (category === "llms") return safe(() => getLlmsAsRepos(), []);
     return [];
   })();
@@ -181,6 +184,7 @@ export default async function TrendingHubPage({ searchParams }: Props) {
   const switcherCounts: Partial<Record<CategoryId, number>> = {
     repos: safe(() => getDerivedRepoCount(), repos.length),
     agents: counts?.agentRepos ?? 0,
+    skills: safe(() => getGithubSkillsTrendingCount(), 0),
     llms: safe(() => getAaLlmsFile().models.length, 0),
     models: safe(() => getOpenrouterFile().models.length, 0),
   };

--- a/src/components/trending/TrendingControlBar.tsx
+++ b/src/components/trending/TrendingControlBar.tsx
@@ -1,7 +1,7 @@
 // TrendingControlBar — single consolidated filter strip BELOW FeaturedRepos.
 // Replaces the prior 3-bar stack (category-tabs / window switcher / language filter).
-// Operator decree: this is an AI-trending screener, no per-language slicing,
-// no Skills/Agents/LLMs/MCP category split — KEY IS TRENDING.
+// Operator decree: this is an AI-trending screener with no per-language
+// slicing. Repo-like Agents and Skills views remain inside this same bar.
 // Three controls in one bar: rank mode + time window + sort metric.
 
 import Link from "next/link";
@@ -26,6 +26,7 @@ function buildModeTabs(counts: Partial<Record<CategoryId, number>>): ModeTab[] {
     { id: "repos-gainer",    label: "Gainer",    cat: "repos",  rank: "gainer",    count: repoCount },
     { id: "repos-trend",     label: "Trend",     cat: "repos",  rank: "trend",     count: repoCount },
     { id: "agents",          label: "Agents",    cat: "agents", rank: "top",       count: counts.agents ?? null },
+    { id: "skills",          label: "Skills",    cat: "skills", rank: "top",       count: counts.skills ?? null },
     { id: "llms",            label: "LLMs",      cat: "llms",   rank: "top",       count: counts.llms ?? null },
     { id: "models",          label: "Models",    cat: "models", rank: "top",       count: counts.models ?? null },
   ];

--- a/src/components/trending/TrendingHubHero.tsx
+++ b/src/components/trending/TrendingHubHero.tsx
@@ -13,6 +13,7 @@ import { getDerivedRepoCount } from "@/lib/derived-repos";
 const CATEGORIES = [
   { id: "repos", label: "Repos", glyph: "R" },
   { id: "agents", label: "Agents", glyph: "A" },
+  { id: "skills", label: "Skills", glyph: "S" },
   { id: "llms", label: "LLMs", glyph: "L" },
   { id: "models", label: "Models", glyph: "M" },
 ] as const;

--- a/src/components/trending/TrendingTable.tsx
+++ b/src/components/trending/TrendingTable.tsx
@@ -52,9 +52,9 @@ export function TrendingTable({
 
   // Non-repo categories (skills / mcp / llms) replace the 24h/7d/30d/Trend
   // columns with category-specific cells supplied by the per-category
-  // mappers via `repo.categoryColumns`. Repo + agents keep the original
+  // mappers via `repo.categoryColumns`. Repos + agents + skills keep the original
   // delta + sparkline layout because they have real timeseries data.
-  const isRepoLike = category === "repos" || category === "agents";
+  const isRepoLike = category === "repos" || category === "agents" || category === "skills";
   const sampleColumns = top.find((r) => r.categoryColumns && r.categoryColumns.length > 0)
     ?.categoryColumns ?? [];
   const extraHeaders = isRepoLike

--- a/src/lib/__tests__/skills-github-trending.test.ts
+++ b/src/lib/__tests__/skills-github-trending.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectGithubSkillsTrending } from "@/lib/skills-github-trending";
+import type { Repo } from "@/lib/types";
+
+function repo(
+  fullName: string,
+  options: {
+    description?: string;
+    topics?: string[];
+    momentumScore?: number;
+  } = {},
+): Repo {
+  const [owner = "", name = ""] = fullName.split("/");
+  return {
+    fullName,
+    owner,
+    name,
+    description: options.description ?? "",
+    topics: options.topics ?? [],
+    momentumScore: options.momentumScore ?? 0,
+  } as Repo;
+}
+
+test("selectGithubSkillsTrending includes canonical packs case-insensitively", () => {
+  const selected = selectGithubSkillsTrending([
+    repo("AnthropicS/Skills", { momentumScore: 1 }),
+    repo("unrelated/runtime", { momentumScore: 100 }),
+  ]);
+
+  assert.deepEqual(selected.map((item) => item.fullName), ["AnthropicS/Skills"]);
+});
+
+test("selectGithubSkillsTrending requires strong skill-pack identity", () => {
+  const selected = selectGithubSkillsTrending([
+    repo("good/agent-skills", { topics: ["agent-skills"], momentumScore: 6 }),
+    repo("good/skills", { topics: ["cursor-skills"], momentumScore: 5 }),
+    repo("nextlevelbuilder/ui-ux-pro-max-skill", {
+      topics: ["ai-skills"],
+      momentumScore: 4,
+    }),
+    repo("coreyhaines31/marketingskills", {
+      description: "Marketing skills for Claude Code and AI agents",
+      momentumScore: 3,
+    }),
+    repo("safishamsi/graphify", {
+      description: "AI coding assistant skill for Claude Code, Codex, Cursor, and Gemini",
+      topics: ["skills"],
+      momentumScore: 2,
+    }),
+    repo("good/spec-pack", {
+      description: "Reusable coding-agent capabilities, each shipped with a SKILL.md file",
+      momentumScore: 1,
+    }),
+    repo("Imbad0202/academic-research-skills", { momentumScore: 0.5 }),
+    repo("noise/soft-skills", {
+      description: "Improve communication and leadership skills for your resume",
+      topics: ["skills"],
+      momentumScore: 99,
+    }),
+    repo("noise/alexa-skills", {
+      description: "Examples for building Alexa skills",
+      topics: ["alexa-skills"],
+      momentumScore: 98,
+    }),
+    repo("noise/agent-runtime", {
+      description: "Agent runtime that includes tools and skills",
+      topics: ["agent-skills"],
+      momentumScore: 97,
+    }),
+    repo("noise/rpg-skill-tree", {
+      description: "A course for designing game skill trees",
+      topics: ["agent-skills"],
+      momentumScore: 96,
+    }),
+    repo("googleworkspace/cli", {
+      description: "Official CLI. Includes AI agent skills.",
+      topics: ["agent-skills"],
+      momentumScore: 95,
+    }),
+    repo("code-yeongyu/oh-my-openagent", {
+      description: "An agent harness and orchestration runtime",
+      topics: ["claude-skills"],
+      momentumScore: 94,
+    }),
+    repo("thedotmack/claude-mem", {
+      description: "Persistent context and memory for every agent",
+      topics: ["claude-skills"],
+      momentumScore: 93,
+    }),
+    repo("calesthio/OpenMontage", {
+      description: "Agentic video production system with 500+ agent skills",
+      topics: ["agentic-ai"],
+      momentumScore: 92,
+    }),
+  ]);
+
+  assert.deepEqual(selected.map((item) => item.fullName), [
+    "good/agent-skills",
+    "good/skills",
+    "nextlevelbuilder/ui-ux-pro-max-skill",
+    "coreyhaines31/marketingskills",
+    "safishamsi/graphify",
+    "good/spec-pack",
+    "Imbad0202/academic-research-skills",
+  ]);
+});
+
+test("selectGithubSkillsTrending ranks canonical packs first, then momentum, and respects limit", () => {
+  const selected = selectGithubSkillsTrending(
+    [
+      repo("community/hot-codex-skills", { topics: ["codex-skills"], momentumScore: 90 }),
+      repo("openai/skills", { momentumScore: 5 }),
+      repo("community/warm-agent-skills", { topics: ["coding-agent-skills"], momentumScore: 50 }),
+      repo("obra/superpowers", { momentumScore: 1 }),
+    ],
+    3,
+  );
+
+  assert.deepEqual(selected.map((item) => item.fullName), [
+    "openai/skills",
+    "obra/superpowers",
+    "community/hot-codex-skills",
+  ]);
+});
+
+test("selectGithubSkillsTrending recognizes primary skill phrasing without admitting bundled-skill products", () => {
+  const selected = selectGithubSkillsTrending([
+    repo("wanshuiyin/Auto-claude-code-research-in-sleep", {
+      description: "ARIS — Lightweight Markdown-only skills for autonomous ML research",
+      topics: ["claude-code-skills"],
+    }),
+    repo("microsoft/waza", {
+      description: "CLI / Framework for Agent Skills - create, test, and measure skills",
+      topics: ["agent-skills"],
+    }),
+    repo("neilsonnn/image-blaster", {
+      description: "An image generation skillset for Claude",
+      topics: ["claude-skills"],
+    }),
+    repo("romainsimon/paperasse", {
+      description: "Skills pour agents IA",
+      topics: ["agent-skills", "claude-skills"],
+    }),
+    repo("EvanBacon/agent-rsvp", {
+      description: "A scheduling skill for agents",
+      topics: ["agent-skills"],
+    }),
+    repo("googleworkspace/cli", {
+      description: "Official CLI. Includes AI agent skills.",
+      topics: ["agent-skills"],
+    }),
+    repo("calesthio/OpenMontage", {
+      description: "Agentic video production system with 500+ agent skills",
+      topics: ["agent-skills"],
+    }),
+  ]);
+
+  assert.deepEqual(selected.map((item) => item.fullName), [
+    "wanshuiyin/Auto-claude-code-research-in-sleep",
+    "microsoft/waza",
+    "neilsonnn/image-blaster",
+    "romainsimon/paperasse",
+    "EvanBacon/agent-rsvp",
+  ]);
+});

--- a/src/lib/category-adapters.ts
+++ b/src/lib/category-adapters.ts
@@ -2,24 +2,28 @@
 // `Repo` shape so the same `TrendingTable` component can render every
 // category surface.
 //
-// 2026-05-24 refocus: Skills + MCP + HuggingFace stripped (operator: GitHub
-// repos are the main seller). The /?cat=llms surface is being replaced by an
-// AA leaderboard view in Wave 4 (separate component, separate row shape).
+// Skills returned in 2026-07 as a strict GitHub-repo view. This does not
+// restore the retired third-party Skills/MCP/HuggingFace leaderboard stack.
 
 import { getGithubAgentsTrending } from "@/lib/agents-github-trending";
+import { getGithubSkillsTrending } from "@/lib/skills-github-trending";
 import { decorateWithMentionsRollup } from "@/lib/derived-repos/decorators/mentions-rollup";
 import type { CategoryId } from "@/components/trending/TrendingHubHero";
 import type { Repo } from "@/lib/types";
 
 export async function refreshCategoryFromStore(category: CategoryId): Promise<void> {
   void category;
-  // No-ops for repos / agents / llms — repos + agents derive from
+  // No-ops for repos / agents / skills / llms — GitHub-backed categories derive from
   // getDerivedRepos() which is refreshed by refreshTrendingFromStore() at the
   // top of the page handler. llms gets its own AA refresh hook in Wave 4.
 }
 
 export function getAgentsAsRepos(): Repo[] {
   return decorateWithMentionsRollup(getGithubAgentsTrending(100));
+}
+
+export function getSkillsAsRepos(): Repo[] {
+  return decorateWithMentionsRollup(getGithubSkillsTrending(100));
 }
 
 // /?cat=llms is being rebuilt around the Artificial Analysis leaderboard

--- a/src/lib/nav-commands.ts
+++ b/src/lib/nav-commands.ts
@@ -27,6 +27,7 @@ export const NAV_COMMANDS: NavCommand[] = [
   { id: "drop", label: "Drop a repo", group: "Discover", href: "/drop", keywords: ["submit", "add", "track", "surface"] },
   // Homepage category views (?cat=) — NL like "show me agents" lands here.
   { id: "cat-agents", label: "Agents", group: "View", href: "/?cat=agents", keywords: ["agent repos", "agentic", "ai agents", "autonomous"] },
+  { id: "cat-skills", label: "Skills", group: "View", href: "/?cat=skills", keywords: ["agent skills", "claude skills", "codex skills", "skill packs"] },
   { id: "cat-llms", label: "LLMs", group: "View", href: "/?cat=llms", keywords: ["language models", "openrouter", "providers"] },
   { id: "cat-models", label: "Models", group: "View", href: "/?cat=models", keywords: ["ai models", "model adoption", "intelligence"] },
   { id: "cat-gainer", label: "Gainers", group: "View", href: "/?cat=gainer", keywords: ["top gainers", "rising", "movers"] },

--- a/src/lib/skills-github-trending.ts
+++ b/src/lib/skills-github-trending.ts
@@ -1,0 +1,114 @@
+// High-confidence coding-agent skill repositories from the derived GitHub
+// corpus. This intentionally rejects the broad word "skills": without an
+// agent/coding qualifier it matches careers, courses, games, and Alexa packs.
+
+import { getDerivedRepos } from "@/lib/derived-repos";
+import type { Repo } from "@/lib/types";
+
+const SKILLS_WHITELIST = new Set([
+  "anthropics/skills",
+  "openai/skills",
+  "mattpocock/skills",
+  "vercel-labs/skills",
+  "browserbase/skills",
+  "sickn33/antigravity-awesome-skills",
+  "github/awesome-copilot",
+  "obra/superpowers",
+]);
+
+const STRONG_TOPICS = new Set([
+  "agent-skill",
+  "agent-skills",
+  "agentic-skill",
+  "agentic-skills",
+  "ai-skill",
+  "ai-skills",
+  "ai-agent-skills",
+  "claude-code-skill",
+  "claude-code-skills",
+  "claude-skill",
+  "claude-skills",
+  "codex-skill",
+  "codex-skills",
+  "copilot-skill",
+  "copilot-skills",
+  "coding-agent-skills",
+  "cursor-skill",
+  "cursor-skills",
+  "gemini-skill",
+  "gemini-skills",
+  "mcp-skill",
+  "mcp-skills",
+  "openclaw-skill",
+  "openclaw-skills",
+  "skill-md",
+]);
+
+const NAME_IDENTITY_RE = /(?:^|[-_.])skills?(?:$|[-_.])|skills?$/i;
+
+const DESCRIPTION_IDENTITY_PATTERNS = [
+  /\bSKILL\.md\b/i,
+  /\b(?:skills?|skillsets?)\s+(?:for|pour)\s+(?:agents?(?:\s+ia)?|ai[\s-]+agents?|coding[\s-]+agents?|claude(?:[\s-]+code)?|codex|copilot|cursor|gemini|openclaw)\b/i,
+  /\b(?:catalog|collection|framework|library|marketplace|pack|repository|repo|suite|toolkit)\s+(?:\/\s+(?:framework|toolkit)\s+)?(?:for\s+|of\s+)?(?:installable\s+|reusable\s+)?(?:ai[\s-]+|agent(?:ic)?[\s-]+|claude(?:[\s-]+code)?[\s-]+|codex[\s-]+|copilot[\s-]+|cursor[\s-]+|gemini[\s-]+|openclaw[\s-]+)?(?:skills?|skillsets?)\b/i,
+  /^(?:an?\s+|the\s+)?(?:(?:ai|coding[\s-]+assistant|claude(?:[\s-]+code)?|codex|copilot|cursor|gemini|openclaw)[\s-]+){0,3}(?:skills?|skillsets?)\b/i,
+  /^(?:lightweight[\s-]+)?(?:markdown[\s-]+only[\s-]+)?(?:skills?|skillsets?)\b/i,
+  /\blightweight[\s-]+markdown[\s-]+only[\s-]+skills?\b/i,
+];
+
+const FALSE_POSITIVE_RE =
+  /\b(?:alexa|career|careers|course|courses|game|games|interview|job|jobs|leadership|lesson|lessons|resume|tutorial|tutorials|upskill|workshop|workshops)\b|soft[\s._-]*skills?|skill[\s._-]*tree/i;
+
+interface RankedSkill {
+  repo: Repo;
+  whitelisted: boolean;
+}
+
+function hasStrongSkillTopic(repo: Repo): boolean {
+  const topics = (repo.topics ?? []).map((topic) => topic.toLowerCase());
+  return topics.some((topic) => STRONG_TOPICS.has(topic));
+}
+
+function hasPrimarySkillIdentity(repo: Repo): boolean {
+  const name = repo.name.toLowerCase();
+  const description = repo.description ?? "";
+
+  if (DESCRIPTION_IDENTITY_PATTERNS.some((pattern) => pattern.test(description))) return true;
+  if (!NAME_IDENTITY_RE.test(name)) return false;
+
+  // A repo literally named `skill`/`skills` is ambiguous. Require a
+  // coding-agent topic unless the description already established identity.
+  if (name === "skill" || name === "skills") return hasStrongSkillTopic(repo);
+  return true;
+}
+
+export function selectGithubSkillsTrending(repos: Repo[], limit = 100): Repo[] {
+  const ranked: RankedSkill[] = [];
+
+  for (const repo of repos) {
+    const key = repo.fullName.toLowerCase();
+    const whitelisted = SKILLS_WHITELIST.has(key);
+    const identity = [repo.fullName, repo.name, repo.description].filter(Boolean).join(" ");
+
+    if (!whitelisted && FALSE_POSITIVE_RE.test(identity)) continue;
+    // Topics are supporting metadata, not identity. Agent runtimes and CLIs
+    // frequently advertise bundled skills; the repo itself must be a skill,
+    // pack, catalog, or skill-management surface to enter this category.
+    if (!whitelisted && !hasPrimarySkillIdentity(repo)) continue;
+    ranked.push({ repo, whitelisted });
+  }
+
+  ranked.sort((a, b) => {
+    if (a.whitelisted !== b.whitelisted) return a.whitelisted ? -1 : 1;
+    return (b.repo.momentumScore ?? 0) - (a.repo.momentumScore ?? 0);
+  });
+
+  return ranked.slice(0, Math.max(0, limit)).map(({ repo }) => repo);
+}
+
+export function getGithubSkillsTrending(limit = 100): Repo[] {
+  return selectGithubSkillsTrending(getDerivedRepos(), limit);
+}
+
+export function getGithubSkillsTrendingCount(): number {
+  return getGithubSkillsTrending(10_000).length;
+}

--- a/tests/e2e/mobile-drawer.spec.ts
+++ b/tests/e2e/mobile-drawer.spec.ts
@@ -28,4 +28,18 @@ test.describe("mobile drawer", () => {
     await expect(drawer).not.toHaveClass(/\bopen\b/);
     await expect(drawer).not.toBeInViewport();
   });
+
+  test("skills mode is active and control groups wrap without overflow", async ({ page }) => {
+    await page.goto("/?cat=skills", { waitUntil: "domcontentloaded" });
+
+    const mode = page.getByRole("group", { name: "Mode" });
+    const skills = mode.getByRole("link", { name: /^Skills/ });
+    await expect(skills).toHaveClass(/\bon\b/);
+    await expect(mode).toHaveCSS("flex-wrap", "wrap");
+
+    const horizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - window.innerWidth,
+    );
+    expect(horizontalOverflow).toBeLessThanOrEqual(0);
+  });
 });

--- a/tests/e2e/v6-routes.spec.ts
+++ b/tests/e2e/v6-routes.spec.ts
@@ -50,6 +50,24 @@ for (const route of PUBLIC_ROUTES) {
   });
 }
 
+const CATEGORY_REDIRECTS = [
+  { source: "/skills", target: "/?cat=skills" },
+  { source: "/agent-repos", target: "/?cat=agents" },
+];
+
+for (const route of CATEGORY_REDIRECTS) {
+  test(`${route.source} redirects to its GitHub-backed category`, async ({ request }) => {
+    const response = await request.get(route.source, {
+      maxRedirects: 0,
+      failOnStatusCode: false,
+    });
+    expect(response.status()).toBe(308);
+    const location = response.headers().location ?? "";
+    const resolved = new URL(location, "http://localhost");
+    expect(`${resolved.pathname}${resolved.search}`).toBe(route.target);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Session-gated routes — anon hit should either render 200 (if the route
 // renders an auth gate inline) or 302/307 redirect to /sign-in. Both are


### PR DESCRIPTION
## What changed
- add a GitHub-backed Skills category with strict primary-identity filtering and 54 useful repos in the bundled corpus
- add Skills navigation/counts/repo-native metrics, correct `/skills` and `/agent-repos` redirects, and mobile wrapping
- add a token-pooled `topic:agent-skills` recent-repo discovery lane

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint` and `npm run lint:guards`
- selector tests: 4/4
- recent-repos discovery tests: 6/6
- worker build
- targeted Playwright route/mobile suite: 27 passed, 1 unrelated cold-compile retry passed
- independent security/reliability review: no P0/P1