### PR TITLE
feat(x-autopilot): maker-tagging fires on trending picks + model-spotlight composer

### DIFF
--- a/src/lib/__tests__/twitter-maker-tag.test.ts
+++ b/src/lib/__tests__/twitter-maker-tag.test.ts
@@ -8,9 +8,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { appendMakerTag, SINGLE_TEXT_BUDGET } from "../twitter/outbound/composer";
+import {
+  appendMakerTag,
+  composeModelSpotlight,
+  SINGLE_TEXT_BUDGET,
+} from "../twitter/outbound/composer";
 import {
   AI_LAB_HANDLES,
+  PROVIDER_HANDLES,
+  resolveProviderHandle,
   resolveRepoHandle,
   sanitizeHandle,
 } from "../twitter/outbound/handles";
@@ -80,4 +86,57 @@ test("appendMakerTag skips when almost nothing would survive the trim", () => {
   const text = "y".repeat(40);
   // maxLen 30: suffix (12) leaves room 18 (<24) -> not worth mangling, skip.
   assert.equal(appendMakerTag(text, "OpenAI", 30), text);
+});
+
+test("resolveProviderHandle maps model providers to verified handles", () => {
+  assert.equal(resolveProviderHandle("moonshotai"), "Kimi_Moonshot");
+  assert.equal(resolveProviderHandle("moonshot"), "Kimi_Moonshot");
+  assert.equal(resolveProviderHandle("Anthropic"), "AnthropicAI"); // case-insensitive
+  assert.equal(resolveProviderHandle("deepseek"), "deepseek_ai");
+  // Unknown provider / nullish -> no tag (never guesses).
+  assert.equal(resolveProviderHandle("some-startup"), null);
+  assert.equal(resolveProviderHandle(""), null);
+  assert.equal(resolveProviderHandle(null), null);
+  // Every mapped handle is itself legal.
+  for (const h of Object.values(PROVIDER_HANDLES)) {
+    assert.equal(sanitizeHandle(h), h, `provider handle invalid: ${h}`);
+  }
+});
+
+test("composeModelSpotlight sells the reason to care, budget-safe", () => {
+  const post = composeModelSpotlight({
+    name: "Kimi K2",
+    provider: "Moonshot AI",
+    inputPricePerMillion: 0.6,
+    outputPricePerMillion: 2.5,
+    contextLength: 256_000,
+    usageRank: 3,
+    wowChange: 0.44,
+    isNew: true,
+  });
+  assert.equal(post.kind, "model_spotlight");
+  assert.ok(post.text.startsWith("Kimi K2 (Moonshot AI)"));
+  assert.ok(post.text.includes("256K context"));
+  assert.ok(post.text.includes("$0.60/M in"));
+  assert.ok(post.text.includes("$2.50/M out"));
+  assert.ok(post.text.includes("New on OpenRouter"));
+  assert.ok(post.text.includes("#3 by usage this week"));
+  assert.ok(post.text.includes("+44% WoW"));
+  // +24 t.co URL still clears 280.
+  assert.ok(post.text.length <= SINGLE_TEXT_BUDGET);
+});
+
+test("composeModelSpotlight handles free models and no signals", () => {
+  const post = composeModelSpotlight({
+    name: "DeepSeek V3",
+    provider: "DeepSeek",
+    inputPricePerMillion: 0,
+    outputPricePerMillion: 0,
+    contextLength: 128_000,
+  });
+  assert.ok(post.text.includes("free in"));
+  assert.ok(post.text.includes("free out"));
+  assert.ok(post.text.includes("128K context"));
+  // No usageRank / wowChange / isNew -> only 3 lines (head, blank, spec).
+  assert.equal(post.text.split("\n").length, 3);
 });

--- a/src/lib/twitter/outbound/composer.ts
+++ b/src/lib/twitter/outbound/composer.ts
@@ -435,6 +435,76 @@ export function appendMakerTag(
 }
 
 // ---------------------------------------------------------------------------
