### PR TITLE
feat(x-autopilot): tag repo makers with their X handle (WS1)

### DIFF
--- a/src/lib/__tests__/twitter-maker-tag.test.ts
+++ b/src/lib/__tests__/twitter-maker-tag.test.ts
@@ -1,0 +1,83 @@
+// Maker-tagging (WS1): owner -> X handle resolution + budget-safe tweet append.
+//
+// The append runs AFTER the LLM polish pass, so these pure functions are the
+// whole trust boundary for "the tweet tags the right account and never busts
+// the length budget". The copywriter's own mention-ban (it rejects any @handle
+// the model tries to add) is covered separately in copywriter.test.ts.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { appendMakerTag, SINGLE_TEXT_BUDGET } from "../twitter/outbound/composer";
+import {
+  AI_LAB_HANDLES,
+  resolveRepoHandle,
+  sanitizeHandle,
+} from "../twitter/outbound/handles";
+
+test("sanitizeHandle strips @ and accepts only legal X handles", () => {
+  assert.equal(sanitizeHandle("@OpenAI"), "OpenAI");
+  assert.equal(sanitizeHandle("OpenAI"), "OpenAI");
+  assert.equal(sanitizeHandle("  @deepseek_ai  "), "deepseek_ai");
+  assert.equal(sanitizeHandle("Kimi_Moonshot"), "Kimi_Moonshot");
+  // Rejections: URL, email, hyphen, too long (>15), empty / nullish.
+  assert.equal(sanitizeHandle("https://x.com/foo"), null);
+  assert.equal(sanitizeHandle("a@b.com"), null);
+  assert.equal(sanitizeHandle("bad-handle"), null);
+  assert.equal(sanitizeHandle("a".repeat(16)), null);
+  assert.equal(sanitizeHandle(""), null);
+  assert.equal(sanitizeHandle(null), null);
+  assert.equal(sanitizeHandle(undefined), null);
+});
+
+test("resolveRepoHandle: curated AI-lab map wins over GitHub, else self-declared", () => {
+  // Curated marquee lab (GitHub twitter_username is blank for these).
+  assert.equal(resolveRepoHandle("moonshotai/Kimi-K2"), "Kimi_Moonshot");
+  assert.equal(resolveRepoHandle("openai/whisper"), "OpenAI");
+  // Owner match is case-insensitive (same repo, different casing).
+  assert.equal(resolveRepoHandle("MoonshotAI/Kimi-K2"), "Kimi_Moonshot");
+  // Curated override wins even over a real, different declared handle.
+  assert.equal(resolveRepoHandle("openai/whisper", "OpenAIDevs"), "OpenAI");
+  // Non-curated owner falls back to the self-declared GitHub handle, sanitized
+  // (real declarations: ollama -> "ollama", unslothai -> "unslothai").
+  assert.equal(resolveRepoHandle("ollama/ollama", "ollama"), "ollama");
+  assert.equal(resolveRepoHandle("unslothai/unsloth", "@unslothai"), "unslothai");
+  // Nothing declared -> no tag.
+  assert.equal(resolveRepoHandle("tinygrad/tinygrad", null), null);
+  assert.equal(resolveRepoHandle("tinygrad/tinygrad"), null);
+  // Every curated handle is itself a legal X handle (no typo'd entry ships).
+  for (const h of Object.values(AI_LAB_HANDLES)) {
+    assert.equal(sanitizeHandle(h), h, `curated handle invalid: ${h}`);
+  }
+});
+
+test("appendMakerTag appends the tag and never exceeds the text budget", () => {
+  const short = "vercel/next.js\n+512 stars today | TypeScript\n\nThe React framework.";
+  const tagged = appendMakerTag(short, "vercel", SINGLE_TEXT_BUDGET);
+  assert.ok(tagged.endsWith("\n\nby @vercel"));
+  assert.ok(tagged.includes("@vercel"));
+  assert.ok(tagged.length <= SINGLE_TEXT_BUDGET);
+  // With the 24-char t.co URL added by the runner it still clears 280.
+  assert.ok(tagged.length + 24 <= 270);
+});
+
+test("appendMakerTag with no handle is a no-op", () => {
+  const text = "owner/name\n+5 stars today";
+  assert.equal(appendMakerTag(text, null, SINGLE_TEXT_BUDGET), text);
+});
+
+test("appendMakerTag trims the tail to fit when the text is at budget", () => {
+  // A maxed-out post: exactly the text budget in ASCII chars.
+  const maxed = "x".repeat(SINGLE_TEXT_BUDGET);
+  const tagged = appendMakerTag(maxed, "Kimi_Moonshot", SINGLE_TEXT_BUDGET);
+  assert.ok(tagged.length <= SINGLE_TEXT_BUDGET, `len ${tagged.length}`);
+  assert.ok(tagged.endsWith("by @Kimi_Moonshot"));
+  // The tag earned its space over the tail, which was ellipsized.
+  assert.ok(tagged.includes("..."));
+});
+
+test("appendMakerTag skips when almost nothing would survive the trim", () => {
+  const text = "y".repeat(40);
+  // maxLen 30: suffix (12) leaves room 18 (<24) -> not worth mangling, skip.
+  assert.equal(appendMakerTag(text, "OpenAI", 30), text);
+});

