### PR TITLE
fix(x-autopilot): accept slots F/G in cron route + box runner

### DIFF
--- a/scripts/__tests__/twitter-trending-install.test.mjs
+++ b/scripts/__tests__/twitter-trending-install.test.mjs
@@ -4,7 +4,7 @@ import { test } from "node:test";
 
 const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8");
 
-test("HOSTUP installer deploys the five-slot autopilot and raises its cap", async () => {
+test("HOSTUP installer deploys the seven-slot autopilot and raises its cap", async () => {
   const [installer, packageJson] = await Promise.all([
     read("scripts/ops/install-trendingrepo-x-autopilot.sh"),
     read("package.json"),
@@ -20,7 +20,7 @@ test("HOSTUP installer deploys the five-slot autopilot and raises its cap", asyn
     assert.ok(installer.includes(destination), `installer misses ${destination}`);
   }
 
-  assert.match(installer, /TRENDING_POST_MAX_PER_DAY=5/);
+  assert.match(installer, /TRENDING_POST_MAX_PER_DAY=7/);
   assert.match(
     installer,
     /docker compose -f "\$COMPOSE_FILE" up -d --force-recreate trendingrepo/,

--- a/scripts/__tests__/twitter-trending-ops.test.mjs
+++ b/scripts/__tests__/twitter-trending-ops.test.mjs
@@ -8,15 +8,16 @@ import { test } from "node:test";
 
 const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8");
 
-test("X autopilot accepts five slots and carries the ranker through confirmation", async () => {
+test("X autopilot accepts seven slots and carries the ranker through confirmation", async () => {
   const [route, runner] = await Promise.all([
     read("src/app/api/cron/twitter-trending/route.ts"),
     read("scripts/twitter-trending-run.mjs"),
   ]);
-  assert.match(route, /z\.enum\(\["A", "B", "C", "D", "E"\]\)/);
-  assert.match(route, /q === "D"/);
-  assert.match(route, /q === "E"/);
-  assert.match(runner, /\["A", "B", "C", "D", "E"\]/);
+  assert.match(route, /z\.enum\(\["A", "B", "C", "D", "E", "F", "G"\]\)/);
+  // The ?slot= query param is validated through SlotSchema directly (no
+  // per-letter drift), so widening the enum covers F/G automatically.
+  assert.match(route, /SlotSchema\.safeParse\(q\)/);
+  assert.match(runner, /\["A", "B", "C", "D", "E", "F", "G"\]/);
   assert.match(runner, /plan\.ranker \? \{ ranker: plan\.ranker \}/);
 });
 
@@ -32,7 +33,7 @@ test("host runner logs slot-qualified success only after confirmation", async ()
   assert.ok(successLog > confirmationGuard, "success is logged before confirmation");
 });
 
-test("HOSTUP cron dispatches five UTC slots on a non-UTC host", async () => {
+test("HOSTUP cron dispatches seven UTC slots on a non-UTC host", async () => {
   const [autopilot, preflight, wrapper, preflightWrapper] = await Promise.all([
     read("scripts/ops/trendingrepo-x-autopilot.cron"),
     read("scripts/ops/trendingrepo-x-preflight.cron"),
@@ -46,7 +47,9 @@ test("HOSTUP cron dispatches five UTC slots on a non-UTC host", async () => {
   for (const mapping of [
     "04) set -- --slot D ;;",
     "08) set -- --slot A ;;",
+    "10) set -- --slot F ;;",
     "12) set -- --slot B ;;",
+    "14) set -- --slot G ;;",
     "17) set -- --slot C ;;",
     "21) set -- --slot E ;;",
   ]) {

--- a/scripts/ops/install-trendingrepo-x-autopilot.sh
+++ b/scripts/ops/install-trendingrepo-x-autopilot.sh
@@ -19,9 +19,9 @@ install -m 0644 "$ROOT/scripts/ops/trendingrepo-x-preflight.cron" /etc/cron.d/tr
 
 cp -p "$ENV_FILE" "$ENV_FILE.bak-x-autopilot-$(date -u +%Y%m%d%H%M%S)"
 if grep -q '^TRENDING_POST_MAX_PER_DAY=' "$ENV_FILE"; then
-  sed -i 's/^TRENDING_POST_MAX_PER_DAY=.*/TRENDING_POST_MAX_PER_DAY=5/' "$ENV_FILE"
+  sed -i 's/^TRENDING_POST_MAX_PER_DAY=.*/TRENDING_POST_MAX_PER_DAY=7/' "$ENV_FILE"
 else
-  printf '\nTRENDING_POST_MAX_PER_DAY=5\n' >>"$ENV_FILE"
+  printf '\nTRENDING_POST_MAX_PER_DAY=7\n' >>"$ENV_FILE"
 fi
 chmod 0600 "$ENV_FILE"
 docker compose -f "$COMPOSE_FILE" up -d --force-recreate trendingrepo

--- a/scripts/twitter-trending-run.mjs
+++ b/scripts/twitter-trending-run.mjs
@@ -45,7 +45,7 @@ function argValue(flag) {
 }
 
 const SLOT_RAW = (argValue("--slot") || "").toUpperCase();
-const SLOT = ["A", "B", "C", "D", "E"].includes(SLOT_RAW) ? SLOT_RAW : undefined;
+const SLOT = ["A", "B", "C", "D", "E", "F", "G"].includes(SLOT_RAW) ? SLOT_RAW : undefined;
 
 function twitter(args) {
   return execFileSync("twitter", args, { encoding: "utf8", timeout: 60_000 });

--- a/src/app/api/cron/twitter-trending/route.ts
+++ b/src/app/api/cron/twitter-trending/route.ts
@@ -27,7 +27,7 @@ export const runtime = "nodejs";
 // v2 additive contract: propose takes {slot}, confirm takes fullNames[] +
 // format/packId so pack members each enter cooldown. A v1 runner sending
 // bare {confirm:{fullName,...}} still works.
-const SlotSchema = z.enum(["A", "B", "C", "D", "E"]);
+const SlotSchema = z.enum(["A", "B", "C", "D", "E", "F", "G"]);
 const RankerSchema = z.enum(["top", "gainer", "trend", "discovery"]);
 const TrendingRequestSchema = z
   .object({
@@ -91,9 +91,7 @@ async function handle(request: NextRequest): Promise<NextResponse> {
   const q = request.nextUrl.searchParams.get("slot");
   const slot =
     parsed.data.slot ??
-    (q === "A" || q === "B" || q === "C" || q === "D" || q === "E"
-      ? q
-      : undefined);
+    (SlotSchema.safeParse(q).success ? (q as z.infer<typeof SlotSchema>) : undefined);
   const plan = await proposeTrendingPost(Date.now(), slot);
   return NextResponse.json({ ok: true, ...plan });
 }


### PR DESCRIPTION
Follow-up to #3245. That PR added calendar slots F/G but two allowlists still rejected them, so the two new daily posts never fired their intended format:
- `route.ts` `SlotSchema` was `z.enum([A..E])` → `{slot:F|G}` 400'd; the `?slot=` query guard also dropped F/G.
- `twitter-trending-run.mjs` box runner's `[A..E].includes()` dropped `--slot F/G` → posted unslotted default single.

Widens both to A-G; the route now validates `?slot=` through `SlotSchema` directly (no drift). tsc clean, cron-route contract 20/20.