+// Model spotlight — WS2: a proper model-launch / adoption post
+// ---------------------------------------------------------------------------
+
+export interface ModelSpotlight {
+  name: string;
+  provider: string;
+  /** USD per million input tokens (0 = free tier). */
+  inputPricePerMillion: number;
+  /** USD per million output tokens (0 = free tier). */
+  outputPricePerMillion: number;
+  contextLength: number;
+  /** OpenRouter weekly usage rank (1 = most used), when known. */
+  usageRank?: number | null;
+  /** WoW usage change as a fraction (0.44 = +44%), when known. */
+  wowChange?: number | null;
+  /** True when the model first appeared in the catalog recently. */
+  isNew?: boolean;
+}
+
+/** "128000" -> "128K", "1000000" -> "1M", else the raw count. */
+function formatContext(tokens: number): string {
+  if (tokens >= 1_000_000) return `${Math.round(tokens / 1_000_000)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+  return `${Math.max(0, Math.round(tokens))}`;
+}
+
+/**
+ * Compose a model-spotlight tweet (ASCII, <=270 effective incl. the 23-char
+ * t.co link). Sells the *reason to care now* — a fresh launch, a usage rank, or
+ * a WoW spike — over the raw catalog line:
+ *
+ *   Kimi K2 (Moonshot AI)
+ *
+ *   256K context | $0.60/M in, $2.50/M out
+ *   New on OpenRouter | #3 by usage this week | +44% WoW
+ *
+ * The provider @mention is appended by the runner via appendMakerTag (same
+ * post-polish path as repo maker-tagging), never here — keeps the copy pure.
+ */
+export function composeModelSpotlight(m: ModelSpotlight): ComposedPost {
+  const name = toAscii(m.name);
+  const provider = toAscii(m.provider);
+  const head = provider ? `${name} (${provider})` : name;
+
+  const priceIn =
+    m.inputPricePerMillion > 0 ? `$${m.inputPricePerMillion.toFixed(2)}/M in` : "free in";
+  const priceOut =
+    m.outputPricePerMillion > 0 ? `$${m.outputPricePerMillion.toFixed(2)}/M out` : "free out";
+  const specLine = `${formatContext(m.contextLength)} context | ${priceIn}, ${priceOut}`;
+
+  const signals: string[] = [];
+  if (m.isNew) signals.push("New on OpenRouter");
+  if (typeof m.usageRank === "number" && m.usageRank > 0 && m.usageRank <= 20) {
+    signals.push(`#${m.usageRank} by usage this week`);
+  }
+  if (typeof m.wowChange === "number" && m.wowChange >= 0.15) {
+    signals.push(`+${Math.round(m.wowChange * 100)}% WoW`);
+  }
+
+  const lines = [head, "", specLine];
+  if (signals.length > 0) lines.push(signals.join(" | "));
+
+  return {
+    kind: "model_spotlight",
+    text: truncateAscii(lines.join("\n"), SINGLE_TEXT_BUDGET),
+    url: absoluteUrl("/?cat=models"),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Content engine v2 — Twitter-register compression + themed pack composer
 // ---------------------------------------------------------------------------
 

--- a/src/lib/twitter/outbound/handles.ts
+++ b/src/lib/twitter/outbound/handles.ts
@@ -40,6 +40,28 @@ export const AI_LAB_HANDLES: Readonly<Record<string, string>> = {
   "deepseek-ai": "deepseek_ai",
 };
 
+/**
+ * Model provider (OpenRouter `provider` string, lowercased) -> verified X
+ * handle. Provider strings differ from GitHub org logins (a model's provider
+ * is "moonshotai" or "anthropic", not the repo owner), so this is its own map.
+ * Same verification bar as AI_LAB_HANDLES — only handles confirmed correct.
+ */
+export const PROVIDER_HANDLES: Readonly<Record<string, string>> = {
+  openai: "OpenAI",
+  anthropic: "AnthropicAI",
+  google: "GoogleDeepMind",
+  "google-deepmind": "GoogleDeepMind",
+  meta: "AIatMeta",
+  "meta-llama": "AIatMeta",
+  mistral: "MistralAI",
+  mistralai: "MistralAI",
+  deepseek: "deepseek_ai",
+  moonshot: "Kimi_Moonshot",
+  moonshotai: "Kimi_Moonshot",
+  qwen: "Alibaba_Qwen",
+  alibaba: "Alibaba_Qwen",
+};
+
 const HANDLE_RE = /^[A-Za-z0-9_]{1,15}$/;
 
 /**
@@ -68,4 +90,16 @@ export function resolveRepoHandle(
   const curated = AI_LAB_HANDLES[owner];
   if (curated) return curated;
   return sanitizeHandle(githubTwitterUsername);
+}
+
+/**
+ * Resolve a model provider's verified X handle for model-spotlight posts.
+ * Returns a bare handle or null when the provider isn't in the verified map
+ * (better no tag than a wrong one).
+ */
+export function resolveProviderHandle(
+  provider: string | null | undefined,
+): string | null {
+  if (!provider) return null;
+  return PROVIDER_HANDLES[provider.trim().toLowerCase()] ?? null;
 }

--- a/src/lib/twitter/outbound/trending-runner.ts
+++ b/src/lib/twitter/outbound/trending-runner.ts
@@ -34,6 +34,7 @@ import { refreshStarActivityDeltasFromStore } from "@/lib/star-activity-deltas";
 import { refreshTwitterSignalsFromStore } from "@/lib/twitter";
 import { refreshAllMentionStores } from "@/lib/refresh-mentions";
 import {
+  fetchRepoCommunityProfileLive,
   getRepoCommunityProfile,
   refreshRepoCommunityProfileFromStore,
 } from "@/lib/repo-community-profile";
@@ -45,7 +46,7 @@ import {
   composeTrendingSingle,
   SINGLE_TEXT_BUDGET,
 } from "./composer";
-import { resolveRepoHandle } from "./handles";
+import { resolveRepoHandle, sanitizeHandle } from "./handles";
 import {
   resolveSlotFormat,
   type SlotFormatKind,
@@ -280,17 +281,34 @@ async function withPolish(p: TrendingProposal): Promise<TrendingProposal> {
 }
 
 /**
- * Resolve the owner's X handle from the community-profile slug (self-declared
- * GitHub `twitter_username`, already batched into Redis by the
- * repo-community-profile worker) plus the curated AI-lab override map. Never
- * throws — a missing profile just means no tag.
+ * Resolve the owner's X handle for a picked repo. Order:
+ *   1. Curated AI-lab map (zero I/O) — labs whose GitHub handle is blank.
+ *   2. The batched community-profile slug (fast, but the worker only profiles
+ *      the dropped tail — trending picks are usually absent here).
+ *   3. A LIVE GitHub owner fetch — the poster picks trending repos, which the
+ *      batch never covers, so without this the tag almost never fires. Deduped
+ *      + rate-limited inside fetchRepoCommunityProfileLive; also warms the slug
+ *      for the repo's profile page. Best-effort — any failure means no tag.
+ * Never throws — a missing handle just means an untagged (still valid) post.
  */
 async function resolveMakerHandle(fullName: string): Promise<string | null> {
+  // 1. Curated AI-lab owner — resolves with no network at all.
+  const curated = resolveRepoHandle(fullName, null);
+  if (curated) return curated;
+
   try {
+    // 2. Batched slug (cheap in-memory read after the refresh).
     await refreshRepoCommunityProfileFromStore(fullName);
-    const tw =
+    let tw =
       getRepoCommunityProfile(fullName)?.ownerProfile?.twitterUsername ?? null;
-    return resolveRepoHandle(fullName, tw);
+
+    // 3. Live owner fetch when the batch hasn't profiled this trending repo.
+    if (!tw) {
+      const live = await fetchRepoCommunityProfileLive(fullName);
+      tw = live?.ownerProfile?.twitterUsername ?? null;
+    }
+
+    return sanitizeHandle(tw);
   } catch {
     return null;
   }

--- a/src/lib/twitter/outbound/types.ts
+++ b/src/lib/twitter/outbound/types.ts
@@ -39,7 +39,8 @@ export type OutboundPostKind =
   | "weekly_recap_item"
   | "idea_published"
   | "trending_single"
-  | "trending_pack";
+  | "trending_pack"
+  | "model_spotlight";
 
 export interface AdapterPostResult {
   /** Provider tweet id, when the adapter actually published. */


### PR DESCRIPTION
Follow-up to #3254.

## WS1 efficacy fix (the important one)
Deployed #3254 but verified it was **inert**: dry-runs produced 0 tags. Root cause — the `repo-community-profile` worker profiles the *dropped tail* (oldest-seen repos), but the poster picks *trending* repos, which are only profiled on-demand. So the handle data was empty for exactly the repos being posted.

`resolveMakerHandle` now resolves in order:
1. Curated AI-lab map (zero I/O)
2. Batched community-profile slug
3. **Live GitHub owner fetch** (`fetchRepoCommunityProfileLive`) when the batch misses — deduped + rate-limited, and warms the slug for the profile page. 7 posts/day = negligible GH cost.

Without this, tagging almost never fired. With it, any picked repo whose owner declared a GitHub `twitter_username` gets tagged.

## WS2 core
- `composeModelSpotlight()` — proper model post: context + $/M in+out + launch/usage/WoW signal, provider @mentioned. Pure, budget-safe (≤246 text).
- `resolveProviderHandle()` — OpenRouter provider → verified X handle.
- Slot wiring + benchmark chart card come next.

71/71 outbound+maker tests green, typecheck clean. Live tagging proof after redeploy.