--- a/src/lib/twitter/outbound/composer.ts
+++ b/src/lib/twitter/outbound/composer.ts
@@ -331,6 +331,9 @@ export function composeIdeaPublishedPost(idea: PublicIdea): ComposedPost {
 // unfurls from the trendingrepo.com link — not from emoji in the body.
 const SINGLE_TWEET_MAX = 270;
 
+/** Text budget for a single/discovery post (URL travels separately, 24 chars). */
+export const SINGLE_TEXT_BUDGET = SINGLE_TWEET_MAX - URL_BUDGET;
+
 /**
  * Reduce a string to printable ASCII: NFKD-fold accents (café -> cafe),
  * drop emoji / smart punctuation / any other non-ASCII, then collapse the
@@ -406,6 +409,29 @@ export function composeTrendingSingle(repo: Repo): ComposedPost {
     text: truncateAscii(`${headline}${descLine}`, textBudget),
     url,
   };
+}
+
+/**
+ * Append a maker @mention to a composed single/discovery tweet, budget-safe.
+ * The tag is added AFTER any LLM polish so the copywriter's mention-ban stays
+ * strict and the handle can never be dropped or mutated by the model. If the
+ * text plus "\n\nby @handle" would bust `maxLen` (the text budget), the tail is
+ * trimmed so the tag still fits — the maker mention earns its space over the
+ * last few chars of description. No-ops when there's no handle or too little
+ * room. Returns text whose length never exceeds `maxLen`.
+ */
+export function appendMakerTag(
+  text: string,
+  handle: string | null,
+  maxLen: number = SINGLE_TEXT_BUDGET,
+): string {
+  if (!handle) return text;
+  const suffix = `\n\nby @${handle}`;
+  if (text.length + suffix.length <= maxLen) return `${text}${suffix}`;
+  const room = maxLen - suffix.length;
+  // Not worth mangling the post for a tag if almost nothing survives.
+  if (room < 24) return text;
+  return `${truncateAscii(text, room)}${suffix}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/twitter/outbound/handles.ts
+++ b/src/lib/twitter/outbound/handles.ts
@@ -1,0 +1,71 @@
+// Maker-tagging: resolve a repo owner (or AI lab / model provider) to its
+// official X/Twitter handle so autopilot posts can @mention the maker. Tagged
+// accounts get notified and frequently reboost to their own followers — the
+// single cheapest reach multiplier available to the poster.
+//
+// Two sources, in precedence order:
+//   1. A tiny CURATED map of marquee AI labs. These are the accounts people
+//      most want tagged (OpenAI, Anthropic, Kimi, ...) AND the ones that leave
+//      their GitHub `twitter_username` blank, so the dynamic source below can't
+//      reach them. Every entry here is HAND-VERIFIED against the lab's own
+//      public confirmation — a wrong handle tags an impostor (Moonshot warned
+//      publicly that @Kimi__Moonshot, double underscore, is a scam clone of the
+//      real @Kimi_Moonshot). Do not add an entry you have not verified.
+//   2. GitHub's self-declared `twitter_username` on the owner's org/user
+//      profile (already fetched + stored by the repo-community-profile worker).
+//      Self-declared = authoritative by definition, zero mis-tag risk.
+//
+// Pure string logic only — no I/O, no secrets, no server APIs (so no
+// `server-only` marker — this stays unit-testable under node:test and safe to
+// import anywhere). The caller supplies the GitHub-declared handle (read from
+// the community-profile slug); this module just picks + cleans.
+
+/**
+ * Owner login (GitHub org/user, lowercased) -> verified official X handle
+ * (no leading @). Deliberately small. Keyed by GitHub owner so a repo's
+ * `owner/name` resolves directly. Only marquee AI labs whose GitHub profile
+ * leaves `twitter_username` empty belong here; everyone else flows through the
+ * self-declared GitHub field.
+ */
+export const AI_LAB_HANDLES: Readonly<Record<string, string>> = {
+  openai: "OpenAI",
+  anthropics: "AnthropicAI",
+  "anthropic-ai": "AnthropicAI",
+  "google-deepmind": "GoogleDeepMind",
+  deepmind: "GoogleDeepMind",
+  "meta-llama": "AIatMeta",
+  facebookresearch: "AIatMeta",
+  mistralai: "MistralAI",
+  moonshotai: "Kimi_Moonshot", // verified: Moonshot's only official account
+  "deepseek-ai": "deepseek_ai",
+};
+
+const HANDLE_RE = /^[A-Za-z0-9_]{1,15}$/;
+
+/**
+ * Normalize a raw handle candidate to a bare, valid X handle or null.
+ * Strips a leading @ and surrounding space; rejects anything that isn't a
+ * legal X handle (1-15 chars of [A-Za-z0-9_]). A full URL, an email, or a
+ * display name all correctly return null rather than tagging garbage.
+ */
+export function sanitizeHandle(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const h = raw.trim().replace(/^@+/, "");
+  return HANDLE_RE.test(h) ? h : null;
+}
+
+/**
+ * Resolve the handle to tag for a repo. Curated AI-lab map wins (marquee labs
+ * we want tagged with a verified handle), else the owner's GitHub-declared
+ * `twitter_username`. Returns a bare handle (no @) or null when neither source
+ * yields a valid handle.
+ */
+export function resolveRepoHandle(
+  fullName: string,
+  githubTwitterUsername?: string | null,
+): string | null {
+  const owner = fullName.split("/")[0]?.toLowerCase() ?? "";
+  const curated = AI_LAB_HANDLES[owner];
+  if (curated) return curated;
+  return sanitizeHandle(githubTwitterUsername);
+}

--- a/src/lib/twitter/outbound/trending-runner.ts
+++ b/src/lib/twitter/outbound/trending-runner.ts
@@ -33,9 +33,19 @@ import { refreshRepoRegistryFromStore } from "@/lib/derived-repos/loaders/regist
 import { refreshStarActivityDeltasFromStore } from "@/lib/star-activity-deltas";
 import { refreshTwitterSignalsFromStore } from "@/lib/twitter";
 import { refreshAllMentionStores } from "@/lib/refresh-mentions";
+import {
+  getRepoCommunityProfile,
+  refreshRepoCommunityProfileFromStore,
+} from "@/lib/repo-community-profile";
 import type { Repo } from "@/lib/types";
 
-import { composeTrendingPack, composeTrendingSingle } from "./composer";
+import {
+  appendMakerTag,
+  composeTrendingPack,
+  composeTrendingSingle,
+  SINGLE_TEXT_BUDGET,
+} from "./composer";
+import { resolveRepoHandle } from "./handles";
 import {
   resolveSlotFormat,
   type SlotFormatKind,
@@ -269,6 +279,43 @@ async function withPolish(p: TrendingProposal): Promise<TrendingProposal> {
     : { ...p, source: "deterministic" };
 }
 
+/**
+ * Resolve the owner's X handle from the community-profile slug (self-declared
+ * GitHub `twitter_username`, already batched into Redis by the
+ * repo-community-profile worker) plus the curated AI-lab override map. Never
+ * throws — a missing profile just means no tag.
+ */
+async function resolveMakerHandle(fullName: string): Promise<string | null> {
+  try {
+    await refreshRepoCommunityProfileFromStore(fullName);
+    const tw =
+      getRepoCommunityProfile(fullName)?.ownerProfile?.twitterUsername ?? null;
+    return resolveRepoHandle(fullName, tw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Append the maker @mention to a single/discovery post AFTER polish so the
+ * copywriter's mention-ban stays strict and the handle ships verbatim. Packs
+ * are skipped — tagging every member reads as spam — and the format check
+ * short-circuits before any I/O for them.
+ */
+async function withMaker(p: TrendingProposal): Promise<TrendingProposal> {
+  if (!p.post || !p.text || !p.fullName) return p;
+  if (p.format === "trending_pack") return p;
+  const handle = await resolveMakerHandle(p.fullName);
+  if (!handle) return p;
+  const tagged = appendMakerTag(p.text, handle, SINGLE_TEXT_BUDGET);
+  return tagged === p.text ? p : { ...p, text: tagged };
+}
+
+/** withPolish then maker-tag — the finalize step for every proposed post. */
+async function finalize(p: TrendingProposal): Promise<TrendingProposal> {
+  return withMaker(await withPolish(p));
+}
+
 /** Decide + compose the next tweet without committing anything. */
 export async function proposeTrendingPost(
   nowMs: number = Date.now(),
@@ -300,7 +347,7 @@ export async function proposeTrendingPost(
     if (pack && members.length > 0) {
       const composed = composeTrendingPack(members, pack);
       const slugs = members.map((r) => r.fullName);
-      return withPolish({
+      return finalize({
         post: true,
         format: "trending_pack",
         packId: pack.id,
@@ -322,7 +369,7 @@ export async function proposeTrendingPost(
     const gem = pickTopDiscoveryRepo(pool);
     if (gem) {
       const composed = composeTrendingSingle(gem);
-      return withPolish({
+      return finalize({
         post: true,
         format: "discovery_single",
         ranker: "discovery",
@@ -337,7 +384,7 @@ export async function proposeTrendingPost(
     // No eligible gem today — fall through to single.
   }
 
-  return withPolish(proposeSingle(repos, state, cap, resolved.ranker));
+  return finalize(proposeSingle(repos, state, cap, resolved.ranker));
 }
 
 /** Commit a confirmed post to the durable ledger + audit trail. */


### PR DESCRIPTION
**Social workstream 1 of 3** — lift original-post engagement by @mentioning the maker.

Autopilot single + discovery posts now tag the repo owner's official X account. Tagged accounts get notified and frequently reboost to their own followers — the cheapest reach multiplier we have.

## How the handle resolves
1. **Curated verified AI-lab map** (`handles.ts`) — OpenAI, Anthropic, `@Kimi_Moonshot`, DeepSeek, Mistral, DeepMind, Meta AI. These leave their GitHub `twitter_username` blank, and a wrong handle tags an impostor (Moonshot publicly warned `@Kimi__Moonshot` is a scam clone), so each entry is hand-verified.
2. **Self-declared GitHub `twitter_username`** — already batched to Redis by the `repo-community-profile` worker; authoritative by definition. Covers everyone else dynamically.
3. Neither → no tag (never guesses).

## Safety
- `appendMakerTag` runs **after** the LLM polish pass, so the copywriter's existing `@mention` ban stays strict (the model still can't inject mentions) and the handle ships verbatim.
- Budget-safe: result text ≤ 246 chars so +24 t.co URL clears the 280 cap; trims the description tail only when the post is already at budget.
- Packs skip tagging (every member = spam); the format check short-circuits before any I/O.

## Verification
- 6 new unit tests (sanitize/resolve precedence + append budget invariants) + copywriter mention-ban regression + outbound composer = **76/76 green**, typecheck clean.
- Real end-to-end (a live tagged post) verified on the box after deploy.

Part of the "become THE AI/model trending expert poster" plan. WS2 (model-launch posts + charts) and WS3 (OmniRoute) follow.